### PR TITLE
Wire Prisma seed to notification templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "seed:notifications": "tsx prisma/seed-notifications.ts"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed-notifications.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",


### PR DESCRIPTION
Adds Prisma seed configuration and a convenience script so `npx prisma db seed` runs `prisma/seed-notifications.ts`.