### PR TITLE
Apply Resend delivery feedback on current main

### DIFF
--- a/docs/messaging-stage-2-apply.md
+++ b/docs/messaging-stage-2-apply.md
@@ -1,46 +1,67 @@
 # Messaging Stage 2 apply guide
 
-Use branch feature/messaging-webhooks-from-main.
+This guide covers the live messaging/webhook setup for SIXFL.
 
-## Added in this follow-up
+## Webhook routes
 
-- src/lib/notifications/webhooks.ts
-- src/app/api/webhooks/resend/route.ts
-- src/app/api/webhooks/twilio/route.ts
-- docs/messaging-stage-2-apply.md
-
-## What is already in main
-
-- src/lib/notifications/providers/resend.ts
-- src/lib/notifications/providers/twilio.ts
-- src/lib/notifications/processor.ts
-- src/lib/notifications/transactional.ts
-- src/app/api/cron/notifications/route.ts
+- Resend delivery feedback: `/api/webhooks/resend`
+- Twilio delivery feedback: `/api/webhooks/twilio`
+- Notification worker/cron: `/api/cron/notifications`
 
 ## Environment variables
 
 Required for email sending:
-- RESEND_API_KEY
-- EMAIL_FROM
+
+- `RESEND_API_KEY`
+- `EMAIL_FROM`
+
+Required for Resend webhook verification:
+
+- `RESEND_WEBHOOK_SECRET`
 
 Required for SMS sending:
-- TWILIO_ACCOUNT_SID
-- TWILIO_AUTH_TOKEN
-- one of TWILIO_MESSAGING_SERVICE_SID or TWILIO_PHONE_NUMBER
+
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- one of `TWILIO_MESSAGING_SERVICE_SID` or `TWILIO_PHONE_NUMBER`
 
 Optional route protection:
-- CRON_SECRET
-- RESEND_WEBHOOK_SECRET
-- TWILIO_WEBHOOK_SECRET
 
-## What this follow-up does
+- `CRON_SECRET`
+- `TWILIO_WEBHOOK_SECRET`
 
-- adds Resend webhook handling for sent/delivered/failed style events
-- adds Twilio webhook handling for sent/delivered/failed style events
-- records provider webhook outcomes back into notification attempts and dispatches
+## Resend production setup
 
-## What is still next
+Register this endpoint in Resend:
 
-- confirm hosting routes and webhook secrets are configured
-- register webhook endpoints with Resend and Twilio
-- optionally add richer delivery reporting in admin UI
+- `https://www.sixfl.co.uk/api/webhooks/resend`
+
+Enable at least these events:
+
+- `email.sent`
+- `email.delivered`
+- `email.delivery_delayed`
+- `email.bounced`
+- `email.failed`
+- `email.suppressed`
+- `email.complained`
+
+Optional engagement events:
+
+- `email.opened`
+- `email.clicked`
+
+Copy the webhook signing secret from Resend into production as `RESEND_WEBHOOK_SECRET`.
+
+## What Resend feedback updates
+
+- verifies Resend delivery webhooks using the signed `svix-*` headers
+- records sent/delivered feedback
+- records failed/bounced/complained/suppressed feedback
+- records delivery delayed feedback
+- updates outbound email message entries with statuses such as `SENT`, `DELIVERED`, `FAILED`, `BOUNCED`, `SUPPRESSED`, `COMPLAINED`, or `DELIVERY_DELAYED`
+- marks recipients as suppressed when Resend reports `email.suppressed` or `email.complained`
+
+## Manual sends
+
+Manual admin sends should process immediately after being queued. Scheduled sends, fixture reminders, payment reminders, and quiet-hours SMS are intentionally left queued until their scheduled send time.

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -2,42 +2,83 @@
 // File: src/app/api/webhooks/resend/route.ts
 // ========================================
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { handleResendWebhook } from "@/lib/notifications/webhooks";
+import {
+  getResendWebhookDeliveryId,
+  verifyResendWebhookRequest,
+} from "@/lib/resend/verifyWebhook";
 
 export const dynamic = "force-dynamic";
 
-function isAuthorized(request: NextRequest) {
-  const configuredSecret = process.env.RESEND_WEBHOOK_SECRET?.trim();
-
-  if (!configuredSecret) {
-    return true;
-  }
-
-  const providedSecret = request.headers.get("x-resend-webhook-secret")?.trim();
-  return providedSecret === configuredSecret;
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
 }
 
