### PR TITLE
Restore powerful squad view for admins

### DIFF
--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -57,9 +57,13 @@ export default async function CaptainTeamLayout({
     notFound();
   }
 
+  const squadHref = access.isAdmin
+    ? `/captain/team/${teamid}/squad`
+    : `/captain/team/${teamid}/captain-squad`;
+
   const navItems = [
     { href: `/captain/team/${teamid}`, label: "Overview" },
-    { href: `/captain/team/${teamid}/captain-squad`, label: "Squad" },
+    { href: squadHref, label: "Squad" },
     ...(team.teamMode === "MANAGED"
       ? [
           { href: `/captain/team/${teamid}/prospects`, label: "Prospects" },
@@ -130,6 +134,15 @@ export default async function CaptainTeamLayout({
                     className="inline-flex items-center rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/80 transition hover:border-emerald-400/30 hover:bg-emerald-500/10 hover:text-white"
                   >
                     Back to admin team
+                  </Link>
+                ) : null}
+
+                {access.isAdmin ? (
+                  <Link
+                    href={`/captain/team/${team.id}/captain-squad`}
+                    className="inline-flex items-center rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100 transition hover:bg-emerald-500/15"
+                  >
+                    Preview weaker captain view
                   </Link>
                 ) : null}
 


### PR DESCRIPTION
## Summary

This restores the original powerful squad experience for SIXFL admins while keeping the weaker captain-only view for appointed captains.

### Changed
- Admin users clicking **Squad** in the captain hub now go to `/captain/team/[teamid]/squad`, which is the powerful managed squad view.
- Normal appointed captains clicking **Squad** still go to `/captain/team/[teamid]/captain-squad`, the safer weaker view.
- Added a clear admin-only button to preview the weaker captain view.

## Why

The previous split protected real captains correctly, but it also changed the normal admin/captain workflow. This keeps the useful powerful view for SIXFL admin use while preserving the safer captain-only route for actual captains.

## Testing

Not run locally from this environment. After deploy, check:
- Admin clicking Squad opens the powerful squad view.
- A non-admin captain clicking Squad opens the weaker captain view.