### PR TITLE
Show total team communications timeline

### DIFF
--- a/src/app/(admin)/admin/teams/[id]/communications/page.tsx
+++ b/src/app/(admin)/admin/teams/[id]/communications/page.tsx
@@ -4,10 +4,15 @@
 
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import {
+  NotificationChannel,
+  NotificationDispatchStatus,
+} from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
+import { buildChargePaymentUrl } from "@/lib/payments/fixture-match-fees";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -22,8 +27,139 @@ type SearchParams = {
   error?: string;
 };
 
+type TimelineItem = {
+  id: string;
+  source: "dispatch" | "message" | "legacyLeadEmail";
+  channel: NotificationChannel;
+  directionLabel: string;
+  statusLabel: string;
+  sourceLabel: string;
+  subject: string;
+  bodyText: string;
+  bodyHtml: string | null;
+  contactLabel: string;
+  contactValue: string | null;
+  occurredAt: Date;
+  failureReason: string | null;
+  cta: { label: string; url: string } | null;
+};
+
 function getDirectionLabel(value: string) {
   return value === "INBOUND" ? "Inbound" : "Outbound";
+}
+
+function formatDispatchStatus(status: NotificationDispatchStatus) {
+  switch (status) {
+    case "QUEUED":
+      return "Queued";
+    case "PROCESSING":
+      return "Processing";
+    case "SENT":
+      return "Sent";
+    case "FAILED":
+      return "Failed";
+    case "CANCELLED":
+      return "Cancelled";
+    case "SKIPPED":
+      return "Skipped";
+    default:
+      return status;
+  }
+}
+
+function getMetadataRecord(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+
+  return metadata as Record<string, unknown>;
+}
+
+function getDispatchOriginLabel(metadata: unknown) {
+  const record = getMetadataRecord(metadata);
+  const value = record?.originLabel;
+
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+
+  return "Notification dispatch";
+}
+
+function getDispatchCta(input: {
+  metadata: unknown;
+  matchFeeCtaUrl?: string | null;
+}) {
+  const metadata = getMetadataRecord(input.metadata);
+
+  const ctaLabel =
+    typeof metadata?.ctaLabel === "string" && metadata.ctaLabel.trim()
+      ? metadata.ctaLabel.trim()
+      : null;
+
+  const ctaUrl =
+    typeof metadata?.ctaUrl === "string" && metadata.ctaUrl.trim()
+      ? metadata.ctaUrl.trim()
+      : null;
+
+  if (ctaLabel && ctaUrl) {
+    return { label: ctaLabel, url: ctaUrl };
+  }
+
+  const paymentUrl =
+    typeof metadata?.paymentUrl === "string" && metadata.paymentUrl.trim()
+      ? metadata.paymentUrl.trim()
+      : null;
+
+  if (paymentUrl) {
+    return { label: "Pay now", url: paymentUrl };
+  }
+
+  if (input.matchFeeCtaUrl) {
+    return {
+      label: "Review & pay match fee",
+      url: input.matchFeeCtaUrl,
+    };
+  }
+
+  return null;
+}
+
+function formatHistoryBodyText(
+  bodyText: string,
+  cta: { label: string; url: string } | null,
+) {
+  const filteredLines = bodyText
+    .trim()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => {
+      const trimmed = line.trim();
+
+      if (trimmed === "{{cta}}") {
+        return false;
+      }
+
+      if (cta && (trimmed === `${cta.label}: ${cta.url}` || trimmed === cta.url)) {
+        return false;
+      }
+
+      return true;
+    });
+
+  return filteredLines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function getTimelineTone(item: TimelineItem) {
+  if (item.failureReason || item.statusLabel === "Failed") {
+    return "border-red-400/20 bg-red-500/10 text-red-200";
+  }
+
+  if (item.directionLabel === "Inbound") {
+    return "border-sky-400/20 bg-sky-500/10 text-sky-100";
+  }
+
+  return "border-emerald-400/20 bg-emerald-500/10 text-emerald-100";
 }
 
 export default async function AdminTeamCommunicationsPage({
@@ -52,6 +188,26 @@ export default async function AdminTeamCommunicationsPage({
           season: true,
         },
       },
+      convertedFromLead: {
+        select: {
+          id: true,
+          contactName: true,
+          email: true,
+          phone: true,
+          emails: {
+            orderBy: {
+              sentAt: "desc",
+            },
+            select: {
+              id: true,
+              subject: true,
+              body: true,
+              sentTo: true,
+              sentAt: true,
+            },
+          },
+        },
+      },
     },
   });
 