-export async function POST(request: NextRequest) {
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-  }
+export async function POST(request: Request): Promise<Response> {
+  const deliveryId = getResendWebhookDeliveryId(request);
 
   try {
-    const payload = (await request.json()) as Record<string, unknown>;
-    const result = await handleResendWebhook(payload);
+    const { event } = await verifyResendWebhookRequest(request);
+    const result = await handleResendWebhook(event);
 
-    return NextResponse.json(result);
+    return jsonResponse({
+      deliveryId,
+      ...result,
+    });
   } catch (error) {
-    return NextResponse.json(
+    const message =
+      error instanceof Error ? error.message : "Resend webhook processing failed.";
+
+    console.error("[resend] delivery webhook failed", {
+      deliveryId,
+      message,
+    });
+
+    if (
+      message.includes("Missing Resend webhook headers") ||
+      message.includes("RESEND_WEBHOOK_SECRET is missing")
+    ) {
+      return jsonResponse(
+        {
+          ok: false,
+          deliveryId,
+          error: message,
+        },
+        400,
+      );
+    }
+
+    if (/signature|verify|verification|timestamp/i.test(message)) {
+      return jsonResponse(
+        {
+          ok: false,
+          deliveryId,
+          error: "Invalid Resend webhook signature.",
+        },
+        401,
+      );
+    }
+
+    return jsonResponse(
       {
         ok: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Resend webhook processing failed.",
+        deliveryId,
+        error: message,
       },
-      { status: 500 },
+      500,
     );
   }
+}
+
+export async function GET(): Promise<Response> {
+  return jsonResponse({
+    ok: true,
+    route: "resend delivery webhook",
+  });
 }

--- a/src/lib/notifications/webhooks.ts
+++ b/src/lib/notifications/webhooks.ts
@@ -13,29 +13,230 @@ function asJsonValue(value: unknown): Prisma.InputJsonValue {
   return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
 }
 
-function extractResendMessageId(payload: Record<string, unknown>) {
-  const directId = payload.email_id;
-  if (typeof directId === "string" && directId.trim()) return directId.trim();
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
 
-  const data = payload.data;
-  if (data && typeof data === "object") {
-    const nestedId = (data as Record<string, unknown>).email_id;
-    if (typeof nestedId === "string" && nestedId.trim()) return nestedId.trim();
+  return value as Record<string, unknown>;
+}
+
+function getStringValue(value: unknown) {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function getNestedString(
+  record: Record<string, unknown> | null,
+  keys: string[],
+) {
+  if (!record) return null;
+
+  let current: unknown = record;
+
+  for (const key of keys) {
+    const currentRecord = asRecord(current);
+    if (!currentRecord) return null;
+
+    current = currentRecord[key];
+  }
+
+  return getStringValue(current);
+}
+
+function extractResendMessageId(payload: Record<string, unknown>) {
+  const data = asRecord(payload.data);
+
+  const candidates = [
+    payload.email_id,
+    payload.emailId,
+    payload.id,
+    data?.email_id,
+    data?.emailId,
+    data?.id,
+    getNestedString(data, ["email", "id"]),
+  ];
+
+  for (const candidate of candidates) {
+    const value = getStringValue(candidate);
+    if (value) return value;
   }
 
   return null;
 }
 
 function extractResendEventType(payload: Record<string, unknown>) {
-  const directType = payload.type;
-  if (typeof directType === "string") return directType.toLowerCase();
+  const directType = getStringValue(payload.type);
+  if (directType) return directType.toLowerCase();
 
   return "unknown";
+}
+
+function extractResendEventReason(
+  payload: Record<string, unknown>,
+  eventType: string,
+) {
+  const data = asRecord(payload.data);
+
+  const candidates = [
+    payload.reason,
+    payload.message,
+    payload.error,
+    data?.reason,
+    data?.message,
+    data?.error,
+    data?.status,
+    data?.bounce_reason,
+    data?.bounceMessage,
+    getNestedString(data, ["bounce", "reason"]),
+    getNestedString(data, ["bounce", "message"]),
+    getNestedString(data, ["complaint", "type"]),
+    getNestedString(data, ["suppression", "reason"]),
+  ];
+
+  for (const candidate of candidates) {
+    const value = getStringValue(candidate);
+
+    if (value && value.toLowerCase() !== eventType) {
+      return `${eventType}: ${value}`;
+    }
+  }
+
+  return eventType;
+}
+
+type ResendEventClassification = {
+  attemptStatus: NotificationAttemptStatus;
+  providerStatus: string;
+  resultStatus: "sent" | "failed" | "delayed" | "engagement";
+  dispatchStatus: NotificationDispatchStatus | null;
+  isFailure: boolean;
+  suppressRecipient: boolean;
+};
+
+const FINAL_NOTIFICATION_DISPATCH_STATUSES: NotificationDispatchStatus[] = [
+  NotificationDispatchStatus.CANCELLED,
+  NotificationDispatchStatus.FAILED,
+  NotificationDispatchStatus.SKIPPED,
+];
+
+function classifyResendEvent(
+  eventType: string,
+): ResendEventClassification | null {
+  switch (eventType) {
+    case "email.sent":
+      return {
+        attemptStatus: NotificationAttemptStatus.SUCCESS,
+        providerStatus: "SENT",
+        resultStatus: "sent",
+        dispatchStatus: NotificationDispatchStatus.SENT,
+        isFailure: false,
+        suppressRecipient: false,
+      };
+    case "email.delivered":
+      return {
+        attemptStatus: NotificationAttemptStatus.SUCCESS,
+        providerStatus: "DELIVERED",
+        resultStatus: "sent",
+        dispatchStatus: NotificationDispatchStatus.SENT,
+        isFailure: false,
+        suppressRecipient: false,
+      };
+    case "email.opened":
+      return {
+        attemptStatus: NotificationAttemptStatus.SUCCESS,
+        providerStatus: "OPENED",
+        resultStatus: "engagement",
+        dispatchStatus: null,
+        isFailure: false,
+        suppressRecipient: false,
+      };
+    case "email.clicked":
+      return {
+        attemptStatus: NotificationAttemptStatus.SUCCESS,
+        providerStatus: "CLICKED",
+        resultStatus: "engagement",
+        dispatchStatus: null,
+        isFailure: false,
+        suppressRecipient: false,
+      };
+    case "email.delivery_delayed":
+      return {
+        attemptStatus: NotificationAttemptStatus.PENDING,
+        providerStatus: "DELIVERY_DELAYED",
+        resultStatus: "delayed",
+        dispatchStatus: null,
+        isFailure: false,
+        suppressRecipient: false,
+      };
+    case "email.bounced":
+      return {
+        attemptStatus: NotificationAttemptStatus.FAILED,
+        providerStatus: "BOUNCED",
+        resultStatus: "failed",
+        dispatchStatus: NotificationDispatchStatus.FAILED,
+        isFailure: true,
+        suppressRecipient: false,
+      };
+    case "email.failed":
+      return {
+        attemptStatus: NotificationAttemptStatus.FAILED,
+        providerStatus: "FAILED",
+        resultStatus: "failed",
+        dispatchStatus: NotificationDispatchStatus.FAILED,
+        isFailure: true,
+        suppressRecipient: false,
+      };
+    case "email.complained":
+      return {
+        attemptStatus: NotificationAttemptStatus.FAILED,
+        providerStatus: "COMPLAINED",
+        resultStatus: "failed",
+        dispatchStatus: NotificationDispatchStatus.FAILED,
+        isFailure: true,
+        suppressRecipient: true,
+      };
+    case "email.suppressed":
+      return {
+        attemptStatus: NotificationAttemptStatus.FAILED,
+        providerStatus: "SUPPRESSED",
+        resultStatus: "failed",
+        dispatchStatus: NotificationDispatchStatus.FAILED,
+        isFailure: true,
+        suppressRecipient: true,
+      };
+    default:
+      return null;
+  }
+}
+
+function getProviderStatusLabel(
+  classification: ResendEventClassification,
+  reason: string,
+) {
+  if (!classification.isFailure && classification.resultStatus !== "delayed") {
+    return classification.providerStatus;
+  }
+
+  return `${classification.providerStatus}: ${reason}`;
+}
+
+function uniqueStrings(values: Array<string | null | undefined>) {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => value?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
 }
 
 export async function handleResendWebhook(payload: Record<string, unknown>) {
   const providerMessageId = extractResendMessageId(payload);
   const eventType = extractResendEventType(payload);
+  const classification = classifyResendEvent(eventType);
 
   if (!providerMessageId) {
     return {
@@ -45,70 +246,162 @@ export async function handleResendWebhook(payload: Record<string, unknown>) {
     };
   }
 
-  const dispatch = await prisma.notificationDispatch.findFirst({
+  if (!classification) {
+    return {
+      ok: true,
+      ignored: true,
+      reason: `Unhandled Resend event: ${eventType}`,
+    };
+  }
+
+  const messageEntries = await prisma.messageEntry.findMany({
     where: {
+      channel: "EMAIL",
+      direction: "OUTBOUND",
+      OR: [
+        { providerMessageId },
+        { resendEmailId: providerMessageId },
+      ],
+    },
+    select: {
+      id: true,
+      notificationDispatchId: true,
+      thread: {
+        select: {
+          recipientId: true,
+        },
+      },
+    },
+  });
+
+  const dispatchIdsFromMessages = uniqueStrings(
+    messageEntries.map((entry) => entry.notificationDispatchId),
+  );
+
+  const dispatchWhere: Prisma.NotificationDispatchWhereInput[] = [
+    {
       provider: "resend",
       providerMessageId,
+    },
+  ];
+
+  if (dispatchIdsFromMessages.length > 0) {
+    dispatchWhere.push({
+      id: {
+        in: dispatchIdsFromMessages,
+      },
+    });
+  }
+
+  const dispatches = await prisma.notificationDispatch.findMany({
+    where: {
+      OR: dispatchWhere,
     },
     select: {
       id: true,
       status: true,
+      recipientId: true,
+      sentAt: true,
     },
   });
 
-  if (!dispatch) {
+  if (dispatches.length === 0 && messageEntries.length === 0) {
     return {
       ok: true,
       ignored: true,
-      reason: "No matching dispatch found.",
+      reason: "No matching dispatch or message entry found.",
     };
   }
 
-  const failureEvents = new Set(["email.bounced", "email.complained", "email.failed"]);
-  const successEvents = new Set(["email.sent", "email.delivered"]);
+  const now = new Date();
+  const reason = extractResendEventReason(payload, eventType);
+  const providerStatus = getProviderStatusLabel(classification, reason);
+  const messageEntryIds = messageEntries.map((entry) => entry.id);
+  const recipientIds = uniqueStrings([
+    ...dispatches.map((dispatch) => dispatch.recipientId),
+    ...messageEntries.map((entry) => entry.thread.recipientId),
+  ]);
 
-  if (failureEvents.has(eventType)) {
-    await prisma.$transaction(async (tx) => {
+  await prisma.$transaction(async (tx) => {
+    for (const dispatch of dispatches) {
       await tx.notificationAttempt.create({
         data: {
           dispatchId: dispatch.id,
           provider: "resend",
-          status: NotificationAttemptStatus.FAILED,
+          status: classification.attemptStatus,
           responsePayload: asJsonValue(payload),
-          errorMessage: eventType,
+          errorMessage:
+            classification.isFailure || classification.resultStatus === "delayed"
+              ? reason
+              : null,
         },
       });
 
-      await tx.notificationDispatch.update({
-        where: { id: dispatch.id },
+      if (classification.dispatchStatus === NotificationDispatchStatus.FAILED) {
+        await tx.notificationDispatch.update({
+          where: { id: dispatch.id },
+          data: {
+            status: NotificationDispatchStatus.FAILED,
+            failedAt: now,
+            failureReason: reason,
+          },
+        });
+      }
+
+      if (
+        classification.dispatchStatus === NotificationDispatchStatus.SENT &&
+        !FINAL_NOTIFICATION_DISPATCH_STATUSES.includes(dispatch.status)
+      ) {
+        await tx.notificationDispatch.update({
+          where: { id: dispatch.id },
+          data: {
+            status: NotificationDispatchStatus.SENT,
+            sentAt: dispatch.sentAt ?? now,
+          },
+        });
+      }
+    }
+
+    if (messageEntryIds.length > 0) {
+      await tx.messageEntry.updateMany({
+        where: {
+          id: {
+            in: messageEntryIds,
+          },
+        },
         data: {
-          status: NotificationDispatchStatus.FAILED,
-          failedAt: new Date(),
-          failureReason: eventType,
+          provider: "resend",
+          providerMessageId,
+          providerStatus,
+          resendEmailId: providerMessageId,
+          resendPayload: asJsonValue(payload),
         },
       });
-    });
+    }
 
-    return { ok: true, updated: true, status: "failed" };
-  }
-
-  if (successEvents.has(eventType)) {
-    await prisma.notificationAttempt.create({
-      data: {
-        dispatchId: dispatch.id,
-        provider: "resend",
-        status: NotificationAttemptStatus.SUCCESS,
-        responsePayload: asJsonValue(payload),
-      },
-    });
-
-    return { ok: true, updated: true, status: "sent" };
-  }
+    if (classification.suppressRecipient && recipientIds.length > 0) {
+      await tx.notificationRecipient.updateMany({
+        where: {
+          id: {
+            in: recipientIds,
+          },
+        },
+        data: {
+          isSuppressed: true,
+          suppressionReason: reason,
+        },
+      });
+    }
+  });
 
   return {
     ok: true,
-    ignored: true,
-    reason: `Unhandled Resend event: ${eventType}`,
+    updated: true,
+    status: classification.resultStatus,
+    eventType,
+    providerStatus,
+    dispatchCount: dispatches.length,
+    messageEntryCount: messageEntries.length,
   };
 }
 


### PR DESCRIPTION
## Summary

- apply the Resend delivery webhook changes onto current main
- verify signed Resend webhooks
- update notification dispatches and message entries with delivery outcomes
- update the messaging setup guide

## Notes

- No database reset
- No destructive migration
- Recreated from current main rather than the stale PR branch