### PR TITLE
Split admin squad console from limited captain squad view

### DIFF
--- a/src/app/(admin)/admin/teams/[id]/squad/page.tsx
+++ b/src/app/(admin)/admin/teams/[id]/squad/page.tsx
@@ -20,7 +20,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata = {
-  title: "Admin Team Squad | SIXFL",
+  title: "Admin Squad Console | SIXFL",
 };
 
 type SearchParams = {
@@ -204,21 +204,28 @@ export default async function AdminTeamSquadPage({
           </Link>
 
           <h1 className="text-3xl font-semibold text-white">
-            {team.name} squad
+            {team.name} admin squad console
           </h1>
 
           <p className="text-sm text-white/60">
-            Admin control for team membership, leadership roles, and organiser
-            structure.
+            Full SIXFL admin control for team membership, leadership roles,
+            organiser structure and managed squad maintenance.
           </p>
         </div>
 
         <div className="flex flex-wrap gap-3">
           <Link
+            href={`/captain/team/${team.id}/captain-squad`}
+            className="inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15"
+          >
+            Preview weaker captain view
+          </Link>
+
+          <Link
             href={`/captain/team/${team.id}/squad`}
             className="inline-flex items-center justify-center rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-2.5 text-sm font-medium text-amber-100 transition hover:bg-amber-500/15"
           >
-            Captain squad view
+            Open managed squad tools
           </Link>
 
           <Link
@@ -246,7 +253,7 @@ export default async function AdminTeamSquadPage({
         <div className="grid gap-8 px-6 py-6 lg:grid-cols-[1.15fr_0.85fr] lg:px-8 lg:py-8">
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
-              Team structure
+              Admin squad console
             </p>
 
             <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
@@ -504,10 +511,17 @@ export default async function AdminTeamSquadPage({
               </Link>
 
               <Link
+                href={`/captain/team/${team.id}/captain-squad`}
+                className="inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15"
+              >
+                Preview weaker captain view
+              </Link>
+
+              <Link
                 href={`/captain/team/${team.id}/squad`}
                 className="inline-flex items-center justify-center rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-2.5 text-sm font-medium text-amber-100 transition hover:bg-amber-500/15"
               >
-                Open captain squad view
+                Open managed squad tools
               </Link>
             </div>
           </section>

--- a/src/app/captain/team/[teamid]/captain-squad/page.tsx
+++ b/src/app/captain/team/[teamid]/captain-squad/page.tsx
@@ -1,0 +1,416 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/captain-squad/page.tsx
+// ========================================
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { TeamRole } from "@prisma/client";
+
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getTeamMemberProfilesByTeamMemberIds } from "@/lib/teamMemberProfiles";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Captain Squad | SIXFL",
+};
+
+type SearchParams = {
+  error?: string;
+};
+
+function getRoleLabel(role: TeamRole) {
+  switch (role) {
+    case "CAPTAIN":
+      return "Captain";
+    case "MANAGER":
+      return "Manager";
+    case "VICE_CAPTAIN":
+      return "Vice captain";
+    case "BACKUP_PLAYER":
+      return "Backup player";
+    case "COACH":
+      return "Coach";
+    case "PLAYER":
+      return "Player";
+    default:
+      return role;
+  }
+}
+
+function getRoleBadgeClasses(role: TeamRole) {
+  switch (role) {
+    case "CAPTAIN":
+      return "border-amber-400/25 bg-amber-500/10 text-amber-100";
+    case "MANAGER":
+      return "border-emerald-400/25 bg-emerald-500/10 text-emerald-100";
+    case "VICE_CAPTAIN":
+      return "border-violet-400/25 bg-violet-500/10 text-violet-100";
+    case "BACKUP_PLAYER":
+      return "border-sky-400/25 bg-sky-500/10 text-sky-100";
+    case "COACH":
+      return "border-white/15 bg-white/5 text-white/80";
+    default:
+      return "border-white/10 bg-white/5 text-white/75";
+  }
+}
+
+function getInitials(name: string | null | undefined) {
+  const parts = (name || "Player")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  return parts.map((part) => part[0]?.toUpperCase() ?? "").join("") || "P";
+}
+
+function formatUkDate(value: Date) {
+  return formatDateTimeInLondon(value, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatPreferredNights(value: unknown) {
+  if (!value) return null;
+
+  if (Array.isArray(value)) {
+    return value.filter(Boolean).join(", ") || null;
+  }
+
+  if (typeof value === "object") {
+    return (
+      Object.values(value as Record<string, unknown>)
+        .flat()
+        .filter(Boolean)
+        .map(String)
+        .join(", ") || null
+    );
+  }
+
+  return String(value);
+}
+
+function DetailPill({ label, value }: { label: string; value: string | null | undefined }) {
+  if (!value?.trim()) return null;
+
+  return (
+    <span className="inline-flex rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-white/70">
+      <span className="text-white/40">{label}:</span>
+      <span className="ml-1 text-white/80">{value}</span>
+    </span>
+  );
+}
+
+export default async function CaptainSquadViewPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ teamid: string }>;
+  searchParams: Promise<SearchParams>;
+}) {
+  const { teamid } = await params;
+  const filters = await searchParams;
+  const access = await requireCaptain(teamid);
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamid },
+    select: {
+      id: true,
+      name: true,
+      league: {
+        select: {
+          id: true,
+          name: true,
+          season: true,
+        },
+      },
+      members: {
+        orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+        select: {
+          id: true,
+          role: true,
+          createdAt: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
+      prospects: {
+        where: {
+          status: "ACTIVE_SQUAD",
+        },
+        orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          updatedAt: true,
+        },
+      },
+    },
+  });
+
+  if (!team) notFound();
+
+  const profileByMemberId = await getTeamMemberProfilesByTeamMemberIds(
+    team.members.map((member) => member.id),
+  );
+
+  const organiserCount = team.members.filter((member) =>
+    ["CAPTAIN", "MANAGER", "VICE_CAPTAIN"].includes(member.role),
+  ).length;
+  const playerCount = team.members.filter((member) => member.role === "PLAYER").length;
+  const backupCount = team.members.filter((member) => member.role === "BACKUP_PLAYER").length;
+  const pendingAccountCount = team.prospects.length;
+  const totalSquadCount = team.members.length + pendingAccountCount;
+  const errorMessage = filters.error ? decodeURIComponent(filters.error) : null;
+
+  return (
+    <div className="space-y-8">
+      <section className="overflow-hidden rounded-3xl border border-emerald-400/15 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.03))] shadow-[0_24px_80px_rgba(0,0,0,0.3)]">
+        <div className="grid gap-8 px-6 py-6 lg:grid-cols-[1.15fr_0.85fr] lg:px-8 lg:py-8">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
+              Captain squad view
+            </p>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Team squad
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm text-white/70 sm:text-base">
+              A captain-safe view of your squad. You can see who is attached to the team and who may need availability chased, but player records, role changes, activation messages and internal notes stay with SIXFL admin.
+            </p>
+
+            <div className="mt-5 flex flex-wrap gap-2">
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/75">
+                {team.league?.name ?? "No league assigned"}
+                {team.league?.season ? ` · ${team.league.season}` : ""}
+              </span>
+              <span className="rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-100">
+                {totalSquadCount} squad player{totalSquadCount === 1 ? "" : "s"}
+              </span>
+              {pendingAccountCount > 0 ? (
+                <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-100">
+                  {pendingAccountCount} awaiting account link
+                </span>
+              ) : null}
+            </div>
+
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link
+                href={`/captain/team/${teamid}`}
+                className="inline-flex items-center rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 transition hover:border-white/20 hover:bg-white/5 hover:text-white"
+              >
+                Back to overview
+              </Link>
+              <Link
+                href={`/captain/team/${teamid}/availability`}
+                className="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/15 px-5 py-3 text-sm font-medium text-emerald-50 transition hover:bg-emerald-500/20"
+              >
+                Open availability
+              </Link>
+              {access.isAdmin ? (
+                <Link
+                  href={`/admin/teams/${teamid}/squad`}
+                  className="inline-flex items-center rounded-full border border-amber-400/30 bg-amber-500/10 px-5 py-3 text-sm font-medium text-amber-100 transition hover:bg-amber-500/15"
+                >
+                  Open admin squad console
+                </Link>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-2">
+            {[
+              { label: "Total squad", value: totalSquadCount, copy: "Linked players plus pending account links.", tone: "emerald" },
+              { label: "Organisers", value: organiserCount, copy: "Captain, manager and vice-captain roles.", tone: "amber" },
+              { label: "Players", value: playerCount, copy: "Regular linked player roles.", tone: "white" },
+              { label: "Backups", value: backupCount, copy: "Backup player roles.", tone: "sky" },
+            ].map((metric) => {
+              const toneClasses =
+                metric.tone === "amber"
+                  ? "border-amber-400/20 bg-amber-500/10 text-amber-100/70"
+                  : metric.tone === "emerald"
+                    ? "border-emerald-400/20 bg-emerald-500/10 text-emerald-100/70"
+                    : metric.tone === "sky"
+                      ? "border-sky-400/20 bg-sky-500/10 text-sky-100/70"
+                      : "border-white/10 bg-white/5 text-white/55";
+
+              return (
+                <div key={metric.label} className={`rounded-3xl border p-5 ${toneClasses}`}>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em]">
+                    {metric.label}
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold text-white">{metric.value}</p>
+                  <p className="mt-2 text-sm text-white/65">{metric.copy}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {errorMessage ? (
+        <section className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">
+          {errorMessage}
+        </section>
+      ) : null}
+
+      <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded-3xl border border-white/10 bg-white/[0.04]">
+          <div className="flex items-center justify-between border-b border-white/10 px-6 py-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+                Current squad
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-white">Players and roles</h2>
+            </div>
+            <div className="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs font-medium text-white/70">
+              {team.members.length} linked
+            </div>
+          </div>
+
+          <div className="divide-y divide-white/10">
+            {team.members.length === 0 ? (
+              <div className="px-6 py-10 text-sm text-white/55">
+                No linked squad members are attached to this team yet.
+              </div>
+            ) : null}
+
+            {team.members.map((member) => {
+              const profile = profileByMemberId.get(member.id);
+              const preferredNights = formatPreferredNights(profile?.preferredNights);
+              const hasPublicProfileDetails = Boolean(
+                profile?.ageBand ||
+                  profile?.preferredPositions ||
+                  profile?.experienceSummary ||
+                  profile?.availabilityLevel ||
+                  preferredNights ||
+                  profile?.availabilitySummary,
+              );
+
+              return (
+                <div key={member.id} className="flex flex-col gap-4 px-6 py-5 xl:flex-row xl:items-start xl:justify-between">
+                  <div className="flex min-w-0 items-start gap-4">
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] text-sm font-black text-white/70">
+                      {getInitials(member.user.name)}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="truncate text-base font-semibold text-white">
+                          {member.user.name || "Unnamed player"}
+                        </div>
+                        <span className={`rounded-full border px-2.5 py-1 text-[11px] font-medium ${getRoleBadgeClasses(member.role)}`}>
+                          {getRoleLabel(member.role)}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-xs text-white/45">
+                        Added {formatUkDate(member.createdAt)}
+                      </div>
+
+                      {hasPublicProfileDetails ? (
+                        <div className="mt-3 space-y-3">
+                          <div className="flex flex-wrap gap-2">
+                            <DetailPill label="Age" value={profile?.ageBand} />
+                            <DetailPill label="Position" value={profile?.preferredPositions} />
+                            <DetailPill label="Level" value={profile?.experienceSummary} />
+                            <DetailPill label="Availability" value={profile?.availabilityLevel} />
+                            <DetailPill label="Nights" value={preferredNights} />
+                          </div>
+
+                          {profile?.availabilitySummary ? (
+                            <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs leading-5 text-white/60">
+                              <span className="font-semibold text-white/70">Availability:</span> {profile.availabilitySummary}
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <div className="mt-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/45">
+                          No public squad profile details saved yet.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+              Captain limits
+            </p>
+            <h2 className="mt-2 text-xl font-semibold text-white">What you can do here</h2>
+            <div className="mt-4 space-y-3 text-sm text-white/65">
+              <p>This view is intentionally lighter than the SIXFL admin console.</p>
+              <p>You can review the squad, check public availability details and use the availability page to manage matchday responses.</p>
+              <p>Only SIXFL admin can edit player records, change roles, remove players, send activation messages or view internal notes.</p>
+            </div>
+          </section>
+
+          {pendingAccountCount > 0 ? (
+            <section className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-6">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">
+                Awaiting account link
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-white">Pending players</h2>
+              <p className="mt-2 text-sm text-amber-100/75">
+                These players are in the squad pipeline but do not yet have a linked SIXFL account.
+              </p>
+              <div className="mt-4 space-y-3">
+                {team.prospects.map((prospect) => {
+                  const fullName = [prospect.firstName, prospect.lastName].filter(Boolean).join(" ").trim();
+
+                  return (
+                    <div key={prospect.id} className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
+                      <div className="font-semibold text-white">{fullName || "Unnamed player"}</div>
+                      <div className="mt-1 text-xs text-white/45">
+                        Added to active squad {formatUkDate(prospect.updatedAt)}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ) : null}
+
+          <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+              Quick actions
+            </p>
+            <div className="mt-4 flex flex-col gap-3">
+              <Link
+                href={`/captain/team/${teamid}/availability`}
+                className="inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15"
+              >
+                Manage availability
+              </Link>
+              <Link
+                href={`/captain/team/${teamid}/fixtures`}
+                className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-white/10"
+              >
+                Open fixtures
+              </Link>
+              <Link
+                href={`/captain/team/${teamid}/results`}
+                className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-white/10"
+              >
+                Open results
+              </Link>
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -59,7 +59,7 @@ export default async function CaptainTeamLayout({
 
   const navItems = [
     { href: `/captain/team/${teamid}`, label: "Overview" },
-    { href: `/captain/team/${teamid}/squad`, label: "Squad" },
+    { href: `/captain/team/${teamid}/captain-squad`, label: "Squad" },
     ...(team.teamMode === "MANAGED"
       ? [
           { href: `/captain/team/${teamid}/prospects`, label: "Prospects" },
@@ -130,6 +130,15 @@ export default async function CaptainTeamLayout({
                     className="inline-flex items-center rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/80 transition hover:border-emerald-400/30 hover:bg-emerald-500/10 hover:text-white"
                   >
                     Back to admin team
+                  </Link>
+                ) : null}
+
+                {access.isAdmin ? (
+                  <Link
+                    href={`/admin/teams/${team.id}/squad`}
+                    className="inline-flex items-center rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100 transition hover:bg-amber-500/15"
+                  >
+                    Admin squad console
                   </Link>
                 ) : null}
 

--- a/src/app/captain/team/[teamid]/squad/actions.ts
+++ b/src/app/captain/team/[teamid]/squad/actions.ts
@@ -23,6 +23,8 @@ const ALLOWED_ROLES: TeamRole[] = [
   "MANAGER",
   "PLAYER",
   "COACH",
+  "VICE_CAPTAIN",
+  "BACKUP_PLAYER",
 ];
 
 function getRoleValue(input: FormDataEntryValue | null): TeamRole {
@@ -41,6 +43,24 @@ function getErrorRedirect(teamid: string, message: string) {
 
 function getSuccessRedirect(teamid: string, saved = "1") {
   return `/captain/team/${teamid}/squad?saved=${encodeURIComponent(saved)}`;
+}
+
+async function requireAdminSquadAccess(teamid: string) {
+  if (!teamid) {
+    redirect("/captain");
+  }
+
+  const access = await requireCaptain(teamid);
+
+  if (!access.isAdmin) {
+    redirect(
+      `/captain/team/${teamid}/captain-squad?error=${encodeURIComponent(
+        "Only SIXFL admins can use managed squad tools.",
+      )}`,
+    );
+  }
+
+  return access;
 }
 
 function getNullableString(value: FormDataEntryValue | null) {
@@ -150,11 +170,7 @@ export async function addSquadMemberAction(formData: FormData) {
   const email = String(formData.get("email") ?? "").trim().toLowerCase();
   const role = getRoleValue(formData.get("role"));
 
-  await requireCaptain(teamid);
-
-  if (!teamid) {
-    redirect("/captain");
-  }
+  await requireAdminSquadAccess(teamid);
 
   if (!email) {
     redirect(getErrorRedirect(teamid, "Enter an email address."));
@@ -202,6 +218,7 @@ export async function addSquadMemberAction(formData: FormData) {
 
   revalidatePath(`/captain/team/${teamid}`);
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   redirect(getSuccessRedirect(teamid, "member-added"));
 }
 
@@ -210,9 +227,9 @@ export async function updateSquadMemberRoleAction(formData: FormData) {
   const membershipId = String(formData.get("membershipId") ?? "").trim();
   const role = getRoleValue(formData.get("role"));
 
-  await requireCaptain(teamid);
+  await requireAdminSquadAccess(teamid);
 
-  if (!teamid || !membershipId) {
+  if (!membershipId) {
     redirect("/captain");
   }
 
@@ -249,7 +266,7 @@ export async function updateSquadMemberRoleAction(formData: FormData) {
         data: {
           captainUserId: membership.userId,
           captainLinkedAt: new Date(),
-          captainLinkedSource: "captain-squad-page",
+          captainLinkedSource: "admin-managed-squad-tools",
         },
       });
     } else if (
@@ -267,6 +284,7 @@ export async function updateSquadMemberRoleAction(formData: FormData) {
 
   revalidatePath(`/captain/team/${teamid}`);
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   redirect(getSuccessRedirect(teamid, "role-updated"));
 }
 
@@ -274,9 +292,9 @@ export async function removeSquadMemberAction(formData: FormData) {
   const teamid = String(formData.get("teamid") ?? "").trim();
   const membershipId = String(formData.get("membershipId") ?? "").trim();
 
-  await requireCaptain(teamid);
+  await requireAdminSquadAccess(teamid);
 
-  if (!teamid || !membershipId) {
+  if (!membershipId) {
     redirect("/captain");
   }
 
@@ -318,6 +336,7 @@ export async function removeSquadMemberAction(formData: FormData) {
 
   revalidatePath(`/captain/team/${teamid}`);
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   redirect(getSuccessRedirect(teamid, "member-removed"));
 }
 
@@ -326,9 +345,9 @@ export async function updateSquadMemberSmsAction(formData: FormData) {
   const membershipId = String(formData.get("membershipId") ?? "").trim();
   const phone = getNullableString(formData.get("phone"));
 
-  await requireCaptain(teamid);
+  await requireAdminSquadAccess(teamid);
 
-  if (!teamid || !membershipId) {
+  if (!membershipId) {
     redirect("/captain");
   }
 
@@ -369,6 +388,7 @@ export async function updateSquadMemberSmsAction(formData: FormData) {
   });
 
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   redirect(getSuccessRedirect(teamid, "member-sms-linked"));
 }
 
@@ -383,11 +403,7 @@ export async function sendSquadEmailAction(formData: FormData) {
   const templateId = getNullableString(formData.get("templateId"));
   const templateKey = getNullableString(formData.get("templateKey"));
 
-  const { user } = await requireCaptain(teamid);
-
-  if (!teamid) {
-    redirect("/captain");
-  }
+  const { user } = await requireAdminSquadAccess(teamid);
 
   if (!subject) {
     redirect(getErrorRedirect(teamid, "Email subject is required."));
@@ -469,8 +485,8 @@ export async function sendSquadEmailAction(formData: FormData) {
       sourceType: "TEAM",
       sourceId: teamid,
       metadata: {
-        origin: "captain_squad_email",
-        originLabel: "Sent to squad from captain hub",
+        origin: "admin_managed_squad_email",
+        originLabel: "Sent to squad from admin managed squad tools",
         teamId: teamid,
         membershipId: member.id,
         userId: member.user.id,
@@ -482,6 +498,7 @@ export async function sendSquadEmailAction(formData: FormData) {
   }
 
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   redirect(getSuccessRedirect(teamid, `squad-email-sent`));
 }
 
@@ -493,11 +510,7 @@ export async function sendSquadSmsAction(formData: FormData) {
     .map((value) => String(value).trim())
     .filter(Boolean);
 
-  const { user } = await requireCaptain(teamid);
-
-  if (!teamid) {
-    redirect("/captain");
-  }
+  const { user } = await requireAdminSquadAccess(teamid);
 
   if (!body) {
     redirect(getErrorRedirect(teamid, "SMS body is required."));
@@ -579,8 +592,8 @@ export async function sendSquadSmsAction(formData: FormData) {
       sourceType: "TEAM",
       sourceId: teamid,
       metadata: {
-        origin: "captain_squad_sms",
-        originLabel: "Sent to squad from captain hub",
+        origin: "admin_managed_squad_sms",
+        originLabel: "Sent to squad from admin managed squad tools",
         teamId: teamid,
         membershipId: item.member.id,
         userId: item.member.user.id,
@@ -590,5 +603,6 @@ export async function sendSquadSmsAction(formData: FormData) {
   }
 
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   redirect(getSuccessRedirect(teamid, `squad-sms-sent`));
 }

--- a/src/app/captain/team/[teamid]/squad/layout.tsx
+++ b/src/app/captain/team/[teamid]/squad/layout.tsx
@@ -3,6 +3,8 @@
 // ========================================
 
 import type { ReactNode } from "react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
 
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
@@ -18,7 +20,11 @@ export default async function CaptainSquadLayout({
   params,
 }: CaptainSquadLayoutProps) {
   const { teamid } = await params;
-  await requireCaptain(teamid);
+  const access = await requireCaptain(teamid);
+
+  if (!access.isAdmin) {
+    redirect(`/captain/team/${teamid}/captain-squad`);
+  }
 
   const whatsappEntries = await prisma.$queryRaw<
     Array<{ id: string; name: string | null; email: string | null }>
@@ -31,9 +37,36 @@ export default async function CaptainSquadLayout({
   `;
 
   return (
-    <>
+    <div className="space-y-6">
+      <section className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5 text-sm text-amber-100 shadow-[0_18px_60px_rgba(0,0,0,0.25)]">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-100/70">
+              Admin-only managed squad tools
+            </p>
+            <h2 className="mt-2 text-lg font-semibold text-white">Powerful squad management view</h2>
+            <p className="mt-1 max-w-3xl text-amber-100/75">
+              This route is kept for SIXFL admin use only. Appointed captains are redirected to the safer captain squad view.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href={`/captain/team/${teamid}/captain-squad`}
+              className="inline-flex items-center rounded-xl border border-white/10 bg-black/20 px-4 py-2.5 text-sm font-medium text-white/80 transition hover:bg-white/5 hover:text-white"
+            >
+              View weaker captain version
+            </Link>
+            <Link
+              href={`/admin/teams/${teamid}/squad`}
+              className="inline-flex items-center rounded-xl border border-emerald-400/30 bg-emerald-500/15 px-4 py-2.5 text-sm font-medium text-emerald-50 transition hover:bg-emerald-500/20"
+            >
+              Open admin squad console
+            </Link>
+          </div>
+        </div>
+      </section>
       {children}
       <WhatsAppSquadBadges entries={whatsappEntries} />
-    </>
+    </div>
   );
 }

--- a/src/app/captain/team/[teamid]/squad/send-activation-sms/route.ts
+++ b/src/app/captain/team/[teamid]/squad/send-activation-sms/route.ts
@@ -58,6 +58,13 @@ function getSquadRedirectUrl(request: NextRequest, teamid: string, query: string
   );
 }
 
+function getCaptainSquadRedirectUrl(request: NextRequest, teamid: string, query: string) {
+  return new URL(
+    `/captain/team/${teamid}/captain-squad${query}`,
+    getPublicRequestOrigin(request),
+  );
+}
+
 function getDisplayName(input: { firstName: string; lastName: string | null }) {
   return [input.firstName, input.lastName].filter(Boolean).join(" ").trim();
 }
@@ -164,7 +171,18 @@ export async function POST(
   const { teamid } = await context.params;
   const formData = await request.formData();
   const prospectId = String(formData.get("prospectId") ?? "").trim();
-  const { user } = await requireCaptain(teamid);
+  const access = await requireCaptain(teamid);
+  const { user } = access;
+
+  if (!access.isAdmin) {
+    return NextResponse.redirect(
+      getCaptainSquadRedirectUrl(
+        request,
+        teamid,
+        "?error=Only%20SIXFL%20admin%20can%20send%20activation%20SMS%20messages.",
+      ),
+    );
+  }
 
   if (!teamid || !prospectId) {
     return NextResponse.redirect(getSquadRedirectUrl(request, teamid, "?error=Missing%20prospect%20details.#pending-activation"));
@@ -220,8 +238,8 @@ export async function POST(
     sourceType: "TEAM_PLAYER_PROSPECT",
     sourceId: prospect.id,
     metadata: {
-      origin: "captain_squad_activation_sms",
-      originLabel: "Activation SMS chase sent from captain squad page",
+      origin: "admin_managed_squad_activation_sms",
+      originLabel: "Activation SMS chase sent from admin managed squad view",
       teamId: teamid,
       prospectId: prospect.id,
       contactName,
@@ -253,6 +271,7 @@ export async function POST(
 
   revalidatePath(`/captain/team/${teamid}`);
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   revalidatePath(`/captain/team/${teamid}/prospects`);
 
   return NextResponse.redirect(

--- a/src/app/captain/team/[teamid]/squad/send-activation/route.ts
+++ b/src/app/captain/team/[teamid]/squad/send-activation/route.ts
@@ -57,6 +57,13 @@ function getSquadRedirectUrl(request: NextRequest, teamid: string, query: string
   );
 }
 
+function getCaptainSquadRedirectUrl(request: NextRequest, teamid: string, query: string) {
+  return new URL(
+    `/captain/team/${teamid}/captain-squad${query}`,
+    getPublicRequestOrigin(request),
+  );
+}
+
 function getDisplayName(input: { firstName: string; lastName: string | null }) {
   return [input.firstName, input.lastName].filter(Boolean).join(" ").trim();
 }
@@ -179,7 +186,18 @@ export async function POST(
   const { teamid } = await context.params;
   const formData = await request.formData();
   const prospectId = String(formData.get("prospectId") ?? "").trim();
-  const { user } = await requireCaptain(teamid);
+  const access = await requireCaptain(teamid);
+  const { user } = access;
+
+  if (!access.isAdmin) {
+    return NextResponse.redirect(
+      getCaptainSquadRedirectUrl(
+        request,
+        teamid,
+        "?error=Only%20SIXFL%20admin%20can%20send%20activation%20emails.",
+      ),
+    );
+  }
 
   if (!teamid || !prospectId) {
     return NextResponse.redirect(
@@ -269,8 +287,8 @@ export async function POST(
       leagueName: team.league?.name ?? null,
     },
     metadata: {
-      origin: "captain_squad_activation_email",
-      originLabel: "Activation email sent from captain squad page",
+      origin: "admin_managed_squad_activation_email",
+      originLabel: "Activation email sent from admin managed squad view",
       teamId: teamid,
       prospectId: prospect.id,
       contactName,
@@ -291,6 +309,7 @@ export async function POST(
 
   revalidatePath(`/captain/team/${teamid}`);
   revalidatePath(`/captain/team/${teamid}/squad`);
+  revalidatePath(`/captain/team/${teamid}/captain-squad`);
   revalidatePath(`/captain/team/${teamid}/prospects`);
   revalidatePath(`/admin/teams/${teamid}/prospects/${prospect.id}/communications`);
   revalidatePath("/admin/messaging");


### PR DESCRIPTION
## Summary

This separates the powerful managed squad tools from the captain-facing squad page.

### Changed
- Added a new limited captain squad view at `/captain/team/[teamid]/captain-squad`.
- Updated the captain hub navigation so **Squad** points to the safer captain view.
- Kept the existing powerful `/captain/team/[teamid]/squad` route as an admin-only managed squad tools area.
- Added an admin-only guard to the old powerful squad route while preserving the existing WhatsApp badge logic.
- Restricted managed squad server actions to SIXFL admins:
  - add squad member
  - update role
  - remove member
  - update linked SMS details
  - send squad email
  - send squad SMS
- Restricted squad activation email/SMS POST routes to admins.
- Renamed the admin team squad page wording to **Admin Squad Console** and added clear links for:
  - previewing the weaker captain view
  - opening managed squad tools
  - opening prospects

## Notes

The new captain view deliberately avoids showing sensitive player data such as emails, phone numbers, internal notes, activation controls, role-change controls, removals, or bulk messaging tools.

## Testing

Not run locally from this environment. This PR should be checked with the normal Vercel/GitHub build before merge.