### PR TITLE
Redesign weekly match card image template

### DIFF
--- a/src/app/api/social/match-card/[cardId]/route.ts
+++ b/src/app/api/social/match-card/[cardId]/route.ts
@@ -15,6 +15,23 @@ export const runtime = "nodejs";
 
 const WIDTH = 1080;
 const HEIGHT = 1350;
+const CARD_X = 60;
+const CARD_Y = 60;
+const CARD_W = 960;
+const CARD_H = 1230;
+
+const COLORS = {
+  background: "#020617",
+  panel: "#07111F",
+  panelSoft: "#0F172A",
+  line: "rgba(148,163,184,0.22)",
+  text: "#F8FAFC",
+  muted: "#94A3B8",
+  soft: "#CBD5E1",
+  green: "#34D399",
+  greenSoft: "#A7F3D0",
+  warning: "#FDE68A",
+};
 
 type CardRow = {
   id: string;
@@ -34,145 +51,6 @@ type FixtureRow = {
   homeScore: number | null;
   awayScore: number | null;
 };
-
-type Glyph = string[];
-
-const GLYPHS: Record<string, Glyph> = {
-  " ": ["000", "000", "000", "000", "000", "000", "000"],
-  A: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
-  B: ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
-  C: ["01111", "10000", "10000", "10000", "10000", "10000", "01111"],
-  D: ["11110", "10001", "10001", "10001", "10001", "10001", "11110"],
-  E: ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
-  F: ["11111", "10000", "10000", "11110", "10000", "10000", "10000"],
-  G: ["01111", "10000", "10000", "10011", "10001", "10001", "01111"],
-  H: ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
-  I: ["11111", "00100", "00100", "00100", "00100", "00100", "11111"],
-  J: ["00111", "00010", "00010", "00010", "10010", "10010", "01100"],
-  K: ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
-  L: ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
-  M: ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
-  N: ["10001", "11001", "10101", "10011", "10001", "10001", "10001"],
-  O: ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
-  P: ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
-  Q: ["01110", "10001", "10001", "10001", "10101", "10010", "01101"],
-  R: ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
-  S: ["01111", "10000", "10000", "01110", "00001", "00001", "11110"],
-  T: ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
-  U: ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
-  V: ["10001", "10001", "10001", "10001", "10001", "01010", "00100"],
-  W: ["10001", "10001", "10001", "10101", "10101", "10101", "01010"],
-  X: ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
-  Y: ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
-  Z: ["11111", "00001", "00010", "00100", "01000", "10000", "11111"],
-  "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
-  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
-  "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
-  "3": ["11110", "00001", "00001", "01110", "00001", "00001", "11110"],
-  "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
-  "5": ["11111", "10000", "10000", "11110", "00001", "00001", "11110"],
-  "6": ["01110", "10000", "10000", "11110", "10001", "10001", "01110"],
-  "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
-  "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
-  "9": ["01110", "10001", "10001", "01111", "00001", "00001", "01110"],
-  ".": ["0", "0", "0", "0", "0", "0", "1"],
-  ",": ["0", "0", "0", "0", "0", "1", "1"],
-  ":": ["0", "1", "1", "0", "1", "1", "0"],
-  "-": ["00000", "00000", "00000", "11111", "00000", "00000", "00000"],
-  "/": ["00001", "00010", "00010", "00100", "01000", "01000", "10000"],
-  "+": ["00000", "00100", "00100", "11111", "00100", "00100", "00000"],
-  "&": ["01100", "10010", "10100", "01000", "10101", "10010", "01101"],
-  "#": ["01010", "11111", "01010", "01010", "11111", "01010", "01010"],
-  "'": ["1", "1", "0", "0", "0", "0", "0"],
-  "!": ["1", "1", "1", "1", "1", "0", "1"],
-  "?": ["01110", "10001", "00001", "00010", "00100", "00000", "00100"],
-  "(": ["001", "010", "100", "100", "100", "010", "001"],
-  ")": ["100", "010", "001", "001", "001", "010", "100"],
-};
-
-function normaliseForGlyphs(value: string) {
-  return value
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[’‘`]/g, "'")
-    .replace(/[“”]/g, '"')
-    .replace(/[–—•]/g, "-")
-    .replace(/£/g, "GBP")
-    .toUpperCase()
-    .replace(/[^A-Z0-9 .,:\-\/+#&'!?()]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function glyphWidth(char: string) {
-  return GLYPHS[char]?.[0]?.length ?? GLYPHS["?"].length;
-}
-
-function measureBlockText(value: string, scale: number) {
-  const text = normaliseForGlyphs(value);
-  if (!text) return 0;
-
-  return text.split("").reduce((sum, char, index) => {
-    const width = glyphWidth(char) * scale;
-    const gap = index === text.length - 1 ? 0 : scale;
-    return sum + width + gap;
-  }, 0);
-}
-
-function fitBlockText(value: string, scale: number, maxWidth: number) {
-  const clean = normaliseForGlyphs(value);
-  if (measureBlockText(clean, scale) <= maxWidth) return clean;
-
-  let next = clean;
-  while (next.length > 1 && measureBlockText(`${next}...`, scale) > maxWidth) {
-    next = next.slice(0, -1).trimEnd();
-  }
-
-  return `${next}...`;
-}
-
-function drawBlockText(
-  ctx: CanvasRenderingContext2D,
-  value: string,
-  x: number,
-  y: number,
-  scale: number,
-  color: string,
-  options?: {
-    align?: "left" | "center" | "right";
-    maxWidth?: number;
-  },
-) {
-  const text = options?.maxWidth
-    ? fitBlockText(value, scale, options.maxWidth)
-    : normaliseForGlyphs(value);
-  const width = measureBlockText(text, scale);
-  const align = options?.align ?? "left";
-  let cursorX = x;
-
-  if (align === "center") cursorX -= width / 2;
-  if (align === "right") cursorX -= width;
-
-  ctx.fillStyle = color;
-
-  for (const char of text) {
-    const glyph = GLYPHS[char] ?? GLYPHS["?"];
-
-    glyph.forEach((row, rowIndex) => {
-      row.split("").forEach((cell, colIndex) => {
-        if (cell !== "1") return;
-        ctx.fillRect(
-          Math.round(cursorX + colIndex * scale),
-          Math.round(y + rowIndex * scale),
-          Math.ceil(scale),
-          Math.ceil(scale),
-        );
-      });
-    });
-
-    cursorX += glyphWidth(char) * scale + scale;
-  }
-}
 
 function roundedRect(
   ctx: CanvasRenderingContext2D,
@@ -226,16 +104,176 @@ function strokeRoundedRect(
   ctx.stroke();
 }
 
+function setFont(
+  ctx: CanvasRenderingContext2D,
+  size: number,
+  weight: "400" | "500" | "600" | "700" | "800" | "900" = "600",
+) {
+  ctx.font = `${weight} ${size}px Arial, Helvetica, sans-serif`;
+}
+
+function cleanText(value: string | null | undefined) {
+  return (value ?? "")
+    .replace(/[’‘`]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function ellipsize(
+  ctx: CanvasRenderingContext2D,
+  value: string,
+  maxWidth: number,
+) {
+  const text = cleanText(value);
+
+  if (!text || ctx.measureText(text).width <= maxWidth) {
+    return text;
+  }
+
+  let next = text;
+  while (next.length > 1 && ctx.measureText(`${next}…`).width > maxWidth) {
+    next = next.slice(0, -1).trimEnd();
+  }
+
+  return `${next}…`;
+}
+
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  value: string,
+  maxWidth: number,
+  maxLines: number,
+) {
+  const words = cleanText(value).split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+
+  for (const word of words) {
+    const current = lines[lines.length - 1] ?? "";
+    const candidate = current ? `${current} ${word}` : word;
+
+    if (ctx.measureText(candidate).width <= maxWidth) {
+      if (lines.length === 0) {
+        lines.push(candidate);
+      } else {
+        lines[lines.length - 1] = candidate;
+      }
+      continue;
+    }
+
+    if (lines.length < maxLines) {
+      lines.push(word);
+      continue;
+    }
+
+    lines[lines.length - 1] = ellipsize(ctx, `${lines[lines.length - 1]} ${word}`, maxWidth);
+  }
+
+  if (lines.length > maxLines) {
+    return lines.slice(0, maxLines);
+  }
+
+  if (lines.length === maxLines) {
+    lines[maxLines - 1] = ellipsize(ctx, lines[maxLines - 1], maxWidth);
+  }
+
+  return lines;
+}
+
+function drawText(
+  ctx: CanvasRenderingContext2D,
+  value: string,
+  x: number,
+  y: number,
+  options: {
+    size: number;
+    weight?: "400" | "500" | "600" | "700" | "800" | "900";
+    color?: string;
+    align?: CanvasTextAlign;
+    baseline?: CanvasTextBaseline;
+    maxWidth?: number;
+  },
+) {
+  setFont(ctx, options.size, options.weight ?? "600");
+  ctx.fillStyle = options.color ?? COLORS.text;
+  ctx.textAlign = options.align ?? "left";
+  ctx.textBaseline = options.baseline ?? "alphabetic";
+
+  const text = options.maxWidth
+    ? ellipsize(ctx, value, options.maxWidth)
+    : cleanText(value);
+
+  ctx.fillText(text, x, y);
+}
+
+function drawWrappedText(
+  ctx: CanvasRenderingContext2D,
+  value: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  options: {
+    size: number;
+    weight?: "400" | "500" | "600" | "700" | "800" | "900";
+    color?: string;
+    align?: CanvasTextAlign;
+    maxLines?: number;
+    lineHeight?: number;
+  },
+) {
+  setFont(ctx, options.size, options.weight ?? "600");
+  ctx.fillStyle = options.color ?? COLORS.text;
+  ctx.textAlign = options.align ?? "left";
+  ctx.textBaseline = "top";
+
+  const maxLines = options.maxLines ?? 2;
+  const lineHeight = options.lineHeight ?? Math.round(options.size * 1.16);
+  const lines = wrapText(ctx, value, maxWidth, maxLines);
+
+  lines.forEach((line, index) => {
+    ctx.fillText(line, x, y + index * lineHeight);
+  });
+
+  return lines.length * lineHeight;
+}
+
+function drawPill(
+  ctx: CanvasRenderingContext2D,
+  label: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  options?: {
+    fill?: string;
+    stroke?: string;
+    text?: string;
+    size?: number;
+  },
+) {
+  fillRoundedRect(ctx, x, y, width, height, height / 2, options?.fill ?? "rgba(52,211,153,0.12)");
+  strokeRoundedRect(ctx, x, y, width, height, height / 2, options?.stroke ?? "rgba(52,211,153,0.28)");
+  drawText(ctx, label, x + width / 2, y + height / 2 + 1, {
+    size: options?.size ?? 24,
+    weight: "800",
+    color: options?.text ?? COLORS.greenSoft,
+    align: "center",
+    baseline: "middle",
+    maxWidth: width - 28,
+  });
+}
+
 function getTitle(postType: SocialPostType) {
-  if (postType === "RESULT") return "RESULTS";
-  if (postType === "UPDATE") return "FIXTURE UPDATE";
-  return "MATCH NIGHT";
+  if (postType === "RESULT") return "Results";
+  if (postType === "UPDATE") return "Fixture update";
+  return "Match night";
 }
 
 function getSubtitle(postType: SocialPostType) {
-  if (postType === "RESULT") return "THIS WEEK'S SCORES";
-  if (postType === "UPDATE") return "LATEST MATCH-NIGHT CHANGES";
-  return "THIS WEEK'S FIXTURES";
+  if (postType === "RESULT") return "This week’s scores";
+  if (postType === "UPDATE") return "Latest match-night changes";
+  return "This week’s fixtures";
 }
 
 function getFixtureLine(fixture: FixtureRow, postType: SocialPostType) {
@@ -248,143 +286,238 @@ function getFixtureLine(fixture: FixtureRow, postType: SocialPostType) {
       left: fixture.homeTeamName,
       middle: `${fixture.homeScore}-${fixture.awayScore}`,
       right: fixture.awayTeamName,
-      meta: fixture.pitch || "FINAL SCORE",
+      meta: fixture.pitch || "Final score",
     };
   }
 
   return {
     left: fixture.homeTeamName,
-    middle: "V",
+    middle: "v",
     right: fixture.awayTeamName,
     meta: [formatTimeInLondon(fixture.kickoffAt), fixture.pitch]
       .filter(Boolean)
-      .join(" - "),
+      .join(" · "),
   };
 }
 
