### PR TITLE
Fix admin prospect promotion to squad

### DIFF
--- a/src/app/(admin)/admin/teams/[id]/prospects/actions.ts
+++ b/src/app/(admin)/admin/teams/[id]/prospects/actions.ts
@@ -182,6 +182,9 @@ export async function convertAdminProspectToMemberAction(formData: FormData) {
     select: {
       id: true,
       email: true,
+      firstName: true,
+      lastName: true,
+      status: true,
     },
   });
 
@@ -189,45 +192,34 @@ export async function convertAdminProspectToMemberAction(formData: FormData) {
     redirect(buildRedirect(teamId, "?error=Prospect%20not%20found."));
   }
 
-  if (!prospect.email) {
-    redirect(
-      buildRedirect(
-        teamId,
-        "?error=Prospect%20needs%20an%20email%20linked%20to%20a%20SIXFL%20account%20before%20promotion.",
-      ),
-    );
-  }
+  const normalizedEmail = prospect.email?.trim().toLowerCase() ?? null;
 
-  const user = await prisma.user.findUnique({
-    where: { email: prospect.email.toLowerCase() },
-    select: {
-      id: true,
-    },
-  });
+  const user = normalizedEmail
+    ? await prisma.user.findUnique({
+        where: { email: normalizedEmail },
+        select: {
+          id: true,
+          email: true,
+        },
+      })
+    : null;
 
-  if (!user) {
-    redirect(
-      buildRedirect(
-        teamId,
-        "?error=No%20existing%20SIXFL%20user%20was%20found%20for%20that%20email.",
-      ),
-    );
-  }
-
-  const existingMembership = await prisma.teamMember.findUnique({
-    where: {
-      userId_teamId: {
-        userId: user.id,
-        teamId,
-      },
-    },
-    select: {
-      id: true,
-    },
-  });
+  const existingMembership = user
+    ? await prisma.teamMember.findUnique({
+        where: {
+          userId_teamId: {
+            userId: user.id,
+            teamId,
+          },
+        },
+        select: {
+          id: true,
+        },
+      })
+    : null;
 
   await prisma.$transaction(async (tx) => {
-    if (!existingMembership) {
+    if (user && !existingMembership) {
       await tx.teamMember.create({
         data: {
           teamId,
@@ -249,5 +241,7 @@ export async function convertAdminProspectToMemberAction(formData: FormData) {
   revalidatePath(`/admin/teams/${teamId}`);
   revalidatePath(`/admin/teams/${teamId}/squad`);
   revalidatePath(`/admin/teams/${teamId}/prospects`);
+  revalidatePath(`/captain/team/${teamId}/squad`);
+  revalidatePath(`/captain/team/${teamId}/prospects`);
   redirect(buildRedirect(teamId, "?saved=promoted"));
 }


### PR DESCRIPTION
Admin prospect promotion now matches the captain flow.

Changes:
- do not block promotion when there is no linked SIXFL user yet
- still create a team member when a matching user exists
- otherwise mark the prospect as ACTIVE_SQUAD so they show as pending activation in squad views
- revalidate both admin and captain squad/prospect screens after promotion