### PR TITLE
Add return control for captain preview

### DIFF
--- a/src/app/(admin)/admin/teams/[id]/captain-preview/exit/route.ts
+++ b/src/app/(admin)/admin/teams/[id]/captain-preview/exit/route.ts
@@ -1,0 +1,63 @@
+// ========================================
+// File: src/app/(admin)/admin/teams/[id]/captain-preview/exit/route.ts
+// ========================================
+
+import { NextResponse } from "next/server";
+
+import { CAPTAIN_ONLY_PREVIEW_COOKIE } from "@/lib/requireCaptain";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+
+function getSafeRedirect(input: {
+  origin: string;
+  teamId: string;
+  requestedTo: string | null;
+}) {
+  const fallback = `/captain/team/${input.teamId}`;
+  const requestedTo = input.requestedTo?.trim();
+
+  if (!requestedTo) {
+    return new URL(fallback, input.origin);
+  }
+
+  try {
+    const target = new URL(requestedTo, input.origin);
+    const allowedPrefix = `/captain/team/${input.teamId}`;
+
+    if (target.origin === input.origin && target.pathname.startsWith(allowedPrefix)) {
+      target.searchParams.delete("captainPreview");
+      return target;
+    }
+  } catch {
+    // Fall through to the safe fallback.
+  }
+
+  return new URL(fallback, input.origin);
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  await requireAdmin();
+
+  const { id } = await params;
+  const url = new URL(request.url);
+  const target = getSafeRedirect({
+    origin: url.origin,
+    teamId: id,
+    requestedTo: url.searchParams.get("to"),
+  });
+  const response = NextResponse.redirect(target);
+
+  response.cookies.set(CAPTAIN_ONLY_PREVIEW_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+
+  return response;
+}

--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -324,6 +324,7 @@ export default async function CaptainTeamLayout({
                     teamId={team.id}
                     isAdmin={access.isAdmin}
                     isManagedTeam={isManagedTeam}
+                    accessMode={access.accessMode}
                   />
 
                   <h1 className="captain-team-heading mt-2 text-2xl font-semibold tracking-tight text-white sm:text-4xl">

--- a/src/components/captain/CaptainViewModeHeader.tsx
+++ b/src/components/captain/CaptainViewModeHeader.tsx
@@ -37,6 +37,8 @@ const CAPTAIN_FACING_REPLACEMENTS = [
   },
 ] as const;
 
+type CaptainAccessMode = "admin-preview" | "captain-preview" | "captain";
+
 function getPathWithPreview(input: {
   pathname: string;
   searchParams: URLSearchParams;
@@ -62,6 +64,17 @@ function getFullAdminHref(input: { pathname: string | null; teamId: string }) {
     new RegExp(`/captain/team/${input.teamId}/captain-squad/?$`),
     `/captain/team/${input.teamId}/squad`,
   );
+}
+
+function getExitCaptainPreviewHref(input: {
+  pathname: string | null;
+  searchParamsKey: string;
+  teamId: string;
+}) {
+  const pathname = input.pathname || `/captain/team/${input.teamId}`;
+  const currentPath = `${pathname}${input.searchParamsKey ? `?${input.searchParamsKey}` : ""}`;
+
+  return `/admin/teams/${input.teamId}/captain-preview/exit?to=${encodeURIComponent(currentPath)}`;
 }
 
 function applyCaptainPreviewToHref(input: { href: string; teamId: string }) {
@@ -118,23 +131,31 @@ export default function CaptainViewModeHeader({
   teamId,
   isAdmin,
   isManagedTeam,
+  accessMode,
 }: {
   teamId: string;
   isAdmin: boolean;
   isManagedTeam: boolean;
+  accessMode?: CaptainAccessMode;
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const searchParamsKey = searchParams.toString();
+  const isCaptainOnlyPreview = accessMode === "captain-preview";
+  const canShowAdminControls = isAdmin || isCaptainOnlyPreview;
   const isLimitedCaptainPreview = Boolean(
-    pathname?.includes("/captain-squad") || searchParams.get(CAPTAIN_PREVIEW_PARAM) === "1",
+    isCaptainOnlyPreview ||
+      pathname?.includes("/captain-squad") ||
+      searchParams.get(CAPTAIN_PREVIEW_PARAM) === "1",
   );
   const previewHref = getPathWithPreview({
     pathname: pathname || `/captain/team/${teamId}/captain-squad`,
     searchParams: new URLSearchParams(searchParamsKey),
     teamId,
   });
-  const fullAdminHref = getFullAdminHref({ pathname, teamId });
+  const fullAdminHref = isCaptainOnlyPreview
+    ? getExitCaptainPreviewHref({ pathname, searchParamsKey, teamId })
+    : getFullAdminHref({ pathname, teamId });
 
   useEffect(() => {
     const root = document.querySelector(".captain-team-shell") ?? document.body;
@@ -176,7 +197,9 @@ export default function CaptainViewModeHeader({
   }, [isLimitedCaptainPreview, searchParamsKey, teamId]);
 
   const overline = isLimitedCaptainPreview
-    ? "Limited captain preview"
+    ? canShowAdminControls
+      ? "Admin captain preview"
+      : "Limited captain preview"
     : isAdmin
       ? "SIXFL admin team view"
       : "SIXFL captain hub";
@@ -191,7 +214,7 @@ export default function CaptainViewModeHeader({
 
   return (
     <>
-      {isAdmin && !isManagedTeam ? (
+      {canShowAdminControls && !isManagedTeam ? (
         <style>{`
           .captain-team-shell a[href="/captain/team/${teamId}/prospects"],
           .captain-team-shell a[href="/captain/team/${teamId}/prospects?${CAPTAIN_PREVIEW_PARAM}=1"] {
@@ -209,7 +232,7 @@ export default function CaptainViewModeHeader({
       </p>
 
       <div className="mt-5 flex flex-wrap gap-3">
-        {isAdmin ? (
+        {canShowAdminControls ? (
           <Link
             href={`/admin/teams/${teamId}`}
             data-captain-preview-ignore="true"
@@ -228,7 +251,7 @@ export default function CaptainViewModeHeader({
           </Link>
         ) : null}
 
-        {isAdmin && isLimitedCaptainPreview ? (
+        {canShowAdminControls && isLimitedCaptainPreview ? (
           <Link
             href={fullAdminHref}
             data-captain-preview-ignore="true"
@@ -238,7 +261,7 @@ export default function CaptainViewModeHeader({
           </Link>
         ) : null}
 
-        {isAdmin ? (
+        {canShowAdminControls ? (
           <Link
             href={`/admin/teams/${teamId}/squad`}
             data-captain-preview-ignore="true"
@@ -248,7 +271,7 @@ export default function CaptainViewModeHeader({
           </Link>
         ) : null}
 
-        {isAdmin && isLimitedCaptainPreview ? (
+        {canShowAdminControls && isLimitedCaptainPreview ? (
           <div className="rounded-2xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-100/90">
             <div className="font-medium text-white">Viewing as captain</div>
             <div className="mt-1 text-amber-100/75">Limited preview mode.</div>


### PR DESCRIPTION
## Summary
- Adds a return route for admins who are previewing the captain experience.
- Passes `accessMode` into the captain header so the header can distinguish a real captain from an admin preview.
- Shows **Return to full admin view** while in captain preview.

## Testing
- Not run locally; repository was edited through GitHub connector only.