### PR TITLE
Add email alerts for new public prospect submissions

### DIFF
--- a/src/app/teams/join/[joinSlug]/actions.ts
+++ b/src/app/teams/join/[joinSlug]/actions.ts
@@ -55,6 +55,24 @@ function getDisplayValue(value: string | null) {
   return value?.trim() ? value.trim() : "—";
 }
 
+function mergeExistingProspectNotes(input: {
+  existingNotes: string | null;
+  publicNotes: string | null;
+}) {
+  if (!input.publicNotes) {
+    return input.existingNotes;
+  }
+
+  const stamp = new Date().toLocaleString("en-GB");
+  const publicEntry = `Public form note (${stamp}): ${input.publicNotes}`;
+
+  if (!input.existingNotes?.trim()) {
+    return publicEntry;
+  }
+
+  return `${input.existingNotes.trim()}\n\n${publicEntry}`;
+}
+
 function buildProspectAlertBody(input: {
   teamName: string;
   joinSlug: string | null;
@@ -69,6 +87,7 @@ function buildProspectAlertBody(input: {
   preferredNights: string[];
   availabilitySummary: string | null;
   notes: string | null;
+  eventLabel: string;
 }) {
   const prospectName =
     getProspectDisplayName({
@@ -80,7 +99,7 @@ function buildProspectAlertBody(input: {
     : null;
 
   return [
-    `A new player prospect has registered interest for ${input.teamName}.`,
+    `${input.eventLabel} for ${input.teamName}.`,
     "",
     `Name: ${prospectName}`,
     `Email: ${getDisplayValue(input.email)}`,
@@ -91,7 +110,7 @@ function buildProspectAlertBody(input: {
     `Availability level: ${getDisplayValue(input.availabilityLevel)}`,
     `Preferred nights: ${input.preferredNights.length ? input.preferredNights.join(", ") : "—"}`,
     `Availability summary: ${getDisplayValue(input.availabilitySummary)}`,
-    `Notes: ${getDisplayValue(input.notes)}`,
+    `Player note: ${getDisplayValue(input.notes)}`,
     "Source: public-join-page",
     ...(joinUrl ? ["", `Join page: ${joinUrl}`] : []),
     "",
@@ -159,31 +178,54 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
     select: {
       id: true,
       status: true,
+      notes: true,
+      source: true,
     },
   });
 
-  if (existing) {
-    redirect(buildRedirect(joinSlug, "?saved=already-registered"));
-  }
+  const eventLabel = existing
+    ? "An existing prospect has completed their player details form"
+    : "A new player prospect has registered interest";
 
-  const prospect = await prisma.teamPlayerProspect.create({
-    data: {
-      teamId: team.id,
-      firstName,
-      lastName,
-      email,
-      phone,
-      ageBand,
-      preferredPositions,
-      experienceSummary,
-      availabilityLevel,
-      preferredNights,
-      availabilitySummary,
-      notes,
-      source: "public-join-page",
-      status: "NEW",
-    },
-  });
+  const prospect = existing
+    ? await prisma.teamPlayerProspect.update({
+        where: { id: existing.id },
+        data: {
+          firstName,
+          lastName,
+          email,
+          phone,
+          ageBand,
+          preferredPositions,
+          experienceSummary,
+          availabilityLevel,
+          preferredNights,
+          availabilitySummary,
+          notes: mergeExistingProspectNotes({
+            existingNotes: existing.notes,
+            publicNotes: notes,
+          }),
+          source: existing.source ?? "public-join-page",
+        },
+      })
+    : await prisma.teamPlayerProspect.create({
+        data: {
+          teamId: team.id,
+          firstName,
+          lastName,
+          email,
+          phone,
+          ageBand,
+          preferredPositions,
+          experienceSummary,
+          availabilityLevel,
+          preferredNights,
+          availabilitySummary,
+          notes,
+          source: "public-join-page",
+          status: "NEW",
+        },
+      });
 
   try {
     const { recipient } = await upsertTeamNotificationRecipient(team.id);
@@ -195,7 +237,9 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
         recipientId: recipient.id,
         channel: NotificationChannel.EMAIL,
         audience: NotificationAudience.TEAM,
-        subject: `New prospect for ${team.name}: ${prospectName}`,
+        subject: existing
+          ? `Prospect details completed for ${team.name}: ${prospectName}`
+          : `New prospect for ${team.name}: ${prospectName}`,
         body: buildProspectAlertBody({
           teamName: team.name,
           joinSlug: team.joinSlug,
@@ -210,13 +254,18 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
           preferredNights,
           availabilitySummary,
           notes,
+          eventLabel,
         }),
         isTransactional: true,
         sourceType: "TEAM_PLAYER_PROSPECT",
         sourceId: prospect.id,
         metadata: {
-          origin: "public_team_join_prospect_alert",
-          originLabel: "New public prospect alert",
+          origin: existing
+            ? "public_team_join_existing_prospect_completed"
+            : "public_team_join_prospect_alert",
+          originLabel: existing
+            ? "Existing prospect completed public details form"
+            : "New public prospect alert",
           teamId: team.id,
           prospectId: prospect.id,
           joinSlug: team.joinSlug,
@@ -230,5 +279,5 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
   revalidatePath(`/captain/team/${team.id}/prospects`);
   revalidatePath(`/admin/teams/${team.id}/prospects`);
   revalidatePath(`/admin/teams/${team.id}`);
-  redirect(buildRedirect(joinSlug, "?saved=1"));
+  redirect(buildRedirect(joinSlug, existing ? "?saved=details-completed" : "?saved=1"));
 }

--- a/src/app/teams/join/[joinSlug]/actions.ts
+++ b/src/app/teams/join/[joinSlug]/actions.ts
@@ -6,8 +6,11 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+import { NotificationAudience, NotificationChannel } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
+import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
+import { queueDirectNotification } from "@/lib/notifications/service";
 
 function normaliseNullableString(value: FormDataEntryValue | null) {
   const parsed = String(value ?? "").trim();
@@ -39,6 +42,61 @@ function buildAvailabilitySummary(
   }
 
   return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+function getProspectDisplayName(input: {
+  firstName: string;
+  lastName: string | null;
+}) {
+  return [input.firstName, input.lastName].filter(Boolean).join(" ").trim();
+}
+
+function getDisplayValue(value: string | null) {
+  return value?.trim() ? value.trim() : "—";
+}
+
+function buildProspectAlertBody(input: {
+  teamName: string;
+  joinSlug: string | null;
+  firstName: string;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  ageBand: string | null;
+  preferredPositions: string | null;
+  experienceSummary: string | null;
+  availabilityLevel: string | null;
+  preferredNights: string[];
+  availabilitySummary: string | null;
+  notes: string | null;
+}) {
+  const prospectName =
+    getProspectDisplayName({
+      firstName: input.firstName,
+      lastName: input.lastName,
+    }) || input.firstName;
+  const joinUrl = input.joinSlug
+    ? `${process.env.NEXTAUTH_URL ?? "https://www.sixfl.co.uk"}/teams/join/${input.joinSlug}`
+    : null;
+
+  return [
+    `A new player prospect has registered interest for ${input.teamName}.`,
+    "",
+    `Name: ${prospectName}`,
+    `Email: ${getDisplayValue(input.email)}`,
+    `Mobile: ${getDisplayValue(input.phone)}`,
+    `Age band: ${getDisplayValue(input.ageBand)}`,
+    `Preferred position: ${getDisplayValue(input.preferredPositions)}`,
+    `Experience: ${getDisplayValue(input.experienceSummary)}`,
+    `Availability level: ${getDisplayValue(input.availabilityLevel)}`,
+    `Preferred nights: ${input.preferredNights.length ? input.preferredNights.join(", ") : "—"}`,
+    `Availability summary: ${getDisplayValue(input.availabilitySummary)}`,
+    `Notes: ${getDisplayValue(input.notes)}`,
+    "Source: public-join-page",
+    ...(joinUrl ? ["", `Join page: ${joinUrl}`] : []),
+    "",
+    "You can review this prospect in the team prospects pipeline.",
+  ].join("\n");
 }
 
 export async function submitTeamJoinProspectAction(formData: FormData) {
@@ -77,6 +135,7 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
     },
     select: {
       id: true,
+      name: true,
       joinSlug: true,
     },
   });
@@ -107,7 +166,7 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
     redirect(buildRedirect(joinSlug, "?saved=already-registered"));
   }
 
-  await prisma.teamPlayerProspect.create({
+  const prospect = await prisma.teamPlayerProspect.create({
     data: {
       teamId: team.id,
       firstName,
@@ -126,6 +185,50 @@ export async function submitTeamJoinProspectAction(formData: FormData) {
     },
   });
 
+  try {
+    const { recipient } = await upsertTeamNotificationRecipient(team.id);
+
+    if (recipient.email?.trim()) {
+      const prospectName = getProspectDisplayName({ firstName, lastName }) || firstName;
+
+      await queueDirectNotification({
+        recipientId: recipient.id,
+        channel: NotificationChannel.EMAIL,
+        audience: NotificationAudience.TEAM,
+        subject: `New prospect for ${team.name}: ${prospectName}`,
+        body: buildProspectAlertBody({
+          teamName: team.name,
+          joinSlug: team.joinSlug,
+          firstName,
+          lastName,
+          email,
+          phone,
+          ageBand,
+          preferredPositions,
+          experienceSummary,
+          availabilityLevel,
+          preferredNights,
+          availabilitySummary,
+          notes,
+        }),
+        isTransactional: true,
+        sourceType: "TEAM_PLAYER_PROSPECT",
+        sourceId: prospect.id,
+        metadata: {
+          origin: "public_team_join_prospect_alert",
+          originLabel: "New public prospect alert",
+          teamId: team.id,
+          prospectId: prospect.id,
+          joinSlug: team.joinSlug,
+          prospectName,
+        },
+      });
+    }
+  } catch {}
+
   revalidatePath(`/teams/join/${joinSlug}`);
+  revalidatePath(`/captain/team/${team.id}/prospects`);
+  revalidatePath(`/admin/teams/${team.id}/prospects`);
+  revalidatePath(`/admin/teams/${team.id}`);
   redirect(buildRedirect(joinSlug, "?saved=1"));
 }

--- a/src/app/teams/join/[joinSlug]/page.tsx
+++ b/src/app/teams/join/[joinSlug]/page.tsx
@@ -50,6 +50,10 @@ function getSavedMessage(saved?: string) {
     return "Thanks — your details have been saved and the organiser has been notified.";
   }
 
+  if (saved === "details-completed") {
+    return "Thanks — your prospect details have been updated and the organiser has been notified.";
+  }
+
   if (saved === "already-registered") {
     return "You have already registered interest for this team.";
   }

--- a/src/app/teams/join/[joinSlug]/page.tsx
+++ b/src/app/teams/join/[joinSlug]/page.tsx
@@ -47,7 +47,7 @@ const NIGHTS = [
 
 function getSavedMessage(saved?: string) {
   if (saved === "1") {
-    return "Thanks — your details have been sent to the team organiser.";
+    return "Thanks — your details have been saved and the organiser has been notified.";
   }
 
   if (saved === "already-registered") {


### PR DESCRIPTION
## Summary
- queue a transactional email alert when a new public team prospect is submitted
- send the alert to the team notification recipient / primary team contact
- keep the prospect save flow resilient if email alerting is not configured

## Notes
- prospect creation still succeeds even if alert queueing fails
- admin and captain prospect views are revalidated after submission