### PR TITLE
Allow pending captains to request magic links

### DIFF
--- a/prisma/seed-notifications.ts
+++ b/prisma/seed-notifications.ts
@@ -105,6 +105,24 @@ We have received your enquiry and we will be in touch shortly.
   });
 
   await upsertTemplate({
+    key: "login-magic-link-email",
+    name: "Login magic link email",
+    description: "Transactional email used for SIXFL sign-in links, including pending captain access.",
+    channel: NotificationChannel.EMAIL,
+    audience: NotificationAudience.GENERAL,
+    subject: "Your SIXFL sign-in link",
+    body: `Hi
+
+Use the secure sign-in link below to access SIXFL.
+
+{{signInUrl}}
+
+{{pendingCaptainNotice}}
+
+If you did not request this email, you can ignore it.`,
+  });
+
+  await upsertTemplate({
     key: "fixture-change-email",
     name: "Fixture change email",
     description: "Transactional email for a fixture change.",

--- a/src/app/(public)/login/check-email/page.tsx
+++ b/src/app/(public)/login/check-email/page.tsx
@@ -5,12 +5,16 @@
 type PageProps = {
   searchParams: Promise<{
     email?: string;
+    pendingCaptain?: string;
+    teamName?: string;
   }>;
 };
 
 export default async function CheckEmailPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const email = params.email ?? "your email address";
+  const pendingCaptain = params.pendingCaptain === "1";
+  const teamName = params.teamName?.trim() || "your team";
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-black px-4 text-white">
@@ -30,7 +34,14 @@ export default async function CheckEmailPage({ searchParams }: PageProps) {
           junk folder.
         </p>
 
-        <div className="mt-8 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+        {pendingCaptain ? (
+          <div className="mt-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+            You haven’t fully registered as captain for {teamName} yet. Open the
+            link in your email first, then complete the team claim step.
+          </div>
+        ) : null}
+
+        <div className="mt-6 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
           Make sure you open the link on this device to complete sign-in.
         </div>
 

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -29,15 +29,21 @@ export default function LoginPage() {
 
     const data = await res.json();
 
-    if (!data.exists) {
+    if (!data.canLogin) {
       setLoading(false);
       setNotice("This email isn’t currently registered with SIXFL.");
       return;
     }
 
+    const callbackUrl = data.pendingCaptain
+      ? data.claimCode
+        ? `/claim?code=${encodeURIComponent(data.claimCode)}`
+        : "/claim"
+      : "/dashboard";
+
     const result = await signIn("email", {
       email,
-      callbackUrl: "/dashboard",
+      callbackUrl,
       redirect: false,
     });
 
@@ -47,7 +53,18 @@ export default function LoginPage() {
       return;
     }
 
-    window.location.href = `/login/check-email?email=${encodeURIComponent(email)}`;
+    const nextUrl = new URL("/login/check-email", window.location.origin);
+    nextUrl.searchParams.set("email", email);
+
+    if (data.pendingCaptain) {
+      nextUrl.searchParams.set("pendingCaptain", "1");
+
+      if (data.teamName) {
+        nextUrl.searchParams.set("teamName", data.teamName);
+      }
+    }
+
+    window.location.href = nextUrl.toString();
   }
 
   return (
@@ -95,7 +112,8 @@ export default function LoginPage() {
         </form>
 
         <p className="mt-4 text-xs text-white/50">
-          Only registered SIXFL players, captains, referees and admins can log in.
+          Registered SIXFL users can log in here. Pending captains can also use
+          their team email to get started and then claim their team.
         </p>
       </div>
     </div>

--- a/src/app/api/auth/check-email/route.ts
+++ b/src/app/api/auth/check-email/route.ts
@@ -4,19 +4,34 @@
 
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getPendingCaptainContext } from "@/lib/auth/pendingCaptain";
 
 export async function POST(req: Request) {
   const { email } = await req.json();
+  const normalizedEmail = String(email ?? "").toLowerCase().trim();
 
-  if (!email) {
-    return NextResponse.json({ exists: false });
+  if (!normalizedEmail) {
+    return NextResponse.json({
+      exists: false,
+      pendingCaptain: false,
+      canLogin: false,
+      claimCode: null,
+      teamName: null,
+    });
   }
 
-  const user = await prisma.user.findUnique({
-    where: { email: email.toLowerCase().trim() },
-  });
+  const [user, pendingCaptain] = await Promise.all([
+    prisma.user.findUnique({
+      where: { email: normalizedEmail },
+    }),
+    getPendingCaptainContext(normalizedEmail),
+  ]);
 
   return NextResponse.json({
     exists: !!user,
+    pendingCaptain: !!pendingCaptain,
+    canLogin: !!user || !!pendingCaptain,
+    claimCode: pendingCaptain?.claimCode ?? null,
+    teamName: pendingCaptain?.teamName ?? null,
   });
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,6 +7,97 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import EmailProvider from "next-auth/providers/email";
 import { Resend } from "resend";
 import { prisma } from "@/lib/prisma";
+import {
+  appendSIXFLTextSignature,
+  buildSIXFLEmailHtml,
+} from "@/lib/email/buildEmail";
+import { renderNotificationText } from "@/lib/notifications/renderer";
+import { getPendingCaptainContext } from "@/lib/auth/pendingCaptain";
+
+function getSiteUrl() {
+  return (
+    process.env.NEXTAUTH_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    "https://www.sixfl.co.uk"
+  ).replace(/\/+$/, "");
+}
+
+function buildClaimUrl(claimCode?: string | null) {
+  const baseUrl = getSiteUrl();
+
+  return claimCode
+    ? `${baseUrl}/claim?code=${encodeURIComponent(claimCode)}`
+    : `${baseUrl}/claim`;
+}
+
+function stripCtaPlaceholder(value: string) {
+  return value.replace(/\{\{\s*cta\s*\}\}/gi, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+async function buildLoginMagicLinkEmail(input: {
+  email: string;
+  url: string;
+  pendingCaptain: Awaited<ReturnType<typeof getPendingCaptainContext>>;
+}) {
+  const template = await prisma.notificationTemplate.findUnique({
+    where: { key: "login-magic-link-email" },
+    select: {
+      isActive: true,
+      subject: true,
+      body: true,
+    },
+  });
+
+  const claimUrl = buildClaimUrl(input.pendingCaptain?.claimCode);
+  const variables = {
+    email: input.email,
+    signInUrl: input.url,
+    teamName: input.pendingCaptain?.teamName ?? "SIXFL",
+    claimUrl,
+    pendingCaptainNotice: input.pendingCaptain
+      ? `It looks like your captain access still needs to be claimed for ${input.pendingCaptain.teamName}. Sign in first, then complete your team claim.`
+      : "",
+  };
+
+  if (template?.isActive && template.subject?.trim() && template.body?.trim()) {
+    const renderedSubject = renderNotificationText(template.subject, variables);
+    const renderedBody = renderNotificationText(template.body, variables);
+
+    return {
+      subject: renderedSubject,
+      text: appendSIXFLTextSignature(stripCtaPlaceholder(renderedBody)),
+      html: buildSIXFLEmailHtml({
+        body: renderedBody,
+      }),
+    };
+  }
+
+  const fallbackBody = input.pendingCaptain
+    ? `Hi
+
+Use the secure sign-in link below to access SIXFL.
+
+${input.url}
+
+It looks like your captain access still needs to be claimed for ${input.pendingCaptain.teamName}. Once you are signed in, complete your team claim here:
+
+${claimUrl}`
+    : `Hi
+
+Use the secure sign-in link below to access SIXFL.
+
+${input.url}
+
+If you did not request this email, you can ignore it.`;
+
+  return {
+    subject: "Your SIXFL sign-in link",
+    text: appendSIXFLTextSignature(fallbackBody),
+    html: buildSIXFLEmailHtml({
+      body: `${fallbackBody}\n\nIf you did not request this email, you can ignore it.`,
+    }),
+  };
+}
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
@@ -16,36 +107,32 @@ export const authOptions: NextAuthOptions = {
       async sendVerificationRequest({ identifier, url, provider }) {
         const email = identifier.toLowerCase().trim();
 
-        const existingUser = await prisma.user.findUnique({
-          where: { email },
-        });
+        const [existingUser, pendingCaptain] = await Promise.all([
+          prisma.user.findUnique({
+            where: { email },
+          }),
+          getPendingCaptainContext(email),
+        ]);
 
-        if (!existingUser) {
+        if (!existingUser && !pendingCaptain) {
           return;
         }
 
         const resend = new Resend(process.env.RESEND_API_KEY);
-
         const from = provider.from ?? process.env.EMAIL_FROM!;
         const to = email;
-        const subject = "Your SIXFL sign-in link";
-
-        const html = `
-          <div style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial;">
-            <h2>SIXFL</h2>
-            <p>Click to sign in:</p>
-            <p><a href="${url}">${url}</a></p>
-            <p style="color:#666;font-size:12px;">
-              If you didn’t request this, you can ignore this email.
-            </p>
-          </div>
-        `;
+        const emailContent = await buildLoginMagicLinkEmail({
+          email,
+          url,
+          pendingCaptain,
+        });
 
         await resend.emails.send({
           from,
           to,
-          subject,
-          html,
+          subject: emailContent.subject,
+          text: emailContent.text,
+          html: emailContent.html,
         });
       },
       from: process.env.EMAIL_FROM!,
@@ -69,11 +156,14 @@ export const authOptions: NextAuthOptions = {
           return false;
         }
 
-        const existingUser = await prisma.user.findUnique({
-          where: { email },
-        });
+        const [existingUser, pendingCaptain] = await Promise.all([
+          prisma.user.findUnique({
+            where: { email },
+          }),
+          getPendingCaptainContext(email),
+        ]);
 
-        if (!existingUser) {
+        if (!existingUser && !pendingCaptain) {
           return false;
         }
       }

--- a/src/components/admin/email-templates/EmailTemplateForm.tsx
+++ b/src/components/admin/email-templates/EmailTemplateForm.tsx
@@ -127,6 +127,9 @@ const TOKENS = [
   "{{claimCode}}",
   "{{claimLink}}",
   "{{captainDashboardUrl}}",
+  "{{signInUrl}}",
+  "{{claimUrl}}",
+  "{{pendingCaptainNotice}}",
   "{{fixtureUrl}}",
   "{{fixturesUrl}}",
   "{{paymentUrl}}",
@@ -227,6 +230,18 @@ function previewReplace(text: string) {
     .replaceAll(
       "{{captainDashboardUrl}}",
       "https://www.sixfl.co.uk/claim?code=H862NY",
+    )
+    .replaceAll(
+      "{{signInUrl}}",
+      "https://www.sixfl.co.uk/api/auth/callback/email?token=demo-token",
+    )
+    .replaceAll(
+      "{{claimUrl}}",
+      "https://www.sixfl.co.uk/claim?code=H862NY",
+    )
+    .replaceAll(
+      "{{pendingCaptainNotice}}",
+      "It looks like your captain access still needs to be claimed for Harrogate Athletic. Sign in first, then complete your team claim.",
     )
     .replaceAll(
       "{{fixtureUrl}}",

--- a/src/lib/auth/pendingCaptain.ts
+++ b/src/lib/auth/pendingCaptain.ts
@@ -23,7 +23,7 @@ export async function getPendingCaptainContext(
     where: {
       captainUserId: null,
       claimCode: {
-        not: null,
+        not: "",
       },
       OR: [
         {

--- a/src/lib/auth/pendingCaptain.ts
+++ b/src/lib/auth/pendingCaptain.ts
@@ -1,0 +1,76 @@
+// ========================================
+// File: src/lib/auth/pendingCaptain.ts
+// ========================================
+
+import { prisma } from "@/lib/prisma";
+
+export type PendingCaptainContext = {
+  teamId: string;
+  teamName: string;
+  claimCode: string;
+};
+
+export async function getPendingCaptainContext(
+  emailInput: string,
+): Promise<PendingCaptainContext | null> {
+  const email = emailInput.trim().toLowerCase();
+
+  if (!email) {
+    return null;
+  }
+
+  const team = await prisma.team.findFirst({
+    where: {
+      captainUserId: null,
+      claimCode: {
+        not: null,
+      },
+      OR: [
+        {
+          captainInviteSentTo: {
+            equals: email,
+            mode: "insensitive",
+          },
+        },
+        {
+          contactEmail: {
+            equals: email,
+            mode: "insensitive",
+          },
+        },
+        {
+          secondaryContactEmail: {
+            equals: email,
+            mode: "insensitive",
+          },
+        },
+      ],
+    },
+    select: {
+      id: true,
+      name: true,
+      claimCode: true,
+    },
+    orderBy: [
+      {
+        captainInviteSentAt: "desc",
+      },
+      {
+        updatedAt: "desc",
+      },
+      {
+        createdAt: "desc",
+      },
+    ],
+  });
+
+  if (!team?.claimCode) {
+    return null;
+  }
+
+  return {
+    teamId: team.id,
+    teamName: team.name,
+    claimCode: team.claimCode,
+  };
+}


### PR DESCRIPTION
## Summary
- allow pending captain emails through the login gate instead of blocking them outright
- send the login magic link using an editable system email template when available
- guide pending captains toward the claim flow after login
- show pending-captain messaging on the check-email screen

## Details
- adds a shared pending captain lookup helper
- updates `/api/auth/check-email` to return pending captain state and claim context
- updates login UI to send pending captains to `/claim`
- seeds a `login-magic-link-email` transactional template for the system email editor
- adds preview tokens for the new login template variables

## Notes
- if the new template has not been seeded yet, auth falls back to a safe built-in email
- once seeded, the login magic link email can be edited in system emails