### PR TITLE
Support separate fixture fees for each team

### DIFF
--- a/src/app/(admin)/admin/fixtures/actions.ts
+++ b/src/app/(admin)/admin/fixtures/actions.ts
@@ -168,6 +168,28 @@ function parseFixtureStatus(value: FormDataEntryValue | null) {
   return str as FixtureStatus;
 }
 
+function parseFixtureTeamFees(formData: FormData) {
+  const homeMatchFeePence = parseOptionalMoneyToPence(
+    formData.get("homeMatchFeePounds"),
+    "Team 1 fee",
+  );
+  const awayMatchFeePence = parseOptionalMoneyToPence(
+    formData.get("awayMatchFeePounds"),
+    "Team 2 fee",
+  );
+
+  const fixtureMatchFeePence = Math.max(
+    homeMatchFeePence ?? 0,
+    awayMatchFeePence ?? 0,
+  );
+
+  return {
+    homeMatchFeePence,
+    awayMatchFeePence,
+    fixtureMatchFeePence: fixtureMatchFeePence > 0 ? fixtureMatchFeePence : null,
+  };
+}
+
 function parseTimeToMinutes(value: string | null) {
   if (!value) return null;
 
@@ -445,10 +467,11 @@ export async function createFixtureAction(formData: FormData) {
   );
   const pitch = parseOptionalString(formData.get("pitch"));
   const status = parseFixtureStatus(formData.get("status"));
-  const matchFeePence = parseOptionalMoneyToPence(
-    formData.get("matchFeePounds"),
-    "Match fee",
-  );
+  const {
+    homeMatchFeePence,
+    awayMatchFeePence,
+    fixtureMatchFeePence,
+  } = parseFixtureTeamFees(formData);
 
   if (homeTeamId === awayTeamId) {
     throw new Error("Team 1 and Team 2 cannot be the same team.");
@@ -522,7 +545,7 @@ export async function createFixtureAction(formData: FormData) {
         position,
         pitch,
         status,
-        matchFeePence,
+        matchFeePence: fixtureMatchFeePence,
       },
     });
 
@@ -535,7 +558,8 @@ export async function createFixtureAction(formData: FormData) {
       kickoffAt,
       homeTeam,
       awayTeam,
-      matchFeePence,
+      homeMatchFeePence,
+      awayMatchFeePence,
     });
 
     return {
@@ -544,7 +568,7 @@ export async function createFixtureAction(formData: FormData) {
     };
   });
 
