### PR TITLE
Stage 2 messaging delivery layer

### DIFF
--- a/docs/messaging-stage-2-apply.md
+++ b/docs/messaging-stage-2-apply.md
@@ -1,0 +1,45 @@
+# Messaging Stage 2 apply guide
+
+Use branch feature/messaging-stage-2-apply.
+
+## Added in stage 2
+
+- src/lib/notifications/providers/resend.ts
+- src/lib/notifications/providers/twilio.ts
+- src/lib/notifications/processor.ts
+- src/lib/notifications/transactional.ts
+- src/lib/notifications/webhooks.ts
+- src/app/api/cron/notifications/route.ts
+- src/app/api/webhooks/resend/route.ts
+- src/app/api/webhooks/twilio/route.ts
+
+## Environment variables
+
+Required for email sending:
+- RESEND_API_KEY
+- EMAIL_FROM
+
+Required for SMS sending:
+- TWILIO_ACCOUNT_SID
+- TWILIO_AUTH_TOKEN
+- one of TWILIO_MESSAGING_SERVICE_SID or TWILIO_PHONE_NUMBER
+
+Optional route protection:
+- CRON_SECRET
+- RESEND_WEBHOOK_SECRET
+- TWILIO_WEBHOOK_SECRET
+
+## What this stage does
+
+- processes queued notifications through a cron route
+- sends email through Resend
+- sends SMS through Twilio using fetch, so no extra dependency is required
+- records provider outcomes back into notification dispatches and attempts
+- adds a transactional helper for queued lead welcome notifications
+
+## What is still next
+
+- bridge the lead create flow into queueLeadWelcomeNotifications
+- admin messaging screens
+- bulk campaign UI and safeguards
+- richer delivery reporting

