### PR TITLE
Add admin fixture publish-and-email flow

### DIFF
--- a/prisma/migrations/20260403_fixture_notifications/migration.sql
+++ b/prisma/migrations/20260403_fixture_notifications/migration.sql
@@ -1,0 +1,16 @@
+-- ========================================
+-- File: prisma/migrations/20260403_fixture_notifications/migration.sql
+-- ========================================
+-- Safe live-data migration for fixture publish state.
+-- This does NOT reset or wipe data.
+
+ALTER TABLE "Fixture"
+ADD COLUMN IF NOT EXISTS "publishedAt" TIMESTAMP(3);
+
+-- Backfill existing fixtures so the live public site does not suddenly go blank.
+UPDATE "Fixture"
+SET "publishedAt" = NOW()
+WHERE "publishedAt" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "Fixture_leagueId_publishedAt_kickoffAt_idx"
+ON "Fixture"("leagueId", "publishedAt", "kickoffAt");

--- a/src/app/(admin)/admin/fixtures/page.tsx
+++ b/src/app/(admin)/admin/fixtures/page.tsx
@@ -1,12 +1,13 @@
 // ========================================
-// File: src/app/admin/fixtures/page.tsx
-// If you already moved route groups, this is:
-// src/app/(admin)/admin/fixtures/page.tsx
+// File: src/app/(admin)/admin/fixtures/page.tsx
 // ========================================
 
+import Link from "next/link";
+import AdminCard from "@/components/admin/AdminCard";
+import FixturesAdminScreen from "@/components/admin/fixtures/FixturesAdminScreen";
+import { publishAndEmailLeagueFixturesAction } from "@/app/(admin)/admin/fixtures/publish-actions";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
-import FixturesAdminScreen from "@/components/admin/fixtures/FixturesAdminScreen";
 
 function formatKickoffLabel(date: Date | null) {
   if (!date) return null;
@@ -117,6 +118,17 @@ export default async function AdminFixturesPage() {
     }),
   ]);
 
