### PR TITLE
Add simple Stripe recurring team payments

### DIFF
--- a/prisma/migrations/20260524213000_simple_team_subscriptions/migration.sql
+++ b/prisma/migrations/20260524213000_simple_team_subscriptions/migration.sql
@@ -1,0 +1,32 @@
+-- Add simple Stripe subscription tracking to teams.
+-- This is additive only and does not alter existing charges or transactions.
+
+ALTER TABLE "Team"
+  ADD COLUMN IF NOT EXISTS "stripeCustomerId" TEXT,
+  ADD COLUMN IF NOT EXISTS "stripeSubscriptionId" TEXT,
+  ADD COLUMN IF NOT EXISTS "subscriptionStatus" TEXT,
+  ADD COLUMN IF NOT EXISTS "subscriptionPriceId" TEXT,
+  ADD COLUMN IF NOT EXISTS "subscriptionCurrentPeriodEnd" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "subscriptionStartedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "subscriptionCancelledAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "subscriptionLastInvoiceId" TEXT,
+  ADD COLUMN IF NOT EXISTS "subscriptionLastPaymentAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "subscriptionLastPaymentFailedAt" TIMESTAMP(3);
+
+ALTER TABLE "PaymentTransaction"
+  ADD COLUMN IF NOT EXISTS "stripeInvoiceId" TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Team_stripeCustomerId_key"
+  ON "Team"("stripeCustomerId")
+  WHERE "stripeCustomerId" IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Team_stripeSubscriptionId_key"
+  ON "Team"("stripeSubscriptionId")
+  WHERE "stripeSubscriptionId" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "Team_subscriptionStatus_idx"
+  ON "Team"("subscriptionStatus");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "PaymentTransaction_stripeInvoiceId_key"
+  ON "PaymentTransaction"("stripeInvoiceId")
+  WHERE "stripeInvoiceId" IS NOT NULL;