-function drawRow(
+function drawFixtureRow(
   ctx: CanvasRenderingContext2D,
   fixture: FixtureRow,
   postType: SocialPostType,
   y: number,
+  rowHeight: number,
 ) {
   const line = getFixtureLine(fixture, postType);
+  const rowX = 100;
+  const rowW = 880;
 
-  fillRoundedRect(ctx, 90, y, 900, 74, 24, "rgba(255,255,255,0.07)");
-  strokeRoundedRect(ctx, 90, y, 900, 74, 24, "rgba(255,255,255,0.12)");
+  fillRoundedRect(ctx, rowX, y, rowW, rowHeight, 28, "rgba(15,23,42,0.92)");
+  strokeRoundedRect(ctx, rowX, y, rowW, rowHeight, 28, "rgba(148,163,184,0.22)");
 
-  drawBlockText(ctx, line.meta || "SIXFL", 126, y + 14, 3, "#94A3B8", {
-    maxWidth: 430,
+  drawText(ctx, line.meta || "SIXFL", rowX + 32, y + 28, {
+    size: 24,
+    weight: "700",
+    color: COLORS.muted,
+    baseline: "middle",
+    maxWidth: 360,
   });
 
   if (fixture.status === "POSTPONED" || fixture.status === "CANCELLED") {
-    drawBlockText(ctx, fixture.status, 938, y + 14, 3, "#FDE68A", {
-      align: "right",
-      maxWidth: 220,
+    drawPill(ctx, fixture.status, rowX + rowW - 190, y + 12, 158, 38, {
+      fill: "rgba(253,230,138,0.12)",
+      stroke: "rgba(253,230,138,0.32)",
+      text: COLORS.warning,
+      size: 18,
     });
   }
 
-  drawBlockText(ctx, line.left, 126, y + 43, 4, "#FFFFFF", {
-    maxWidth: 340,
+  const teamTop = y + 54;
+  const teamWidth = 340;
+  const teamFontSize = rowHeight >= 124 ? 34 : 30;
+
+  drawWrappedText(ctx, line.left.toUpperCase(), rowX + 32, teamTop, teamWidth, {
+    size: teamFontSize,
+    weight: "900",
+    color: COLORS.text,
+    maxLines: 2,
+    lineHeight: Math.round(teamFontSize * 1.04),
   });
 
-  drawBlockText(ctx, line.middle, 540, y + 39, 5, "#34D399", {
-    align: "center",
-    maxWidth: 110,
+  drawPill(ctx, line.middle.toUpperCase(), 504, y + rowHeight / 2 - 30, 72, 60, {
+    fill: "rgba(52,211,153,0.16)",
+    stroke: "rgba(52,211,153,0.35)",
+    text: COLORS.green,
+    size: postType === "RESULT" ? 24 : 30,
   });
 
-  drawBlockText(ctx, line.right, 954, y + 43, 4, "#FFFFFF", {
+  drawWrappedText(ctx, line.right.toUpperCase(), rowX + rowW - 32, teamTop, teamWidth, {
+    size: teamFontSize,
+    weight: "900",
+    color: COLORS.text,
     align: "right",
-    maxWidth: 340,
+    maxLines: 2,
+    lineHeight: Math.round(teamFontSize * 1.04),
   });
+}
+
+function getFixtureLayout(count: number) {
+  if (count <= 2) return { rowHeight: 140, rowGap: 18 };
+  if (count <= 4) return { rowHeight: 124, rowGap: 16 };
+  if (count <= 6) return { rowHeight: 108, rowGap: 14 };
+  return { rowHeight: 96, rowGap: 12 };
 }
 
 function drawCard(card: CardRow, fixtures: FixtureRow[]) {
   const canvas = createCanvas(WIDTH, HEIGHT);
   const ctx = canvas.getContext("2d");
 
-  ctx.fillStyle = "#020617";
+  ctx.fillStyle = COLORS.background;
   ctx.fillRect(0, 0, WIDTH, HEIGHT);
 
-  const topGlow = ctx.createRadialGradient(540, 0, 0, 540, 0, 760);
-  topGlow.addColorStop(0, "rgba(16,185,129,0.38)");
-  topGlow.addColorStop(1, "rgba(2,6,23,0)");
-  ctx.fillStyle = topGlow;
+  const bgGradient = ctx.createLinearGradient(0, 0, WIDTH, HEIGHT);
+  bgGradient.addColorStop(0, "rgba(16,185,129,0.35)");
+  bgGradient.addColorStop(0.42, "rgba(15,23,42,0.18)");
+  bgGradient.addColorStop(1, "rgba(2,6,23,0.98)");
+  ctx.fillStyle = bgGradient;
   ctx.fillRect(0, 0, WIDTH, HEIGHT);
-
-  ctx.fillStyle = "rgba(16,185,129,0.09)";
-  ctx.beginPath();
-  ctx.arc(118, 160, 230, 0, Math.PI * 2);
-  ctx.fill();
 
   ctx.fillStyle = "rgba(52,211,153,0.08)";
   ctx.beginPath();
-  ctx.arc(954, 1236, 300, 0, Math.PI * 2);
+  ctx.arc(158, 112, 280, 0, Math.PI * 2);
   ctx.fill();
 
-  fillRoundedRect(ctx, 54, 54, 972, 1242, 54, "rgba(255,255,255,0.035)");
-  strokeRoundedRect(ctx, 54, 54, 972, 1242, 54, "rgba(255,255,255,0.12)");
+  ctx.fillStyle = "rgba(14,165,233,0.07)";
+  ctx.beginPath();
+  ctx.arc(965, 1188, 330, 0, Math.PI * 2);
+  ctx.fill();
 
-  const panel = ctx.createLinearGradient(90, 250, 990, 1120);
-  panel.addColorStop(0, "rgba(15,23,42,0.96)");
-  panel.addColorStop(1, "rgba(2,6,23,0.98)");
-  fillRoundedRect(ctx, 90, 250, 900, 900, 44, panel);
-  strokeRoundedRect(ctx, 90, 250, 900, 900, 44, "rgba(255,255,255,0.12)");
+  fillRoundedRect(ctx, CARD_X, CARD_Y, CARD_W, CARD_H, 54, "rgba(2,6,23,0.58)");
+  strokeRoundedRect(ctx, CARD_X, CARD_Y, CARD_W, CARD_H, 54, "rgba(255,255,255,0.14)");
 
-  const title = getTitle(card.postType);
-  const subtitle = getSubtitle(card.postType);
-  const dateLabel = formatWeeklyCardDate(card.fixtureDate);
+  drawPill(ctx, "SIXFL", 100, 104, 150, 52, {
+    fill: "rgba(52,211,153,0.14)",
+    stroke: "rgba(52,211,153,0.3)",
+    text: COLORS.greenSoft,
+    size: 24,
+  });
+
   const shortDateLabel = formatWeeklyCardShortDate(card.fixtureDate).toUpperCase();
-  const leagueLabel = card.season
-    ? `${card.leagueName} - ${card.season}`
-    : card.leagueName;
+  drawPill(ctx, shortDateLabel, 730, 104, 250, 52, {
+    fill: "rgba(255,255,255,0.06)",
+    stroke: "rgba(255,255,255,0.14)",
+    text: COLORS.soft,
+    size: 22,
+  });
 
-  drawBlockText(ctx, "SIXFL", 90, 100, 5, "#34D399");
-  drawBlockText(ctx, shortDateLabel, 990, 104, 3, "#A7F3D0", {
-    align: "right",
-    maxWidth: 270,
+  drawText(ctx, getTitle(card.postType), 100, 245, {
+    size: 78,
+    weight: "900",
+    color: COLORS.text,
+    baseline: "alphabetic",
+    maxWidth: 840,
   });
-  drawBlockText(ctx, title, 90, 160, 10, "#FFFFFF", { maxWidth: 760 });
-  drawBlockText(ctx, subtitle, 94, 226, 4, "#94A3B8", { maxWidth: 650 });
-  drawBlockText(ctx, leagueLabel, 540, 310, 3, "#A7F3D0", {
-    align: "center",
-    maxWidth: 760,
+
+  drawText(ctx, getSubtitle(card.postType), 104, 296, {
+    size: 32,
+    weight: "700",
+    color: COLORS.greenSoft,
+    maxWidth: 820,
   });
-  drawBlockText(ctx, dateLabel, 540, 354, 4, "#F8FAFC", {
-    align: "center",
-    maxWidth: 660,
-  });
+
+  const leagueLabel = card.season
+    ? `${card.leagueName} · ${card.season}`
+    : card.leagueName;
+  const dateLabel = formatWeeklyCardDate(card.fixtureDate);
 
   const visibleFixtures = fixtures.slice(0, 8);
-  const startY = 430;
-  const rowGap = 96;
+  const { rowHeight, rowGap } = getFixtureLayout(visibleFixtures.length);
+  const rowsHeight = visibleFixtures.length * rowHeight + Math.max(0, visibleFixtures.length - 1) * rowGap;
+  const fixturePanelHeight = Math.max(430, rowsHeight + 190);
+  const fixturePanelY = 340;
 
-  visibleFixtures.forEach((fixture, index) => {
-    drawRow(ctx, fixture, card.postType, startY + index * rowGap);
+  const panelGradient = ctx.createLinearGradient(100, fixturePanelY, 980, fixturePanelY + fixturePanelHeight);
+  panelGradient.addColorStop(0, "rgba(15,23,42,0.94)");
+  panelGradient.addColorStop(1, "rgba(2,6,23,0.98)");
+
+  fillRoundedRect(ctx, 86, fixturePanelY, 908, fixturePanelHeight, 44, panelGradient);
+  strokeRoundedRect(ctx, 86, fixturePanelY, 908, fixturePanelHeight, 44, "rgba(148,163,184,0.18)");
+
+  drawWrappedText(ctx, leagueLabel.toUpperCase(), 540, fixturePanelY + 36, 790, {
+    size: 28,
+    weight: "800",
+    color: COLORS.greenSoft,
+    align: "center",
+    maxLines: 2,
+    lineHeight: 32,
   });
 
+  drawText(ctx, dateLabel.toUpperCase(), 540, fixturePanelY + 112, {
+    size: 38,
+    weight: "900",
+    color: COLORS.text,
+    align: "center",
+    baseline: "middle",
+    maxWidth: 780,
+  });
+
+  const startY = fixturePanelY + 166;
+
+  if (visibleFixtures.length === 0) {
+    drawText(ctx, "No fixtures selected yet", 540, startY + 84, {
+      size: 34,
+      weight: "800",
+      color: COLORS.muted,
+      align: "center",
+      baseline: "middle",
+      maxWidth: 760,
+    });
+  } else {
+    visibleFixtures.forEach((fixture, index) => {
+      drawFixtureRow(
+        ctx,
+        fixture,
+        card.postType,
+        startY + index * (rowHeight + rowGap),
+        rowHeight,
+      );
+    });
+  }
+
   if (fixtures.length > visibleFixtures.length) {
-    drawBlockText(
+    drawPill(
       ctx,
-      `+ ${fixtures.length - visibleFixtures.length} MORE FIXTURES`,
-      540,
-      startY + visibleFixtures.length * rowGap + 8,
-      4,
-      "#A7F3D0",
-      { align: "center", maxWidth: 620 },
+      `+ ${fixtures.length - visibleFixtures.length} more fixtures`,
+      332,
+      startY + rowsHeight + 22,
+      416,
+      50,
+      {
+        fill: "rgba(52,211,153,0.12)",
+        stroke: "rgba(52,211,153,0.28)",
+        text: COLORS.greenSoft,
+        size: 22,
+      },
     );
   }
 
-  fillRoundedRect(ctx, 90, 1186, 900, 70, 26, "rgba(16,185,129,0.14)");
-  strokeRoundedRect(ctx, 90, 1186, 900, 70, 26, "rgba(52,211,153,0.24)");
-
-  drawBlockText(ctx, "6-A-SIDE FOOTBALL. DONE PROPERLY.", 540, 1208, 4, "#D1FAE5", {
+  const footerY = 1178;
+  fillRoundedRect(ctx, 100, footerY, 880, 76, 30, "rgba(52,211,153,0.15)");
+  strokeRoundedRect(ctx, 100, footerY, 880, 76, 30, "rgba(52,211,153,0.26)");
+  drawText(ctx, "6-a-side football. Done properly.", 540, footerY + 40, {
+    size: 34,
+    weight: "900",
+    color: COLORS.text,
     align: "center",
-    maxWidth: 760,
+    baseline: "middle",
+    maxWidth: 780,
   });
-  drawBlockText(ctx, "SIXFL.CO.UK", 540, 1270, 3, "#64748B", {
+  drawText(ctx, "sixfl.co.uk", 540, 1282, {
+    size: 26,
+    weight: "800",
+    color: COLORS.muted,
     align: "center",
-    maxWidth: 250,
+    baseline: "middle",
+    maxWidth: 260,
   });
 
   return canvas.toBuffer("image/png");

--- a/src/app/api/social/match-card/[cardId]/route.ts
+++ b/src/app/api/social/match-card/[cardId]/route.ts
@@ -314,8 +314,8 @@ function drawFixtureRow(
   fillRoundedRect(ctx, rowX, y, rowW, rowHeight, 28, "rgba(15,23,42,0.92)");
   strokeRoundedRect(ctx, rowX, y, rowW, rowHeight, 28, "rgba(148,163,184,0.22)");
 
-  drawText(ctx, line.meta || "SIXFL", rowX + 32, y + 28, {
-    size: 24,
+  drawText(ctx, line.meta || "SIXFL", rowX + 32, y + (rowHeight >= 100 ? 28 : 22), {
+    size: rowHeight >= 100 ? 24 : 18,
     weight: "700",
     color: COLORS.muted,
     baseline: "middle",
@@ -331,40 +331,53 @@ function drawFixtureRow(
     });
   }
 
-  const teamTop = y + 54;
+  const teamTop = y + (rowHeight >= 100 ? 54 : 42);
   const teamWidth = 340;
-  const teamFontSize = rowHeight >= 124 ? 34 : 30;
+  const teamFontSize =
+    rowHeight >= 124 ? 34 : rowHeight >= 100 ? 30 : rowHeight >= 84 ? 26 : 22;
+  const teamMaxLines = rowHeight >= 100 ? 2 : 1;
 
   drawWrappedText(ctx, line.left.toUpperCase(), rowX + 32, teamTop, teamWidth, {
     size: teamFontSize,
     weight: "900",
     color: COLORS.text,
-    maxLines: 2,
+    maxLines: teamMaxLines,
     lineHeight: Math.round(teamFontSize * 1.04),
   });
 
-  drawPill(ctx, line.middle.toUpperCase(), 504, y + rowHeight / 2 - 30, 72, 60, {
-    fill: "rgba(52,211,153,0.16)",
-    stroke: "rgba(52,211,153,0.35)",
-    text: COLORS.green,
-    size: postType === "RESULT" ? 24 : 30,
-  });
+  const centrePillHeight = Math.min(60, Math.max(42, rowHeight - 28));
+  const centrePillWidth = postType === "RESULT" ? 104 : 72;
+
+  drawPill(
+    ctx,
+    line.middle.toUpperCase(),
+    540 - centrePillWidth / 2,
+    y + rowHeight / 2 - centrePillHeight / 2,
+    centrePillWidth,
+    centrePillHeight,
+    {
+      fill: "rgba(52,211,153,0.16)",
+      stroke: "rgba(52,211,153,0.35)",
+      text: COLORS.green,
+      size: postType === "RESULT" ? 24 : rowHeight >= 100 ? 30 : 22,
+    },
+  );
 
   drawWrappedText(ctx, line.right.toUpperCase(), rowX + rowW - 32, teamTop, teamWidth, {
     size: teamFontSize,
     weight: "900",
     color: COLORS.text,
     align: "right",
-    maxLines: 2,
+    maxLines: teamMaxLines,
     lineHeight: Math.round(teamFontSize * 1.04),
   });
 }
 
 function getFixtureLayout(count: number) {
   if (count <= 2) return { rowHeight: 140, rowGap: 18 };
-  if (count <= 4) return { rowHeight: 124, rowGap: 16 };
-  if (count <= 6) return { rowHeight: 108, rowGap: 14 };
-  return { rowHeight: 96, rowGap: 12 };
+  if (count <= 4) return { rowHeight: 118, rowGap: 14 };
+  if (count <= 6) return { rowHeight: 92, rowGap: 12 };
+  return { rowHeight: 72, rowGap: 9 };
 }
 
 function drawCard(card: CardRow, fixtures: FixtureRow[]) {
@@ -429,10 +442,10 @@ function drawCard(card: CardRow, fixtures: FixtureRow[]) {
     : card.leagueName;
   const dateLabel = formatWeeklyCardDate(card.fixtureDate);
 
-  const visibleFixtures = fixtures.slice(0, 8);
+  const visibleFixtures = fixtures.length > 8 ? fixtures.slice(0, 7) : fixtures.slice(0, 8);
   const { rowHeight, rowGap } = getFixtureLayout(visibleFixtures.length);
   const rowsHeight = visibleFixtures.length * rowHeight + Math.max(0, visibleFixtures.length - 1) * rowGap;
-  const fixturePanelHeight = Math.max(430, rowsHeight + 190);
+  const fixturePanelHeight = Math.max(430, Math.min(824, rowsHeight + 190));
   const fixturePanelY = 340;
 
   const panelGradient = ctx.createLinearGradient(100, fixturePanelY, 980, fixturePanelY + fixturePanelHeight);


### PR DESCRIPTION
## Summary
- Replaces the old pixel-font weekly match card renderer with a cleaner poster-style social graphic.
- Uses normal readable typography instead of the custom block glyph font.
- Allows league names and team names to wrap/fit more gracefully.
- Reduces brutal truncation and improves spacing for short and longer fixture lists.

## Testing
- Not run locally; repository was edited through GitHub connector only.