### PR TITLE
Render login magic link as button

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -17,6 +17,9 @@ import {
   getPendingCaptainContext,
 } from "@/lib/auth/pendingCaptain";
 
+const LOGIN_CTA_LABEL = "Sign in to SIXFL";
+const CTA_PLACEHOLDER = "{{cta}}";
+
 function getSiteUrl() {
   return (
     process.env.NEXTAUTH_URL?.trim() ||
@@ -35,6 +38,21 @@ function buildClaimUrl(claimCode?: string | null) {
 
 function stripCtaPlaceholder(value: string) {
   return value.replace(/\{\{\s*cta\s*\}\}/gi, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function replaceRawSignInUrlWithCta(input: { body: string; url: string }) {
+  const body = input.body.trim();
+  const url = input.url.trim();
+
+  if (!body || !url) return body;
+  if (body.includes(CTA_PLACEHOLDER)) return body;
+
+  const escapedUrl = url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const replaced = body.replace(new RegExp(escapedUrl, "g"), CTA_PLACEHOLDER);
+
+  return replaced.includes(CTA_PLACEHOLDER)
+    ? replaced.replace(/\n{3,}/g, "\n\n").trim()
+    : `${body}\n\n${CTA_PLACEHOLDER}`;
 }
 
 async function recordSuccessfulLogin(input: { userId?: string | null; email?: string | null }) {
@@ -120,29 +138,42 @@ async function buildLoginMagicLinkEmail(input: {
       ? `It looks like your captain access still needs to be claimed for ${input.pendingCaptain.teamName}. Sign in first, then complete your team claim.`
       : "",
   };
+  const loginCta = {
+    label: LOGIN_CTA_LABEL,
+    url: input.url,
+  };
 
   if (template?.isActive && template.subject?.trim() && template.body?.trim()) {
     const renderedSubject = renderNotificationText(template.subject, variables);
     const renderedBody = renderNotificationText(template.body, variables);
+    const htmlBody = replaceRawSignInUrlWithCta({
+      body: renderedBody,
+      url: input.url,
+    });
 
     return {
       subject: renderedSubject,
       text: appendSIXFLTextSignature(stripCtaPlaceholder(renderedBody)),
       html: buildSIXFLEmailHtml({
-        body: renderedBody,
+        body: htmlBody,
+        cta: loginCta,
       }),
     };
   }
 
-  const fallbackBody = input.pendingCaptain
+  const fallbackTextBody = input.pendingCaptain
     ? `Hi\n\nUse the secure sign-in link below to access SIXFL.\n\n${input.url}\n\nIt looks like your captain access still needs to be claimed for ${input.pendingCaptain.teamName}. Once you are signed in, complete your team claim here:\n\n${claimUrl}`
     : `Hi\n\nUse the secure sign-in link below to access SIXFL.\n\n${input.url}\n\nIf you did not request this email, you can ignore it.`;
+  const fallbackHtmlBody = input.pendingCaptain
+    ? `Hi\n\nUse the secure sign-in button below to access SIXFL.\n\n${CTA_PLACEHOLDER}\n\nIt looks like your captain access still needs to be claimed for ${input.pendingCaptain.teamName}. Once you are signed in, complete your team claim here:\n\n${claimUrl}`
+    : `Hi\n\nUse the secure sign-in button below to access SIXFL.\n\n${CTA_PLACEHOLDER}\n\nIf you did not request this email, you can ignore it.`;
 
   return {
     subject: "Your SIXFL sign-in link",
-    text: appendSIXFLTextSignature(fallbackBody),
+    text: appendSIXFLTextSignature(fallbackTextBody),
     html: buildSIXFLEmailHtml({
-      body: `${fallbackBody}\n\nIf you did not request this email, you can ignore it.`,
+      body: fallbackHtmlBody,
+      cta: loginCta,
     }),
   };
 }


### PR DESCRIPTION
## Summary
- Renders the magic login URL as a proper email CTA button.
- Replaces raw sign-in URLs with `{{cta}}` in HTML emails so Outlook does not need to auto-link long wrapped URLs.
- Keeps the raw URL in the plain-text fallback.

## Testing
- Not run locally; repository was edited through GitHub connector only.