### PR TITLE
Support separate fixture fees for team 1 and team 2

### DIFF
--- a/src/app/(admin)/admin/fixtures/actions.ts
+++ b/src/app/(admin)/admin/fixtures/actions.ts
@@ -196,6 +196,21 @@ function getKickoffMinutes(kickoffAt: Date) {
   return getLondonMinutesSinceMidnight(kickoffAt);
 }
 
+function getLegacyFixtureMatchFeePence(input: {
+  homeMatchFeePence: number | null;
+  awayMatchFeePence: number | null;
+}) {
+  if (input.homeMatchFeePence === null && input.awayMatchFeePence === null) {
+    return null;
+  }
+
+  if (input.homeMatchFeePence === input.awayMatchFeePence) {
+    return input.homeMatchFeePence;
+  }
+
+  return Math.max(input.homeMatchFeePence ?? 0, input.awayMatchFeePence ?? 0) || null;
+}
+
 function isKickoffAllowed(
   kickoffAt: Date,
   homeTeam: TeamSchedulingRule,
@@ -445,10 +460,18 @@ export async function createFixtureAction(formData: FormData) {
   );
   const pitch = parseOptionalString(formData.get("pitch"));
   const status = parseFixtureStatus(formData.get("status"));
-  const matchFeePence = parseOptionalMoneyToPence(
-    formData.get("matchFeePounds"),
-    "Match fee",
+  const homeMatchFeePence = parseOptionalMoneyToPence(
+    formData.get("homeMatchFeePounds"),
+    "Team 1 match fee",
   );
+  const awayMatchFeePence = parseOptionalMoneyToPence(
+    formData.get("awayMatchFeePounds"),
+    "Team 2 match fee",
+  );
+  const legacyMatchFeePence = getLegacyFixtureMatchFeePence({
+    homeMatchFeePence,
+    awayMatchFeePence,
+  });
 
   if (homeTeamId === awayTeamId) {
     throw new Error("Team 1 and Team 2 cannot be the same team.");
@@ -522,7 +545,7 @@ export async function createFixtureAction(formData: FormData) {
         position,
         pitch,
         status,
-        matchFeePence,
+        matchFeePence: legacyMatchFeePence,
       },
     });
 
@@ -535,7 +558,8 @@ export async function createFixtureAction(formData: FormData) {
       kickoffAt,
       homeTeam,
       awayTeam,
-      matchFeePence,
+      homeMatchFeePence,
+      awayMatchFeePence,
     });
 
     return {
@@ -544,7 +568,7 @@ export async function createFixtureAction(formData: FormData) {
     };
   });
 
