### PR TITLE
Add WhatsApp marker to admin users

### DIFF
--- a/prisma/migrations/20260511130000_add_user_whatsapp_marker/migration.sql
+++ b/prisma/migrations/20260511130000_add_user_whatsapp_marker/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "usesWhatsapp" BOOLEAN NOT NULL DEFAULT false;

--- a/src/app/(admin)/admin/teams/[id]/squad/page.tsx
+++ b/src/app/(admin)/admin/teams/[id]/squad/page.tsx
@@ -4,7 +4,7 @@
 
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { TeamRole } from "@prisma/client";
+import { Prisma, TeamRole } from "@prisma/client";
 
 import FormListboxField from "@/components/ui/FormListboxField";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
@@ -159,6 +159,19 @@ export default async function AdminTeamSquadPage({
   if (!team) {
     notFound();
   }
+
+  const memberUserIds = team.members.map((member) => member.user.id);
+  const whatsappRows = memberUserIds.length
+    ? await prisma.$queryRaw<Array<{ id: string; usesWhatsapp: boolean }>>`
+        SELECT id, "usesWhatsapp"
+        FROM "User"
+        WHERE id IN (${Prisma.join(memberUserIds)})
+      `
+    : [];
+
+  const whatsappByUserId = new Map(
+    whatsappRows.map((row) => [row.id, Boolean(row.usesWhatsapp)]),
+  );
 
   const captainCount = team.members.filter(
     (member) => member.role === "CAPTAIN",
@@ -322,87 +335,105 @@ export default async function AdminTeamSquadPage({
                 No squad members are attached to this team yet.
               </div>
             ) : (
-              team.members.map((member) => (
-                <div
-                  key={member.id}
-                  className="flex flex-col gap-5 px-6 py-5 xl:flex-row xl:items-center xl:justify-between"
-                >
-                  <div className="flex min-w-0 items-start gap-4">
-                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-sm font-black text-white/70">
-                      {getInitials(member.user.name, member.user.email)}
-                    </div>
+              team.members.map((member) => {
+                const usesWhatsapp = whatsappByUserId.get(member.user.id) ?? false;
 
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <div className="truncate text-base font-semibold text-white">
-                          {member.user.name || "Unnamed user"}
+                return (
+                  <div
+                    key={member.id}
+                    className="flex flex-col gap-5 px-6 py-5 xl:flex-row xl:items-center xl:justify-between"
+                  >
+                    <div className="flex min-w-0 items-start gap-4">
+                      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-sm font-black text-white/70">
+                        {getInitials(member.user.name, member.user.email)}
+                      </div>
+
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <div className="truncate text-base font-semibold text-white">
+                              {member.user.name || "Unnamed user"}
+                            </div>
+                            {usesWhatsapp ? (
+                              <span
+                                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-500/10"
+                                title="Uses WhatsApp"
+                              >
+                                <img
+                                  src="/WhatsApp-Logo.png"
+                                  alt="WhatsApp"
+                                  className="h-4 w-4 object-contain"
+                                />
+                              </span>
+                            ) : null}
+                          </div>
+
+                          <span
+                            className={`rounded-full border px-2.5 py-1 text-[11px] font-medium ${getRoleBadgeClasses(
+                              member.role,
+                            )}`}
+                          >
+                            {getRoleLabel(member.role)}
+                          </span>
                         </div>
 
-                        <span
-                          className={`rounded-full border px-2.5 py-1 text-[11px] font-medium ${getRoleBadgeClasses(
-                            member.role,
-                          )}`}
-                        >
-                          {getRoleLabel(member.role)}
-                        </span>
-                      </div>
+                        <div className="mt-2 text-sm text-white/65">
+                          {member.user.email || "No email on account"}
+                        </div>
 
-                      <div className="mt-2 text-sm text-white/65">
-                        {member.user.email || "No email on account"}
-                      </div>
-
-                      <div className="mt-1 text-xs text-white/45">
-                        Added {formatUkDateTime(member.createdAt)}
+                        <div className="mt-1 text-xs text-white/45">
+                          Added {formatUkDateTime(member.createdAt)}
+                        </div>
                       </div>
                     </div>
-                  </div>
 
-                  <div className="flex flex-col gap-3 sm:flex-row xl:items-center">
-                    <form
-                      action={updateAdminSquadMemberRoleAction}
-                      className="flex flex-wrap items-center gap-3"
-                    >
-                      <input type="hidden" name="teamId" value={team.id} />
-                      <input
-                        type="hidden"
-                        name="membershipId"
-                        value={member.id}
-                      />
-
-                      <div className="min-w-[240px]">
-                        <FormListboxField
-                          name="role"
-                          value={member.role}
-                          options={roleOptions}
-                          placeholder="Select role"
+                    <div className="flex flex-col gap-3 sm:flex-row xl:items-center">
+                      <form
+                        action={updateAdminSquadMemberRoleAction}
+                        className="flex flex-wrap items-center gap-3"
+                      >
+                        <input type="hidden" name="teamId" value={team.id} />
+                        <input
+                          type="hidden"
+                          name="membershipId"
+                          value={member.id}
                         />
-                      </div>
 
-                      <button
-                        type="submit"
-                        className="inline-flex items-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15"
-                      >
-                        Update role
-                      </button>
-                    </form>
+                        <div className="min-w-[240px]">
+                          <FormListboxField
+                            name="role"
+                            value={member.role}
+                            options={roleOptions}
+                            placeholder="Select role"
+                          />
+                        </div>
 
-                    <form action={removeAdminSquadMemberAction}>
-                      <input type="hidden" name="teamId" value={team.id} />
-                      <input
-                        type="hidden"
-                        name="membershipId"
-                        value={member.id}
-                      />
-                      <button
-                        type="submit"
-                        className="inline-flex items-center rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-2.5 text-sm font-medium text-red-100 transition hover:bg-red-500/15"
-                      >
-                        Remove
-                      </button>
-                    </form>
+                        <button
+                          type="submit"
+                          className="inline-flex items-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15"
+                        >
+                          Update role
+                        </button>
+                      </form>
+
+                      <form action={removeAdminSquadMemberAction}>
+                        <input type="hidden" name="teamId" value={team.id} />
+                        <input
+                          type="hidden"
+                          name="membershipId"
+                          value={member.id}
+                        />
+                        <button
+                          type="submit"
+                          className="inline-flex items-center rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-2.5 text-sm font-medium text-red-100 transition hover:bg-red-500/15"
+                        >
+                          Remove
+                        </button>
+                      </form>
+                    </div>
                   </div>
-                </div>
-              ))
+                );
+              })
             )}
           </div>
         </div>

--- a/src/app/(admin)/admin/users/actions.ts
+++ b/src/app/(admin)/admin/users/actions.ts
@@ -36,6 +36,7 @@ export async function updateAdminUserProfileAction(formData: FormData) {
 
   const userId = String(formData.get("userId") ?? "").trim();
   const name = String(formData.get("name") ?? "").trim();
+  const usesWhatsapp = formData.get("usesWhatsapp") === "on";
   const from = getSafeRedirectPath(formData.get("from"), "/admin/users");
 
   if (!userId) {
@@ -46,14 +47,25 @@ export async function updateAdminUserProfileAction(formData: FormData) {
     redirect(appendStatusToPath(from, "error", "Name is required."));
   }
 
-  await prisma.user.update({
-    where: { id: userId },
-    data: {
-      name,
-    },
+  await prisma.$transaction(async (tx) => {
+    await tx.user.update({
+      where: { id: userId },
+      data: {
+        name,
+      },
+    });
+
+    await tx.$executeRaw`
+      UPDATE "User"
+      SET "usesWhatsapp" = ${usesWhatsapp}
+      WHERE id = ${userId}
+    `;
   });
 
   revalidatePath("/admin/users");
+  revalidatePath("/admin/captains");
+  revalidatePath("/admin/teams");
+  revalidatePath("/captain");
   redirect(appendStatusToPath(from, "saved", "1"));
 }
 

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -2,6 +2,7 @@
 // File: src/app/(admin)/admin/users/page.tsx
 // ========================================
 
+import { Prisma } from "@prisma/client";
 import Link from "next/link";
 
 import { prisma } from "@/lib/prisma";
@@ -68,6 +69,18 @@ export default async function AdminUsersPage({
     },
   });
 
+  const whatsappRows = users.length
+    ? await prisma.$queryRaw<Array<{ id: string; usesWhatsapp: boolean }>>`
+        SELECT id, "usesWhatsapp"
+        FROM "User"
+        WHERE id IN (${Prisma.join(users.map((user) => user.id))})
+      `
+    : [];
+
+  const whatsappByUserId = new Map(
+    whatsappRows.map((row) => [row.id, Boolean(row.usesWhatsapp)]),
+  );
+
   const emails = users
     .map((user) => normaliseEmail(user.email))
     .filter((email): email is string => Boolean(email));
@@ -96,7 +109,7 @@ export default async function AdminUsersPage({
 
   const savedMessage = sp.saved
     ? sp.saved === "1"
-      ? "User name updated."
+      ? "User details updated."
       : decodeURIComponent(sp.saved)
     : null;
 
@@ -111,7 +124,7 @@ export default async function AdminUsersPage({
             Users
           </h1>
           <p className="max-w-3xl text-sm text-white/60 sm:text-base">
-            Search users, fix missing names, and link user accounts to matching squad prospects.
+            Search users, fix missing names, mark WhatsApp contacts, and link user accounts to matching squad prospects.
           </p>
         </div>
 
@@ -170,6 +183,7 @@ export default async function AdminUsersPage({
             const email = normaliseEmail(user.email);
             const prospects = email ? prospectsByEmail.get(email) ?? [] : [];
             const isLinked = user.teamMembers.length > 0;
+            const usesWhatsapp = whatsappByUserId.get(user.id) ?? false;
             const repairHref = email
               ? `/admin/users/link-prospect?email=${encodeURIComponent(email)}`
               : "/admin/users/link-prospect";
@@ -183,8 +197,22 @@ export default async function AdminUsersPage({
 
                   <div className="min-w-0 space-y-3">
                     <div className="flex flex-wrap items-center gap-2">
-                      <div className="truncate text-base font-semibold text-white">
-                        {user.name || "Unnamed user"}
+                      <div className="flex min-w-0 items-center gap-2">
+                        <div className="truncate text-base font-semibold text-white">
+                          {user.name || "Unnamed user"}
+                        </div>
+                        {usesWhatsapp ? (
+                          <span
+                            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-500/10"
+                            title="Uses WhatsApp"
+                          >
+                            <img
+                              src="/WhatsApp-Logo.png"
+                              alt="WhatsApp"
+                              className="h-4 w-4 object-contain"
+                            />
+                          </span>
+                        ) : null}
                       </div>
                       <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-medium text-white/70">
                         {user.role}
@@ -273,11 +301,36 @@ export default async function AdminUsersPage({
                     />
                   </div>
 
+                  <label className="flex cursor-pointer items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 transition hover:bg-white/[0.06]">
+                    <span className="flex items-center gap-3">
+                      <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl border border-emerald-400/20 bg-emerald-500/10">
+                        <img
+                          src="/WhatsApp-Logo.png"
+                          alt=""
+                          className="h-5 w-5 object-contain"
+                        />
+                      </span>
+                      <span>
+                        <span className="block text-sm font-semibold text-white">Show WhatsApp logo</span>
+                        <span className="block text-xs text-white/45">Adds the WhatsApp icon beside this user&apos;s name.</span>
+                      </span>
+                    </span>
+                    <span className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-white/10 bg-black/30 p-0.5">
+                      <input
+                        type="checkbox"
+                        name="usesWhatsapp"
+                        defaultChecked={usesWhatsapp}
+                        className="peer sr-only"
+                      />
+                      <span className="h-5 w-5 rounded-full bg-white/45 transition peer-checked:translate-x-5 peer-checked:bg-emerald-300" />
+                    </span>
+                  </label>
+
                   <button
                     type="submit"
                     className="inline-flex items-center rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-emerald-500"
                   >
-                    Save name
+                    Save user
                   </button>
                 </form>
               </div>


### PR DESCRIPTION
## Summary
- Adds a `usesWhatsapp` marker column to users with a safe, non-destructive Prisma migration.
- Adds a premium checkbox/toggle to `/admin/users` so admins can mark whether a user uses WhatsApp.
- Shows `/WhatsApp-Logo.png` next to marked users on the admin users screen and the admin team squad screen.

## Notes
- Assumes the image is available in the public folder as `WhatsApp-Logo.png`, so the browser path is `/WhatsApp-Logo.png`.
- Deploy with the normal non-destructive migration flow (`prisma migrate deploy`) so the new column exists before the updated page is used.