### PR TITLE
Show and process single lead SMS sends

### DIFF
--- a/src/app/(admin)/admin/leads/[id]/actions.ts
+++ b/src/app/(admin)/admin/leads/[id]/actions.ts
@@ -16,6 +16,7 @@ import {
   NotificationChannel,
   TeamRole,
 } from "@prisma/client";
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import {
@@ -27,6 +28,7 @@ import {
   mergeEmailTemplateContext,
   resolveTemplateText,
 } from "@/lib/email/template-context";
+import { processNotificationQueue } from "@/lib/notifications/processor";
 import { queueDirectNotification } from "@/lib/notifications/service";
 import { normalizeUkMobileNumber } from "@/lib/phone/normalize";
 
@@ -272,6 +274,14 @@ async function ensureLeadSmsNotificationRecipient(input: {
   });
 
   return recipient;
+}
+
+async function processLeadSmsImmediately() {
+  try {
+    await processNotificationQueue(10);
+  } catch (error) {
+    console.error("Failed to process lead SMS immediately", error);
+  }
 }
 
 // ========================================
@@ -533,6 +543,13 @@ export async function sendLeadSmsAction(formData: FormData) {
       createdByUserId: user?.id ?? null,
     });
 
+    await logNotificationDispatchToThread({
+      dispatch,
+      recipient,
+    });
+
+    await processLeadSmsImmediately();
+
     if (lead.status === LeadStatus.NEW) {
       await prisma.interestLead.update({
         where: { id: lead.id },
@@ -545,6 +562,7 @@ export async function sendLeadSmsAction(formData: FormData) {
 
     revalidatePath("/admin/leads");
     revalidatePath(`/admin/leads/${lead.id}`);
+    revalidatePath("/admin/messaging");
 
     return {
       ok: true,


### PR DESCRIPTION
## Summary

- log single-lead SMS sends to the communications timeline immediately
- process single-lead SMS sends immediately after queueing
- revalidate the lead and messaging pages after sending

## Why

The lead detail page SMS form queued the notification dispatch, but did not log it to the message timeline or process it immediately. That made it look like nothing happened after sending a lead SMS.

## Notes

- No database reset
- No destructive migration