### PR TITLE
Fix team bulk nullable prospect build

### DIFF
--- a/src/app/(admin)/admin/communications/team-bulk-actions.ts
+++ b/src/app/(admin)/admin/communications/team-bulk-actions.ts
@@ -185,7 +185,7 @@ async function getTeamCommunicationRecipientContext(input: {
       },
     });
 
-    if (!prospect) return null;
+    if (!prospect?.team) return null;
 
     const displayName = fullName(prospect) || prospect.firstName;
     const leagueName = prospect.team.league


### PR DESCRIPTION
## Summary
- Guards the team bulk communication prospect path so unassigned prospects are skipped instead of treating `prospect.team` as always present.

## Testing
- Not run locally; repository was edited through GitHub connector only.