@@ -59,27 +215,157 @@ export default async function AdminTeamCommunicationsPage({
     notFound();
   }
 
-  const { snapshot } = await upsertTeamNotificationRecipient(team.id);
+  const { snapshot, recipient } = await upsertTeamNotificationRecipient(team.id);
 
-  const threads = await prisma.messageThread.findMany({
-    where: {
-      sourceType: "TEAM",
-      sourceId: team.id,
-    },
-    include: {
-      messages: {
-        orderBy: [{ createdAt: "desc" }],
-        take: 100,
+  const [dispatches, threads] = await Promise.all([
+    prisma.notificationDispatch.findMany({
+      where: {
+        OR: [
+          {
+            sourceType: "TEAM",
+            sourceId: team.id,
+          },
+          {
+            recipientId: recipient.id,
+          },
+        ],
       },
-    },
-    orderBy: [{ latestMessageAt: "desc" }, { updatedAt: "desc" }],
-  });
+      include: {
+        recipient: true,
+      },
+      orderBy: [{ createdAt: "desc" }],
+    }),
+    prisma.messageThread.findMany({
+      where: {
+        OR: [{ teamId: team.id }, { recipientId: recipient.id }],
+      },
+      include: {
+        messages: {
+          orderBy: [{ createdAt: "desc" }],
+          take: 250,
+        },
+      },
+      orderBy: [{ latestMessageAt: "desc" }, { updatedAt: "desc" }],
+      take: 100,
+    }),
+  ]);
 
-  const messages = threads
-    .flatMap((thread) => thread.messages.map((message) => ({ thread, message })))
-    .sort((a, b) => b.message.createdAt.getTime() - a.message.createdAt.getTime());
+  const matchFeeChargeIds = Array.from(
+    new Set(
+      dispatches
+        .filter(
+          (dispatch) =>
+            dispatch.sourceType === "FIXTURE_MATCH_FEE" ||
+            dispatch.sourceType === "FIXTURE_MATCH_FEE_REMINDER",
+        )
+        .map((dispatch) => dispatch.sourceId)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  const matchFeeCharges = matchFeeChargeIds.length
+    ? await prisma.paymentCharge.findMany({
+        where: {
+          id: {
+            in: matchFeeChargeIds,
+          },
+        },
+        select: {
+          id: true,
+          paymentToken: true,
+        },
+      })
+    : [];
+
+  const matchFeeCtaUrlByChargeId = new Map(
+    matchFeeCharges
+      .filter((charge) => Boolean(charge.paymentToken))
+      .map((charge) => [
+        charge.id,
+        buildChargePaymentUrl(charge.paymentToken as string),
+      ]),
+  );
+
+  const timeline: TimelineItem[] = [
+    ...dispatches.map((dispatch) => {
+      const matchFeeCtaUrl =
+        dispatch.sourceType === "FIXTURE_MATCH_FEE" ||
+        dispatch.sourceType === "FIXTURE_MATCH_FEE_REMINDER"
+          ? dispatch.sourceId
+            ? matchFeeCtaUrlByChargeId.get(dispatch.sourceId) ?? null
+            : null
+          : null;
+
+      const cta = getDispatchCta({
+        metadata: dispatch.metadata,
+        matchFeeCtaUrl,
+      });
+
+      return {
+        id: `dispatch-${dispatch.id}`,
+        source: "dispatch" as const,
+        channel: dispatch.channel,
+        directionLabel: "Outbound",
+        statusLabel: formatDispatchStatus(dispatch.status),
+        sourceLabel: getDispatchOriginLabel(dispatch.metadata),
+        subject:
+          dispatch.subject?.trim() ||
+          (dispatch.channel === NotificationChannel.SMS ? "SMS message" : "Email"),
+        bodyText: formatHistoryBodyText(dispatch.bodyText, cta),
+        bodyHtml:
+          dispatch.channel === NotificationChannel.EMAIL
+            ? dispatch.bodyHtml ?? null
+            : null,
+        contactLabel: dispatch.recipient.displayName || team.name,
+        contactValue:
+          dispatch.channel === NotificationChannel.SMS
+            ? dispatch.recipient.phone || null
+            : dispatch.recipient.email || null,
+        occurredAt: dispatch.sentAt ?? dispatch.createdAt,
+        failureReason: dispatch.failureReason,
+        cta,
+      };
+    }),
+    ...threads.flatMap((thread) =>
+      thread.messages.map((message) => ({
+        id: `message-${message.id}`,
+        source: "message" as const,
+        channel: message.channel,
+        directionLabel: getDirectionLabel(message.direction),
+        statusLabel: message.providerStatus || "Recorded",
+        sourceLabel: "Inbox thread",
+        subject: message.subject || `${message.channel} message`,
+        bodyText: message.textBody || message.body || "",
+        bodyHtml: message.channel === "EMAIL" ? message.htmlBody || null : null,
+        contactLabel: thread.contactName || snapshot.teamName || team.name,
+        contactValue: message.toEmail || message.toNumber || message.fromNumber || null,
+        occurredAt: message.receivedAt ?? message.sentAt ?? message.createdAt,
+        failureReason: null,
+        cta: null,
+      })),
+    ),
+    ...(team.convertedFromLead?.emails ?? []).map((email) => ({
+      id: `lead-email-${email.id}`,
+      source: "legacyLeadEmail" as const,
+      channel: NotificationChannel.EMAIL,
+      directionLabel: "Outbound",
+      statusLabel: "Sent",
+      sourceLabel: "Converted lead history",
+      subject: email.subject?.trim() || "Email",
+      bodyText: email.body,
+      bodyHtml: null,
+      contactLabel: team.convertedFromLead?.contactName || team.name,
+      contactValue: email.sentTo,
+      occurredAt: email.sentAt,
+      failureReason: null,
+      cta: null,
+    })),
+  ].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
 
   const inboxUrl = `/admin/messages?composeTeam=${encodeURIComponent(team.id)}`;
+  const emailCount = timeline.filter((item) => item.channel === NotificationChannel.EMAIL).length;
+  const smsCount = timeline.filter((item) => item.channel === NotificationChannel.SMS).length;
+  const inboundCount = timeline.filter((item) => item.directionLabel === "Inbound").length;
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">
@@ -93,7 +379,7 @@ export default async function AdminTeamCommunicationsPage({
           </Link>
           <h1 className="text-3xl font-semibold text-white">{team.name} communications</h1>
           <p className="text-sm text-white/60">
-            Team communication history stays here. New sends and live replies are now handled from the admin inbox.
+            Full team communication history in one place, combining dispatches, inbox thread messages, and converted lead email history.
           </p>
         </div>
 
@@ -123,13 +409,13 @@ export default async function AdminTeamCommunicationsPage({
         <div className="grid gap-8 px-6 py-6 lg:grid-cols-[1.05fr_0.95fr] lg:px-8 lg:py-8">
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
-              Communications history
+              Total history
             </p>
             <h2 className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
-              Team timeline
+              Unified timeline
             </h2>
             <p className="mt-3 max-w-2xl text-sm text-white/70 sm:text-base">
-              Keep a clean team-level record of what has been sent and received, while using the inbox as the single operational place to send new messages and manage replies.
+              This view combines team dispatches, inbox replies, inbox outbound messages, and converted lead email history into one team-level record.
             </p>
 
             <div className="mt-5 flex flex-wrap gap-2">
@@ -153,20 +439,22 @@ export default async function AdminTeamCommunicationsPage({
             </div>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid gap-3 sm:grid-cols-4">
             <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">Threads</p>
-              <p className="mt-3 text-3xl font-semibold text-white">{threads.length}</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">Timeline</p>
+              <p className="mt-3 text-3xl font-semibold text-white">{timeline.length}</p>
             </div>
             <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">Messages</p>
-              <p className="mt-3 text-3xl font-semibold text-white">{messages.length}</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">Email</p>
+              <p className="mt-3 text-3xl font-semibold text-white">{emailCount}</p>
             </div>
             <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">Unread</p>
-              <p className="mt-3 text-3xl font-semibold text-white">
-                {threads.reduce((sum, thread) => sum + thread.unreadForAdminCount, 0)}
-              </p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">SMS</p>
+              <p className="mt-3 text-3xl font-semibold text-white">{smsCount}</p>
+            </div>
+            <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">Inbound</p>
+              <p className="mt-3 text-3xl font-semibold text-white">{inboundCount}</p>
             </div>
           </div>
         </div>
@@ -174,18 +462,18 @@ export default async function AdminTeamCommunicationsPage({
 
       <section className="grid gap-6 xl:grid-cols-[0.42fr_1.58fr]">
         <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Sending moved</p>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Operational note</p>
           <h2 className="mt-2 text-xl font-semibold text-white">Use the inbox</h2>
           <p className="mt-3 text-sm leading-6 text-white/65">
-            Sending and reply controls have been removed from this page so there is one clear place to manage team communications.
+            This page is now the total team communications history. New sends and live reply handling still happen from the admin inbox.
           </p>
 
           <div className="mt-5 space-y-3">
             <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-white/70">
-              Team pages now show history and context only.
+              History here is pulled from multiple sources, not just one thread view.
             </div>
             <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-white/70">
-              The admin inbox is now the single place to send messages and manage replies.
+              Use the admin inbox for active messaging and reply handling.
             </div>
             <Link
               href={inboxUrl}
@@ -205,49 +493,75 @@ export default async function AdminTeamCommunicationsPage({
           </div>
 
           <div className="divide-y divide-white/10">
-            {messages.length === 0 ? (
+            {timeline.length === 0 ? (
               <div className="px-6 py-10 text-sm text-white/55">
                 No communications have been logged for this team yet.
               </div>
             ) : (
-              messages.map(({ thread, message }) => (
-                <div key={message.id} className="space-y-3 px-6 py-5">
+              timeline.map((item) => (
+                <div key={item.id} className="space-y-3 px-6 py-5">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] text-white/70">
-                      {message.channel}
+                      {item.channel}
+                    </span>
+                    <span className={`rounded-full border px-2.5 py-1 text-[11px] ${getTimelineTone(item)}`}>
+                      {item.directionLabel}
                     </span>
                     <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] text-white/70">
-                      {getDirectionLabel(message.direction)}
+                      {item.statusLabel}
                     </span>
                     <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] text-white/55">
-                      {message.providerStatus || "RECORDED"}
+                      {item.sourceLabel}
                     </span>
                   </div>
 
                   <div>
                     <div className="text-sm font-semibold text-white">
-                      {message.subject || `${message.channel} message`}
+                      {item.subject}
                     </div>
                     <div className="mt-1 text-xs text-white/45">
-                      {thread.contactName || team.name}
-                      {message.toEmail ? ` · ${message.toEmail}` : ""}
-                      {message.toNumber ? ` · ${message.toNumber}` : ""}
+                      {item.contactLabel}
+                      {item.contactValue ? ` · ${item.contactValue}` : ""}
                     </div>
                   </div>
 
-                  {message.channel === "EMAIL" && message.htmlBody ? (
+                  {item.channel === NotificationChannel.EMAIL && item.bodyHtml ? (
                     <div className="overflow-hidden rounded-2xl border border-white/10 bg-white">
-                      <div dangerouslySetInnerHTML={{ __html: message.htmlBody }} />
+                      <div dangerouslySetInnerHTML={{ __html: item.bodyHtml }} />
                     </div>
                   ) : (
-                    <div className="whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/30 p-4 text-sm leading-6 text-white/80">
-                      {message.textBody || message.body}
-                    </div>
+                    <>
+                      <div className="whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/30 p-4 text-sm leading-6 text-white/80">
+                        {item.bodyText}
+                      </div>
+
+                      {item.cta ? (
+                        <div className="mt-3">
+                          <a
+                            href={item.cta.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+                          >
+                            {item.cta.label}
+                          </a>
+                          <div className="mt-2 break-all text-xs text-emerald-300">
+                            {item.cta.url}
+                          </div>
+                        </div>
+                      ) : null}
+                    </>
                   )}
 
                   <div className="text-xs text-white/45">
-                    {message.createdAt.toLocaleString()}
+                    {item.occurredAt.toLocaleString()}
                   </div>
+
+                  {item.failureReason ? (
+                    <div className="text-xs text-red-300">
+                      Failure: {item.failureReason}
+                    </div>
+                  ) : null}
                 </div>
               ))
             )}


### PR DESCRIPTION
## Summary
- turn the team communications page into a true unified history view
- include notification dispatch history, inbox thread messages, and converted lead email history together
- sort everything into one chronological timeline
- keep the admin inbox as the operational place to send new messages and handle replies

## Result
The team communications page now gives a total team-level view instead of only showing thread-linked messages.