--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -1,0 +1,50 @@
+// ========================================
+// File: src/app/api/cron/notifications/route.ts
+// ========================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { processNotificationQueue } from "@/lib/notifications/processor";
+
+export const dynamic = "force-dynamic";
+
+function isAuthorized(request: NextRequest) {
+  const configuredSecret = process.env.CRON_SECRET?.trim();
+
+  if (!configuredSecret) {
+    return true;
+  }
+
+  const authHeader = request.headers.get("authorization")?.trim();
+  const bearerSecret = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7).trim()
+    : null;
+  const headerSecret = request.headers.get("x-cron-secret")?.trim();
+
+  return bearerSecret === configuredSecret || headerSecret === configuredSecret;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await processNotificationQueue(25);
+
+    return NextResponse.json({
+      ok: true,
+      ...result,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Notification cron processing failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,43 @@
+// ========================================
+// File: src/app/api/webhooks/resend/route.ts
+// ========================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { handleResendWebhook } from "@/lib/notifications/webhooks";
+
+export const dynamic = "force-dynamic";
+
+function isAuthorized(request: NextRequest) {
+  const configuredSecret = process.env.RESEND_WEBHOOK_SECRET?.trim();
+
+  if (!configuredSecret) {
+    return true;
+  }
+
+  const providedSecret = request.headers.get("x-resend-webhook-secret")?.trim();
+  return providedSecret === configuredSecret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const payload = (await request.json()) as Record<string, unknown>;
+    const result = await handleResendWebhook(payload);
+
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Resend webhook processing failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/webhooks/twilio/route.ts
+++ b/src/app/api/webhooks/twilio/route.ts
@@ -1,0 +1,47 @@
+// ========================================
+// File: src/app/api/webhooks/twilio/route.ts
+// ========================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { handleTwilioWebhook } from "@/lib/notifications/webhooks";
+
+export const dynamic = "force-dynamic";
+
+function isAuthorized(request: NextRequest) {
+  const configuredSecret = process.env.TWILIO_WEBHOOK_SECRET?.trim();
+
+  if (!configuredSecret) {
+    return true;
+  }
+
+  const providedSecret = request.headers.get("x-twilio-webhook-secret")?.trim();
+  return providedSecret === configuredSecret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const formData = await request.formData();
+    const payload = Object.fromEntries(
+      Array.from(formData.entries()).map(([key, value]) => [key, String(value)]),
+    ) as Record<string, string>;
+
+    const result = await handleTwilioWebhook(payload);
+
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Twilio webhook processing failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/notifications/processor.ts
+++ b/src/lib/notifications/processor.ts
@@ -1,0 +1,150 @@
+// ========================================
+// File: src/lib/notifications/processor.ts
+// ========================================
+
+import { NotificationChannel } from "@prisma/client";
+import {
+  getDueNotificationDispatches,
+  markNotificationDispatchFailed,
+  markNotificationDispatchProcessing,
+  markNotificationDispatchSent,
+} from "./service";
+import { sendEmailWithResend } from "./providers/resend";
+import { sendSmsWithTwilio } from "./providers/twilio";
+
+export type ProcessNotificationQueueResult = {
+  processed: number;
+  sent: number;
+  failed: number;
+  skipped: number;
+  items: Array<{
+    dispatchId: string;
+    status: "sent" | "failed" | "skipped";
+    channel: NotificationChannel;
+    provider?: string;
+    message?: string;
+  }>;
+};
+
+export async function processNotificationQueue(limit = 25) {
+  const dueDispatches = await getDueNotificationDispatches(limit);
+
+  const result: ProcessNotificationQueueResult = {
+    processed: dueDispatches.length,
+    sent: 0,
+    failed: 0,
+    skipped: 0,
+    items: [],
+  };
+
+  for (const dispatch of dueDispatches) {
+    try {
+      if (dispatch.channel === NotificationChannel.EMAIL) {
+        if (!dispatch.recipient.email?.trim()) {
+          result.skipped += 1;
+          result.items.push({
+            dispatchId: dispatch.id,
+            status: "skipped",
+            channel: dispatch.channel,
+            message: "Recipient email missing.",
+          });
+          continue;
+        }
+
+        if (!dispatch.subject?.trim()) {
+          throw new Error("Email dispatch is missing a subject.");
+        }
+
+        await markNotificationDispatchProcessing(dispatch.id);
+
+        const sendResult = await sendEmailWithResend({
+          to: dispatch.recipient.email,
+          subject: dispatch.subject,
+          text: dispatch.bodyText,
+          html: dispatch.bodyHtml,
+        });
+
+        await markNotificationDispatchSent({
+          dispatchId: dispatch.id,
+          provider: sendResult.provider,
+          providerMessageId: sendResult.providerMessageId,
+          responsePayload: sendResult.responsePayload,
+        });
+
+        result.sent += 1;
+        result.items.push({
+          dispatchId: dispatch.id,
+          status: "sent",
+          channel: dispatch.channel,
+          provider: sendResult.provider,
+        });
+        continue;
+      }
+
+      if (dispatch.channel === NotificationChannel.SMS) {
+        if (!dispatch.recipient.phone?.trim()) {
+          result.skipped += 1;
+          result.items.push({
+            dispatchId: dispatch.id,
+            status: "skipped",
+            channel: dispatch.channel,
+            message: "Recipient phone missing.",
+          });
+          continue;
+        }
+
+        await markNotificationDispatchProcessing(dispatch.id);
+
+        const sendResult = await sendSmsWithTwilio({
+          to: dispatch.recipient.phone,
+          body: dispatch.bodyText,
+        });
+
+        await markNotificationDispatchSent({
+          dispatchId: dispatch.id,
+          provider: sendResult.provider,
+          providerMessageId: sendResult.providerMessageId,
+          responsePayload: sendResult.responsePayload,
+        });
+
+        result.sent += 1;
+        result.items.push({
+          dispatchId: dispatch.id,
+          status: "sent",
+          channel: dispatch.channel,
+          provider: sendResult.provider,
+        });
+        continue;
+      }
+
+      result.skipped += 1;
+      result.items.push({
+        dispatchId: dispatch.id,
+        status: "skipped",
+        channel: dispatch.channel,
+        message: "Unsupported notification channel.",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Notification processing failed.";
+
+      await markNotificationDispatchFailed({
+        dispatchId: dispatch.id,
+        provider:
+          dispatch.channel === NotificationChannel.EMAIL ? "resend" : "twilio",
+        errorMessage: message,
+      });
+
+      result.failed += 1;
+      result.items.push({
+        dispatchId: dispatch.id,
+        status: "failed",
+        channel: dispatch.channel,
+        provider:
+          dispatch.channel === NotificationChannel.EMAIL ? "resend" : "twilio",
+        message,
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/lib/notifications/providers/resend.ts
+++ b/src/lib/notifications/providers/resend.ts
@@ -1,0 +1,59 @@
+// ========================================
+// File: src/lib/notifications/providers/resend.ts
+// ========================================
+
+import { Resend } from "resend";
+import type { Prisma } from "@prisma/client";
+
+export type SendNotificationEmailInput = {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string | null;
+};
+
+export type NotificationProviderSendResult = {
+  provider: string;
+  providerMessageId: string | null;
+  responsePayload?: Prisma.InputJsonValue;
+};
+
+function getResendClient() {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new Error("RESEND_API_KEY is missing.");
+  }
+
+  return new Resend(apiKey);
+}
+
+function getEmailFromAddress() {
+  const value = process.env.EMAIL_FROM?.trim();
+
+  if (!value) {
+    throw new Error("EMAIL_FROM is missing.");
+  }
+
+  return value;
+}
+
+export async function sendEmailWithResend(
+  input: SendNotificationEmailInput,
+): Promise<NotificationProviderSendResult> {
+  const resend = getResendClient();
+
+  const response = await resend.emails.send({
+    from: getEmailFromAddress(),
+    to: input.to,
+    subject: input.subject,
+    text: input.text,
+    ...(input.html ? { html: input.html } : {}),
+  });
+
+  return {
+    provider: "resend",
+    providerMessageId: response.data?.id ?? null,
+    responsePayload: response as Prisma.InputJsonValue,
+  };
+}

--- a/src/lib/notifications/providers/twilio.ts
+++ b/src/lib/notifications/providers/twilio.ts
@@ -1,0 +1,91 @@
+// ========================================
+// File: src/lib/notifications/providers/twilio.ts
+// ========================================
+
+import type { Prisma } from "@prisma/client";
+
+export type SendNotificationSmsInput = {
+  to: string;
+  body: string;
+};
+
+export type NotificationProviderSendResult = {
+  provider: string;
+  providerMessageId: string | null;
+  responsePayload?: Prisma.InputJsonValue;
+};
+
+function getTwilioCredentials() {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID?.trim();
+  const authToken = process.env.TWILIO_AUTH_TOKEN?.trim();
+  const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID?.trim();
+  const fromNumber = process.env.TWILIO_PHONE_NUMBER?.trim();
+
+  if (!accountSid) {
+    throw new Error("TWILIO_ACCOUNT_SID is missing.");
+  }
+
+  if (!authToken) {
+    throw new Error("TWILIO_AUTH_TOKEN is missing.");
+  }
+
+  if (!messagingServiceSid && !fromNumber) {
+    throw new Error(
+      "Either TWILIO_MESSAGING_SERVICE_SID or TWILIO_PHONE_NUMBER must be set.",
+    );
+  }
+
+  return {
+    accountSid,
+    authToken,
+    messagingServiceSid,
+    fromNumber,
+  };
+}
+
+export async function sendSmsWithTwilio(
+  input: SendNotificationSmsInput,
+): Promise<NotificationProviderSendResult> {
+  const credentials = getTwilioCredentials();
+
+  const body = new URLSearchParams({
+    To: input.to,
+    Body: input.body,
+    ...(credentials.messagingServiceSid
+      ? { MessagingServiceSid: credentials.messagingServiceSid }
+      : { From: credentials.fromNumber! }),
+  });
+
+  const response = await fetch(
+    `https://api.twilio.com/2010-04-01/Accounts/${credentials.accountSid}/Messages.json`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${Buffer.from(
+          `${credentials.accountSid}:${credentials.authToken}`,
+        ).toString("base64")}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body.toString(),
+      cache: "no-store",
+    },
+  );
+
+  const payload = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    const message =
+      typeof payload.message === "string"
+        ? payload.message
+        : "Twilio SMS send failed.";
+
+    throw new Error(message);
+  }
+
+  return {
+    provider: "twilio",
+    providerMessageId:
+      typeof payload.sid === "string" ? payload.sid : null,
+    responsePayload: payload as Prisma.InputJsonValue,
+  };
+}

--- a/src/lib/notifications/transactional.ts
+++ b/src/lib/notifications/transactional.ts
@@ -1,0 +1,84 @@
+// ========================================
+// File: src/lib/notifications/transactional.ts
+// ========================================
+
+import {
+  InterestLead,
+  NotificationAudience,
+  NotificationRecipientSourceType,
+} from "@prisma/client";
+import { queueNotificationFromTemplate } from "./service";
+import { upsertNotificationRecipient } from "./recipients";
+
+function getLeadFirstName(contactName?: string | null) {
+  return contactName?.trim().split(/\s+/)[0] || "there";
+}
+
+export async function queueLeadWelcomeNotifications(input: {
+  lead: Pick<
+    InterestLead,
+    | "id"
+    | "contactName"
+    | "email"
+    | "phone"
+    | "interestType"
+    | "area"
+    | "teamName"
+    | "marketingConsent"
+  >;
+  signupUrl?: string;
+}) {
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.LEAD,
+    sourceId: input.lead.id,
+    audience: NotificationAudience.LEAD,
+    displayName: input.lead.contactName,
+    email: input.lead.email,
+    phone: input.lead.phone,
+    marketingEmailOptIn: input.lead.marketingConsent,
+    marketingSmsOptIn: input.lead.marketingConsent,
+    metadata: {
+      interestType: input.lead.interestType,
+      area: input.lead.area,
+      teamName: input.lead.teamName,
+    },
+  });
+
+  const baseVariables = {
+    firstName: getLeadFirstName(input.lead.contactName),
+    interestType: input.lead.interestType,
+    area: input.lead.area || "Not provided",
+    teamName: input.lead.teamName || "Not provided",
+    signupUrl: input.signupUrl || "https://www.sixfl.co.uk/register-interest",
+  };
+
+  const queued = [
+    await queueNotificationFromTemplate({
+      templateKey: "lead-welcome-email",
+      recipientId: recipient.id,
+      sourceType: "interest-lead",
+      sourceId: input.lead.id,
+      variables: baseVariables,
+      metadata: {
+        event: "lead.welcome.email",
+      },
+    }),
+  ];
+
+  if (input.lead.phone?.trim()) {
+    queued.push(
+      await queueNotificationFromTemplate({
+        templateKey: "lead-welcome-sms",
+        recipientId: recipient.id,
+        sourceType: "interest-lead",
+        sourceId: input.lead.id,
+        variables: baseVariables,
+        metadata: {
+          event: "lead.welcome.sms",
+        },
+      }),
+    );
+  }
+
+  return queued;
+}

--- a/src/lib/notifications/webhooks.ts
+++ b/src/lib/notifications/webhooks.ts
@@ -1,0 +1,193 @@
+// ========================================
+// File: src/lib/notifications/webhooks.ts
+// ========================================
+
+import {
+  NotificationAttemptStatus,
+  NotificationDispatchStatus,
+  Prisma,
+} from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+function asJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
+}
+
+function extractResendMessageId(payload: Record<string, unknown>) {
+  const directId = payload.email_id;
+  if (typeof directId === "string" && directId.trim()) return directId.trim();
+
+  const data = payload.data;
+  if (data && typeof data === "object") {
+    const nestedId = (data as Record<string, unknown>).email_id;
+    if (typeof nestedId === "string" && nestedId.trim()) return nestedId.trim();
+  }
+
+  return null;
+}
+
+function extractResendEventType(payload: Record<string, unknown>) {
+  const directType = payload.type;
+  if (typeof directType === "string") return directType.toLowerCase();
+
+  return "unknown";
+}
+
+export async function handleResendWebhook(payload: Record<string, unknown>) {
+  const providerMessageId = extractResendMessageId(payload);
+  const eventType = extractResendEventType(payload);
+
+  if (!providerMessageId) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "Missing provider message id.",
+    };
+  }
+
+  const dispatch = await prisma.notificationDispatch.findFirst({
+    where: {
+      provider: "resend",
+      providerMessageId,
+    },
+    select: {
+      id: true,
+      status: true,
+    },
+  });
+
+  if (!dispatch) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "No matching dispatch found.",
+    };
+  }
+
+  const failureEvents = new Set(["email.bounced", "email.complained", "email.failed"]);
+  const successEvents = new Set(["email.sent", "email.delivered"]);
+
+  if (failureEvents.has(eventType)) {
+    await prisma.$transaction(async (tx) => {
+      await tx.notificationAttempt.create({
+        data: {
+          dispatchId: dispatch.id,
+          provider: "resend",
+          status: NotificationAttemptStatus.FAILED,
+          responsePayload: asJsonValue(payload),
+          errorMessage: eventType,
+        },
+      });
+
+      await tx.notificationDispatch.update({
+        where: { id: dispatch.id },
+        data: {
+          status: NotificationDispatchStatus.FAILED,
+          failedAt: new Date(),
+          failureReason: eventType,
+        },
+      });
+    });
+
+    return { ok: true, updated: true, status: "failed" };
+  }
+
+  if (successEvents.has(eventType)) {
+    await prisma.notificationAttempt.create({
+      data: {
+        dispatchId: dispatch.id,
+        provider: "resend",
+        status: NotificationAttemptStatus.SUCCESS,
+        responsePayload: asJsonValue(payload),
+      },
+    });
+
+    return { ok: true, updated: true, status: "sent" };
+  }
+
+  return {
+    ok: true,
+    ignored: true,
+    reason: `Unhandled Resend event: ${eventType}`,
+  };
+}
+
+export async function handleTwilioWebhook(payload: Record<string, string>) {
+  const providerMessageId = payload.MessageSid?.trim();
+  const messageStatus = payload.MessageStatus?.trim().toLowerCase() || "unknown";
+  const errorMessage = payload.ErrorMessage?.trim() || null;
+
+  if (!providerMessageId) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "Missing Twilio MessageSid.",
+    };
+  }
+
+  const dispatch = await prisma.notificationDispatch.findFirst({
+    where: {
+      provider: "twilio",
+      providerMessageId,
+    },
+    select: {
+      id: true,
+      status: true,
+    },
+  });
+
+  if (!dispatch) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "No matching dispatch found.",
+    };
+  }
+
+  const failureStatuses = new Set(["failed", "undelivered"]);
+  const successStatuses = new Set(["sent", "delivered"]);
+
+  if (failureStatuses.has(messageStatus)) {
+    await prisma.$transaction(async (tx) => {
+      await tx.notificationAttempt.create({
+        data: {
+          dispatchId: dispatch.id,
+          provider: "twilio",
+          status: NotificationAttemptStatus.FAILED,
+          responsePayload: asJsonValue(payload),
+          errorMessage: errorMessage || messageStatus,
+        },
+      });
+
+      await tx.notificationDispatch.update({
+        where: { id: dispatch.id },
+        data: {
+          status: NotificationDispatchStatus.FAILED,
+          failedAt: new Date(),
+          failureReason: errorMessage || messageStatus,
+        },
+      });
+    });
+
+    return { ok: true, updated: true, status: "failed" };
+  }
+
+  if (successStatuses.has(messageStatus)) {
+    await prisma.notificationAttempt.create({
+      data: {
+        dispatchId: dispatch.id,
+        provider: "twilio",
+        status: NotificationAttemptStatus.SUCCESS,
+        responsePayload: asJsonValue(payload),
+      },
+    });
+
+    return { ok: true, updated: true, status: "sent" };
+  }
+
+  return {
+    ok: true,
+    ignored: true,
+    reason: `Unhandled Twilio status: ${messageStatus}`,
+  };
+}


### PR DESCRIPTION
## Superseded

This older draft PR was based on an outdated branch chain and is being closed to avoid confusion.

The missing webhook/doc work has been recreated cleanly from `main` in PR #7:
- `src/lib/notifications/webhooks.ts`
- `src/app/api/webhooks/resend/route.ts`
- `src/app/api/webhooks/twilio/route.ts`
- `docs/messaging-stage-2-apply.md`

Most of the rest of the stage 2 delivery layer is already present in `main`.