### PR TITLE
Add messaging webhooks on top of main

### DIFF
--- a/docs/messaging-stage-2-apply.md
+++ b/docs/messaging-stage-2-apply.md
@@ -1,0 +1,46 @@
+# Messaging Stage 2 apply guide
+
+Use branch feature/messaging-webhooks-from-main.
+
+## Added in this follow-up
+
+- src/lib/notifications/webhooks.ts
+- src/app/api/webhooks/resend/route.ts
+- src/app/api/webhooks/twilio/route.ts
+- docs/messaging-stage-2-apply.md
+
+## What is already in main
+
+- src/lib/notifications/providers/resend.ts
+- src/lib/notifications/providers/twilio.ts
+- src/lib/notifications/processor.ts
+- src/lib/notifications/transactional.ts
+- src/app/api/cron/notifications/route.ts
+
+## Environment variables
+
+Required for email sending:
+- RESEND_API_KEY
+- EMAIL_FROM
+
+Required for SMS sending:
+- TWILIO_ACCOUNT_SID
+- TWILIO_AUTH_TOKEN
+- one of TWILIO_MESSAGING_SERVICE_SID or TWILIO_PHONE_NUMBER
+
+Optional route protection:
+- CRON_SECRET
+- RESEND_WEBHOOK_SECRET
+- TWILIO_WEBHOOK_SECRET
+
+## What this follow-up does
+
+- adds Resend webhook handling for sent/delivered/failed style events
+- adds Twilio webhook handling for sent/delivered/failed style events
+- records provider webhook outcomes back into notification attempts and dispatches
+
+## What is still next
+
+- confirm hosting routes and webhook secrets are configured
+- register webhook endpoints with Resend and Twilio
+- optionally add richer delivery reporting in admin UI

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,43 @@
+// ========================================
+// File: src/app/api/webhooks/resend/route.ts
+// ========================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { handleResendWebhook } from "@/lib/notifications/webhooks";
+
+export const dynamic = "force-dynamic";
+
+function isAuthorized(request: NextRequest) {
+  const configuredSecret = process.env.RESEND_WEBHOOK_SECRET?.trim();
+
+  if (!configuredSecret) {
+    return true;
+  }
+
+  const providedSecret = request.headers.get("x-resend-webhook-secret")?.trim();
+  return providedSecret === configuredSecret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const payload = (await request.json()) as Record<string, unknown>;
+    const result = await handleResendWebhook(payload);
+
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Resend webhook processing failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/webhooks/twilio/route.ts
+++ b/src/app/api/webhooks/twilio/route.ts
@@ -1,0 +1,47 @@
+// ========================================
+// File: src/app/api/webhooks/twilio/route.ts
+// ========================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { handleTwilioWebhook } from "@/lib/notifications/webhooks";
+
+export const dynamic = "force-dynamic";
+
+function isAuthorized(request: NextRequest) {
+  const configuredSecret = process.env.TWILIO_WEBHOOK_SECRET?.trim();
+
+  if (!configuredSecret) {
+    return true;
+  }
+
+  const providedSecret = request.headers.get("x-twilio-webhook-secret")?.trim();
+  return providedSecret === configuredSecret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const formData = await request.formData();
+    const payload = Object.fromEntries(
+      Array.from(formData.entries()).map(([key, value]) => [key, String(value)]),
+    ) as Record<string, string>;
+
+    const result = await handleTwilioWebhook(payload);
+
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Twilio webhook processing failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/notifications/webhooks.ts
+++ b/src/lib/notifications/webhooks.ts
@@ -1,0 +1,193 @@
+// ========================================
+// File: src/lib/notifications/webhooks.ts
+// ========================================
+
+import {
+  NotificationAttemptStatus,
+  NotificationDispatchStatus,
+  Prisma,
+} from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+function asJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
+}
+
+function extractResendMessageId(payload: Record<string, unknown>) {
+  const directId = payload.email_id;
+  if (typeof directId === "string" && directId.trim()) return directId.trim();
+
+  const data = payload.data;
+  if (data && typeof data === "object") {
+    const nestedId = (data as Record<string, unknown>).email_id;
+    if (typeof nestedId === "string" && nestedId.trim()) return nestedId.trim();
+  }
+
+  return null;
+}
+
+function extractResendEventType(payload: Record<string, unknown>) {
+  const directType = payload.type;
+  if (typeof directType === "string") return directType.toLowerCase();
+
+  return "unknown";
+}
+
+export async function handleResendWebhook(payload: Record<string, unknown>) {
+  const providerMessageId = extractResendMessageId(payload);
+  const eventType = extractResendEventType(payload);
+
+  if (!providerMessageId) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "Missing provider message id.",
+    };
+  }
+
+  const dispatch = await prisma.notificationDispatch.findFirst({
+    where: {
+      provider: "resend",
+      providerMessageId,
+    },
+    select: {
+      id: true,
+      status: true,
+    },
+  });
+
+  if (!dispatch) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "No matching dispatch found.",
+    };
+  }
+
+  const failureEvents = new Set(["email.bounced", "email.complained", "email.failed"]);
+  const successEvents = new Set(["email.sent", "email.delivered"]);
+
+  if (failureEvents.has(eventType)) {
+    await prisma.$transaction(async (tx) => {
+      await tx.notificationAttempt.create({
+        data: {
+          dispatchId: dispatch.id,
+          provider: "resend",
+          status: NotificationAttemptStatus.FAILED,
+          responsePayload: asJsonValue(payload),
+          errorMessage: eventType,
+        },
+      });
+
+      await tx.notificationDispatch.update({
+        where: { id: dispatch.id },
+        data: {
+          status: NotificationDispatchStatus.FAILED,
+          failedAt: new Date(),
+          failureReason: eventType,
+        },
+      });
+    });
+
+    return { ok: true, updated: true, status: "failed" };
+  }
+
+  if (successEvents.has(eventType)) {
+    await prisma.notificationAttempt.create({
+      data: {
+        dispatchId: dispatch.id,
+        provider: "resend",
+        status: NotificationAttemptStatus.SUCCESS,
+        responsePayload: asJsonValue(payload),
+      },
+    });
+
+    return { ok: true, updated: true, status: "sent" };
+  }
+
+  return {
+    ok: true,
+    ignored: true,
+    reason: `Unhandled Resend event: ${eventType}`,
+  };
+}
+
+export async function handleTwilioWebhook(payload: Record<string, string>) {
+  const providerMessageId = payload.MessageSid?.trim();
+  const messageStatus = payload.MessageStatus?.trim().toLowerCase() || "unknown";
+  const errorMessage = payload.ErrorMessage?.trim() || null;
+
+  if (!providerMessageId) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "Missing Twilio MessageSid.",
+    };
+  }
+
+  const dispatch = await prisma.notificationDispatch.findFirst({
+    where: {
+      provider: "twilio",
+      providerMessageId,
+    },
+    select: {
+      id: true,
+      status: true,
+    },
+  });
+
+  if (!dispatch) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: "No matching dispatch found.",
+    };
+  }
+
+  const failureStatuses = new Set(["failed", "undelivered"]);
+  const successStatuses = new Set(["sent", "delivered"]);
+
+  if (failureStatuses.has(messageStatus)) {
+    await prisma.$transaction(async (tx) => {
+      await tx.notificationAttempt.create({
+        data: {
+          dispatchId: dispatch.id,
+          provider: "twilio",
+          status: NotificationAttemptStatus.FAILED,
+          responsePayload: asJsonValue(payload),
+          errorMessage: errorMessage || messageStatus,
+        },
+      });
+
+      await tx.notificationDispatch.update({
+        where: { id: dispatch.id },
+        data: {
+          status: NotificationDispatchStatus.FAILED,
+          failedAt: new Date(),
+          failureReason: errorMessage || messageStatus,
+        },
+      });
+    });
+
+    return { ok: true, updated: true, status: "failed" };
+  }
+
+  if (successStatuses.has(messageStatus)) {
+    await prisma.notificationAttempt.create({
+      data: {
+        dispatchId: dispatch.id,
+        provider: "twilio",
+        status: NotificationAttemptStatus.SUCCESS,
+        responsePayload: asJsonValue(payload),
+      },
+    });
+
+    return { ok: true, updated: true, status: "sent" };
+  }
+
+  return {
+    ok: true,
+    ignored: true,
+    reason: `Unhandled Twilio status: ${messageStatus}`,
+  };
+}


### PR DESCRIPTION
## Summary
- add the missing Resend and Twilio webhook routes on top of current `main`
- add shared notification webhook handlers
- include a focused apply guide for the remaining stage 2 webhook work

## Why
PR #2 is based on an old branch chain and most of its delivery layer is already in `main`. This follow-up brings over only the missing webhook/doc pieces in a clean PR from `main`.

## Added here
- `src/lib/notifications/webhooks.ts`
- `src/app/api/webhooks/resend/route.ts`
- `src/app/api/webhooks/twilio/route.ts`
- `docs/messaging-stage-2-apply.md`

## Notes
- queue processor, Resend provider, Twilio provider, cron route and transactional helper are already in `main`
- after merge, webhook secrets/routes still need configuring in the hosting/provider dashboards