-  if ((matchFeePence ?? 0) > 0 && created.activeCharges.length > 0) {
+  if (created.activeCharges.length > 0) {
     try {
       await queueFixtureMatchFeeEmails({
         fixtureId: created.fixture.id,
@@ -554,7 +578,8 @@ export async function createFixtureAction(formData: FormData) {
         kickoffAt,
         homeTeam,
         awayTeam,
-        matchFeePence,
+        homeMatchFeePence,
+        awayMatchFeePence,
         charges: created.activeCharges,
         mode: "all",
       });
@@ -596,10 +621,18 @@ export async function updateFixtureAction(formData: FormData) {
   );
   const pitch = parseOptionalString(formData.get("pitch"));
   const status = parseFixtureStatus(formData.get("status"));
-  const matchFeePence = parseOptionalMoneyToPence(
-    formData.get("matchFeePounds"),
-    "Match fee",
+  const homeMatchFeePence = parseOptionalMoneyToPence(
+    formData.get("homeMatchFeePounds"),
+    "Team 1 match fee",
   );
+  const awayMatchFeePence = parseOptionalMoneyToPence(
+    formData.get("awayMatchFeePounds"),
+    "Team 2 match fee",
+  );
+  const legacyMatchFeePence = getLegacyFixtureMatchFeePence({
+    homeMatchFeePence,
+    awayMatchFeePence,
+  });
 
   if (homeTeamId === awayTeamId) {
     throw new Error("Team 1 and Team 2 cannot be the same team.");
@@ -690,7 +723,8 @@ export async function updateFixtureAction(formData: FormData) {
       kickoffAt,
       homeTeam,
       awayTeam,
-      matchFeePence,
+      homeMatchFeePence,
+      awayMatchFeePence,
     });
 
     const updatedFixture = await tx.fixture.update({
@@ -706,7 +740,7 @@ export async function updateFixtureAction(formData: FormData) {
         position,
         pitch,
         status,
-        matchFeePence,
+        matchFeePence: legacyMatchFeePence,
       },
     });
 
@@ -717,11 +751,11 @@ export async function updateFixtureAction(formData: FormData) {
   });
 
   const hadExistingFee = (fixture.matchFeePence ?? 0) > 0;
-  const hasMatchFee = (matchFeePence ?? 0) > 0;
+  const hasMatchFee = (homeMatchFeePence ?? 0) > 0 || (awayMatchFeePence ?? 0) > 0;
   const teamsChanged =
     fixture.homeTeamId !== homeTeamId || fixture.awayTeamId !== awayTeamId;
   const feeAmountChanged =
-    (fixture.matchFeePence ?? 0) !== (matchFeePence ?? 0);
+    (fixture.matchFeePence ?? 0) !== (legacyMatchFeePence ?? 0);
 
   const shouldSendInitialFeeEmail =
     !hadExistingFee || teamsChanged || feeAmountChanged;
@@ -751,7 +785,8 @@ export async function updateFixtureAction(formData: FormData) {
         kickoffAt,
         homeTeam,
         awayTeam,
-        matchFeePence,
+        homeMatchFeePence,
+        awayMatchFeePence,
         charges: updated.activeCharges,
         mode: shouldSendInitialFeeEmail ? "all" : "reminders_only",
       });

--- a/src/app/(admin)/admin/fixtures/page.tsx
+++ b/src/app/(admin)/admin/fixtures/page.tsx
@@ -3,7 +3,7 @@
 // ========================================
 
 import Link from "next/link";
-import { FixtureCaptainConfirmationStatus } from "@prisma/client";
+import { FixtureCaptainConfirmationStatus, PaymentChargeStatus } from "@prisma/client";
 import AdminCard from "@/components/admin/AdminCard";
 import FixturesAdminScreen from "@/components/admin/fixtures/FixturesAdminScreen";
 import { publishAndEmailLeagueFixturesAction } from "@/app/(admin)/admin/fixtures/publish-actions";
@@ -235,6 +235,18 @@ export default async function AdminFixturesPage({
         kickoffAt: true,
         publishedAt: true,
         matchFeePence: true,
+        paymentCharges: {
+          where: {
+            status: {
+              not: PaymentChargeStatus.VOID,
+            },
+          },
+          select: {
+            teamId: true,
+            amountPence: true,
+            status: true,
+          },
+        },
 
         socialPostType: true,
         socialPostStatus: true,
@@ -352,6 +364,13 @@ export default async function AdminFixturesPage({
           ? getFallbackConfirmationStatus(fixture.kickoffAt)
           : null);
 
+      const homeMatchFeePence =
+        fixture.paymentCharges.find((charge) => charge.teamId === fixture.homeTeamId)
+          ?.amountPence ?? null;
+      const awayMatchFeePence =
+        fixture.paymentCharges.find((charge) => charge.teamId === fixture.awayTeamId)
+          ?.amountPence ?? null;
+
       return {
         id: fixture.id,
         leagueId: fixture.leagueId,
@@ -371,6 +390,8 @@ export default async function AdminFixturesPage({
         pitch: fixture.pitch,
         status: fixture.status,
         matchFeePence: fixture.matchFeePence,
+        homeMatchFeePence,
+        awayMatchFeePence,
         homeScore: fixture.result?.homeScore ?? null,
         awayScore: fixture.result?.awayScore ?? null,
         resultIsDisputed: fixture.result?.isDisputed ?? false,
@@ -535,8 +556,7 @@ export default async function AdminFixturesPage({
                       Published
                     </div>
                     <div className="mt-1 text-lg font-semibold text-emerald-300">
-                      {item.published}
-                    </div>
+                      {item.published}</div>
                   </div>
                   <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-3">
                     <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">

--- a/src/components/admin/fixtures/FixturesAdminScreen.tsx
+++ b/src/components/admin/fixtures/FixturesAdminScreen.tsx
@@ -83,6 +83,8 @@ type FixtureItem = {
   pitch: string | null;
   status: FixtureStatus;
   matchFeePence: number | null;
+  homeMatchFeePence: number | null;
+  awayMatchFeePence: number | null;
   homeScore: number | null;
   awayScore: number | null;
   resultIsDisputed: boolean;
@@ -725,7 +727,8 @@ export default function FixturesAdminScreen({
   const [editRound, setEditRound] = useState("");
   const [editPosition, setEditPosition] = useState("");
   const [editPitch, setEditPitch] = useState("");
-  const [editMatchFee, setEditMatchFee] = useState("");
+  const [editHomeMatchFee, setEditHomeMatchFee] = useState("");
+  const [editAwayMatchFee, setEditAwayMatchFee] = useState("");
   const [editStatus, setEditStatus] = useState<FixtureStatus>("SCHEDULED");
 
   useEffect(() => {
@@ -873,7 +876,8 @@ export default function FixturesAdminScreen({
     setEditRound(fixture.round?.toString() ?? "");
     setEditPosition(fixture.position?.toString() ?? "");
     setEditPitch(fixture.pitch ?? "");
-    setEditMatchFee(formatMoneyInputValue(fixture.matchFeePence));
+    setEditHomeMatchFee(formatMoneyInputValue(fixture.homeMatchFeePence));
+    setEditAwayMatchFee(formatMoneyInputValue(fixture.awayMatchFeePence));
     setEditStatus(fixture.status);
   }
 
@@ -889,7 +893,8 @@ export default function FixturesAdminScreen({
     setEditRound("");
     setEditPosition("");
     setEditPitch("");
-    setEditMatchFee("");
+    setEditHomeMatchFee("");
+    setEditAwayMatchFee("");
     setEditStatus("SCHEDULED");
   }
 
@@ -931,7 +936,7 @@ export default function FixturesAdminScreen({
             <SectionHeading
               eyebrow="Manual match"
               title="Create fixture"
-              description="Add a specific match with full control over teams, venue, referee, week, pitch, status and the per-team match fee."
+              description="Add a specific match with full control over teams, venue, referee, week, pitch, status and separate match fees for each team."
             />
           </div>
 
@@ -1048,18 +1053,32 @@ export default function FixturesAdminScreen({
 
               <div>
                 <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
-                  Match fee per team (£)
+                  Team 1 fee (£)
                 </label>
                 <input
                   type="number"
                   step="0.01"
                   min="0"
-                  name="matchFeePounds"
+                  name="homeMatchFeePounds"
                   placeholder="e.g. 30.00"
                   className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
                 />
+              </div>
+
+              <div>
+                <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                  Team 2 fee (£)
+                </label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  name="awayMatchFeePounds"
+                  placeholder="e.g. 0.00"
+                  className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
+                />
                 <p className="mt-2 text-xs text-white/40">
-                  When set, SIXFL will create one charge per team and email payment links immediately.
+                  Set a different amount for each team, or leave one side blank to only charge the other team.
                 </p>
               </div>
             </div>
@@ -1502,15 +1521,30 @@ export default function FixturesAdminScreen({
 
                 <div>
                   <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
-                    Match fee per team (£)
+                    Team 1 fee (£)
                   </label>
                   <input
                     type="number"
                     step="0.01"
                     min="0"
-                    name="matchFeePounds"
-                    value={editMatchFee}
-                    onChange={(event) => setEditMatchFee(event.target.value)}
+                    name="homeMatchFeePounds"
+                    value={editHomeMatchFee}
+                    onChange={(event) => setEditHomeMatchFee(event.target.value)}
+                    className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                    Team 2 fee (£)
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    name="awayMatchFeePounds"
+                    value={editAwayMatchFee}
+                    onChange={(event) => setEditAwayMatchFee(event.target.value)}
                     className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20"
                   />
                 </div>
@@ -1607,9 +1641,18 @@ export default function FixturesAdminScreen({
                           ? ` • Game ${fixture.position}`
                           : ""}
                       </div>
-                      {fixture.matchFeePence !== null && fixture.matchFeePence > 0 ? (
-                        <div className="mt-2 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-200">
-                          Match fee {formatMoney(fixture.matchFeePence)} per team
+                      {fixture.homeMatchFeePence !== null || fixture.awayMatchFeePence !== null ? (
+                        <div className="mt-2 flex flex-wrap gap-2 text-xs font-semibold">
+                          {fixture.homeMatchFeePence !== null ? (
+                            <div className="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-emerald-200">
+                              Team 1 {formatMoney(fixture.homeMatchFeePence)}
+                            </div>
+                          ) : null}
+                          {fixture.awayMatchFeePence !== null ? (
+                            <div className="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-emerald-200">
+                              Team 2 {formatMoney(fixture.awayMatchFeePence)}
+                            </div>
+                          ) : null}
                         </div>
                       ) : null}
                     </td>

--- a/src/lib/payments/fixture-match-fees.ts
+++ b/src/lib/payments/fixture-match-fees.ts
@@ -32,7 +32,8 @@ type SyncFixtureMatchFeeChargesInput = {
   kickoffAt: Date;
   homeTeam: FixtureMatchFeeTeam;
   awayTeam: FixtureMatchFeeTeam;
-  matchFeePence: number | null;
+  homeMatchFeePence: number | null;
+  awayMatchFeePence: number | null;
 };
 
 type PaymentChargeDbClient = Pick<
@@ -52,6 +53,7 @@ type QueueFixtureMatchFeeEmailsInput = SyncFixtureMatchFeeChargesInput & {
     teamName: string;
     teamLogoUrl: string | null;
     paymentToken: string | null;
+    amountPence: number;
   }>;
   mode?: "all" | "reminders_only";
 };
@@ -193,21 +195,30 @@ export async function syncFixtureMatchFeeCharges(
     orderBy: [{ createdAt: "asc" }],
   });
 
-  const desiredFee =
-    input.matchFeePence && input.matchFeePence > 0 ? input.matchFeePence : null;
-
-  const desiredTeams = desiredFee
-    ? [
-        {
-          team: input.homeTeam,
-          opponent: input.awayTeam,
-        },
-        {
-          team: input.awayTeam,
-          opponent: input.homeTeam,
-        },
-      ]
-    : [];
+  const desiredTeams = [
+    {
+      team: input.homeTeam,
+      opponent: input.awayTeam,
+      amountPence:
+        input.homeMatchFeePence && input.homeMatchFeePence > 0
+          ? input.homeMatchFeePence
+          : null,
+    },
+    {
+      team: input.awayTeam,
+      opponent: input.homeTeam,
+      amountPence:
+        input.awayMatchFeePence && input.awayMatchFeePence > 0
+          ? input.awayMatchFeePence
+          : null,
+    },
+  ].filter(
+    (entry): entry is {
+      team: FixtureMatchFeeTeam;
+      opponent: FixtureMatchFeeTeam;
+      amountPence: number;
+    } => entry.amountPence !== null,
+  );
 
   const desiredTeamIds = new Set(desiredTeams.map((entry) => entry.team.id));
   const voidedChargeIds: string[] = [];
@@ -242,7 +253,7 @@ export async function syncFixtureMatchFeeCharges(
     });
   }
 
-  if (!desiredFee) {
+  if (desiredTeams.length === 0) {
     for (const charge of existingCharges) {
       const paidTotalPence = getChargePaidTotal(charge.transactions);
 
@@ -282,6 +293,7 @@ export async function syncFixtureMatchFeeCharges(
     teamName: string;
     teamLogoUrl: string | null;
     paymentToken: string | null;
+    amountPence: number;
   }> = [];
 
   for (const entry of desiredTeams) {
@@ -308,7 +320,7 @@ export async function syncFixtureMatchFeeCharges(
           fixtureId: input.fixtureId,
           title,
           description,
-          amountPence: desiredFee,
+          amountPence: entry.amountPence,
           dueDate: input.kickoffAt,
           status: PaymentChargeStatus.OPEN,
           paymentToken: createPaymentToken(),
@@ -321,6 +333,7 @@ export async function syncFixtureMatchFeeCharges(
         teamName: entry.team.name,
         teamLogoUrl: entry.team.logoUrl ?? null,
         paymentToken: createdCharge.paymentToken,
+        amountPence: createdCharge.amountPence,
       });
 
       continue;
@@ -328,7 +341,7 @@ export async function syncFixtureMatchFeeCharges(
 
     const paidTotalPence = getChargePaidTotal(existingCharge.transactions);
 
-    if (paidTotalPence > 0 && existingCharge.amountPence !== desiredFee) {
+    if (paidTotalPence > 0 && existingCharge.amountPence !== entry.amountPence) {
       throw new Error(
         `Cannot change the match fee amount for ${existingCharge.team.name} because a payment has already been recorded.`,
       );
@@ -342,9 +355,9 @@ export async function syncFixtureMatchFeeCharges(
         fixtureId: input.fixtureId,
         title,
         description,
-        amountPence: desiredFee,
+        amountPence: entry.amountPence,
         dueDate: input.kickoffAt,
-        status: getChargeStatusFromAmounts(desiredFee, paidTotalPence),
+        status: getChargeStatusFromAmounts(entry.amountPence, paidTotalPence),
         paymentToken: existingCharge.paymentToken ?? createPaymentToken(),
       },
     });
@@ -356,6 +369,7 @@ export async function syncFixtureMatchFeeCharges(
         teamName: entry.team.name,
         teamLogoUrl: entry.team.logoUrl ?? null,
         paymentToken: updatedCharge.paymentToken,
+        amountPence: updatedCharge.amountPence,
       });
     }
   }
@@ -421,7 +435,7 @@ export async function queueFixtureMatchFeeEmails(
           leagueDisplayName,
           fixtureName: `${input.homeTeam.name} vs ${input.awayTeam.name}`,
           kickoffLabel: formatKickoffLabel(input.kickoffAt),
-          amount: formatMoney(input.matchFeePence ?? 0),
+          amount: formatMoney(charge.amountPence),
           paymentUrl: buildChargePaymentUrl(charge.paymentToken),
         },
         emailBranding: {
@@ -430,7 +444,7 @@ export async function queueFixtureMatchFeeEmails(
           leagueName: leagueDisplayName,
         },
         paymentSummary: {
-          amount: formatMoney(input.matchFeePence ?? 0),
+          amount: formatMoney(charge.amountPence),
           reason: `${input.homeTeam.name} vs ${input.awayTeam.name}`,
         },
       });


### PR DESCRIPTION
## Superseded

Closing this older PR to avoid confusion.

The separate Team 1 / Team 2 fixture fee work is now already present in `main`, including:
- separate fee parsing in `src/app/(admin)/admin/fixtures/actions.ts`
- per-team charge syncing in `src/lib/payments/fixture-match-fees.ts`
- Team 1 / Team 2 fee fields in `src/components/admin/fixtures/FixturesAdminScreen.tsx`

No merge from this older PR is needed.