### PR TITLE
Fix template delete button action

### DIFF
--- a/src/components/admin/templates/DeleteTemplateButton.tsx
+++ b/src/components/admin/templates/DeleteTemplateButton.tsx
@@ -28,18 +28,26 @@ export default function DeleteTemplateButton({
   templateName,
 }: DeleteTemplateButtonProps) {
   return (
-    <form
-      onSubmit={(event) => {
-        const confirmed = window.confirm(
-          `Delete \"${templateName}\"? This cannot be undone.`,
-        );
+    <div
+      onClick={(event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+          return;
+        }
 
-        if (!confirmed) {
-          event.preventDefault();
+        if (target.closest("button[type='submit']")) {
+          const confirmed = window.confirm(
+            `Delete \"${templateName}\"? This cannot be undone.`,
+          );
+
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
         }
       }}
     >
       <SubmitButton />
-    </form>
+    </div>
   );
 }


### PR DESCRIPTION
Repairs the templates delete button by removing the nested form behavior that stopped the delete action from firing.