### PR TITLE
Add weekly social match cards

### DIFF
--- a/prisma/migrations/20260428231500_add_weekly_social_match_cards/migration.sql
+++ b/prisma/migrations/20260428231500_add_weekly_social_match_cards/migration.sql
@@ -1,0 +1,64 @@
+-- ========================================
+-- File: prisma/migrations/20260428231500_add_weekly_social_match_cards/migration.sql
+-- ========================================
+
+CREATE TABLE "SocialMatchCard" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "fixtureDate" TIMESTAMP(3) NOT NULL,
+  "round" INTEGER,
+  "postType" "SocialPostType" NOT NULL DEFAULT 'FIXTURE',
+  "postStatus" "SocialPostStatus" NOT NULL DEFAULT 'NONE',
+  "caption" TEXT,
+  "imageUrl" TEXT,
+  "externalPostId" TEXT,
+  "lastError" TEXT,
+  "needsApproval" BOOLEAN NOT NULL DEFAULT true,
+  "queuedAt" TIMESTAMP(3),
+  "approvedAt" TIMESTAMP(3),
+  "publishedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "SocialMatchCard_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "SocialMatchCardFixture" (
+  "id" TEXT NOT NULL,
+  "socialMatchCardId" TEXT NOT NULL,
+  "fixtureId" TEXT NOT NULL,
+  "position" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "SocialMatchCardFixture_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "SocialMatchCard_leagueId_fixtureDate_postType_key"
+  ON "SocialMatchCard"("leagueId", "fixtureDate", "postType");
+
+CREATE INDEX "SocialMatchCard_leagueId_fixtureDate_idx"
+  ON "SocialMatchCard"("leagueId", "fixtureDate");
+
+CREATE INDEX "SocialMatchCard_postStatus_idx"
+  ON "SocialMatchCard"("postStatus");
+
+CREATE INDEX "SocialMatchCard_postType_idx"
+  ON "SocialMatchCard"("postType");
+
+CREATE UNIQUE INDEX "SocialMatchCardFixture_socialMatchCardId_fixtureId_key"
+  ON "SocialMatchCardFixture"("socialMatchCardId", "fixtureId");
+
+CREATE INDEX "SocialMatchCardFixture_fixtureId_idx"
+  ON "SocialMatchCardFixture"("fixtureId");
+
+ALTER TABLE "SocialMatchCard"
+  ADD CONSTRAINT "SocialMatchCard_leagueId_fkey"
+  FOREIGN KEY ("leagueId") REFERENCES "League"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SocialMatchCardFixture"
+  ADD CONSTRAINT "SocialMatchCardFixture_socialMatchCardId_fkey"
+  FOREIGN KEY ("socialMatchCardId") REFERENCES "SocialMatchCard"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SocialMatchCardFixture"
+  ADD CONSTRAINT "SocialMatchCardFixture_fixtureId_fkey"
+  FOREIGN KEY ("fixtureId") REFERENCES "Fixture"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/app/(admin)/admin/social/page.tsx
+++ b/src/app/(admin)/admin/social/page.tsx
@@ -3,15 +3,68 @@
 // ========================================
 
 import Link from "next/link";
-import { SocialPostStatus } from "@prisma/client";
+import { FixtureStatus, SocialPostStatus, SocialPostType } from "@prisma/client";
 import AdminCard from "@/components/admin/AdminCard";
+import CopyCaptionButton from "@/components/admin/social/CopyCaptionButton";
 import {
-  markFixtureSocialDraftedAction,
-  markFixtureSocialPublishedAction,
-} from "@/app/(admin)/admin/social/actions";
+  approveWeeklyMatchCardAction,
+  deleteWeeklyMatchCardAction,
+  generateWeeklyMatchCardAction,
+  markWeeklyMatchCardPublishedAction,
+  publishWeeklyMatchCardAction,
+} from "@/app/(admin)/admin/social/weekly-actions";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
-import CopyCaptionButton from "@/components/admin/social/CopyCaptionButton";
+import {
+  formatDateTimeInLondon,
+  formatTimeInLondon,
+  toLondonDateInputValue,
+} from "@/lib/datetime/london";
+import {
+  formatWeeklyCardShortDate,
+  getWeeklyPostTypeLabel,
+} from "@/lib/social/weekly-match-card";
+
+type WeeklyCardRow = {
+  id: string;
+  leagueId: string;
+  leagueName: string;
+  leagueSeason: string | null;
+  leagueSlug: string | null;
+  fixtureDate: Date;
+  postType: SocialPostType;
+  postStatus: SocialPostStatus;
+  caption: string | null;
+  imageUrl: string | null;
+  externalPostId: string | null;
+  lastError: string | null;
+  queuedAt: Date | null;
+  approvedAt: Date | null;
+  publishedAt: Date | null;
+  updatedAt: Date;
+  fixtureCount: number;
+};
+
+type MatchNightGroup = {
+  key: string;
+  leagueId: string;
+  leagueName: string;
+  leagueSeason: string | null;
+  leagueSlug: string;
+  fixtureDateInput: string;
+  fixtureDateLabel: string;
+  firstKickoffAt: Date;
+  lastKickoffAt: Date;
+  fixtureCount: number;
+  scheduledCount: number;
+  completedCount: number;
+  updateCount: number;
+  disputedCount: number;
+};
+
+function cx(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
 
 function formatTimestamp(value: Date | null) {
   if (!value) return null;
@@ -61,66 +114,197 @@ function formatStatus(status: SocialPostStatus) {
   }
 }
 
+function leagueLabel(input: { leagueName: string; leagueSeason: string | null }) {
+  return input.leagueSeason
+    ? `${input.leagueName} • ${input.leagueSeason}`
+    : input.leagueName;
+}
 
+function MetricPill({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3">
+      <div className="truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
+        {label}
+      </div>
+      <div className="mt-1 text-lg font-semibold text-white">{value}</div>
+    </div>
+  );
+}
+
+function ActionButton({
+  children,
+  tone = "default",
+}: {
+  children: React.ReactNode;
+  tone?: "default" | "emerald" | "sky" | "rose";
+}) {
+  return (
+    <button
+      type="submit"
+      className={cx(
+        "inline-flex h-10 items-center justify-center rounded-xl border px-3 text-xs font-semibold transition",
+        tone === "emerald" &&
+          "border-emerald-400/20 bg-emerald-400/10 text-emerald-200 hover:border-emerald-300/30 hover:bg-emerald-400/15",
+        tone === "sky" &&
+          "border-sky-400/20 bg-sky-400/10 text-sky-200 hover:border-sky-300/30 hover:bg-sky-400/15",
+        tone === "rose" &&
+          "border-rose-400/20 bg-rose-500/10 text-rose-200 hover:border-rose-300/30 hover:bg-rose-500/15",
+        tone === "default" &&
+          "border-white/10 bg-white/[0.05] text-white hover:border-white/20 hover:bg-white/[0.08]",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function groupFixturesByMatchNight(
+  fixtures: Array<{
+    id: string;
+    kickoffAt: Date;
+    status: FixtureStatus;
+    league: {
+      id: string;
+      name: string;
+      season: string | null;
+      slug: string;
+    };
+    result: {
+      isDisputed: boolean;
+    } | null;
+  }>,
+) {
+  const map = new Map<string, MatchNightGroup>();
+
+  for (const fixture of fixtures) {
+    const dateInput = toLondonDateInputValue(fixture.kickoffAt);
+    const key = `${fixture.league.id}:${dateInput}`;
+    const current = map.get(key);
+
+    if (!current) {
+      map.set(key, {
+        key,
+        leagueId: fixture.league.id,
+        leagueName: fixture.league.name,
+        leagueSeason: fixture.league.season,
+        leagueSlug: fixture.league.slug,
+        fixtureDateInput: dateInput,
+        fixtureDateLabel: formatDateTimeInLondon(fixture.kickoffAt, {
+          weekday: "long",
+          day: "numeric",
+          month: "long",
+        }),
+        firstKickoffAt: fixture.kickoffAt,
+        lastKickoffAt: fixture.kickoffAt,
+        fixtureCount: 0,
+        scheduledCount: 0,
+        completedCount: 0,
+        updateCount: 0,
+        disputedCount: 0,
+      });
+    }
+
+    const group = map.get(key);
+
+    if (!group) continue;
+
+    group.fixtureCount += 1;
+    group.scheduledCount += fixture.status === "SCHEDULED" ? 1 : 0;
+    group.completedCount += fixture.status === "COMPLETED" ? 1 : 0;
+    group.updateCount +=
+      fixture.status === "POSTPONED" || fixture.status === "CANCELLED" ? 1 : 0;
+    group.disputedCount += fixture.result?.isDisputed ? 1 : 0;
+
+    if (fixture.kickoffAt < group.firstKickoffAt) {
+      group.firstKickoffAt = fixture.kickoffAt;
+    }
+
+    if (fixture.kickoffAt > group.lastKickoffAt) {
+      group.lastKickoffAt = fixture.kickoffAt;
+    }
+  }
+
+  return Array.from(map.values()).sort(
+    (a, b) => a.firstKickoffAt.getTime() - b.firstKickoffAt.getTime(),
+  );
+}
 
 export default async function AdminSocialPage() {
   await requireAdmin();
 
-  const fixtures = await prisma.fixture.findMany({
-    where: {
-      socialPostStatus: {
-        in: [
-          SocialPostStatus.QUEUED,
-          SocialPostStatus.DRAFTED,
-          SocialPostStatus.APPROVED,
-          SocialPostStatus.PUBLISHED,
-          SocialPostStatus.FAILED,
-        ],
-      },
-    },
-    orderBy: [{ updatedAt: "desc" }],
-    select: {
-      id: true,
-      status: true,
-      socialPostType: true,
-      socialPostStatus: true,
-      socialCaption: true,
-      socialImageUrl: true,
-      socialQueuedAt: true,
-      socialApprovedAt: true,
-      socialPublishedAt: true,
-      leagueId: true,
-      league: {
-        select: {
-          name: true,
-          season: true,
+  const today = new Date();
+  const start = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const end = new Date(today.getTime() + 45 * 24 * 60 * 60 * 1000);
+
+  const [sourceFixtures, weeklyCards] = await Promise.all([
+    prisma.fixture.findMany({
+      where: {
+        kickoffAt: {
+          gte: start,
+          lt: end,
+        },
+        status: {
+          in: ["SCHEDULED", "COMPLETED", "POSTPONED", "CANCELLED"],
+        },
+        league: {
+          isActive: true,
         },
       },
-      homeTeam: {
-        select: {
-          name: true,
+      orderBy: [{ kickoffAt: "asc" }, { pitch: "asc" }, { position: "asc" }],
+      select: {
+        id: true,
+        kickoffAt: true,
+        status: true,
+        league: {
+          select: {
+            id: true,
+            name: true,
+            season: true,
+            slug: true,
+          },
+        },
+        result: {
+          select: {
+            isDisputed: true,
+          },
         },
       },
-      awayTeam: {
-        select: {
-          name: true,
-        },
-      },
-      result: {
-        select: {
-          homeScore: true,
-          awayScore: true,
-        },
-      },
-      kickoffAt: true,
-    },
-  });
+    }),
+    prisma.$queryRaw<WeeklyCardRow[]>`
+      SELECT
+        c."id",
+        c."leagueId",
+        l."name" AS "leagueName",
+        l."season" AS "leagueSeason",
+        l."slug" AS "leagueSlug",
+        c."fixtureDate",
+        c."postType",
+        c."postStatus",
+        c."caption",
+        c."imageUrl",
+        c."externalPostId",
+        c."lastError",
+        c."queuedAt",
+        c."approvedAt",
+        c."publishedAt",
+        c."updatedAt",
+        COUNT(cf."id")::int AS "fixtureCount"
+      FROM "SocialMatchCard" c
+      INNER JOIN "League" l ON l."id" = c."leagueId"
+      LEFT JOIN "SocialMatchCardFixture" cf ON cf."socialMatchCardId" = c."id"
+      GROUP BY c."id", l."name", l."season", l."slug"
+      ORDER BY c."updatedAt" DESC
+      LIMIT 40
+    `,
+  ]);
+
+  const matchNights = groupFixturesByMatchNight(sourceFixtures).slice(0, 18);
 
   const counts = {
-    drafted: fixtures.filter((f) => f.socialPostStatus === "DRAFTED").length,
-    approved: fixtures.filter((f) => f.socialPostStatus === "APPROVED").length,
-    published: fixtures.filter((f) => f.socialPostStatus === "PUBLISHED").length,
-    failed: fixtures.filter((f) => f.socialPostStatus === "FAILED").length,
+    drafted: weeklyCards.filter((card) => card.postStatus === "DRAFTED").length,
+    approved: weeklyCards.filter((card) => card.postStatus === "APPROVED").length,
+    published: weeklyCards.filter((card) => card.postStatus === "PUBLISHED").length,
+    failed: weeklyCards.filter((card) => card.postStatus === "FAILED").length,
   };
 
   return (
@@ -129,47 +313,153 @@ export default async function AdminSocialPage() {
         <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
           <div className="space-y-3">
             <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-300">
-              Social queue
+              Weekly social cards
             </div>
             <div>
               <h1 className="text-3xl font-semibold tracking-tight text-white md:text-4xl">
-                Publish to Meta Business Suite
+                Publish one match card per league night
               </h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60 md:text-base">
-                Open the image, copy the caption, publish in Meta Business Suite,
-                then mark the post as published here.
+                Generate a single unified image and caption for each match night,
+                then publish it to Facebook and Instagram from one controlled queue.
               </p>
             </div>
           </div>
 
           <div className="grid w-full gap-3 sm:grid-cols-2 xl:w-auto xl:grid-cols-4">
-            <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3">
-              <div className="truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
-                Draft ready
-              </div>
-              <div className="mt-1 text-lg font-semibold text-white">{counts.drafted}</div>
-            </div>
-            <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3">
-              <div className="truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
-                Approved
-              </div>
-              <div className="mt-1 text-lg font-semibold text-white">{counts.approved}</div>
-            </div>
-            <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3">
-              <div className="truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
-                Published
-              </div>
-              <div className="mt-1 text-lg font-semibold text-white">{counts.published}</div>
-            </div>
-            <div className="min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3">
-              <div className="truncate text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
-                Failed
-              </div>
-              <div className="mt-1 text-lg font-semibold text-white">{counts.failed}</div>
-            </div>
+            <MetricPill label="Draft ready" value={counts.drafted} />
+            <MetricPill label="Approved" value={counts.approved} />
+            <MetricPill label="Published" value={counts.published} />
+            <MetricPill label="Failed" value={counts.failed} />
           </div>
         </div>
       </div>
+
+      <AdminCard className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-0 shadow-[0_24px_80px_rgba(0,0,0,0.32)]">
+        <div className="border-b border-white/10 px-6 py-6 md:px-8">
+          <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div className="space-y-2">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
+                Generate weekly cards
+              </div>
+              <h2 className="text-2xl font-semibold tracking-tight text-white">
+                Suggested match nights
+              </h2>
+              <p className="max-w-2xl text-sm leading-6 text-white/55">
+                These are grouped from the fixture list, so each button creates one
+                Facebook/Instagram card for the whole night.
+              </p>
+            </div>
+            <Link
+              href="/admin/fixtures"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-3 text-xs font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
+            >
+              Open fixtures
+            </Link>
+          </div>
+        </div>
+
+        {matchNights.length === 0 ? (
+          <div className="px-6 py-10 md:px-8">
+            <div className="rounded-3xl border border-dashed border-white/10 bg-black/20 px-6 py-12 text-center">
+              <h3 className="text-lg font-semibold text-white">No match nights found</h3>
+              <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-white/50">
+                Add or publish fixtures first, then return here to generate weekly
+                social cards.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="divide-y divide-white/10">
+            {matchNights.map((night) => {
+              const kickoffWindow = `${formatTimeInLondon(night.firstKickoffAt)} - ${formatTimeInLondon(night.lastKickoffAt)}`;
+              const canGenerateResults =
+                night.completedCount > 0 && night.disputedCount === 0;
+
+              return (
+                <div
+                  key={night.key}
+                  className="grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_auto] md:px-8"
+                >
+                  <div className="space-y-4">
+                    <div>
+                      <div className="text-lg font-semibold text-white">
+                        {leagueLabel(night)}
+                      </div>
+                      <div className="mt-1 text-sm text-white/50">
+                        {night.fixtureDateLabel} • {kickoffWindow}
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white/70">
+                        {night.fixtureCount} fixtures
+                      </span>
+                      <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+                        {night.scheduledCount} scheduled
+                      </span>
+                      <span className="rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1 text-xs font-semibold text-sky-200">
+                        {night.completedCount} completed
+                      </span>
+                      {night.updateCount > 0 ? (
+                        <span className="rounded-full border border-amber-400/20 bg-amber-400/10 px-3 py-1 text-xs font-semibold text-amber-200">
+                          {night.updateCount} updates
+                        </span>
+                      ) : null}
+                      {night.disputedCount > 0 ? (
+                        <span className="rounded-full border border-rose-400/20 bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-200">
+                          {night.disputedCount} disputed
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2 lg:justify-end">
+                    {night.scheduledCount + night.updateCount > 0 ? (
+                      <form action={generateWeeklyMatchCardAction}>
+                        <input type="hidden" name="leagueId" value={night.leagueId} />
+                        <input
+                          type="hidden"
+                          name="fixtureDate"
+                          value={night.fixtureDateInput}
+                        />
+                        <input type="hidden" name="postType" value="FIXTURE" />
+                        <ActionButton tone="emerald">Generate match card</ActionButton>
+                      </form>
+                    ) : null}
+
+                    {canGenerateResults ? (
+                      <form action={generateWeeklyMatchCardAction}>
+                        <input type="hidden" name="leagueId" value={night.leagueId} />
+                        <input
+                          type="hidden"
+                          name="fixtureDate"
+                          value={night.fixtureDateInput}
+                        />
+                        <input type="hidden" name="postType" value="RESULT" />
+                        <ActionButton tone="sky">Generate results card</ActionButton>
+                      </form>
+                    ) : null}
+
+                    {night.updateCount > 0 ? (
+                      <form action={generateWeeklyMatchCardAction}>
+                        <input type="hidden" name="leagueId" value={night.leagueId} />
+                        <input
+                          type="hidden"
+                          name="fixtureDate"
+                          value={night.fixtureDateInput}
+                        />
+                        <input type="hidden" name="postType" value="UPDATE" />
+                        <ActionButton>Generate update card</ActionButton>
+                      </form>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </AdminCard>
 
       <AdminCard className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03] p-0 shadow-[0_24px_80px_rgba(0,0,0,0.32)]">
         <div className="border-b border-white/10 px-6 py-6 md:px-8">
@@ -178,94 +468,87 @@ export default async function AdminSocialPage() {
               Ready to post
             </div>
             <h2 className="text-2xl font-semibold tracking-tight text-white">
-              Social drafts
+              Weekly social queue
             </h2>
+            <p className="max-w-2xl text-sm leading-6 text-white/55">
+              Approve, publish, copy captions, and open the generated image from
+              one queue. This replaces the old one-post-per-fixture flow.
+            </p>
           </div>
         </div>
 
-        {fixtures.length === 0 ? (
+        {weeklyCards.length === 0 ? (
           <div className="px-6 py-10 md:px-8">
             <div className="rounded-3xl border border-dashed border-white/10 bg-black/20 px-6 py-12 text-center">
-              <h3 className="text-lg font-semibold text-white">No social drafts yet</h3>
+              <h3 className="text-lg font-semibold text-white">No weekly cards yet</h3>
               <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-white/50">
-                Generate a draft from Fixtures and it will appear here.
+                Generate one from a suggested match night above and it will appear here.
               </p>
             </div>
           </div>
         ) : (
           <div className="divide-y divide-white/10">
-            {fixtures.map((fixture) => {
-              const title = `${fixture.homeTeam?.name ?? "Team 1"} vs ${fixture.awayTeam?.name ?? "Team 2"}`;
-              const homeScore = fixture.result?.homeScore ?? null;
-const awayScore = fixture.result?.awayScore ?? null;
-
-const resultLabel =
-  homeScore !== null && awayScore !== null
-    ? `${homeScore}-${awayScore}`
-    : null;
+            {weeklyCards.map((card) => {
+              const title = `${getWeeklyPostTypeLabel(card.postType)} • ${leagueLabel(card)}`;
+              const dateLabel = formatWeeklyCardShortDate(card.fixtureDate);
 
               return (
                 <div
-                  key={fixture.id}
-                  className="grid gap-6 px-6 py-6 md:grid-cols-[minmax(0,1.2fr)_auto] md:px-8"
+                  key={card.id}
+                  className="grid gap-6 px-6 py-6 xl:grid-cols-[minmax(0,1.2fr)_auto] md:px-8"
                 >
                   <div className="space-y-4">
                     <div className="flex flex-wrap items-center gap-3">
                       <div className="text-lg font-semibold text-white">{title}</div>
 
-                      {resultLabel ? (
-                        <span className="inline-flex rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white/80">
-                          {resultLabel}
-                        </span>
-                      ) : null}
+                      <span className="inline-flex rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white/70">
+                        {dateLabel}
+                      </span>
+
+                      <span className="inline-flex rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white/70">
+                        {card.fixtureCount} fixtures
+                      </span>
 
                       <span
-                        className={[
+                        className={cx(
                           "inline-flex rounded-full border px-3 py-1 text-xs font-semibold",
-                          getStatusTone(fixture.socialPostStatus),
-                        ].join(" ")}
+                          getStatusTone(card.postStatus),
+                        )}
                       >
-                        {formatStatus(fixture.socialPostStatus)}
+                        {formatStatus(card.postStatus)}
                       </span>
                     </div>
 
-                    <div className="text-sm text-white/45">
-                      {(fixture.league?.season
-                        ? `${fixture.league.name} • ${fixture.league.season}`
-                        : fixture.league?.name) ?? "League"}
-                      {" • "}
-                      {new Intl.DateTimeFormat("en-GB", {
-                        weekday: "short",
-                        day: "2-digit",
-                        month: "short",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      }).format(fixture.kickoffAt)}
-                    </div>
+                    {card.caption ? (
+                      <div className="whitespace-pre-line rounded-2xl border border-white/10 bg-black/25 p-4 text-sm leading-6 text-white/78">
+                        {card.caption}
+                      </div>
+                    ) : null}
 
-                    {fixture.socialCaption ? (
-                      <div className="rounded-2xl border border-white/10 bg-black/25 p-4 text-sm leading-6 text-white/78">
-                        {fixture.socialCaption}
+                    {card.lastError ? (
+                      <div className="rounded-2xl border border-rose-400/20 bg-rose-500/10 p-4 text-sm leading-6 text-rose-100">
+                        {card.lastError}
                       </div>
                     ) : null}
 
                     <div className="flex flex-wrap gap-4 text-xs text-white/45">
-                      {fixture.socialQueuedAt ? (
-                        <span>Queued {formatTimestamp(fixture.socialQueuedAt)}</span>
+                      {card.queuedAt ? (
+                        <span>Generated {formatTimestamp(card.queuedAt)}</span>
                       ) : null}
-                      {fixture.socialApprovedAt ? (
-                        <span>Approved {formatTimestamp(fixture.socialApprovedAt)}</span>
+                      {card.approvedAt ? (
+                        <span>Approved {formatTimestamp(card.approvedAt)}</span>
                       ) : null}
-                      {fixture.socialPublishedAt ? (
-                        <span>Published {formatTimestamp(fixture.socialPublishedAt)}</span>
+                      {card.publishedAt ? (
+                        <span>Published {formatTimestamp(card.publishedAt)}</span>
                       ) : null}
+                      {card.externalPostId ? <span>External ID saved</span> : null}
                     </div>
                   </div>
 
-                  <div className="flex flex-wrap gap-2 md:flex-col md:items-end">
-                    {fixture.socialImageUrl ? (
+                  <div className="flex flex-wrap gap-2 xl:flex-col xl:items-end">
+                    {card.imageUrl ? (
                       <a
-                        href={fixture.socialImageUrl}
+                        href={card.imageUrl}
                         target="_blank"
                         rel="noreferrer"
                         className="inline-flex h-10 items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-3 text-xs font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
@@ -274,38 +557,44 @@ const resultLabel =
                       </a>
                     ) : null}
 
-                    {fixture.socialCaption ? (
-                      <CopyCaptionButton caption={fixture.socialCaption} />
+                    {card.caption ? <CopyCaptionButton caption={card.caption} /> : null}
+
+                    <form action={generateWeeklyMatchCardAction}>
+                      <input type="hidden" name="leagueId" value={card.leagueId} />
+                      <input
+                        type="hidden"
+                        name="fixtureDate"
+                        value={toLondonDateInputValue(card.fixtureDate)}
+                      />
+                      <input type="hidden" name="postType" value={card.postType} />
+                      <ActionButton>Regenerate</ActionButton>
+                    </form>
+
+                    {card.postStatus === "DRAFTED" || card.postStatus === "FAILED" ? (
+                      <form action={approveWeeklyMatchCardAction}>
+                        <input type="hidden" name="cardId" value={card.id} />
+                        <ActionButton tone="sky">Approve</ActionButton>
+                      </form>
                     ) : null}
 
-                    <Link
-                      href={`/admin/fixtures`}
-                      className="inline-flex h-10 items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-3 text-xs font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
-                    >
-                      Open fixtures
-                    </Link>
+                    {card.postStatus === "APPROVED" ? (
+                      <form action={publishWeeklyMatchCardAction}>
+                        <input type="hidden" name="cardId" value={card.id} />
+                        <ActionButton tone="emerald">Publish to Meta</ActionButton>
+                      </form>
+                    ) : null}
 
-                    {fixture.socialPostStatus !== "PUBLISHED" ? (
-                      <form action={markFixtureSocialPublishedAction}>
-                        <input type="hidden" name="fixtureId" value={fixture.id} />
-                        <button
-                          type="submit"
-                          className="inline-flex h-10 items-center justify-center rounded-xl border border-emerald-400/20 bg-emerald-400/10 px-3 text-xs font-semibold text-emerald-200 transition hover:border-emerald-300/30 hover:bg-emerald-400/15"
-                        >
-                          Mark as published
-                        </button>
+                    {card.postStatus !== "PUBLISHED" ? (
+                      <form action={markWeeklyMatchCardPublishedAction}>
+                        <input type="hidden" name="cardId" value={card.id} />
+                        <ActionButton>Mark published</ActionButton>
                       </form>
-                    ) : (
-                      <form action={markFixtureSocialDraftedAction}>
-                        <input type="hidden" name="fixtureId" value={fixture.id} />
-                        <button
-                          type="submit"
-                          className="inline-flex h-10 items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-3 text-xs font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
-                        >
-                          Move back to draft
-                        </button>
-                      </form>
-                    )}
+                    ) : null}
+
+                    <form action={deleteWeeklyMatchCardAction}>
+                      <input type="hidden" name="cardId" value={card.id} />
+                      <ActionButton tone="rose">Delete card</ActionButton>
+                    </form>
                   </div>
                 </div>
               );

--- a/src/app/(admin)/admin/social/weekly-actions.ts
+++ b/src/app/(admin)/admin/social/weekly-actions.ts
@@ -1,0 +1,460 @@
+// ========================================
+// File: src/app/(admin)/admin/social/weekly-actions.ts
+// ========================================
+
+"use server";
+
+import { randomUUID } from "node:crypto";
+import { SocialPostStatus, SocialPostType } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { parseLondonDateTime } from "@/lib/datetime/london";
+import {
+  buildWeeklyMatchCardCaption,
+  getBaseUrl,
+  getWeeklyMatchCardImageUrl,
+  type WeeklyMatchCardFixture,
+  type WeeklySocialPostType,
+} from "@/lib/social/weekly-match-card";
+
+function parseRequiredString(
+  value: FormDataEntryValue | null,
+  fieldName: string,
+) {
+  const str = String(value ?? "").trim();
+
+  if (!str) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  return str;
+}
+
+function parseWeeklyPostType(value: FormDataEntryValue | null) {
+  const raw = String(value ?? "").trim();
+
+  if (raw === "RESULT" || raw === "UPDATE" || raw === "FIXTURE") {
+    return raw as WeeklySocialPostType;
+  }
+
+  return "FIXTURE" as const;
+}
+
+function getFixtureDateBounds(dateInput: string) {
+  const start = parseLondonDateTime(dateInput, "00:00");
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+
+  return { start, end };
+}
+
+function revalidateWeeklySocialPaths(input?: { leagueSlug?: string | null }) {
+  revalidatePath("/admin/social");
+  revalidatePath("/admin/fixtures");
+
+  if (input?.leagueSlug) {
+    revalidatePath(`/leagues/${input.leagueSlug}`);
+    revalidatePath(`/leagues/${input.leagueSlug}/fixtures`);
+  }
+}
+
+async function getFixturesForWeeklyCard(input: {
+  leagueId: string;
+  start: Date;
+  end: Date;
+  postType: WeeklySocialPostType;
+}) {
+  const fixtures = await prisma.fixture.findMany({
+    where: {
+      leagueId: input.leagueId,
+      kickoffAt: {
+        gte: input.start,
+        lt: input.end,
+      },
+      status:
+        input.postType === "RESULT"
+          ? "COMPLETED"
+          : input.postType === "UPDATE"
+            ? { in: ["POSTPONED", "CANCELLED"] }
+            : { in: ["SCHEDULED", "POSTPONED", "CANCELLED"] },
+    },
+    orderBy: [{ kickoffAt: "asc" }, { pitch: "asc" }, { position: "asc" }],
+    select: {
+      id: true,
+      kickoffAt: true,
+      pitch: true,
+      status: true,
+      homeTeam: {
+        select: {
+          name: true,
+        },
+      },
+      awayTeam: {
+        select: {
+          name: true,
+        },
+      },
+      result: {
+        select: {
+          homeScore: true,
+          awayScore: true,
+          isDisputed: true,
+        },
+      },
+    },
+  });
+
+  if (input.postType === "RESULT") {
+    const disputed = fixtures.find((fixture) => fixture.result?.isDisputed);
+
+    if (disputed) {
+      throw new Error("Disputed results cannot be added to a weekly results card.");
+    }
+  }
+
+  return fixtures.map<WeeklyMatchCardFixture>((fixture) => ({
+    id: fixture.id,
+    kickoffAt: fixture.kickoffAt,
+    pitch: fixture.pitch,
+    status: fixture.status,
+    homeTeamName: fixture.homeTeam.name,
+    awayTeamName: fixture.awayTeam.name,
+    homeScore: fixture.result?.homeScore ?? null,
+    awayScore: fixture.result?.awayScore ?? null,
+  }));
+}
+
+async function postWeeklyPublishWebhook(input: {
+  cardId: string;
+  postType: WeeklySocialPostType;
+  caption: string;
+  imageUrl: string;
+  fixtureDate: Date;
+  platforms: Array<"facebook" | "instagram">;
+}) {
+  const webhookUrl = process.env.SOCIAL_PUBLISH_WEBHOOK_URL?.trim();
+
+  if (!webhookUrl) {
+    return {
+      ok: false,
+      reason: "SOCIAL_PUBLISH_WEBHOOK_URL is not configured.",
+    } as const;
+  }
+
+  const secret = process.env.SOCIAL_WEBHOOK_SECRET?.trim() || "";
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(secret ? { "x-sixfl-social-secret": secret } : {}),
+    },
+    body: JSON.stringify({
+      event: "weekly.social.publish.requested",
+      cardId: input.cardId,
+      socialMatchCardId: input.cardId,
+      socialPostType: input.postType,
+      caption: input.caption,
+      imageUrl: input.imageUrl,
+      fixtureDate: input.fixtureDate.toISOString(),
+      platforms: input.platforms,
+      callbackUrl: `${getBaseUrl()}/api/social/callback`,
+      branding: {
+        name: "SIXFL",
+        tagline: "6-a-side football. Done properly.",
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    return {
+      ok: false,
+      reason: text || `Publish webhook failed with status ${response.status}.`,
+    } as const;
+  }
+
+  return { ok: true } as const;
+}
+
+type CardLookupRow = {
+  id: string;
+  leagueId: string;
+  leagueSlug: string | null;
+  fixtureDate: Date;
+  postType: SocialPostType;
+  postStatus: SocialPostStatus;
+  caption: string | null;
+  imageUrl: string | null;
+};
+
+async function getCard(cardId: string) {
+  const rows = await prisma.$queryRaw<CardLookupRow[]>`
+    SELECT
+      c."id",
+      c."leagueId",
+      l."slug" AS "leagueSlug",
+      c."fixtureDate",
+      c."postType",
+      c."postStatus",
+      c."caption",
+      c."imageUrl"
+    FROM "SocialMatchCard" c
+    INNER JOIN "League" l ON l."id" = c."leagueId"
+    WHERE c."id" = ${cardId}
+    LIMIT 1
+  `;
+
+  return rows[0] ?? null;
+}
+
+export async function generateWeeklyMatchCardAction(formData: FormData) {
+  await requireAdmin();
+
+  const leagueId = parseRequiredString(formData.get("leagueId"), "League ID");
+  const dateInput = parseRequiredString(formData.get("fixtureDate"), "Fixture date");
+  const postType = parseWeeklyPostType(formData.get("postType"));
+  const { start, end } = getFixtureDateBounds(dateInput);
+
+  const league = await prisma.league.findUnique({
+    where: { id: leagueId },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+    },
+  });
+
+  if (!league) {
+    throw new Error("League not found.");
+  }
+
+  const fixtures = await getFixturesForWeeklyCard({
+    leagueId,
+    start,
+    end,
+    postType,
+  });
+
+  if (fixtures.length === 0) {
+    throw new Error("No fixtures were found for that league and date.");
+  }
+
+  const caption = buildWeeklyMatchCardCaption({
+    postType,
+    leagueName: league.name,
+    fixtureDate: start,
+    fixtures,
+  });
+
+  const cardId = randomUUID();
+  const imageUrl = getWeeklyMatchCardImageUrl(cardId);
+
+  await prisma.$transaction(async (tx) => {
+    const upserted = await tx.$queryRaw<Array<{ id: string }>>`
+      INSERT INTO "SocialMatchCard" (
+        "id",
+        "leagueId",
+        "fixtureDate",
+        "round",
+        "postType",
+        "postStatus",
+        "caption",
+        "imageUrl",
+        "lastError",
+        "needsApproval",
+        "queuedAt",
+        "approvedAt",
+        "publishedAt",
+        "updatedAt"
+      ) VALUES (
+        ${cardId},
+        ${leagueId},
+        ${start},
+        ${null},
+        ${postType}::"SocialPostType",
+        ${SocialPostStatus.DRAFTED}::"SocialPostStatus",
+        ${caption},
+        ${imageUrl},
+        ${null},
+        ${true},
+        ${new Date()},
+        ${null},
+        ${null},
+        ${new Date()}
+      )
+      ON CONFLICT ("leagueId", "fixtureDate", "postType")
+      DO UPDATE SET
+        "caption" = EXCLUDED."caption",
+        "imageUrl" = CONCAT(${getBaseUrl()}, '/api/social/match-card/', "SocialMatchCard"."id"),
+        "postStatus" = ${SocialPostStatus.DRAFTED}::"SocialPostStatus",
+        "lastError" = NULL,
+        "queuedAt" = NOW(),
+        "approvedAt" = NULL,
+        "publishedAt" = NULL,
+        "updatedAt" = NOW()
+      RETURNING "id"
+    `;
+
+    const resolvedCardId = upserted[0]?.id ?? cardId;
+
+    await tx.$executeRaw`
+      DELETE FROM "SocialMatchCardFixture"
+      WHERE "socialMatchCardId" = ${resolvedCardId}
+    `;
+
+    for (const [index, fixture] of fixtures.entries()) {
+      await tx.$executeRaw`
+        INSERT INTO "SocialMatchCardFixture" (
+          "id",
+          "socialMatchCardId",
+          "fixtureId",
+          "position"
+        ) VALUES (
+          ${randomUUID()},
+          ${resolvedCardId},
+          ${fixture.id},
+          ${index}
+        )
+      `;
+    }
+  });
+
+  revalidateWeeklySocialPaths({ leagueSlug: league.slug });
+}
+
+export async function approveWeeklyMatchCardAction(formData: FormData) {
+  await requireAdmin();
+
+  const cardId = parseRequiredString(formData.get("cardId"), "Card ID");
+  const card = await getCard(cardId);
+
+  if (!card) {
+    throw new Error("Weekly match card not found.");
+  }
+
+  await prisma.$executeRaw`
+    UPDATE "SocialMatchCard"
+    SET
+      "postStatus" = ${SocialPostStatus.APPROVED}::"SocialPostStatus",
+      "approvedAt" = NOW(),
+      "lastError" = NULL,
+      "updatedAt" = NOW()
+    WHERE "id" = ${cardId}
+  `;
+
+  revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+}
+
+export async function publishWeeklyMatchCardAction(formData: FormData) {
+  await requireAdmin();
+
+  const cardId = parseRequiredString(formData.get("cardId"), "Card ID");
+  const card = await getCard(cardId);
+
+  if (!card) {
+    throw new Error("Weekly match card not found.");
+  }
+
+  if (card.postStatus !== SocialPostStatus.APPROVED) {
+    await prisma.$executeRaw`
+      UPDATE "SocialMatchCard"
+      SET
+        "lastError" = ${`Publish blocked because status was ${card.postStatus}. Approve the card first.`},
+        "updatedAt" = NOW()
+      WHERE "id" = ${cardId}
+    `;
+
+    revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+    return;
+  }
+
+  if (!card.caption || !card.imageUrl) {
+    await prisma.$executeRaw`
+      UPDATE "SocialMatchCard"
+      SET
+        "postStatus" = ${SocialPostStatus.FAILED}::"SocialPostStatus",
+        "lastError" = 'No caption or image URL found for this weekly card.',
+        "updatedAt" = NOW()
+      WHERE "id" = ${cardId}
+    `;
+
+    revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+    return;
+  }
+
+  const result = await postWeeklyPublishWebhook({
+    cardId,
+    postType: card.postType as WeeklySocialPostType,
+    caption: card.caption,
+    imageUrl: card.imageUrl,
+    fixtureDate: card.fixtureDate,
+    platforms: ["facebook", "instagram"],
+  });
+
+  if (!result.ok) {
+    await prisma.$executeRaw`
+      UPDATE "SocialMatchCard"
+      SET
+        "postStatus" = ${SocialPostStatus.FAILED}::"SocialPostStatus",
+        "lastError" = ${result.reason},
+        "updatedAt" = NOW()
+      WHERE "id" = ${cardId}
+    `;
+
+    revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+    return;
+  }
+
+  await prisma.$executeRaw`
+    UPDATE "SocialMatchCard"
+    SET
+      "postStatus" = ${SocialPostStatus.QUEUED}::"SocialPostStatus",
+      "lastError" = NULL,
+      "updatedAt" = NOW()
+    WHERE "id" = ${cardId}
+  `;
+
+  revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+}
+
+export async function markWeeklyMatchCardPublishedAction(formData: FormData) {
+  await requireAdmin();
+
+  const cardId = parseRequiredString(formData.get("cardId"), "Card ID");
+  const card = await getCard(cardId);
+
+  if (!card) {
+    throw new Error("Weekly match card not found.");
+  }
+
+  await prisma.$executeRaw`
+    UPDATE "SocialMatchCard"
+    SET
+      "postStatus" = ${SocialPostStatus.PUBLISHED}::"SocialPostStatus",
+      "publishedAt" = NOW(),
+      "lastError" = NULL,
+      "updatedAt" = NOW()
+    WHERE "id" = ${cardId}
+  `;
+
+  revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+}
+
+export async function deleteWeeklyMatchCardAction(formData: FormData) {
+  await requireAdmin();
+
+  const cardId = parseRequiredString(formData.get("cardId"), "Card ID");
+  const card = await getCard(cardId);
+
+  if (!card) {
+    throw new Error("Weekly match card not found.");
+  }
+
+  await prisma.$executeRaw`
+    DELETE FROM "SocialMatchCard"
+    WHERE "id" = ${cardId}
+  `;
+
+  revalidateWeeklySocialPaths({ leagueSlug: card.leagueSlug });
+}

--- a/src/app/api/social/callback/route.ts
+++ b/src/app/api/social/callback/route.ts
@@ -87,55 +87,55 @@ async function handleWeeklyCardCallback(body: SocialCallbackBody) {
 
   const status = isValidSocialPostStatus(body.socialPostStatus)
     ? body.socialPostStatus
-    : undefined;
+    : null;
   const postType = isValidSocialPostType(body.socialPostType)
     ? body.socialPostType
-    : undefined;
+    : null;
   const caption =
     typeof body.socialCaption === "string"
       ? body.socialCaption.trim() || null
-      : undefined;
+      : null;
   const imageUrl =
     typeof body.socialImageUrl === "string"
       ? body.socialImageUrl.trim() || null
-      : undefined;
+      : null;
   const externalPostId =
     typeof body.externalPostId === "string"
       ? body.externalPostId.trim() || null
       : typeof body.socialDraftExternalId === "string"
         ? body.socialDraftExternalId.trim() || null
-        : undefined;
+        : null;
   const lastError =
     typeof body.socialLastError === "string"
       ? body.socialLastError.trim() || null
-      : undefined;
+      : null;
 
   const publishedAt = (() => {
     if (typeof body.socialPublishedAt !== "string" || !body.socialPublishedAt.trim()) {
-      return undefined;
+      return null;
     }
 
     const parsed = new Date(body.socialPublishedAt);
-    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
   })();
 
   await prisma.$executeRaw`
     UPDATE "SocialMatchCard"
     SET
-      "postStatus" = COALESCE(${status ?? null}::"SocialPostStatus", "postStatus"),
-      "postType" = COALESCE(${postType ?? null}::"SocialPostType", "postType"),
+      "postStatus" = COALESCE(${status}::"SocialPostStatus", "postStatus"),
+      "postType" = COALESCE(${postType}::"SocialPostType", "postType"),
       "caption" = COALESCE(${caption}, "caption"),
       "imageUrl" = COALESCE(${imageUrl}, "imageUrl"),
       "externalPostId" = COALESCE(${externalPostId}, "externalPostId"),
       "lastError" = CASE
-        WHEN ${status ?? null}::"SocialPostStatus" = ${SocialPostStatus.FAILED}::"SocialPostStatus" THEN COALESCE(${lastError}, 'Social publish callback reported a failure.')
+        WHEN ${status}::"SocialPostStatus" = ${SocialPostStatus.FAILED}::"SocialPostStatus" THEN COALESCE(${lastError}, 'Social publish callback reported a failure.')
         WHEN ${lastError} IS NOT NULL THEN ${lastError}
-        WHEN ${status ?? null}::"SocialPostStatus" IN (${SocialPostStatus.DRAFTED}::"SocialPostStatus", ${SocialPostStatus.PUBLISHED}::"SocialPostStatus") THEN NULL
+        WHEN ${status}::"SocialPostStatus" IN (${SocialPostStatus.DRAFTED}::"SocialPostStatus", ${SocialPostStatus.PUBLISHED}::"SocialPostStatus") THEN NULL
         ELSE "lastError"
       END,
       "publishedAt" = CASE
-        WHEN ${status ?? null}::"SocialPostStatus" = ${SocialPostStatus.PUBLISHED}::"SocialPostStatus" THEN COALESCE(${publishedAt ?? null}, NOW())
-        ELSE COALESCE(${publishedAt ?? null}, "publishedAt")
+        WHEN ${status}::"SocialPostStatus" = ${SocialPostStatus.PUBLISHED}::"SocialPostStatus" THEN COALESCE(${publishedAt}, NOW())
+        ELSE COALESCE(${publishedAt}, "publishedAt")
       END,
       "updatedAt" = NOW()
     WHERE "id" = ${cardId}

--- a/src/app/api/social/callback/route.ts
+++ b/src/app/api/social/callback/route.ts
@@ -39,40 +39,123 @@ function revalidateFixturePaths(input: {
 
 type SocialCallbackBody = {
   fixtureId?: unknown;
+  cardId?: unknown;
+  socialMatchCardId?: unknown;
   socialPostStatus?: unknown;
   socialPostType?: unknown;
   socialCaption?: unknown;
   socialImageUrl?: unknown;
   socialDraftExternalId?: unknown;
+  externalPostId?: unknown;
   socialLastError?: unknown;
   socialPublishedAt?: unknown;
 };
 
-export async function POST(request: NextRequest) {
-  if (!isValidSocialWebhookRequest(request)) {
+async function handleWeeklyCardCallback(body: SocialCallbackBody) {
+  const cardId =
+    typeof body.cardId === "string"
+      ? body.cardId.trim()
+      : typeof body.socialMatchCardId === "string"
+        ? body.socialMatchCardId.trim()
+        : "";
+
+  if (!cardId) {
+    return null;
+  }
+
+  const rows = await prisma.$queryRaw<
+    Array<{ id: string; leagueId: string; leagueSlug: string | null }>
+  >`
+    SELECT
+      c."id",
+      c."leagueId",
+      l."slug" AS "leagueSlug"
+    FROM "SocialMatchCard" c
+    INNER JOIN "League" l ON l."id" = c."leagueId"
+    WHERE c."id" = ${cardId}
+    LIMIT 1
+  `;
+
+  const card = rows[0];
+
+  if (!card) {
     return NextResponse.json(
-      { ok: false, error: "Unauthorised" },
-      { status: 401 },
+      { ok: false, error: "Weekly match card not found" },
+      { status: 404 },
     );
   }
 
-  let body: SocialCallbackBody;
+  const status = isValidSocialPostStatus(body.socialPostStatus)
+    ? body.socialPostStatus
+    : undefined;
+  const postType = isValidSocialPostType(body.socialPostType)
+    ? body.socialPostType
+    : undefined;
+  const caption =
+    typeof body.socialCaption === "string"
+      ? body.socialCaption.trim() || null
+      : undefined;
+  const imageUrl =
+    typeof body.socialImageUrl === "string"
+      ? body.socialImageUrl.trim() || null
+      : undefined;
+  const externalPostId =
+    typeof body.externalPostId === "string"
+      ? body.externalPostId.trim() || null
+      : typeof body.socialDraftExternalId === "string"
+        ? body.socialDraftExternalId.trim() || null
+        : undefined;
+  const lastError =
+    typeof body.socialLastError === "string"
+      ? body.socialLastError.trim() || null
+      : undefined;
 
-  try {
-    body = (await request.json()) as SocialCallbackBody;
-  } catch {
-    return NextResponse.json(
-      { ok: false, error: "Invalid JSON body" },
-      { status: 400 },
-    );
-  }
+  const publishedAt = (() => {
+    if (typeof body.socialPublishedAt !== "string" || !body.socialPublishedAt.trim()) {
+      return undefined;
+    }
 
+    const parsed = new Date(body.socialPublishedAt);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  })();
+
+  await prisma.$executeRaw`
+    UPDATE "SocialMatchCard"
+    SET
+      "postStatus" = COALESCE(${status ?? null}::"SocialPostStatus", "postStatus"),
+      "postType" = COALESCE(${postType ?? null}::"SocialPostType", "postType"),
+      "caption" = COALESCE(${caption}, "caption"),
+      "imageUrl" = COALESCE(${imageUrl}, "imageUrl"),
+      "externalPostId" = COALESCE(${externalPostId}, "externalPostId"),
+      "lastError" = CASE
+        WHEN ${status ?? null}::"SocialPostStatus" = ${SocialPostStatus.FAILED}::"SocialPostStatus" THEN COALESCE(${lastError}, 'Social publish callback reported a failure.')
+        WHEN ${lastError} IS NOT NULL THEN ${lastError}
+        WHEN ${status ?? null}::"SocialPostStatus" IN (${SocialPostStatus.DRAFTED}::"SocialPostStatus", ${SocialPostStatus.PUBLISHED}::"SocialPostStatus") THEN NULL
+        ELSE "lastError"
+      END,
+      "publishedAt" = CASE
+        WHEN ${status ?? null}::"SocialPostStatus" = ${SocialPostStatus.PUBLISHED}::"SocialPostStatus" THEN COALESCE(${publishedAt ?? null}, NOW())
+        ELSE COALESCE(${publishedAt ?? null}, "publishedAt")
+      END,
+      "updatedAt" = NOW()
+    WHERE "id" = ${cardId}
+  `;
+
+  revalidateFixturePaths({
+    leagueId: card.leagueId,
+    leagueSlug: card.leagueSlug,
+  });
+
+  return NextResponse.json({ ok: true, cardId });
+}
+
+async function handleFixtureCallback(body: SocialCallbackBody) {
   const fixtureId =
     typeof body.fixtureId === "string" ? body.fixtureId.trim() : "";
 
   if (!fixtureId) {
     return NextResponse.json(
-      { ok: false, error: "fixtureId is required" },
+      { ok: false, error: "fixtureId or cardId is required" },
       { status: 400 },
     );
   }
@@ -174,4 +257,32 @@ export async function POST(request: NextRequest) {
     fixtureId,
     applied: updates,
   });
+}
+
+export async function POST(request: NextRequest) {
+  if (!isValidSocialWebhookRequest(request)) {
+    return NextResponse.json(
+      { ok: false, error: "Unauthorised" },
+      { status: 401 },
+    );
+  }
+
+  let body: SocialCallbackBody;
+
+  try {
+    body = (await request.json()) as SocialCallbackBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const weeklyResponse = await handleWeeklyCardCallback(body);
+
+  if (weeklyResponse) {
+    return weeklyResponse;
+  }
+
+  return handleFixtureCallback(body);
 }

--- a/src/app/api/social/match-card/[cardId]/route.ts
+++ b/src/app/api/social/match-card/[cardId]/route.ts
@@ -1,0 +1,223 @@
+// ========================================
+// File: src/app/api/social/match-card/[cardId]/route.ts
+// ========================================
+
+import sharp from "sharp";
+import { SocialPostType } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import {
+  formatWeeklyCardDate,
+  formatWeeklyCardShortDate,
+} from "@/lib/social/weekly-match-card";
+import { formatTimeInLondon } from "@/lib/datetime/london";
+
+export const runtime = "nodejs";
+
+const WIDTH = 1080;
+const HEIGHT = 1350;
+
+type CardRow = {
+  id: string;
+  leagueName: string;
+  season: string | null;
+  fixtureDate: Date;
+  postType: SocialPostType;
+};
+
+type FixtureRow = {
+  id: string;
+  kickoffAt: Date;
+  pitch: string | null;
+  status: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  homeScore: number | null;
+  awayScore: number | null;
+};
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function fitText(value: string, maxLength: number) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+}
+
+function getTitle(postType: SocialPostType) {
+  if (postType === "RESULT") return "RESULTS";
+  if (postType === "UPDATE") return "FIXTURE UPDATE";
+  return "MATCH NIGHT";
+}
+
+function getSubtitle(postType: SocialPostType) {
+  if (postType === "RESULT") return "This week's scores";
+  if (postType === "UPDATE") return "Latest match-night changes";
+  return "This week's fixtures";
+}
+
+function getFixtureLine(fixture: FixtureRow, postType: SocialPostType) {
+  if (
+    postType === "RESULT" &&
+    fixture.homeScore !== null &&
+    fixture.awayScore !== null
+  ) {
+    return {
+      left: fixture.homeTeamName,
+      middle: `${fixture.homeScore} - ${fixture.awayScore}`,
+      right: fixture.awayTeamName,
+      meta: fixture.pitch || "Final score",
+    };
+  }
+
+  return {
+    left: fixture.homeTeamName,
+    middle: "v",
+    right: fixture.awayTeamName,
+    meta: [formatTimeInLondon(fixture.kickoffAt), fixture.pitch]
+      .filter(Boolean)
+      .join(" • "),
+  };
+}
+
+function renderRows(fixtures: FixtureRow[], postType: SocialPostType) {
+  const visibleFixtures = fixtures.slice(0, 8);
+  const startY = 430;
+  const rowGap = 96;
+
+  const rows = visibleFixtures
+    .map((fixture, index) => {
+      const y = startY + index * rowGap;
+      const line = getFixtureLine(fixture, postType);
+      const statusBadge =
+        fixture.status === "POSTPONED" || fixture.status === "CANCELLED"
+          ? `<text x="938" y="${y + 31}" text-anchor="end" fill="#FDE68A" font-size="20" font-weight="800" letter-spacing="1.5">${escapeXml(fixture.status)}</text>`
+          : "";
+
+      return `
+        <g>
+          <rect x="90" y="${y}" width="900" height="74" rx="24" fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.12)"/>
+          <text x="126" y="${y + 31}" fill="#94A3B8" font-size="20" font-weight="700">${escapeXml(line.meta || "SIXFL")}</text>
+          ${statusBadge}
+          <text x="126" y="${y + 58}" fill="#FFFFFF" font-size="28" font-weight="850">${escapeXml(fitText(line.left, 22))}</text>
+          <text x="540" y="${y + 58}" text-anchor="middle" fill="#34D399" font-size="32" font-weight="900">${escapeXml(line.middle)}</text>
+          <text x="954" y="${y + 58}" text-anchor="end" fill="#FFFFFF" font-size="28" font-weight="850">${escapeXml(fitText(line.right, 22))}</text>
+        </g>`;
+    })
+    .join("\n");
+
+  const extra =
+    fixtures.length > visibleFixtures.length
+      ? `<text x="540" y="${startY + visibleFixtures.length * rowGap + 28}" text-anchor="middle" fill="#A7F3D0" font-size="24" font-weight="800">+ ${fixtures.length - visibleFixtures.length} more fixtures</text>`
+      : "";
+
+  return `${rows}${extra}`;
+}
+
+function buildSvg(card: CardRow, fixtures: FixtureRow[]) {
+  const title = getTitle(card.postType);
+  const subtitle = getSubtitle(card.postType);
+  const dateLabel = formatWeeklyCardDate(card.fixtureDate);
+  const shortDateLabel = formatWeeklyCardShortDate(card.fixtureDate).toUpperCase();
+  const leagueLabel = card.season
+    ? `${card.leagueName} • ${card.season}`
+    : card.leagueName;
+
+  return `
+    <svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <radialGradient id="topGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(540 0) rotate(90) scale(760 760)">
+          <stop stop-color="#10B981" stop-opacity="0.38"/>
+          <stop offset="1" stop-color="#020617" stop-opacity="0"/>
+        </radialGradient>
+        <linearGradient id="panel" x1="90" y1="250" x2="990" y2="1120" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#0F172A" stop-opacity="0.96"/>
+          <stop offset="1" stop-color="#020617" stop-opacity="0.98"/>
+        </linearGradient>
+      </defs>
+
+      <rect width="${WIDTH}" height="${HEIGHT}" fill="#020617"/>
+      <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#topGlow)"/>
+      <circle cx="118" cy="160" r="230" fill="#10B981" opacity="0.09"/>
+      <circle cx="954" cy="1236" r="300" fill="#34D399" opacity="0.08"/>
+
+      <rect x="54" y="54" width="972" height="1242" rx="54" fill="rgba(255,255,255,0.035)" stroke="rgba(255,255,255,0.12)"/>
+      <rect x="90" y="250" width="900" height="900" rx="44" fill="url(#panel)" stroke="rgba(255,255,255,0.12)"/>
+
+      <text x="90" y="128" fill="#34D399" font-size="30" font-weight="900" letter-spacing="6">SIXFL</text>
+      <text x="990" y="128" text-anchor="end" fill="#A7F3D0" font-size="20" font-weight="800" letter-spacing="3">${escapeXml(shortDateLabel)}</text>
+
+      <text x="90" y="206" fill="#FFFFFF" font-size="74" font-weight="950" letter-spacing="-3">${escapeXml(title)}</text>
+      <text x="94" y="250" fill="#94A3B8" font-size="28" font-weight="700">${escapeXml(subtitle)}</text>
+
+      <text x="540" y="330" text-anchor="middle" fill="#A7F3D0" font-size="25" font-weight="850" letter-spacing="1.5">${escapeXml(fitText(leagueLabel, 54).toUpperCase())}</text>
+      <text x="540" y="372" text-anchor="middle" fill="#F8FAFC" font-size="32" font-weight="900">${escapeXml(dateLabel)}</text>
+
+      ${renderRows(fixtures, card.postType)}
+
+      <rect x="90" y="1186" width="900" height="70" rx="26" fill="rgba(16,185,129,0.14)" stroke="rgba(52,211,153,0.24)"/>
+      <text x="540" y="1229" text-anchor="middle" fill="#D1FAE5" font-size="28" font-weight="900">6-a-side football. Done properly.</text>
+      <text x="540" y="1288" text-anchor="middle" fill="#64748B" font-size="20" font-weight="750">sixfl.co.uk</text>
+    </svg>`;
+}
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ cardId: string }> },
+) {
+  const { cardId } = await context.params;
+
+  const cards = await prisma.$queryRaw<CardRow[]>`
+    SELECT
+      c."id",
+      l."name" AS "leagueName",
+      l."season",
+      c."fixtureDate",
+      c."postType"
+    FROM "SocialMatchCard" c
+    INNER JOIN "League" l ON l."id" = c."leagueId"
+    WHERE c."id" = ${cardId}
+    LIMIT 1
+  `;
+
+  const card = cards[0];
+
+  if (!card) {
+    return new Response("Weekly social match card not found", { status: 404 });
+  }
+
+  const fixtures = await prisma.$queryRaw<FixtureRow[]>`
+    SELECT
+      f."id",
+      f."kickoffAt",
+      f."pitch",
+      f."status",
+      ht."name" AS "homeTeamName",
+      at."name" AS "awayTeamName",
+      r."homeScore",
+      r."awayScore"
+    FROM "SocialMatchCardFixture" cf
+    INNER JOIN "Fixture" f ON f."id" = cf."fixtureId"
+    INNER JOIN "Team" ht ON ht."id" = f."homeTeamId"
+    INNER JOIN "Team" at ON at."id" = f."awayTeamId"
+    LEFT JOIN "MatchResult" r ON r."fixtureId" = f."id"
+    WHERE cf."socialMatchCardId" = ${cardId}
+    ORDER BY cf."position" ASC, f."kickoffAt" ASC
+  `;
+
+  const svg = buildSvg(card, fixtures);
+  const output = await sharp(Buffer.from(svg)).png().toBuffer();
+
+  return new Response(new Uint8Array(output), {
+    status: 200,
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=60, s-maxage=60",
+    },
+  });
+}

--- a/src/lib/social/weekly-match-card.ts
+++ b/src/lib/social/weekly-match-card.ts
@@ -1,0 +1,134 @@
+// ========================================
+// File: src/lib/social/weekly-match-card.ts
+// ========================================
+
+import { SocialPostType } from "@prisma/client";
+import { formatDateTimeInLondon, formatTimeInLondon } from "@/lib/datetime/london";
+
+export type WeeklySocialPostType = Extract<
+  SocialPostType,
+  "FIXTURE" | "RESULT" | "UPDATE"
+>;
+
+export type WeeklyMatchCardFixture = {
+  id: string;
+  kickoffAt: Date;
+  pitch: string | null;
+  status: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  homeScore: number | null;
+  awayScore: number | null;
+};
+
+export function getBaseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL?.trim() ||
+    process.env.NEXTAUTH_URL?.trim() ||
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+}
+
+export function getWeeklyMatchCardImageUrl(cardId: string) {
+  return `${getBaseUrl()}/api/social/match-card/${cardId}`;
+}
+
+export function formatWeeklyCardDate(value: Date | string) {
+  return formatDateTimeInLondon(value, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+export function formatWeeklyCardShortDate(value: Date | string) {
+  return formatDateTimeInLondon(value, {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+  });
+}
+
+export function getWeeklyPostTypeLabel(postType: SocialPostType | string) {
+  switch (postType) {
+    case "RESULT":
+      return "Results card";
+    case "UPDATE":
+      return "Update card";
+    case "FIXTURE":
+    default:
+      return "Match card";
+  }
+}
+
+export function normaliseSocialText(value: string) {
+  return value
+    .replaceAll("’", "'")
+    .replaceAll("‘", "'")
+    .replaceAll("“", '"')
+    .replaceAll("”", '"')
+    .replaceAll("•", "-")
+    .replaceAll("–", "-")
+    .replaceAll("—", "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildFixtureLine(input: {
+  fixture: WeeklyMatchCardFixture;
+  postType: WeeklySocialPostType;
+}) {
+  const time = formatTimeInLondon(input.fixture.kickoffAt);
+  const pitch = input.fixture.pitch ? ` - ${input.fixture.pitch}` : "";
+
+  if (
+    input.postType === "RESULT" &&
+    input.fixture.homeScore !== null &&
+    input.fixture.awayScore !== null
+  ) {
+    return `${input.fixture.homeTeamName} ${input.fixture.homeScore}-${input.fixture.awayScore} ${input.fixture.awayTeamName}`;
+  }
+
+  if (input.postType === "UPDATE") {
+    const status = input.fixture.status.toLowerCase();
+    return `${time}${pitch} - ${input.fixture.homeTeamName} v ${input.fixture.awayTeamName} (${status})`;
+  }
+
+  return `${time}${pitch} - ${input.fixture.homeTeamName} v ${input.fixture.awayTeamName}`;
+}
+
+export function buildWeeklyMatchCardCaption(input: {
+  postType: WeeklySocialPostType;
+  leagueName: string;
+  fixtureDate: Date;
+  fixtures: WeeklyMatchCardFixture[];
+}) {
+  const dateLabel = formatWeeklyCardDate(input.fixtureDate);
+  const heading =
+    input.postType === "RESULT"
+      ? `${input.leagueName} results - ${dateLabel}`
+      : input.postType === "UPDATE"
+        ? `${input.leagueName} fixture update - ${dateLabel}`
+        : `${input.leagueName} fixtures - ${dateLabel}`;
+
+  const lines = input.fixtures
+    .slice(0, 10)
+    .map((fixture) => buildFixtureLine({ fixture, postType: input.postType }));
+
+  const suffix =
+    input.fixtures.length > 10
+      ? [`+ ${input.fixtures.length - 10} more fixtures on the night.`]
+      : [];
+
+  return normaliseSocialText(
+    [
+      heading,
+      "",
+      ...lines,
+      ...suffix,
+      "",
+      "6-a-side football. Done properly.",
+      "#SIXFL #SixASideFootball #GrassrootsFootball",
+    ].join("\n"),
+  );
+}

--- a/src/lib/social/weekly-match-card.ts
+++ b/src/lib/social/weekly-match-card.ts
@@ -70,7 +70,10 @@ export function normaliseSocialText(value: string) {
     .replaceAll("•", "-")
     .replaceAll("–", "-")
     .replaceAll("—", "-")
-    .replace(/\s+/g, " ")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+/g, " ").trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 


### PR DESCRIPTION
## Summary

Replaces the admin social workflow with a weekly match-card workflow so SIXFL can publish one unified Facebook/Instagram card per league match night instead of one post per fixture.

### Added
- New weekly social match-card migration with `SocialMatchCard` and `SocialMatchCardFixture` tables.
- Weekly card helpers for captions, image URLs, and date labels.
- Admin server actions to generate, approve, publish, mark published, and delete weekly cards.
- New PNG image endpoint at `/api/social/match-card/[cardId]` for a vertical 1080x1350 match-night card.
- Callback support for both old fixture-level payloads and new `cardId` / `socialMatchCardId` payloads.
- Reworked `/admin/social` around suggested match nights and a weekly social queue.

## Notes
- Existing fixture social fields/actions are left in place for backwards compatibility.
- The new main workflow is Admin → Social → generate one card per league night.
- Publish webhook event is now `weekly.social.publish.requested` and includes `cardId`, `caption`, `imageUrl`, `fixtureDate`, and platforms.

## Safety
- No existing fixture/result/team data is deleted or reset.
- Migration only creates new tables and indexes.
- Existing callback path still accepts fixture-level callbacks.