### PR TITLE
Fix managed squad profile backfill errors

### DIFF
--- a/src/lib/teamMemberProfiles.ts
+++ b/src/lib/teamMemberProfiles.ts
@@ -47,6 +47,29 @@ function serializeJsonNullable(value: Prisma.JsonValue | null | undefined) {
   return JSON.stringify(value);
 }
 
+async function getSafeSourceProspectId(input: {
+  client: PrismaClientLike;
+  teamMemberId: string;
+  sourceProspectId: string;
+}) {
+  const existing = await input.client.$queryRaw<
+    Array<{ teamMemberId: string }>
+  >`
+    SELECT "teamMemberId"
+    FROM "TeamMemberProfile"
+    WHERE "sourceProspectId" = ${input.sourceProspectId}
+    LIMIT 1
+  `;
+
+  const existingTeamMemberId = existing[0]?.teamMemberId ?? null;
+
+  if (existingTeamMemberId && existingTeamMemberId !== input.teamMemberId) {
+    return null;
+  }
+
+  return input.sourceProspectId;
+}
+
 export async function upsertTeamMemberProfileFromProspect(input: {
   client: PrismaClientLike;
   teamMemberId: string;
@@ -54,47 +77,65 @@ export async function upsertTeamMemberProfileFromProspect(input: {
 }) {
   const id = randomUUID();
   const preferredNightsJson = serializeJsonNullable(input.prospect.preferredNights);
+  const sourceProspectId = await getSafeSourceProspectId({
+    client: input.client,
+    teamMemberId: input.teamMemberId,
+    sourceProspectId: input.prospect.id,
+  });
 
-  await input.client.$executeRaw`
-    INSERT INTO "TeamMemberProfile" (
-      "id",
-      "teamMemberId",
-      "sourceProspectId",
-      "phone",
-      "ageBand",
-      "preferredPositions",
-      "experienceSummary",
-      "availabilityLevel",
-      "preferredNights",
-      "availabilitySummary",
-      "notes",
-      "updatedAt"
-    ) VALUES (
-      ${id},
-      ${input.teamMemberId},
-      ${input.prospect.id},
-      ${trimNullable(input.prospect.phone)},
-      ${trimNullable(input.prospect.ageBand)},
-      ${trimNullable(input.prospect.preferredPositions)},
-      ${trimNullable(input.prospect.experienceSummary)},
-      ${trimNullable(input.prospect.availabilityLevel)},
-      CAST(${preferredNightsJson} AS jsonb),
-      ${trimNullable(input.prospect.availabilitySummary)},
-      ${trimNullable(input.prospect.notes)},
-      NOW()
-    )
-    ON CONFLICT ("teamMemberId") DO UPDATE SET
-      "sourceProspectId" = COALESCE("TeamMemberProfile"."sourceProspectId", EXCLUDED."sourceProspectId"),
-      "phone" = COALESCE(NULLIF(EXCLUDED."phone", ''), "TeamMemberProfile"."phone"),
-      "ageBand" = COALESCE(NULLIF(EXCLUDED."ageBand", ''), "TeamMemberProfile"."ageBand"),
-      "preferredPositions" = COALESCE(NULLIF(EXCLUDED."preferredPositions", ''), "TeamMemberProfile"."preferredPositions"),
-      "experienceSummary" = COALESCE(NULLIF(EXCLUDED."experienceSummary", ''), "TeamMemberProfile"."experienceSummary"),
-      "availabilityLevel" = COALESCE(NULLIF(EXCLUDED."availabilityLevel", ''), "TeamMemberProfile"."availabilityLevel"),
-      "preferredNights" = COALESCE(EXCLUDED."preferredNights", "TeamMemberProfile"."preferredNights"),
-      "availabilitySummary" = COALESCE(NULLIF(EXCLUDED."availabilitySummary", ''), "TeamMemberProfile"."availabilitySummary"),
-      "notes" = COALESCE(NULLIF(EXCLUDED."notes", ''), "TeamMemberProfile"."notes"),
-      "updatedAt" = NOW()
-  `;
+  await input.client.$executeRawUnsafe(
+    `
+      INSERT INTO "TeamMemberProfile" (
+        "id",
+        "teamMemberId",
+        "sourceProspectId",
+        "phone",
+        "ageBand",
+        "preferredPositions",
+        "experienceSummary",
+        "availabilityLevel",
+        "preferredNights",
+        "availabilitySummary",
+        "notes",
+        "updatedAt"
+      ) VALUES (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7,
+        $8,
+        $9::jsonb,
+        $10,
+        $11,
+        NOW()
+      )
+      ON CONFLICT ("teamMemberId") DO UPDATE SET
+        "sourceProspectId" = COALESCE("TeamMemberProfile"."sourceProspectId", EXCLUDED."sourceProspectId"),
+        "phone" = COALESCE(NULLIF(EXCLUDED."phone", ''), "TeamMemberProfile"."phone"),
+        "ageBand" = COALESCE(NULLIF(EXCLUDED."ageBand", ''), "TeamMemberProfile"."ageBand"),
+        "preferredPositions" = COALESCE(NULLIF(EXCLUDED."preferredPositions", ''), "TeamMemberProfile"."preferredPositions"),
+        "experienceSummary" = COALESCE(NULLIF(EXCLUDED."experienceSummary", ''), "TeamMemberProfile"."experienceSummary"),
+        "availabilityLevel" = COALESCE(NULLIF(EXCLUDED."availabilityLevel", ''), "TeamMemberProfile"."availabilityLevel"),
+        "preferredNights" = COALESCE(EXCLUDED."preferredNights", "TeamMemberProfile"."preferredNights"),
+        "availabilitySummary" = COALESCE(NULLIF(EXCLUDED."availabilitySummary", ''), "TeamMemberProfile"."availabilitySummary"),
+        "notes" = COALESCE(NULLIF(EXCLUDED."notes", ''), "TeamMemberProfile"."notes"),
+        "updatedAt" = NOW()
+    `,
+    id,
+    input.teamMemberId,
+    sourceProspectId,
+    trimNullable(input.prospect.phone),
+    trimNullable(input.prospect.ageBand),
+    trimNullable(input.prospect.preferredPositions),
+    trimNullable(input.prospect.experienceSummary),
+    trimNullable(input.prospect.availabilityLevel),
+    preferredNightsJson,
+    trimNullable(input.prospect.availabilitySummary),
+    trimNullable(input.prospect.notes),
+  );
 }
 
 export async function getTeamMemberProfilesByTeamMemberIds(teamMemberIds: string[]) {


### PR DESCRIPTION
## Summary

- fix the managed squad profile backfill raw upsert used by the availability reminder job
- bind the JSON value with an explicit `$9::jsonb` placeholder instead of casting a Prisma template value inline
- avoid unique `sourceProspectId` conflicts by only linking the source prospect when it is not already linked to another team member

## Why

The managed squad availability cron was returning 200, but the backfill section was reporting `Invalid prisma.$executeRaw...` errors. This keeps the reminder job working while removing the noisy backfill failures.

## Notes

- No database reset
- No destructive migration
- Runtime-only safe backfill fix