### PR TITLE
Track managed player fee payment method

### DIFF
--- a/src/app/(admin)/admin/teams/[id]/match-fees/actions.ts
+++ b/src/app/(admin)/admin/teams/[id]/match-fees/actions.ts
@@ -62,6 +62,38 @@ function getMatchFeesPath(teamId: string, fixtureId?: string, suffix = "") {
   return `/admin/teams/${teamId}/match-fees${query}`;
 }
 
+function getPaidMethodNote(method: string) {
+  switch (method) {
+    case "CASH":
+      return "Paid cash";
+    case "ONLINE":
+      return "Paid online/manual";
+    case "CARD":
+      return "Paid by card";
+    case "BANK_TRANSFER":
+      return "Paid by bank transfer";
+    default:
+      return "Paid manually";
+  }
+}
+
+function mergePaymentNote(input: {
+  existingNote: string | null;
+  methodNote: string;
+}) {
+  const existingNote = input.existingNote?.trim();
+
+  if (!existingNote) {
+    return input.methodNote;
+  }
+
+  if (existingNote.includes(input.methodNote)) {
+    return existingNote;
+  }
+
+  return `${existingNote}\n${input.methodNote}`;
+}
+
 export async function createPlayerMatchFeesAction(formData: FormData) {
   await requireAdmin();
 
@@ -212,6 +244,57 @@ export async function updatePlayerMatchFeeStatusAction(formData: FormData) {
       paidAt: status === "PAID" ? now : null,
       waivedAt: status === "WAIVED" ? now : null,
       cancelledAt: status === "CANCELLED" ? now : null,
+    },
+  });
+
+  revalidatePath(getMatchFeesPath(teamId, fixtureId));
+  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
+}
+
+export async function markPlayerMatchFeePaidAction(formData: FormData) {
+  await requireAdmin();
+
+  const teamId = getString(formData, "teamId");
+  const fixtureId = getString(formData, "fixtureId");
+  const feeId = getString(formData, "feeId");
+  const method = getString(formData, "method");
+
+  if (!teamId || !fixtureId || !feeId) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
+  }
+
+  const existingFee = await prisma.playerMatchFee.findFirst({
+    where: {
+      id: feeId,
+      teamId,
+      fixtureId,
+    },
+    select: {
+      id: true,
+      note: true,
+    },
+  });
+
+  if (!existingFee) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
+  }
+
+  const now = new Date();
+  const methodNote = getPaidMethodNote(method);
+
+  await prisma.playerMatchFee.update({
+    where: {
+      id: existingFee.id,
+    },
+    data: {
+      status: "PAID",
+      paidAt: now,
+      waivedAt: null,
+      cancelledAt: null,
+      note: mergePaymentNote({
+        existingNote: existingFee.note,
+        methodNote,
+      }),
     },
   });
 

--- a/src/app/(admin)/admin/teams/[id]/match-fees/page.tsx
+++ b/src/app/(admin)/admin/teams/[id]/match-fees/page.tsx
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import {
   createPlayerMatchFeesAction,
+  markPlayerMatchFeePaidAction,
   updatePlayerMatchFeeAmountAction,
   updatePlayerMatchFeeStatusAction,
 } from "./actions";