--- a/src/app/(admin)/admin/payments/subscriptions/page.tsx
+++ b/src/app/(admin)/admin/payments/subscriptions/page.tsx
@@ -1,0 +1,254 @@
+// ========================================
+// File: src/app/(admin)/admin/payments/subscriptions/page.tsx
+// ========================================
+
+import Link from "next/link";
+
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { listTeamSubscriptionSnapshots } from "@/lib/payments/team-subscriptions";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Admin Payment Subscriptions | SIXFL",
+};
+
+function formatDate(value: Date | null) {
+  if (!value) return "—";
+
+  return formatDateTimeInLondon(value, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(value: Date | null) {
+  if (!value) return "—";
+
+  return formatDateTimeInLondon(value, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatStatus(status: string | null) {
+  if (!status) return "Not set up";
+
+  const labels: Record<string, string> = {
+    active: "Active",
+    trialing: "Trialling",
+    past_due: "Past due",
+    unpaid: "Unpaid",
+    incomplete: "Setup incomplete",
+    incomplete_expired: "Setup expired",
+    canceled: "Cancelled",
+    paused: "Paused",
+  };
+
+  return labels[status] ?? status.replaceAll("_", " ");
+}
+
+function getStatusTone(status: string | null) {
+  switch (status) {
+    case "active":
+    case "trialing":
+      return "border-emerald-400/25 bg-emerald-500/10 text-emerald-100";
+    case "past_due":
+    case "unpaid":
+    case "incomplete":
+      return "border-amber-400/25 bg-amber-500/10 text-amber-100";
+    case "canceled":
+    case "incomplete_expired":
+      return "border-red-400/25 bg-red-500/10 text-red-100";
+    default:
+      return "border-white/10 bg-white/[0.05] text-white/60";
+  }
+}
+
+function maskStripeId(value: string | null) {
+  if (!value) return "—";
+  if (value.length <= 12) return value;
+  return `${value.slice(0, 8)}…${value.slice(-4)}`;
+}
+
+export default async function AdminPaymentSubscriptionsPage() {
+  await requireAdmin();
+
+  const subscriptions = await listTeamSubscriptionSnapshots();
+  const activeCount = subscriptions.filter((item) =>
+    ["active", "trialing"].includes(item.subscriptionStatus ?? ""),
+  ).length;
+  const attentionCount = subscriptions.filter((item) =>
+    ["past_due", "unpaid", "incomplete"].includes(item.subscriptionStatus ?? ""),
+  ).length;
+  const failedCount = subscriptions.filter(
+    (item) => item.subscriptionLastPaymentFailedAt,
+  ).length;
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-8 px-6 py-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300/75">
+            Payments
+          </p>
+          <h1 className="text-3xl font-semibold text-white">
+            Recurring subscriptions
+          </h1>
+          <p className="max-w-3xl text-sm leading-6 text-white/60">
+            Simple Stripe subscription tracking for teams. Successful Stripe renewal invoices are recorded as payment transactions.
+          </p>
+        </div>
+
+        <Link
+          href="/admin/payments"
+          className="inline-flex h-11 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] px-5 text-sm font-semibold text-white/75 transition hover:bg-white/[0.07] hover:text-white"
+        >
+          Back to payments
+        </Link>
+      </div>
+
+      <section className="grid gap-4 md:grid-cols-4">
+        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/45">
+            Subscriptions
+          </div>
+          <div className="mt-3 text-3xl font-semibold text-white">
+            {subscriptions.length}
+          </div>
+          <p className="mt-2 text-sm text-white/50">Teams with Stripe subscription data.</p>
+        </div>
+
+        <div className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100/70">
+            Active
+          </div>
+          <div className="mt-3 text-3xl font-semibold text-white">
+            {activeCount}
+          </div>
+          <p className="mt-2 text-sm text-emerald-100/75">Active or trialling.</p>
+        </div>
+
+        <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-100/70">
+            Needs attention
+          </div>
+          <div className="mt-3 text-3xl font-semibold text-white">
+            {attentionCount}
+          </div>
+          <p className="mt-2 text-sm text-amber-100/75">Past due, unpaid, or incomplete.</p>
+        </div>
+
+        <div className="rounded-3xl border border-red-400/20 bg-red-500/10 p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-red-100/70">
+            Failed payment marker
+          </div>
+          <div className="mt-3 text-3xl font-semibold text-white">
+            {failedCount}
+          </div>
+          <p className="mt-2 text-sm text-red-100/75">Teams with a recorded failed invoice.</p>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Team subscriptions</h2>
+            <p className="mt-1 text-sm text-white/55">
+              Stripe remains the source of truth. This screen shows what SIXFL has recorded from webhooks.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          {subscriptions.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-8 text-sm text-white/55">
+              No recurring subscriptions have been recorded yet.
+            </div>
+          ) : null}
+
+          {subscriptions.map((item) => (
+            <div key={item.id} className="rounded-2xl border border-white/10 bg-[#0d1428] p-4">
+              <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      href={`/admin/teams/${item.id}`}
+                      className="text-base font-semibold text-white transition hover:text-emerald-200"
+                    >
+                      {item.name}
+                    </Link>
+                    <span
+                      className={[
+                        "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]",
+                        getStatusTone(item.subscriptionStatus),
+                      ].join(" ")}
+                    >
+                      {formatStatus(item.subscriptionStatus)}
+                    </span>
+                  </div>
+
+                  <div className="mt-1 text-sm text-white/55">
+                    {item.leagueName
+                      ? `${item.leagueName}${item.leagueSeason ? ` · ${item.leagueSeason}` : ""}`
+                      : "No league assigned"}
+                  </div>
+
+                  <div className="mt-3 grid gap-2 text-xs text-white/45 sm:grid-cols-2 lg:grid-cols-3">
+                    <div>Customer: {maskStripeId(item.stripeCustomerId)}</div>
+                    <div>Subscription: {maskStripeId(item.stripeSubscriptionId)}</div>
+                    <div>Price: {maskStripeId(item.subscriptionPriceId)}</div>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 text-sm text-white/60 sm:grid-cols-2 xl:min-w-[520px] xl:grid-cols-4 xl:text-right">
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                      Next renewal
+                    </div>
+                    <div className="mt-1 text-white/80">
+                      {formatDate(item.subscriptionCurrentPeriodEnd)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                      Last paid
+                    </div>
+                    <div className="mt-1 text-white/80">
+                      {formatDateTime(item.subscriptionLastPaymentAt)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                      Last failed
+                    </div>
+                    <div className={[
+                      "mt-1",
+                      item.subscriptionLastPaymentFailedAt ? "text-red-200" : "text-white/80",
+                    ].join(" ")}
+                    >
+                      {formatDateTime(item.subscriptionLastPaymentFailedAt)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                      Cancelled
+                    </div>
+                    <div className="mt-1 text-white/80">
+                      {formatDateTime(item.subscriptionCancelledAt)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -10,6 +10,12 @@ import {
   getChargeStatusFromAmounts,
 } from "@/lib/payments/charge-status";
 import { cancelQueuedMatchFeeNotificationDispatches } from "@/lib/payments/fixture-match-fees";
+import {
+  markTeamSubscriptionDeleted,
+  markTeamSubscriptionInvoiceFailed,
+  recordTeamSubscriptionInvoicePaid,
+  syncTeamSubscriptionFromStripe,
+} from "@/lib/payments/team-subscriptions";
 import { prisma } from "@/lib/prisma";
 import {
   getStripeServerClient,
@@ -22,6 +28,15 @@ function getPaymentIntentId(session: Stripe.Checkout.Session) {
   return typeof session.payment_intent === "string"
     ? session.payment_intent
     : session.payment_intent?.id ?? null;
+}
+
+function getStripeId(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : null;
+  }
+  return null;
 }
 
 async function hasExistingTransaction(sessionId: string) {
@@ -147,7 +162,41 @@ async function handleCompletedPlayerMatchFeeCheckoutSession(
   return true;
 }
 
-async function handleCompletedCheckoutSession(session: Stripe.Checkout.Session) {
+async function handleCompletedTeamSubscriptionCheckoutSession(
+  session: Stripe.Checkout.Session,
+  stripe: Stripe,
+) {
+  const isTeamSubscriptionSession =
+    session.mode === "subscription" || session.metadata?.type === "team_subscription";
+
+  if (!isTeamSubscriptionSession) {
+    return false;
+  }
+
+  const subscriptionId = getStripeId(session.subscription);
+  const teamId = session.metadata?.teamId?.trim() || session.client_reference_id || null;
+
+  if (!subscriptionId) {
+    return true;
+  }
+
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  await syncTeamSubscriptionFromStripe({ subscription, teamId });
+
+  return true;
+}
+
+async function handleCompletedCheckoutSession(
+  session: Stripe.Checkout.Session,
+  stripe: Stripe,
+) {
+  const handledTeamSubscription =
+    await handleCompletedTeamSubscriptionCheckoutSession(session, stripe);
+
+  if (handledTeamSubscription) {
+    return;
+  }
+
   const handledPlayerMatchFee =
     await handleCompletedPlayerMatchFeeCheckoutSession(session);
 
@@ -267,7 +316,36 @@ export async function POST(request: Request) {
       case "checkout.session.async_payment_succeeded": {
         await handleCompletedCheckoutSession(
           event.data.object as Stripe.Checkout.Session,
+          stripe,
         );
+        break;
+      }
+      case "customer.subscription.created":
+      case "customer.subscription.updated": {
+        await syncTeamSubscriptionFromStripe({
+          subscription: event.data.object as Stripe.Subscription,
+        });
+        break;
+      }
+      case "customer.subscription.deleted": {
+        await markTeamSubscriptionDeleted({
+          subscription: event.data.object as Stripe.Subscription,
+        });
+        break;
+      }
+      case "invoice.paid":
+      case "invoice.payment_succeeded": {
+        await recordTeamSubscriptionInvoicePaid({
+          invoice: event.data.object as Stripe.Invoice,
+          stripe,
+        });
+        break;
+      }
+      case "invoice.payment_failed": {
+        await markTeamSubscriptionInvoiceFailed({
+          invoice: event.data.object as Stripe.Invoice,
+          stripe,
+        });
         break;
       }
       default:

--- a/src/app/captain/team/[teamid]/payments/manage-subscription/route.ts
+++ b/src/app/captain/team/[teamid]/payments/manage-subscription/route.ts
@@ -1,0 +1,39 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/payments/manage-subscription/route.ts
+// ========================================
+
+import { NextResponse } from "next/server";
+
+import { getTeamSubscriptionSnapshot } from "@/lib/payments/team-subscriptions";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getPublicSiteUrl, getStripeServerClient } from "@/lib/stripe/client";
+
+export const dynamic = "force-dynamic";
+
+function buildReturnUrl(teamId: string, state?: "missing_customer") {
+  const url = new URL(`/captain/team/${teamId}/payments`, `${getPublicSiteUrl()}/`);
+  if (state) url.searchParams.set("subscription", state);
+  return url.toString();
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await context.params;
+  await requireCaptain(teamid);
+
+  const subscription = await getTeamSubscriptionSnapshot(teamid);
+
+  if (!subscription?.stripeCustomerId) {
+    return NextResponse.redirect(buildReturnUrl(teamid, "missing_customer"), 303);
+  }
+
+  const stripe = getStripeServerClient();
+  const portalSession = await stripe.billingPortal.sessions.create({
+    customer: subscription.stripeCustomerId,
+    return_url: buildReturnUrl(teamid),
+  });
+
+  return NextResponse.redirect(portalSession.url, 303);
+}

--- a/src/app/captain/team/[teamid]/payments/page.tsx
+++ b/src/app/captain/team/[teamid]/payments/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { getTeamSubscriptionSnapshot } from "@/lib/payments/team-subscriptions";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
 
@@ -52,6 +53,46 @@ function getChargeStatusTone(status: string) {
   }
 }
 
+function formatSubscriptionStatus(status: string | null) {
+  if (!status) return "Not set up";
+
+  const labels: Record<string, string> = {
+    active: "Active",
+    trialing: "Trialling",
+    past_due: "Past due",
+    unpaid: "Unpaid",
+    incomplete: "Setup incomplete",
+    incomplete_expired: "Setup expired",
+    canceled: "Cancelled",
+    paused: "Paused",
+  };
+
+  return labels[status] ?? status.replaceAll("_", " ");
+}
+
+function getSubscriptionTone(status: string | null) {
+  switch (status) {
+    case "active":
+    case "trialing":
+      return "border-emerald-400/25 bg-emerald-500/10 text-emerald-100";
+    case "past_due":
+    case "unpaid":
+    case "incomplete":
+      return "border-amber-400/25 bg-amber-500/10 text-amber-100";
+    case "canceled":
+    case "incomplete_expired":
+      return "border-red-400/25 bg-red-500/10 text-red-100";
+    default:
+      return "border-white/10 bg-white/[0.05] text-white/60";
+  }
+}
+
+function isManagedByStripe(status: string | null) {
+  return ["active", "trialing", "past_due", "unpaid", "incomplete", "paused"].includes(
+    status ?? "",
+  );
+}
+
 function formatUkDate(value: Date) {
   return formatDateTimeInLondon(value, {
     day: "2-digit",
@@ -96,65 +137,88 @@ function getFixtureLabel(
   )}`;
 }
 
+function getSubscriptionMessage(state?: string) {
+  switch (state) {
+    case "success":
+      return "Automatic payment setup started. Stripe will confirm it here once the payment is complete.";
+    case "cancelled":
+      return "Automatic payment setup was cancelled.";
+    case "active":
+      return "Automatic payments are already active or being managed by Stripe.";
+    case "missing_price":
+      return "Automatic payments are not configured yet. Ask an admin to add the Stripe subscription price ID.";
+    case "missing_customer":
+      return "A Stripe customer has not been created for this team yet.";
+    default:
+      return null;
+  }
+}
+
 export default async function CaptainPaymentsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ teamid: string }>;
+  searchParams?: Promise<{ subscription?: string }>;
 }) {
   const { teamid } = await params;
+  const sp = (await searchParams) ?? {};
   await requireCaptain(teamid);
 
-  const team = await prisma.team.findUnique({
-    where: { id: teamid },
-    select: {
-      id: true,
-      name: true,
-      paymentCharges: {
-        orderBy: [{ createdAt: "desc" }],
-        include: {
-          transactions: {
-            select: {
-              id: true,
-              amountPence: true,
-            },
-          },
-          fixture: {
-            select: {
-              id: true,
-              kickoffAt: true,
-              homeTeam: {
-                select: {
-                  name: true,
-                },
+  const [team, subscription] = await Promise.all([
+    prisma.team.findUnique({
+      where: { id: teamid },
+      select: {
+        id: true,
+        name: true,
+        paymentCharges: {
+          orderBy: [{ createdAt: "desc" }],
+          include: {
+            transactions: {
+              select: {
+                id: true,
+                amountPence: true,
               },
-              awayTeam: {
-                select: {
-                  name: true,
+            },
+            fixture: {
+              select: {
+                id: true,
+                kickoffAt: true,
+                homeTeam: {
+                  select: {
+                    name: true,
+                  },
+                },
+                awayTeam: {
+                  select: {
+                    name: true,
+                  },
                 },
               },
             },
           },
         },
-      },
-      paymentTransactions: {
-        orderBy: [{ paidAt: "desc" }],
-        take: 20,
-        select: {
-          id: true,
-          amountPence: true,
-          method: true,
-          reference: true,
-          notes: true,
-          paidAt: true,
-          charge: {
-            select: {
-              title: true,
+        paymentTransactions: {
+          orderBy: [{ paidAt: "desc" }],
+          take: 20,
+          select: {
+            id: true,
+            amountPence: true,
+            method: true,
+            reference: true,
+            notes: true,
+            paidAt: true,
+            charge: {
+              select: {
+                title: true,
+              },
             },
           },
         },
       },
-    },
-  });
+    }),
+    getTeamSubscriptionSnapshot(teamid),
+  ]);
 
   if (!team) {
     notFound();
@@ -173,8 +237,18 @@ export default async function CaptainPaymentsPage({
     return sum + Math.max(charge.amountPence - paid, 0);
   }, 0);
 
+  const subscriptionMessage = getSubscriptionMessage(sp.subscription);
+  const canOpenPortal = Boolean(subscription?.stripeCustomerId);
+  const subscriptionIsManaged = isManagedByStripe(subscription?.subscriptionStatus ?? null);
+
   return (
     <div className="space-y-8">
+      {subscriptionMessage ? (
+        <div className="rounded-2xl border border-white/10 bg-black/30 px-5 py-4 text-sm text-white/70">
+          {subscriptionMessage}
+        </div>
+      ) : null}
+
       <section className="grid gap-4 md:grid-cols-3">
         <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">
@@ -210,6 +284,73 @@ export default async function CaptainPaymentsPage({
           <p className="mt-2 text-sm text-emerald-100/75">
             Most recent recorded team payments.
           </p>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-emerald-400/20 bg-emerald-500/10">
+        <div className="flex flex-col gap-6 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100/70">
+              Automatic payments
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold text-white">
+              Recurring team payments
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-50/75">
+              Set up a recurring Stripe payment for your team. Successful renewal payments will be recorded automatically in the SIXFL payment history.
+            </p>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <span
+                className={[
+                  "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]",
+                  getSubscriptionTone(subscription?.subscriptionStatus ?? null),
+                ].join(" ")}
+              >
+                {formatSubscriptionStatus(subscription?.subscriptionStatus ?? null)}
+              </span>
+
+              {subscription?.subscriptionCurrentPeriodEnd ? (
+                <span className="inline-flex rounded-full border border-white/10 bg-black/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-white/65">
+                  Next renewal {formatUkDate(subscription.subscriptionCurrentPeriodEnd)}
+                </span>
+              ) : null}
+
+              {subscription?.subscriptionLastPaymentAt ? (
+                <span className="inline-flex rounded-full border border-white/10 bg-black/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-white/65">
+                  Last paid {formatUkDate(subscription.subscriptionLastPaymentAt)}
+                </span>
+              ) : null}
+
+              {subscription?.subscriptionLastPaymentFailedAt ? (
+                <span className="inline-flex rounded-full border border-red-400/25 bg-red-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-red-100">
+                  Last failed {formatUkDate(subscription.subscriptionLastPaymentFailedAt)}
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row">
+            <form action={`/captain/team/${team.id}/payments/start-subscription`} method="post">
+              <button
+                type="submit"
+                className="inline-flex h-12 w-full items-center justify-center rounded-2xl bg-emerald-300 px-5 text-sm font-semibold text-black transition hover:bg-emerald-200 sm:w-auto"
+              >
+                {subscriptionIsManaged ? "Replace automatic payment" : "Set up automatic payments"}
+              </button>
+            </form>
+
+            {canOpenPortal ? (
+              <form action={`/captain/team/${team.id}/payments/manage-subscription`} method="post">
+                <button
+                  type="submit"
+                  className="inline-flex h-12 w-full items-center justify-center rounded-2xl border border-white/10 bg-black/20 px-5 text-sm font-semibold text-white transition hover:bg-black/30 sm:w-auto"
+                >
+                  Manage in Stripe
+                </button>
+              </form>
+            ) : null}
+          </div>
         </div>
       </section>
 

--- a/src/app/captain/team/[teamid]/payments/start-subscription/route.ts
+++ b/src/app/captain/team/[teamid]/payments/start-subscription/route.ts
@@ -1,0 +1,113 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/payments/start-subscription/route.ts
+// ========================================
+
+import { NextResponse } from "next/server";
+
+import {
+  getTeamSubscriptionPriceId,
+  getTeamSubscriptionSnapshot,
+} from "@/lib/payments/team-subscriptions";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getPublicSiteUrl, getStripeServerClient } from "@/lib/stripe/client";
+
+export const dynamic = "force-dynamic";
+
+function buildReturnUrl(teamId: string, state: "success" | "cancelled" | "active" | "missing_price") {
+  const url = new URL(`/captain/team/${teamId}/payments`, `${getPublicSiteUrl()}/`);
+  url.searchParams.set("subscription", state);
+  return url.toString();
+}
+
+function isSubscriptionActive(status: string | null | undefined) {
+  return ["active", "trialing", "past_due", "unpaid", "incomplete"].includes(status ?? "");
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await context.params;
+  await requireCaptain(teamid);
+
+  let priceId: string;
+
+  try {
+    priceId = getTeamSubscriptionPriceId();
+  } catch {
+    return NextResponse.redirect(buildReturnUrl(teamid, "missing_price"), 303);
+  }
+
+  const [team, subscription] = await Promise.all([
+    prisma.team.findUnique({
+      where: { id: teamid },
+      select: {
+        id: true,
+        name: true,
+        contactEmail: true,
+        secondaryContactEmail: true,
+        leagueId: true,
+        league: {
+          select: {
+            name: true,
+            season: true,
+          },
+        },
+      },
+    }),
+    getTeamSubscriptionSnapshot(teamid),
+  ]);
+
+  if (!team) {
+    return NextResponse.redirect(new URL("/captain", `${getPublicSiteUrl()}/`), 303);
+  }
+
+  if (subscription?.stripeSubscriptionId && isSubscriptionActive(subscription.subscriptionStatus)) {
+    return NextResponse.redirect(buildReturnUrl(teamid, "active"), 303);
+  }
+
+  const stripe = getStripeServerClient();
+  const returnUrl = buildReturnUrl(teamid, "success");
+  const cancelUrl = buildReturnUrl(teamid, "cancelled");
+  const customerEmail =
+    team.contactEmail?.trim() || team.secondaryContactEmail?.trim() || undefined;
+  const description = team.league?.name
+    ? `${team.name} · ${team.league.name}${team.league.season ? ` ${team.league.season}` : ""}`
+    : team.name;
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    client_reference_id: team.id,
+    customer: subscription?.stripeCustomerId || undefined,
+    customer_email: subscription?.stripeCustomerId ? undefined : customerEmail,
+    success_url: returnUrl,
+    cancel_url: cancelUrl,
+    line_items: [
+      {
+        price: priceId,
+        quantity: 1,
+      },
+    ],
+    metadata: {
+      type: "team_subscription",
+      teamId: team.id,
+      leagueId: team.leagueId ?? "",
+    },
+    subscription_data: {
+      metadata: {
+        type: "team_subscription",
+        teamId: team.id,
+        leagueId: team.leagueId ?? "",
+        teamName: team.name,
+      },
+      description,
+    },
+  });
+
+  if (!session.url) {
+    throw new Error("Stripe subscription checkout URL was not returned.");
+  }
+
+  return NextResponse.redirect(session.url, 303);
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   CalendarDaysIcon,
+  CreditCardIcon,
   DocumentTextIcon,
   ExclamationTriangleIcon,
   MapPinIcon,
@@ -71,6 +72,11 @@ const navigation = [
     name: "Payments",
     href: "/admin/payments",
     icon: DocumentTextIcon,
+  },
+  {
+    name: "Subscriptions",
+    href: "/admin/payments/subscriptions",
+    icon: CreditCardIcon,
   },
   {
     name: "Referees",
@@ -187,6 +193,7 @@ export default function AdminSidebar({
                     {item.name === "Social" && "Drafts and publishing"}
                     {item.name === "Result Disputes" && "Captain-raised issues"}
                     {item.name === "Payments" && "Charges and payments"}
+                    {item.name === "Subscriptions" && "Recurring Stripe billing"}
                     {item.name === "Referees" && "Officials and assignments"}
                     {item.name === "Leads" && "Inbound enquiries"}
                     {item.name === "Communications" &&

--- a/src/lib/payments/team-subscriptions.ts
+++ b/src/lib/payments/team-subscriptions.ts
@@ -1,0 +1,416 @@
+// ========================================
+// File: src/lib/payments/team-subscriptions.ts
+// ========================================
+
+import type Stripe from "stripe";
+
+import { prisma } from "@/lib/prisma";
+
+type TeamSubscriptionDb = Pick<
+  typeof prisma,
+  "$executeRaw" | "$queryRaw" | "paymentTransaction"
+>;
+
+type RawTeamSubscriptionRow = {
+  id: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  subscriptionStatus: string | null;
+  subscriptionPriceId: string | null;
+  subscriptionCurrentPeriodEnd: Date | null;
+  subscriptionStartedAt: Date | null;
+  subscriptionCancelledAt: Date | null;
+  subscriptionLastInvoiceId: string | null;
+  subscriptionLastPaymentAt: Date | null;
+  subscriptionLastPaymentFailedAt: Date | null;
+};
+
+export type TeamSubscriptionSnapshot = RawTeamSubscriptionRow;
+
+export type TeamSubscriptionListItem = RawTeamSubscriptionRow & {
+  name: string;
+  leagueName: string | null;
+  leagueSeason: string | null;
+};
+
+type StripeInvoiceLike = Stripe.Invoice & {
+  subscription?: string | Stripe.Subscription | null;
+  customer?: string | Stripe.Customer | null;
+  payment_intent?: string | Stripe.PaymentIntent | null;
+  charge?: string | Stripe.Charge | null;
+  amount_paid?: number | null;
+  total?: number | null;
+  status_transitions?: {
+    paid_at?: number | null;
+  } | null;
+};
+
+type StripeSubscriptionLike = Stripe.Subscription & {
+  current_period_end?: number | null;
+  current_period_start?: number | null;
+  canceled_at?: number | null;
+  ended_at?: number | null;
+  trial_end?: number | null;
+};
+
+function toDateFromUnix(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? new Date(value * 1000)
+    : null;
+}
+
+function getStripeId(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : null;
+  }
+  return null;
+}
+
+function getSubscriptionPriceId(subscription: Stripe.Subscription) {
+  const firstItem = subscription.items?.data?.[0];
+  return firstItem?.price?.id ?? null;
+}
+
+function getSubscriptionPeriodEnd(subscription: Stripe.Subscription) {
+  const typed = subscription as StripeSubscriptionLike;
+  return toDateFromUnix(typed.current_period_end ?? typed.trial_end ?? null);
+}
+
+function getSubscriptionCancelledAt(subscription: Stripe.Subscription) {
+  const typed = subscription as StripeSubscriptionLike;
+  return toDateFromUnix(typed.canceled_at ?? typed.ended_at ?? null);
+}
+
+export function getTeamSubscriptionPriceId() {
+  const value =
+    process.env.STRIPE_TEAM_SUBSCRIPTION_PRICE_ID?.trim() ||
+    process.env.STRIPE_TEAM_WEEKLY_PRICE_ID?.trim() ||
+    process.env.STRIPE_TEAM_MONTHLY_PRICE_ID?.trim();
+
+  if (!value) {
+    throw new Error(
+      "Missing STRIPE_TEAM_SUBSCRIPTION_PRICE_ID, STRIPE_TEAM_WEEKLY_PRICE_ID, or STRIPE_TEAM_MONTHLY_PRICE_ID.",
+    );
+  }
+
+  return value;
+}
+
+export async function getTeamSubscriptionSnapshot(
+  teamId: string,
+  db: TeamSubscriptionDb = prisma,
+) {
+  const rows = await db.$queryRaw<RawTeamSubscriptionRow[]>`
+    SELECT
+      "id",
+      "stripeCustomerId",
+      "stripeSubscriptionId",
+      "subscriptionStatus",
+      "subscriptionPriceId",
+      "subscriptionCurrentPeriodEnd",
+      "subscriptionStartedAt",
+      "subscriptionCancelledAt",
+      "subscriptionLastInvoiceId",
+      "subscriptionLastPaymentAt",
+      "subscriptionLastPaymentFailedAt"
+    FROM "Team"
+    WHERE "id" = ${teamId}
+    LIMIT 1
+  `;
+
+  return rows[0] ?? null;
+}
+
+export async function listTeamSubscriptionSnapshots(
+  db: TeamSubscriptionDb = prisma,
+) {
+  return db.$queryRaw<TeamSubscriptionListItem[]>`
+    SELECT
+      t."id",
+      t."name",
+      l."name" AS "leagueName",
+      l."season" AS "leagueSeason",
+      t."stripeCustomerId",
+      t."stripeSubscriptionId",
+      t."subscriptionStatus",
+      t."subscriptionPriceId",
+      t."subscriptionCurrentPeriodEnd",
+      t."subscriptionStartedAt",
+      t."subscriptionCancelledAt",
+      t."subscriptionLastInvoiceId",
+      t."subscriptionLastPaymentAt",
+      t."subscriptionLastPaymentFailedAt"
+    FROM "Team" t
+    LEFT JOIN "League" l ON l."id" = t."leagueId"
+    WHERE t."stripeCustomerId" IS NOT NULL
+      OR t."stripeSubscriptionId" IS NOT NULL
+      OR t."subscriptionStatus" IS NOT NULL
+    ORDER BY
+      CASE
+        WHEN t."subscriptionStatus" IN ('active', 'trialing') THEN 0
+        WHEN t."subscriptionStatus" IN ('past_due', 'unpaid', 'incomplete') THEN 1
+        WHEN t."subscriptionStatus" IS NULL THEN 3
+        ELSE 2
+      END,
+      t."name" ASC
+  `;
+}
+
+export async function setTeamStripeCustomerId(input: {
+  teamId: string;
+  stripeCustomerId: string;
+  db?: TeamSubscriptionDb;
+}) {
+  const db = input.db ?? prisma;
+
+  await db.$executeRaw`
+    UPDATE "Team"
+    SET "stripeCustomerId" = ${input.stripeCustomerId}
+    WHERE "id" = ${input.teamId}
+  `;
+}
+
+export async function findTeamIdForStripeSubscription(input: {
+  stripeSubscriptionId?: string | null;
+  stripeCustomerId?: string | null;
+  metadataTeamId?: string | null;
+  db?: TeamSubscriptionDb;
+}) {
+  const db = input.db ?? prisma;
+  const metadataTeamId = input.metadataTeamId?.trim() || null;
+
+  if (metadataTeamId) {
+    const rows = await db.$queryRaw<Array<{ id: string }>>`
+      SELECT "id"
+      FROM "Team"
+      WHERE "id" = ${metadataTeamId}
+      LIMIT 1
+    `;
+
+    if (rows[0]?.id) return rows[0].id;
+  }
+
+  if (input.stripeSubscriptionId) {
+    const rows = await db.$queryRaw<Array<{ id: string }>>`
+      SELECT "id"
+      FROM "Team"
+      WHERE "stripeSubscriptionId" = ${input.stripeSubscriptionId}
+      LIMIT 1
+    `;
+
+    if (rows[0]?.id) return rows[0].id;
+  }
+
+  if (input.stripeCustomerId) {
+    const rows = await db.$queryRaw<Array<{ id: string }>>`
+      SELECT "id"
+      FROM "Team"
+      WHERE "stripeCustomerId" = ${input.stripeCustomerId}
+      LIMIT 1
+    `;
+
+    if (rows[0]?.id) return rows[0].id;
+  }
+
+  return null;
+}
+
+export async function syncTeamSubscriptionFromStripe(input: {
+  subscription: Stripe.Subscription;
+  teamId?: string | null;
+  db?: TeamSubscriptionDb;
+}) {
+  const db = input.db ?? prisma;
+  const subscription = input.subscription;
+  const typedSubscription = subscription as StripeSubscriptionLike;
+  const stripeSubscriptionId = subscription.id;
+  const stripeCustomerId = getStripeId(subscription.customer);
+  const teamId =
+    input.teamId?.trim() ||
+    (await findTeamIdForStripeSubscription({
+      stripeSubscriptionId,
+      stripeCustomerId,
+      metadataTeamId: subscription.metadata?.teamId,
+      db,
+    }));
+
+  if (!teamId) return null;
+
+  await db.$executeRaw`
+    UPDATE "Team"
+    SET
+      "stripeCustomerId" = COALESCE(${stripeCustomerId}, "stripeCustomerId"),
+      "stripeSubscriptionId" = ${stripeSubscriptionId},
+      "subscriptionStatus" = ${subscription.status},
+      "subscriptionPriceId" = ${getSubscriptionPriceId(subscription)},
+      "subscriptionCurrentPeriodEnd" = ${getSubscriptionPeriodEnd(subscription)},
+      "subscriptionStartedAt" = COALESCE("subscriptionStartedAt", ${toDateFromUnix(typedSubscription.created)}),
+      "subscriptionCancelledAt" = ${getSubscriptionCancelledAt(subscription)}
+    WHERE "id" = ${teamId}
+  `;
+
+  return teamId;
+}
+
+export async function markTeamSubscriptionDeleted(input: {
+  subscription: Stripe.Subscription;
+  db?: TeamSubscriptionDb;
+}) {
+  const db = input.db ?? prisma;
+  const subscription = input.subscription;
+  const stripeSubscriptionId = subscription.id;
+  const stripeCustomerId = getStripeId(subscription.customer);
+  const teamId = await findTeamIdForStripeSubscription({
+    stripeSubscriptionId,
+    stripeCustomerId,
+    metadataTeamId: subscription.metadata?.teamId,
+    db,
+  });
+
+  if (!teamId) return null;
+
+  await db.$executeRaw`
+    UPDATE "Team"
+    SET
+      "subscriptionStatus" = ${subscription.status || "canceled"},
+      "subscriptionCancelledAt" = ${getSubscriptionCancelledAt(subscription) ?? new Date()},
+      "subscriptionCurrentPeriodEnd" = ${getSubscriptionPeriodEnd(subscription)}
+    WHERE "id" = ${teamId}
+  `;
+
+  return teamId;
+}
+
+async function hasRecordedStripeInvoice(input: {
+  stripeInvoiceId: string;
+  db: TeamSubscriptionDb;
+}) {
+  const rows = await input.db.$queryRaw<Array<{ id: string }>>`
+    SELECT "id"
+    FROM "PaymentTransaction"
+    WHERE "stripeInvoiceId" = ${input.stripeInvoiceId}
+    LIMIT 1
+  `;
+
+  return Boolean(rows[0]?.id);
+}
+
+export async function recordTeamSubscriptionInvoicePaid(input: {
+  invoice: Stripe.Invoice;
+  stripe?: Stripe;
+  db?: TeamSubscriptionDb;
+}) {
+  const db = input.db ?? prisma;
+  const invoice = input.invoice as StripeInvoiceLike;
+  const stripeInvoiceId = invoice.id;
+
+  if (!stripeInvoiceId) return null;
+  if (await hasRecordedStripeInvoice({ stripeInvoiceId, db })) return null;
+
+  let stripeSubscriptionId = getStripeId(invoice.subscription);
+  let stripeCustomerId = getStripeId(invoice.customer);
+  let metadataTeamId = invoice.metadata?.teamId?.trim() || null;
+
+  if ((!metadataTeamId || !stripeSubscriptionId) && stripeSubscriptionId && input.stripe) {
+    const subscription = await input.stripe.subscriptions.retrieve(stripeSubscriptionId);
+    metadataTeamId = metadataTeamId || subscription.metadata?.teamId?.trim() || null;
+    stripeCustomerId = stripeCustomerId || getStripeId(subscription.customer);
+    await syncTeamSubscriptionFromStripe({ subscription, db });
+  }
+
+  const teamId = await findTeamIdForStripeSubscription({
+    stripeSubscriptionId,
+    stripeCustomerId,
+    metadataTeamId,
+    db,
+  });
+
+  if (!teamId) return null;
+
+  const amountPence = invoice.amount_paid ?? invoice.total ?? 0;
+  if (amountPence <= 0) return null;
+
+  const paidAt =
+    toDateFromUnix(invoice.status_transitions?.paid_at) ??
+    toDateFromUnix(invoice.created) ??
+    new Date();
+
+  const paymentIntentId = getStripeId(invoice.payment_intent);
+  const stripeChargeId = getStripeId(invoice.charge);
+
+  const transaction = await db.paymentTransaction.create({
+    data: {
+      teamId,
+      chargeId: null,
+      amountPence,
+      method: "STRIPE",
+      reference: stripeInvoiceId,
+      notes: "Recurring team subscription paid via Stripe.",
+      paidAt,
+      stripePaymentIntentId: paymentIntentId,
+      stripeChargeId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  await db.$executeRaw`
+    UPDATE "PaymentTransaction"
+    SET "stripeInvoiceId" = ${stripeInvoiceId}
+    WHERE "id" = ${transaction.id}
+  `;
+
+  await db.$executeRaw`
+    UPDATE "Team"
+    SET
+      "subscriptionLastInvoiceId" = ${stripeInvoiceId},
+      "subscriptionLastPaymentAt" = ${paidAt},
+      "subscriptionLastPaymentFailedAt" = NULL
+    WHERE "id" = ${teamId}
+  `;
+
+  return transaction.id;
+}
+
+export async function markTeamSubscriptionInvoiceFailed(input: {
+  invoice: Stripe.Invoice;
+  stripe?: Stripe;
+  db?: TeamSubscriptionDb;
+}) {
+  const db = input.db ?? prisma;
+  const invoice = input.invoice as StripeInvoiceLike;
+
+  let stripeSubscriptionId = getStripeId(invoice.subscription);
+  let stripeCustomerId = getStripeId(invoice.customer);
+  let metadataTeamId = invoice.metadata?.teamId?.trim() || null;
+
+  if ((!metadataTeamId || !stripeSubscriptionId) && stripeSubscriptionId && input.stripe) {
+    const subscription = await input.stripe.subscriptions.retrieve(stripeSubscriptionId);
+    metadataTeamId = metadataTeamId || subscription.metadata?.teamId?.trim() || null;
+    stripeCustomerId = stripeCustomerId || getStripeId(subscription.customer);
+    await syncTeamSubscriptionFromStripe({ subscription, db });
+  }
+
+  const teamId = await findTeamIdForStripeSubscription({
+    stripeSubscriptionId,
+    stripeCustomerId,
+    metadataTeamId,
+    db,
+  });
+
+  if (!teamId) return null;
+
+  await db.$executeRaw`
+    UPDATE "Team"
+    SET
+      "subscriptionLastInvoiceId" = ${invoice.id ?? null},
+      "subscriptionLastPaymentFailedAt" = ${new Date()},
+      "subscriptionStatus" = COALESCE("subscriptionStatus", 'past_due')
+    WHERE "id" = ${teamId}
+  `;
+
+  return teamId;
+}


### PR DESCRIPTION
## Summary

Adds the simple first version of recurring Stripe team payments without changing the existing one-off charge/match-fee payment system.

This supersedes PR #66, which was opened from an older branch and showed as not mergeable. This PR is based from the current `main` branch.

### Included

- Adds additive-only database columns for team Stripe subscription tracking.
- Adds `stripeInvoiceId` tracking on `PaymentTransaction` to prevent duplicate recurring invoice records.
- Adds captain route to start a Stripe Checkout subscription.
- Adds captain route to open Stripe Billing Portal for card/payment management.
- Extends the existing Stripe webhook to handle:
  - `checkout.session.completed` for subscription setup
  - `customer.subscription.created`
  - `customer.subscription.updated`
  - `customer.subscription.deleted`
  - `invoice.paid`
  - `invoice.payment_succeeded`
  - `invoice.payment_failed`
- Records successful recurring Stripe invoices as unallocated `PaymentTransaction` rows with `method: STRIPE`.
- Adds an automatic payments card to the captain payments page.
- Adds an admin recurring subscriptions screen at `/admin/payments/subscriptions`.
- Adds admin navigation for recurring subscriptions while preserving the existing Queue item.

## Required production variables

Set one of these Stripe recurring price IDs in Railway/Vercel before using the captain setup button:

```txt
STRIPE_TEAM_SUBSCRIPTION_PRICE_ID
```

Fallbacks are also supported:

```txt
STRIPE_TEAM_WEEKLY_PRICE_ID
STRIPE_TEAM_MONTHLY_PRICE_ID
```

Existing variables are still required:

```txt
STRIPE_SECRET_KEY
STRIPE_WEBHOOK_SECRET
NEXT_PUBLIC_SITE_URL / SITE_URL / NEXTAUTH_URL
```

## Stripe webhook events to enable/check

```txt
checkout.session.completed
checkout.session.async_payment_succeeded
customer.subscription.created
customer.subscription.updated
customer.subscription.deleted
invoice.paid
invoice.payment_succeeded
invoice.payment_failed
```

## Safety notes

- No production reset is required.
- Migration is additive only.
- Existing `PaymentCharge` and match-fee checkout flow remain intact.
- Recurring payments are recorded as `PaymentTransaction` records first; no automatic future `PaymentCharge` generation in this simple phase.

## Testing

Not run locally in this environment. Please rely on CI/build output before merging.
