### PR TITLE
Show WhatsApp logo on captain squad page

### DIFF
--- a/src/app/captain/team/[teamid]/squad/WhatsAppSquadBadges.tsx
+++ b/src/app/captain/team/[teamid]/squad/WhatsAppSquadBadges.tsx
@@ -1,0 +1,110 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/squad/WhatsAppSquadBadges.tsx
+// ========================================
+
+"use client";
+
+import { useEffect } from "react";
+
+type WhatsAppBadgeEntry = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
+type WhatsAppSquadBadgesProps = {
+  entries: WhatsAppBadgeEntry[];
+};
+
+function makeBadge() {
+  const badge = document.createElement("span");
+  badge.setAttribute("data-sixfl-whatsapp-badge", "true");
+  badge.setAttribute("title", "Uses WhatsApp");
+  badge.className =
+    "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-500/10";
+
+  const image = document.createElement("img");
+  image.src = "/WhatsApp-Logo.png";
+  image.alt = "WhatsApp";
+  image.className = "h-4 w-4 object-contain";
+
+  badge.appendChild(image);
+
+  return badge;
+}
+
+function getTextNodesContaining(value: string) {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const matches: Text[] = [];
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    if (node.textContent?.includes(value)) {
+      matches.push(node);
+    }
+  }
+
+  return matches;
+}
+
+function findSquadRowFromEmail(email: string) {
+  const emailNodes = getTextNodesContaining(email);
+
+  for (const node of emailNodes) {
+    const parentElement = node.parentElement;
+    const row = parentElement?.closest("div.flex.flex-col.gap-5.px-6.py-5");
+
+    if (row instanceof HTMLElement) {
+      return row;
+    }
+  }
+
+  return null;
+}
+
+function findNameElement(row: HTMLElement, name: string | null, email: string | null) {
+  const expectedLabel = (name || email || "Unnamed user").trim();
+  if (!expectedLabel) return null;
+
+  const candidates = Array.from(row.querySelectorAll("div"));
+
+  return (
+    candidates.find((candidate) => {
+      const element = candidate as HTMLElement;
+      return (
+        element.textContent?.trim() === expectedLabel &&
+        element.className.includes("font-semibold") &&
+        element.className.includes("text-white")
+      );
+    }) ?? null
+  );
+}
+
+function addWhatsAppBadges(entries: WhatsAppBadgeEntry[]) {
+  for (const entry of entries) {
+    if (!entry.email?.trim()) continue;
+
+    const row = findSquadRowFromEmail(entry.email.trim());
+    if (!row || row.querySelector("[data-sixfl-whatsapp-badge='true']")) continue;
+
+    const nameElement = findNameElement(row, entry.name, entry.email);
+    if (!nameElement) continue;
+
+    nameElement.insertAdjacentElement("afterend", makeBadge());
+  }
+}
+
+export default function WhatsAppSquadBadges({ entries }: WhatsAppSquadBadgesProps) {
+  useEffect(() => {
+    if (entries.length === 0) return;
+
+    addWhatsAppBadges(entries);
+
+    const observer = new MutationObserver(() => addWhatsAppBadges(entries));
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [entries]);
+
+  return null;
+}

--- a/src/app/captain/team/[teamid]/squad/layout.tsx
+++ b/src/app/captain/team/[teamid]/squad/layout.tsx
@@ -1,0 +1,35 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/squad/layout.tsx
+// ========================================
+
+import { prisma } from "@/lib/prisma";
+import WhatsAppSquadBadges from "./WhatsAppSquadBadges";
+
+type CaptainSquadLayoutProps = {
+  children: React.ReactNode;
+  params: Promise<{ teamid: string }>;
+};
+
+export default async function CaptainSquadLayout({
+  children,
+  params,
+}: CaptainSquadLayoutProps) {
+  const { teamid } = await params;
+
+  const whatsappEntries = await prisma.$queryRaw<
+    Array<{ id: string; name: string | null; email: string | null }>
+  >`
+    SELECT u.id, u.name, u.email
+    FROM "TeamMember" tm
+    INNER JOIN "User" u ON u.id = tm."userId"
+    WHERE tm."teamId" = ${teamid}
+      AND u."usesWhatsapp" = true
+  `;
+
+  return (
+    <>
+      {children}
+      <WhatsAppSquadBadges entries={whatsappEntries} />
+    </>
+  );
+}

--- a/src/app/captain/team/[teamid]/squad/layout.tsx
+++ b/src/app/captain/team/[teamid]/squad/layout.tsx
@@ -2,11 +2,14 @@
 // File: src/app/captain/team/[teamid]/squad/layout.tsx
 // ========================================
 
+import type { ReactNode } from "react";
+
 import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
 import WhatsAppSquadBadges from "./WhatsAppSquadBadges";
 
 type CaptainSquadLayoutProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   params: Promise<{ teamid: string }>;
 };
 
@@ -15,6 +18,7 @@ export default async function CaptainSquadLayout({
   params,
 }: CaptainSquadLayoutProps) {
   const { teamid } = await params;
+  await requireCaptain(teamid);
 
   const whatsappEntries = await prisma.$queryRaw<
     Array<{ id: string; name: string | null; email: string | null }>


### PR DESCRIPTION
## Summary
- Adds the WhatsApp marker to the captain squad screen at `/captain/team/[teamid]/squad`.
- Uses the existing admin tick-box setting and shows `/WhatsApp-Logo.png` beside marked linked squad members.
- Keeps the route protected with `requireCaptain(teamid)` before loading the WhatsApp marker data.

## Notes
- This follows on from the merged admin users WhatsApp marker work.
- The image filename still needs to match `public/WhatsApp-Logo.png` exactly.