@@ -240,6 +241,18 @@ export default async function AdminManagedPlayerMatchFeesPage({
     { total: 0, paid: 0, open: 0, waived: 0 },
   );
 
+  const cashTotal = fees.reduce((sum, fee) => {
+    return fee.status === "PAID" && fee.note?.includes("Paid cash")
+      ? sum + fee.amountPence
+      : sum;
+  }, 0);
+
+  const onlineTotal = fees.reduce((sum, fee) => {
+    return fee.status === "PAID" && fee.note?.includes("Paid online")
+      ? sum + fee.amountPence
+      : sum;
+  }, 0);
+
   const paidCount = fees.filter((fee) => fee.status === "PAID").length;
   const openCount = fees.filter((fee) => fee.status === "OPEN").length;
   const savedMessage = getSavedMessage(sp.saved);
@@ -322,6 +335,21 @@ export default async function AdminManagedPlayerMatchFeesPage({
           <p className="mt-1 text-sm text-sky-100/70">Manual admin override.</p>
         </div>
       </section>
+
+      {fees.length > 0 ? (
+        <section className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+            <p className="text-xs uppercase tracking-[0.16em] text-white/45">Cash collected</p>
+            <p className="mt-2 text-2xl font-semibold text-white">{formatMoney(cashTotal)}</p>
+            <p className="mt-1 text-sm text-white/50">Marked using the Paid cash button.</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+            <p className="text-xs uppercase tracking-[0.16em] text-white/45">Online/manual collected</p>
+            <p className="mt-2 text-2xl font-semibold text-white">{formatMoney(onlineTotal)}</p>
+            <p className="mt-1 text-sm text-white/50">Marked using the Paid online button.</p>
+          </div>
+        </section>
+      ) : null}
 
       <section className="grid gap-6 xl:grid-cols-[0.9fr_1.3fr]">
         <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
@@ -503,7 +531,7 @@ export default async function AdminManagedPlayerMatchFeesPage({
           <div>
             <h2 className="text-lg font-semibold text-white">Fee tracker</h2>
             <p className="mt-1 text-sm text-white/55">
-              Manual tracking for the selected fixture. Payment links can be added once this workflow is proven.
+              Manual tracking for the selected fixture. Use Paid cash or Paid online so the night can be reconciled properly.
             </p>
           </div>
           {selectedFixture ? (
@@ -541,6 +569,8 @@ export default async function AdminManagedPlayerMatchFeesPage({
                 ? [fee.prospect.email, fee.prospect.phone].filter(Boolean).join(" · ") || "No contact"
                 : "No contact";
 
+            const statusButtons = ["OPEN", "WAIVED", "CANCELLED"] as PlayerMatchFeeStatus[];
+
             return (
               <div
                 key={fee.id}
@@ -563,6 +593,11 @@ export default async function AdminManagedPlayerMatchFeesPage({
                     {fee.waivedAt ? ` · Waived ${formatUkDateTime(fee.waivedAt)}` : ""}
                     {fee.cancelledAt ? ` · Cancelled ${formatUkDateTime(fee.cancelledAt)}` : ""}
                   </div>
+                  {fee.note ? (
+                    <div className="mt-2 whitespace-pre-line rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs leading-5 text-white/55">
+                      {fee.note}
+                    </div>
+                  ) : null}
                 </div>
 
                 <div className="flex flex-wrap gap-2 lg:justify-end">
@@ -585,7 +620,35 @@ export default async function AdminManagedPlayerMatchFeesPage({
                     </button>
                   </form>
 
-                  {(["OPEN", "PAID", "WAIVED", "CANCELLED"] as PlayerMatchFeeStatus[]).map((status) => (
+                  <form action={markPlayerMatchFeePaidAction}>
+                    <input type="hidden" name="teamId" value={team.id} />
+                    <input type="hidden" name="fixtureId" value={fee.fixtureId} />
+                    <input type="hidden" name="feeId" value={fee.id} />
+                    <input type="hidden" name="method" value="CASH" />
+                    <button
+                      type="submit"
+                      disabled={fee.status === "PAID" && fee.note?.includes("Paid cash")}
+                      className="rounded-xl border border-emerald-400/20 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      Paid cash
+                    </button>
+                  </form>
+
+                  <form action={markPlayerMatchFeePaidAction}>
+                    <input type="hidden" name="teamId" value={team.id} />
+                    <input type="hidden" name="fixtureId" value={fee.fixtureId} />
+                    <input type="hidden" name="feeId" value={fee.id} />
+                    <input type="hidden" name="method" value="ONLINE" />
+                    <button
+                      type="submit"
+                      disabled={fee.status === "PAID" && fee.note?.includes("Paid online")}
+                      className="rounded-xl border border-sky-400/20 bg-sky-500/10 px-3 py-2 text-sm font-medium text-sky-100 transition hover:bg-sky-500/15 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      Paid online
+                    </button>
+                  </form>
+
+                  {statusButtons.map((status) => (
                     <form key={status} action={updatePlayerMatchFeeStatusAction}>
                       <input type="hidden" name="teamId" value={team.id} />
                       <input type="hidden" name="fixtureId" value={fee.fixtureId} />


### PR DESCRIPTION
Adds a safer first version of managed player fee payment method tracking without a Prisma migration.

Changes:
- Adds `markPlayerMatchFeePaidAction` to mark a player fee as paid while recording the method in the existing `note` field.
- Adds `Paid cash` and `Paid online` buttons to the managed player match fee tracker.
- Keeps `Open`, `Waived`, and `Cancelled` actions.
- Displays fee notes so the method is visible on each row.
- Adds cash collected and online/manual collected totals.

Why no schema change yet:
- This avoids a production database migration while proving the managed squad workflow quickly.
- Later, we can promote this into proper `paymentMethod` / `paymentReference` fields once the workflow is confirmed.

Note:
- Branch appears one commit behind main because main moved while the branch was being prepared. Review/merge after updating the branch if needed.