+  const publishSummary = leagues.map((league) => {
+    const leagueFixtures = fixtures.filter((fixture) => fixture.leagueId === league.id);
+    const scheduled = leagueFixtures.filter((fixture) => fixture.status === "SCHEDULED").length;
+
+    return {
+      league,
+      total: leagueFixtures.length,
+      scheduled,
+    };
+  });
+
   const screenData = {
     leagues,
     teams,
@@ -145,7 +157,65 @@ export default async function AdminFixturesPage() {
   };
 
   return (
-    <div className="w-full px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+    <div className="w-full space-y-8 px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+      <AdminCard className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/[0.03] p-0 shadow-[0_24px_80px_rgba(0,0,0,0.32)]">
+        <div className="border-b border-white/10 px-6 py-6 md:px-8">
+          <div className="space-y-2">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
+              Publish & notify
+            </div>
+            <h2 className="text-2xl font-semibold tracking-tight text-white">
+              Send fixtures to teams
+            </h2>
+            <p className="max-w-3xl text-sm leading-6 text-white/60">
+              Publish the next batch of fixtures for a league and automatically queue team emails plus pre-match reminders.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 px-6 py-6 md:grid-cols-2 md:px-8 xl:grid-cols-3">
+          {publishSummary.map((item) => (
+            <div key={item.league.id} className="rounded-3xl border border-white/10 bg-black/30 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="truncate text-lg font-semibold text-white">{item.league.name}</div>
+                  <div className="mt-1 text-sm text-white/45">{item.league.season || "No season set"}</div>
+                </div>
+                <Link
+                  href={`/leagues/${item.league.slug}`}
+                  target="_blank"
+                  className="inline-flex shrink-0 rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-semibold text-white/80 transition hover:border-white/20 hover:bg-white/[0.08]"
+                >
+                  Public
+                </Link>
+              </div>
+
+              <div className="mt-5 grid grid-cols-2 gap-3">
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">Total</div>
+                  <div className="mt-1 text-lg font-semibold text-white">{item.total}</div>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">Scheduled</div>
+                  <div className="mt-1 text-lg font-semibold text-white">{item.scheduled}</div>
+                </div>
+              </div>
+
+              <form action={publishAndEmailLeagueFixturesAction} className="mt-5">
+                <input type="hidden" name="leagueId" value={item.league.id} />
+                <button
+                  type="submit"
+                  disabled={item.total === 0}
+                  className="inline-flex h-12 w-full items-center justify-center rounded-2xl bg-emerald-400 px-5 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Publish fixtures & email teams
+                </button>
+              </form>
+            </div>
+          ))}
+        </div>
+      </AdminCard>
+
       <FixturesAdminScreen {...screenData} />
     </div>
   );

--- a/src/app/(admin)/admin/fixtures/publish-actions.ts
+++ b/src/app/(admin)/admin/fixtures/publish-actions.ts
@@ -1,0 +1,242 @@
+// ========================================
+// File: src/app/(admin)/admin/fixtures/publish-actions.ts
+// ========================================
+
+"use server";
+
+import { NotificationAudience, NotificationChannel } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { queueDirectNotification } from "@/lib/notifications/service";
+import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
+
+function parseRequiredString(value: FormDataEntryValue | null, fieldName: string) {
+  const str = String(value ?? "").trim();
+
+  if (!str) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  return str;
+}
+
+function getSiteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    process.env.SITE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_APP_URL?.trim() ||
+    process.env.APP_URL?.trim() ||
+    "https://www.sixfl.co.uk"
+  );
+}
+
+function buildAbsoluteUrl(path: string) {
+  return new URL(path, getSiteUrl()).toString();
+}
+
+function formatKickoff(date: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(date));
+}
+
+function unique(values: string[]) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+type UnpublishedFixtureRow = {
+  id: string;
+};
+
+function buildFixtureLine(
+  fixture: {
+    kickoffAt: Date;
+    pitch: string | null;
+    homeTeam: { id: string; name: string };
+    awayTeam: { id: string; name: string };
+    venue: { name: string } | null;
+  },
+  teamId: string,
+) {
+  const isHome = fixture.homeTeam.id === teamId;
+  const opponent = isHome ? fixture.awayTeam.name : fixture.homeTeam.name;
+
+  return `${formatKickoff(fixture.kickoffAt)} — ${
+    isHome ? `Home vs ${opponent}` : `Away at ${opponent}`
+  } — ${fixture.pitch ?? "Pitch TBC"} — ${fixture.venue?.name ?? "Venue TBC"}`;
+}
+
+export async function publishAndEmailLeagueFixturesAction(formData: FormData) {
+  await requireAdmin();
+
+  const leagueId = parseRequiredString(formData.get("leagueId"), "League");
+
+  const league = await prisma.league.findUnique({
+    where: { id: leagueId },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      season: true,
+    },
+  });
+
+  if (!league) {
+    throw new Error("League not found.");
+  }
+
+  const unpublishedFixtures = await prisma.$queryRaw<UnpublishedFixtureRow[]>`
+    SELECT "id"
+    FROM "Fixture"
+    WHERE "leagueId" = ${leagueId}
+      AND "publishedAt" IS NULL
+    ORDER BY "kickoffAt" ASC
+  `;
+
+  const fixtureIds = unpublishedFixtures.map((row) => row.id);
+
+  if (fixtureIds.length === 0) {
+    revalidatePath("/admin/fixtures");
+    revalidatePath(`/admin/leagues/${leagueId}`);
+    revalidatePath(`/admin/leagues/${leagueId}/fixtures`);
+    redirect("/admin/fixtures");
+  }
+
+  await prisma.$executeRaw`
+    UPDATE "Fixture"
+    SET "publishedAt" = NOW()
+    WHERE "leagueId" = ${leagueId}
+      AND "publishedAt" IS NULL
+  `;
+
+  const fixtures = await prisma.fixture.findMany({
+    where: {
+      id: {
+        in: fixtureIds,
+      },
+    },
+    orderBy: {
+      kickoffAt: "asc",
+    },
+    select: {
+      id: true,
+      kickoffAt: true,
+      pitch: true,
+      homeTeam: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      awayTeam: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      venue: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  });
+
+  const teamIds = unique(
+    fixtures.flatMap((fixture) => [fixture.homeTeam.id, fixture.awayTeam.id]),
+  );
+
+  const fixturesUrl = buildAbsoluteUrl(`/leagues/${league.slug}/fixtures`);
+
+  for (const teamId of teamIds) {
+    const { snapshot, recipient } = await upsertTeamNotificationRecipient(teamId);
+    const teamFixtures = fixtures.filter(
+      (fixture) =>
+        fixture.homeTeam.id === teamId || fixture.awayTeam.id === teamId,
+    );
+
+    if (teamFixtures.length > 0) {
+      const body = [
+        `Hi ${snapshot.primaryContact.name ?? snapshot.teamName},`,
+        "",
+        `Your fixtures for ${league.name}${league.season ? ` (${league.season})` : ""} are now live.`,
+        "",
+        ...teamFixtures.map((fixture) => buildFixtureLine(fixture, teamId)),
+        "",
+        "You will also receive automatic reminders before kickoff.",
+      ].join("\n");
+
+      await queueDirectNotification({
+        recipientId: recipient.id,
+        channel: NotificationChannel.EMAIL,
+        audience: NotificationAudience.TEAM,
+        subject: `${league.name} fixtures are live`,
+        body,
+        isTransactional: true,
+        sourceType: "LEAGUE_FIXTURE_DIGEST",
+        sourceId: league.id,
+        metadata: {
+          kind: "fixture_publish_digest",
+          teamId,
+          leagueId: league.id,
+        },
+        emailCta: {
+          label: "View fixtures",
+          url: fixturesUrl,
+        },
+      });
+    }
+  }
+
+  for (const fixture of fixtures) {
+    for (const teamId of [fixture.homeTeam.id, fixture.awayTeam.id]) {
+      const { recipient } = await upsertTeamNotificationRecipient(teamId);
+
+      const reminderTimes = [
+        new Date(fixture.kickoffAt.getTime() - 48 * 60 * 60 * 1000),
+        new Date(fixture.kickoffAt.getTime() - 6 * 60 * 60 * 1000),
+      ].filter((date) => date.getTime() > Date.now());
+
+      for (const scheduledFor of reminderTimes) {
+        await queueDirectNotification({
+          recipientId: recipient.id,
+          channel: NotificationChannel.EMAIL,
+          audience: NotificationAudience.TEAM,
+          subject: `${league.name} fixture reminder`,
+          body: [
+            `Hi,`,
+            "",
+            `Reminder: ${buildFixtureLine(fixture, teamId)}`,
+            "",
+            "Please make sure your team is ready for kickoff.",
+          ].join("\n"),
+          isTransactional: true,
+          sourceType: "FIXTURE_REMINDER",
+          sourceId: fixture.id,
+          metadata: {
+            kind: "fixture_reminder",
+            teamId,
+            leagueId: league.id,
+          },
+          scheduledFor,
+          emailCta: {
+            label: "View fixtures",
+            url: fixturesUrl,
+          },
+        });
+      }
+    }
+  }
+
+  revalidatePath("/admin/fixtures");
+  revalidatePath(`/admin/leagues/${leagueId}`);
+  revalidatePath(`/admin/leagues/${leagueId}/fixtures`);
+
+  redirect("/admin/fixtures");
+}


### PR DESCRIPTION
## Summary
- add a safe fixture publish migration for the new `publishedAt` column
- add an admin-led publish action that marks unpublished fixtures as live and emails teams
- queue pre-match reminder emails from the same publish flow
- add publish controls to the admin fixtures page

## Notes
This PR keeps the implementation build-safe by introducing the publish/email flow through a separate server action file and wiring it into the admin fixtures page.

## Included now
- migration for `publishedAt`
- admin publish button and flow
- fixture digest emails
- scheduled reminder emails

## Follow-up candidates
- automatic fixture update / postponement / cancellation emails from edit actions
- public-page filtering based on publish state across all league views
- captain-facing resend / contact controls
