### PR TITLE
Fix captain prospects linked user type guard

### DIFF
--- a/src/app/captain/team/[teamid]/prospects/page.tsx
+++ b/src/app/captain/team/[teamid]/prospects/page.tsx
@@ -408,7 +408,8 @@ export default async function CaptainProspectsPage({
   ]);
 
   const linkedUsers: LinkedUserRecord[] = linkedUsersRaw.filter(
-    (user): user is LinkedUserRecord => Boolean(user.email),
+    (user): user is LinkedUserRecord =>
+      typeof user.email === "string" && user.email.trim().length > 0,
   );
 
   const linkedUserByEmail = new Map(


### PR DESCRIPTION
## Superseded

This PR is being closed to avoid confusion.

The underlying TypeScript fix is already present in `main` in commit `7137b912ec467c00745becca5fc0a5ec21ed87d2` (`Fix prospect page linked user typing for build`).

No separate merge from this PR is needed.