-  if ((matchFeePence ?? 0) > 0 && created.activeCharges.length > 0) {
+  if (created.activeCharges.length > 0) {
     try {
       await queueFixtureMatchFeeEmails({
         fixtureId: created.fixture.id,
@@ -554,7 +578,8 @@ export async function createFixtureAction(formData: FormData) {
         kickoffAt,
         homeTeam,
         awayTeam,
-        matchFeePence,
+        homeMatchFeePence,
+        awayMatchFeePence,
         charges: created.activeCharges,
         mode: "all",
       });
@@ -596,10 +621,11 @@ export async function updateFixtureAction(formData: FormData) {
   );
   const pitch = parseOptionalString(formData.get("pitch"));
   const status = parseFixtureStatus(formData.get("status"));
-  const matchFeePence = parseOptionalMoneyToPence(
-    formData.get("matchFeePounds"),
-    "Match fee",
-  );
+  const {
+    homeMatchFeePence,
+    awayMatchFeePence,
+    fixtureMatchFeePence,
+  } = parseFixtureTeamFees(formData);
 
   if (homeTeamId === awayTeamId) {
     throw new Error("Team 1 and Team 2 cannot be the same team.");
@@ -690,7 +716,8 @@ export async function updateFixtureAction(formData: FormData) {
       kickoffAt,
       homeTeam,
       awayTeam,
-      matchFeePence,
+      homeMatchFeePence,
+      awayMatchFeePence,
     });
 
     const updatedFixture = await tx.fixture.update({
@@ -706,7 +733,7 @@ export async function updateFixtureAction(formData: FormData) {
         position,
         pitch,
         status,
-        matchFeePence,
+        matchFeePence: fixtureMatchFeePence,
       },
     });
 
@@ -717,11 +744,11 @@ export async function updateFixtureAction(formData: FormData) {
   });
 
   const hadExistingFee = (fixture.matchFeePence ?? 0) > 0;
-  const hasMatchFee = (matchFeePence ?? 0) > 0;
+  const hasMatchFee = (fixtureMatchFeePence ?? 0) > 0;
   const teamsChanged =
     fixture.homeTeamId !== homeTeamId || fixture.awayTeamId !== awayTeamId;
   const feeAmountChanged =
-    (fixture.matchFeePence ?? 0) !== (matchFeePence ?? 0);
+    (fixture.matchFeePence ?? 0) !== (fixtureMatchFeePence ?? 0);
 
   const shouldSendInitialFeeEmail =
     !hadExistingFee || teamsChanged || feeAmountChanged;
@@ -751,7 +778,8 @@ export async function updateFixtureAction(formData: FormData) {
         kickoffAt,
         homeTeam,
         awayTeam,
-        matchFeePence,
+        homeMatchFeePence,
+        awayMatchFeePence,
         charges: updated.activeCharges,
         mode: shouldSendInitialFeeEmail ? "all" : "reminders_only",
       });

--- a/src/app/(admin)/admin/fixtures/page.tsx
+++ b/src/app/(admin)/admin/fixtures/page.tsx
@@ -270,6 +270,13 @@ export default async function AdminFixturesPage({
             name: true,
           },
         },
+        paymentCharges: {
+          select: {
+            teamId: true,
+            amountPence: true,
+            status: true,
+          },
+        },
         result: {
           select: {
             homeScore: true,
@@ -340,6 +347,21 @@ export default async function AdminFixturesPage({
           (item) => item.teamId === fixture.awayTeamId,
         ) ?? null;
 
+      const activeCharges = fixture.paymentCharges.filter(
+        (charge) => charge.status !== "VOID",
+      );
+      const homeCharge = activeCharges.find(
+        (charge) => charge.teamId === fixture.homeTeamId,
+      );
+      const awayCharge = activeCharges.find(
+        (charge) => charge.teamId === fixture.awayTeamId,
+      );
+      const legacyFee = fixture.matchFeePence ?? null;
+      const homeMatchFeePence =
+        homeCharge?.amountPence ?? (legacyFee && !awayCharge ? legacyFee : null);
+      const awayMatchFeePence =
+        awayCharge?.amountPence ?? (legacyFee && !homeCharge ? legacyFee : null);
+
       const homeConfirmationStatus =
         homeConfirmation?.status ??
         (fixture.status === "SCHEDULED" && fixture.kickoffAt > new Date()
@@ -371,6 +393,8 @@ export default async function AdminFixturesPage({
         pitch: fixture.pitch,
         status: fixture.status,
         matchFeePence: fixture.matchFeePence,
+        homeMatchFeePence,
+        awayMatchFeePence,
         homeScore: fixture.result?.homeScore ?? null,
         awayScore: fixture.result?.awayScore ?? null,
         resultIsDisputed: fixture.result?.isDisputed ?? false,

--- a/src/components/admin/fixtures/FixturesAdminScreen.tsx
+++ b/src/components/admin/fixtures/FixturesAdminScreen.tsx
@@ -83,6 +83,8 @@ type FixtureItem = {
   pitch: string | null;
   status: FixtureStatus;
   matchFeePence: number | null;
+  homeMatchFeePence: number | null;
+  awayMatchFeePence: number | null;
   homeScore: number | null;
   awayScore: number | null;
   resultIsDisputed: boolean;
@@ -725,7 +727,8 @@ export default function FixturesAdminScreen({
   const [editRound, setEditRound] = useState("");
   const [editPosition, setEditPosition] = useState("");
   const [editPitch, setEditPitch] = useState("");
-  const [editMatchFee, setEditMatchFee] = useState("");
+  const [editHomeMatchFee, setEditHomeMatchFee] = useState("");
+  const [editAwayMatchFee, setEditAwayMatchFee] = useState("");
   const [editStatus, setEditStatus] = useState<FixtureStatus>("SCHEDULED");
 
   useEffect(() => {
@@ -873,7 +876,8 @@ export default function FixturesAdminScreen({
     setEditRound(fixture.round?.toString() ?? "");
     setEditPosition(fixture.position?.toString() ?? "");
     setEditPitch(fixture.pitch ?? "");
-    setEditMatchFee(formatMoneyInputValue(fixture.matchFeePence));
+    setEditHomeMatchFee(formatMoneyInputValue(fixture.homeMatchFeePence));
+    setEditAwayMatchFee(formatMoneyInputValue(fixture.awayMatchFeePence));
     setEditStatus(fixture.status);
   }
 
@@ -889,7 +893,8 @@ export default function FixturesAdminScreen({
     setEditRound("");
     setEditPosition("");
     setEditPitch("");
-    setEditMatchFee("");
+    setEditHomeMatchFee("");
+    setEditAwayMatchFee("");
     setEditStatus("SCHEDULED");
   }
 
@@ -931,7 +936,7 @@ export default function FixturesAdminScreen({
             <SectionHeading
               eyebrow="Manual match"
               title="Create fixture"
-              description="Add a specific match with full control over teams, venue, referee, week, pitch, status and the per-team match fee."
+              description="Add a specific match with full control over teams, venue, referee, week, pitch, status and separate fees for each team."
             />
           </div>
 
@@ -1046,20 +1051,35 @@ export default function FixturesAdminScreen({
                 />
               </div>
 
-              <div>
-                <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
-                  Match fee per team (£)
-                </label>
-                <input
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  name="matchFeePounds"
-                  placeholder="e.g. 30.00"
-                  className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
-                />
-                <p className="mt-2 text-xs text-white/40">
-                  When set, SIXFL will create one charge per team and email payment links immediately.
+              <div className="xl:col-span-2 grid gap-6 xl:grid-cols-2">
+                <div>
+                  <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                    Team 1 fee (£)
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    name="homeMatchFeePounds"
+                    placeholder="e.g. 30.00"
+                    className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
+                  />
+                </div>
+                <div>
+                  <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                    Team 2 fee (£)
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    name="awayMatchFeePounds"
+                    placeholder="e.g. 15.00"
+                    className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
+                  />
+                </div>
+                <p className="xl:col-span-2 -mt-2 text-xs text-white/40">
+                  Leave either side blank if that team should not be charged. Each team will get its own payment request amount.
                 </p>
               </div>
             </div>
@@ -1500,19 +1520,35 @@ export default function FixturesAdminScreen({
                   />
                 </div>
 
-                <div>
-                  <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
-                    Match fee per team (£)
-                  </label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    name="matchFeePounds"
-                    value={editMatchFee}
-                    onChange={(event) => setEditMatchFee(event.target.value)}
-                    className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
-                  />
+                <div className="xl:col-span-2 grid gap-6 xl:grid-cols-2">
+                  <div>
+                    <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                      Team 1 fee (£)
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      name="homeMatchFeePounds"
+                      value={editHomeMatchFee}
+                      onChange={(event) => setEditHomeMatchFee(event.target.value)}
+                      className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                      Team 2 fee (£)
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      name="awayMatchFeePounds"
+                      value={editAwayMatchFee}
+                      onChange={(event) => setEditAwayMatchFee(event.target.value)}
+                      className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
+                    />
+                  </div>
                 </div>
               </div>
 
@@ -1607,9 +1643,18 @@ export default function FixturesAdminScreen({
                           ? ` • Game ${fixture.position}`
                           : ""}
                       </div>
-                      {fixture.matchFeePence !== null && fixture.matchFeePence > 0 ? (
-                        <div className="mt-2 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-200">
-                          Match fee {formatMoney(fixture.matchFeePence)} per team
+                      {fixture.homeMatchFeePence || fixture.awayMatchFeePence ? (
+                        <div className="mt-2 flex flex-wrap gap-2 text-xs font-semibold">
+                          {fixture.homeMatchFeePence ? (
+                            <span className="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-emerald-200">
+                              Team 1 {formatMoney(fixture.homeMatchFeePence)}
+                            </span>
+                          ) : null}
+                          {fixture.awayMatchFeePence ? (
+                            <span className="inline-flex rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1 text-sky-200">
+                              Team 2 {formatMoney(fixture.awayMatchFeePence)}
+                            </span>
+                          ) : null}
                         </div>
                       ) : null}
                     </td>

--- a/src/lib/payments/fixture-match-fees.ts
+++ b/src/lib/payments/fixture-match-fees.ts
@@ -32,7 +32,8 @@ type SyncFixtureMatchFeeChargesInput = {
   kickoffAt: Date;
   homeTeam: FixtureMatchFeeTeam;
   awayTeam: FixtureMatchFeeTeam;
-  matchFeePence: number | null;
+  homeMatchFeePence: number | null;
+  awayMatchFeePence: number | null;
 };
 
 type PaymentChargeDbClient = Pick<
@@ -52,6 +53,7 @@ type QueueFixtureMatchFeeEmailsInput = SyncFixtureMatchFeeChargesInput & {
     teamName: string;
     teamLogoUrl: string | null;
     paymentToken: string | null;
+    amountPence: number;
   }>;
   mode?: "all" | "reminders_only";
 };
@@ -193,21 +195,26 @@ export async function syncFixtureMatchFeeCharges(
     orderBy: [{ createdAt: "asc" }],
   });
 
-  const desiredFee =
-    input.matchFeePence && input.matchFeePence > 0 ? input.matchFeePence : null;
-
-  const desiredTeams = desiredFee
-    ? [
-        {
-          team: input.homeTeam,
-          opponent: input.awayTeam,
-        },
-        {
-          team: input.awayTeam,
-          opponent: input.homeTeam,
-        },
-      ]
-    : [];
+  const desiredTeams = [
+    ...(input.homeMatchFeePence && input.homeMatchFeePence > 0
+      ? [
+          {
+            team: input.homeTeam,
+            opponent: input.awayTeam,
+            amountPence: input.homeMatchFeePence,
+          },
+        ]
+      : []),
+    ...(input.awayMatchFeePence && input.awayMatchFeePence > 0
+      ? [
+          {
+            team: input.awayTeam,
+            opponent: input.homeTeam,
+            amountPence: input.awayMatchFeePence,
+          },
+        ]
+      : []),
+  ];
 
   const desiredTeamIds = new Set(desiredTeams.map((entry) => entry.team.id));
   const voidedChargeIds: string[] = [];
@@ -242,7 +249,7 @@ export async function syncFixtureMatchFeeCharges(
     });
   }
 
-  if (!desiredFee) {
+  if (desiredTeams.length === 0) {
     for (const charge of existingCharges) {
       const paidTotalPence = getChargePaidTotal(charge.transactions);
 
@@ -282,6 +289,7 @@ export async function syncFixtureMatchFeeCharges(
     teamName: string;
     teamLogoUrl: string | null;
     paymentToken: string | null;
+    amountPence: number;
   }> = [];
 
   for (const entry of desiredTeams) {
@@ -308,7 +316,7 @@ export async function syncFixtureMatchFeeCharges(
           fixtureId: input.fixtureId,
           title,
           description,
-          amountPence: desiredFee,
+          amountPence: entry.amountPence,
           dueDate: input.kickoffAt,
           status: PaymentChargeStatus.OPEN,
           paymentToken: createPaymentToken(),
@@ -321,6 +329,7 @@ export async function syncFixtureMatchFeeCharges(
         teamName: entry.team.name,
         teamLogoUrl: entry.team.logoUrl ?? null,
         paymentToken: createdCharge.paymentToken,
+        amountPence: createdCharge.amountPence,
       });
 
       continue;
@@ -328,7 +337,7 @@ export async function syncFixtureMatchFeeCharges(
 
     const paidTotalPence = getChargePaidTotal(existingCharge.transactions);
 
-    if (paidTotalPence > 0 && existingCharge.amountPence !== desiredFee) {
+    if (paidTotalPence > 0 && existingCharge.amountPence !== entry.amountPence) {
       throw new Error(
         `Cannot change the match fee amount for ${existingCharge.team.name} because a payment has already been recorded.`,
       );
@@ -342,9 +351,9 @@ export async function syncFixtureMatchFeeCharges(
         fixtureId: input.fixtureId,
         title,
         description,
-        amountPence: desiredFee,
+        amountPence: entry.amountPence,
         dueDate: input.kickoffAt,
-        status: getChargeStatusFromAmounts(desiredFee, paidTotalPence),
+        status: getChargeStatusFromAmounts(entry.amountPence, paidTotalPence),
         paymentToken: existingCharge.paymentToken ?? createPaymentToken(),
       },
     });
@@ -356,6 +365,7 @@ export async function syncFixtureMatchFeeCharges(
         teamName: entry.team.name,
         teamLogoUrl: entry.team.logoUrl ?? null,
         paymentToken: updatedCharge.paymentToken,
+        amountPence: updatedCharge.amountPence,
       });
     }
   }
@@ -421,7 +431,7 @@ export async function queueFixtureMatchFeeEmails(
           leagueDisplayName,
           fixtureName: `${input.homeTeam.name} vs ${input.awayTeam.name}`,
           kickoffLabel: formatKickoffLabel(input.kickoffAt),
-          amount: formatMoney(input.matchFeePence ?? 0),
+          amount: formatMoney(charge.amountPence),
           paymentUrl: buildChargePaymentUrl(charge.paymentToken),
         },
         emailBranding: {
@@ -430,7 +440,7 @@ export async function queueFixtureMatchFeeEmails(
           leagueName: leagueDisplayName,
         },
         paymentSummary: {
-          amount: formatMoney(input.matchFeePence ?? 0),
+          amount: formatMoney(charge.amountPence),
           reason: `${input.homeTeam.name} vs ${input.awayTeam.name}`,
         },
       });


### PR DESCRIPTION
## Summary
- allow admin fixtures to store and edit separate Team 1 and Team 2 fees
- sync fixture payment charges per team using each side's own amount
- derive existing team-specific fixture fees from active payment charges in the admin fixtures page
- show separate fee badges in the fixtures table

## Result
You can now leave one side blank, charge only one team, or charge both teams different amounts from the fixture screen.