### PR TITLE
Add player dashboard login email button

### DIFF
--- a/src/app/api/captain/team/[teamid]/send-player-login-link/route.ts
+++ b/src/app/api/captain/team/[teamid]/send-player-login-link/route.ts
@@ -1,0 +1,86 @@
+// ========================================
+// File: src/app/api/captain/team/[teamid]/send-player-login-link/route.ts
+// ========================================
+
+import { NextResponse } from "next/server";
+
+import { sendDashboardLoginEmail } from "@/lib/auth/sendDashboardLoginEmail";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+
+export const dynamic = "force-dynamic";
+
+function getPlayerDisplayName(input: { name: string | null; email: string | null }) {
+  return input.name?.trim() || input.email?.trim() || "Player";
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const body = (await request.json().catch(() => null)) as {
+    membershipId?: string;
+  } | null;
+  const membershipId = body?.membershipId?.trim() ?? "";
+
+  if (!teamid?.trim() || !membershipId) {
+    return NextResponse.json(
+      { error: "Missing team or player." },
+      { status: 400 },
+    );
+  }
+
+  const membership = await prisma.teamMember.findFirst({
+    where: {
+      id: membershipId,
+      teamId: teamid,
+    },
+    select: {
+      id: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      team: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: "Player not found in this squad." },
+      { status: 404 },
+    );
+  }
+
+  const email = membership.user.email?.trim().toLowerCase() ?? "";
+
+  if (!email) {
+    return NextResponse.json(
+      { error: "This player does not have an email address saved." },
+      { status: 400 },
+    );
+  }
+
+  await sendDashboardLoginEmail({
+    email,
+    displayName: getPlayerDisplayName(membership.user),
+    teamName: membership.team.name,
+    callbackPath: `/player/team/${teamid}`,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    message: `Dashboard sign-in email sent to ${email}.`,
+  });
+}

--- a/src/app/captain/team/[teamid]/captain-squad/layout.tsx
+++ b/src/app/captain/team/[teamid]/captain-squad/layout.tsx
@@ -1,0 +1,16 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/captain-squad/layout.tsx
+// ========================================
+
+import type { ReactNode } from "react";
+
+import PlayerDashboardLoginEmailButtons from "@/components/captain/PlayerDashboardLoginEmailButtons";
+
+export default function CaptainSquadLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PlayerDashboardLoginEmailButtons />
+      {children}
+    </>
+  );
+}

--- a/src/components/captain/AdminPlayerPreviewLinks.tsx
+++ b/src/components/captain/AdminPlayerPreviewLinks.tsx
@@ -9,6 +9,7 @@ import { usePathname } from "next/navigation";
 
 const injectedLinkClassName =
   "inline-flex w-full items-center justify-center whitespace-nowrap rounded-xl px-4 py-2.5 text-center text-sm font-medium transition";
+const dashboardLoginButtonClassName = `${injectedLinkClassName} border border-emerald-400/30 bg-emerald-500/10 text-emerald-100 hover:bg-emerald-500/15 disabled:cursor-not-allowed disabled:opacity-60`;
 
 type LoginStatusItem = {
   membershipId: string;
@@ -85,6 +86,59 @@ function getLoginStatusCopy(status?: LoginStatusItem) {
     detail: "This linked account has not signed in since login tracking was added.",
     className: "border-amber-400/20 bg-amber-500/10 text-amber-100",
   };
+}
+
+function setDashboardLoginButtonState(
+  button: HTMLButtonElement,
+  state: "idle" | "sending" | "sent" | "error",
+) {
+  switch (state) {
+    case "sending":
+      button.disabled = true;
+      button.textContent = "Sending login email…";
+      break;
+    case "sent":
+      button.disabled = true;
+      button.textContent = "Login email sent";
+      break;
+    case "error":
+      button.disabled = false;
+      button.textContent = "Try login email again";
+      break;
+    default:
+      button.disabled = false;
+      button.textContent = "Send login email";
+  }
+}
+
+async function sendDashboardLoginEmail(input: {
+  teamId: string;
+  membershipId: string;
+  button: HTMLButtonElement;
+}) {
+  setDashboardLoginButtonState(input.button, "sending");
+
+  try {
+    const response = await fetch(`/api/captain/team/${input.teamId}/send-player-login-link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ membershipId: input.membershipId }),
+    });
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+      message?: string;
+    } | null;
+
+    if (!response.ok) {
+      throw new Error(payload?.error ?? "Login email could not be sent.");
+    }
+
+    input.button.title = payload?.message ?? "Dashboard sign-in email sent.";
+    setDashboardLoginButtonState(input.button, "sent");
+  } catch (error) {
+    setDashboardLoginButtonState(input.button, "error");
+    window.alert(error instanceof Error ? error.message : "Login email could not be sent.");
+  }
 }
 
 function normaliseActionLayout(actionsContainer: HTMLElement) {
@@ -196,6 +250,33 @@ function addLoginStatusBlock(input: {
   }
 }
 
+function addDashboardLoginEmailButton(input: {
+  actionsContainer: HTMLElement;
+  teamId: string;
+  membershipId: string;
+}) {
+  const existingButton = input.actionsContainer.querySelector<HTMLButtonElement>(
+    `button[data-dashboard-login-email="${input.membershipId}"]`,
+  );
+
+  if (existingButton) return;
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.dataset.dashboardLoginEmail = input.membershipId;
+  button.className = dashboardLoginButtonClassName;
+  button.textContent = "Send login email";
+  button.addEventListener("click", () => {
+    void sendDashboardLoginEmail({
+      teamId: input.teamId,
+      membershipId: input.membershipId,
+      button,
+    });
+  });
+
+  input.actionsContainer.appendChild(button);
+}
+
 function addPreviewLinks(pathname: string, statusByMembershipId = new Map<string, LoginStatusItem>()) {
   const teamId = getTeamIdFromPathname(pathname);
   if (!teamId) return;
@@ -223,6 +304,7 @@ function addPreviewLinks(pathname: string, statusByMembershipId = new Map<string
       membershipId,
       status: statusByMembershipId.get(membershipId),
     });
+    addDashboardLoginEmailButton({ actionsContainer, teamId, membershipId });
 
     const existingLink = actionsContainer.querySelector(
       `a[data-admin-player-preview-link="${membershipId}"]`,

--- a/src/components/captain/PlayerDashboardLoginEmailButtons.tsx
+++ b/src/components/captain/PlayerDashboardLoginEmailButtons.tsx
@@ -1,0 +1,172 @@
+// ========================================
+// File: src/components/captain/PlayerDashboardLoginEmailButtons.tsx
+// ========================================
+
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+const buttonBaseClassName =
+  "inline-flex w-full items-center justify-center whitespace-nowrap rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-center text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto";
+
+function getTeamIdFromPathname(pathname: string) {
+  const match = pathname.match(/\/captain\/team\/([^/]+)\/(?:squad|captain-squad)(?:\/)?$/);
+  return match?.[1] ?? null;
+}
+
+function getMembershipIdFromEditHref(href: string, teamId: string) {
+  const match = href.match(new RegExp(`^/captain/team/${teamId}/squad/([^/]+)/edit$`));
+  return match?.[1] ?? null;
+}
+
+function setButtonState(button: HTMLButtonElement, state: "idle" | "sending" | "sent" | "error") {
+  switch (state) {
+    case "sending":
+      button.disabled = true;
+      button.textContent = "Sending login email…";
+      break;
+    case "sent":
+      button.disabled = true;
+      button.textContent = "Login email sent";
+      break;
+    case "error":
+      button.disabled = false;
+      button.textContent = "Try login email again";
+      break;
+    default:
+      button.disabled = false;
+      button.textContent = "Send login email";
+  }
+}
+
+async function sendLoginEmail(input: {
+  teamId: string;
+  membershipId: string;
+  button: HTMLButtonElement;
+}) {
+  setButtonState(input.button, "sending");
+
+  try {
+    const response = await fetch(`/api/captain/team/${input.teamId}/send-player-login-link`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ membershipId: input.membershipId }),
+    });
+
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+      message?: string;
+    } | null;
+
+    if (!response.ok) {
+      throw new Error(payload?.error ?? "Login email could not be sent.");
+    }
+
+    setButtonState(input.button, "sent");
+    input.button.title = payload?.message ?? "Dashboard sign-in email sent.";
+  } catch (error) {
+    setButtonState(input.button, "error");
+    window.alert(error instanceof Error ? error.message : "Login email could not be sent.");
+  }
+}
+
+function addButtonToActionsContainer(input: {
+  actionsContainer: HTMLElement;
+  teamId: string;
+  membershipId: string;
+}) {
+  const existingButton = input.actionsContainer.querySelector<HTMLButtonElement>(
+    `button[data-dashboard-login-email="${input.membershipId}"]`,
+  );
+
+  if (existingButton) return;
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.dataset.dashboardLoginEmail = input.membershipId;
+  button.className = buttonBaseClassName;
+  button.textContent = "Send login email";
+  button.addEventListener("click", () => {
+    void sendLoginEmail({
+      teamId: input.teamId,
+      membershipId: input.membershipId,
+      button,
+    });
+  });
+
+  input.actionsContainer.appendChild(button);
+}
+
+function addButtonsToAdminSquadPage(teamId: string) {
+  const roleForms = Array.from(
+    document.querySelectorAll<HTMLFormElement>('main form input[name="membershipId"]'),
+  )
+    .map((input) => input.closest("form"))
+    .filter((form): form is HTMLFormElement => form instanceof HTMLFormElement)
+    .filter((form) => Boolean(form.querySelector('input[name="teamid"]')));
+
+  for (const form of roleForms) {
+    const membershipId = form
+      .querySelector<HTMLInputElement>('input[name="membershipId"]')
+      ?.value.trim();
+
+    if (!membershipId) continue;
+
+    const actionsContainer = form.parentElement;
+    if (!(actionsContainer instanceof HTMLElement)) continue;
+
+    addButtonToActionsContainer({ actionsContainer, teamId, membershipId });
+  }
+}
+
+function addButtonsToCaptainSquadPage(teamId: string) {
+  const editLinks = Array.from(
+    document.querySelectorAll<HTMLAnchorElement>(`a[href^="/captain/team/${teamId}/squad/"][href$="/edit"]`),
+  );
+
+  for (const editLink of editLinks) {
+    const href = editLink.getAttribute("href") ?? "";
+    const membershipId = getMembershipIdFromEditHref(href, teamId);
+    const actionsContainer = editLink.parentElement;
+
+    if (!membershipId || !(actionsContainer instanceof HTMLElement)) continue;
+
+    addButtonToActionsContainer({ actionsContainer, teamId, membershipId });
+  }
+}
+
+function addDashboardLoginButtons(pathname: string) {
+  const teamId = getTeamIdFromPathname(pathname);
+  if (!teamId) return;
+
+  addButtonsToAdminSquadPage(teamId);
+  addButtonsToCaptainSquadPage(teamId);
+}
+
+export default function PlayerDashboardLoginEmailButtons() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let observer: MutationObserver | null = null;
+
+    const run = () => {
+      observer?.disconnect();
+      addDashboardLoginButtons(pathname);
+      observer?.observe(document.body, { childList: true, subtree: true });
+    };
+
+    run();
+
+    observer = new MutationObserver(run);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer?.disconnect();
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/src/lib/auth/sendDashboardLoginEmail.ts
+++ b/src/lib/auth/sendDashboardLoginEmail.ts
@@ -1,0 +1,163 @@
+// ========================================
+// File: src/lib/auth/sendDashboardLoginEmail.ts
+// ========================================
+
+import { createHash, randomBytes } from "crypto";
+import { Resend } from "resend";
+
+import {
+  appendSIXFLTextSignature,
+  buildSIXFLEmailHtml,
+} from "@/lib/email/buildEmail";
+import { prisma } from "@/lib/prisma";
+
+const LOGIN_CTA_LABEL = "Sign in to SIXFL";
+const LOGIN_LINK_TTL_HOURS = 24;
+
+function getSiteUrl() {
+  return (
+    process.env.NEXTAUTH_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    "https://www.sixfl.co.uk"
+  ).replace(/\/+$/, "");
+}
+
+function getEmailFrom() {
+  const from = process.env.EMAIL_FROM?.trim();
+
+  if (!from) {
+    throw new Error("Email sending is not configured.");
+  }
+
+  return from;
+}
+
+function getAuthSecret() {
+  const secret = process.env.NEXTAUTH_SECRET?.trim();
+
+  if (!secret) {
+    throw new Error("Login links are not configured.");
+  }
+
+  return secret;
+}
+
+function hashVerificationToken(token: string) {
+  return createHash("sha256")
+    .update(`${token}${getAuthSecret()}`)
+    .digest("hex");
+}
+
+function buildMagicLink(input: { email: string; token: string; callbackUrl: string }) {
+  const params = new URLSearchParams({
+    callbackUrl: input.callbackUrl,
+    token: input.token,
+    email: input.email,
+  });
+
+  return `${getSiteUrl()}/api/auth/callback/email?${params.toString()}`;
+}
+
+function getFirstName(displayName: string | null | undefined, email: string) {
+  const fromName = displayName?.trim().split(/\s+/).filter(Boolean)[0];
+  const fromEmail = email.split("@")[0]?.replace(/[._-]+/g, " ").trim().split(/\s+/)[0];
+
+  return fromName || fromEmail || "there";
+}
+
+export async function createDashboardLoginLink(input: {
+  email: string;
+  callbackPath: string;
+}) {
+  const email = input.email.trim().toLowerCase();
+  const callbackPath = input.callbackPath.trim().startsWith("/")
+    ? input.callbackPath.trim()
+    : "/dashboard";
+  const callbackUrl = `${getSiteUrl()}${callbackPath}`;
+  const token = randomBytes(32).toString("hex");
+  const expires = new Date(Date.now() + LOGIN_LINK_TTL_HOURS * 60 * 60 * 1000);
+
+  await prisma.verificationToken.create({
+    data: {
+      identifier: email,
+      token: hashVerificationToken(token),
+      expires,
+    },
+  });
+
+  return {
+    url: buildMagicLink({ email, token, callbackUrl }),
+    expires,
+  };
+}
+
+export async function sendDashboardLoginEmail(input: {
+  email: string;
+  displayName?: string | null;
+  teamName?: string | null;
+  callbackPath: string;
+}) {
+  const email = input.email.trim().toLowerCase();
+
+  if (!email) {
+    throw new Error("Player email address is missing.");
+  }
+
+  const loginLink = await createDashboardLoginLink({
+    email,
+    callbackPath: input.callbackPath,
+  });
+  const firstName = getFirstName(input.displayName, email);
+  const teamLine = input.teamName?.trim()
+    ? `This will take you to your SIXFL dashboard for ${input.teamName.trim()}.`
+    : "This will take you to your SIXFL dashboard.";
+  const body = [
+    `Hi ${firstName},`,
+    "",
+    "Use the secure button below to sign in to SIXFL.",
+    "",
+    "{{cta}}",
+    "",
+    teamLine,
+    "",
+    `This link expires in ${LOGIN_LINK_TTL_HOURS} hours and can only be used with ${email}.`,
+    "",
+    "If you did not request this email, you can ignore it.",
+  ].join("\n");
+  const textBody = [
+    `Hi ${firstName},`,
+    "",
+    "Use the secure sign-in link below to access SIXFL.",
+    "",
+    loginLink.url,
+    "",
+    teamLine,
+    "",
+    `This link expires in ${LOGIN_LINK_TTL_HOURS} hours and can only be used with ${email}.`,
+    "",
+    "If you did not request this email, you can ignore it.",
+  ].join("\n");
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  await resend.emails.send({
+    from: getEmailFrom(),
+    to: email,
+    subject: "Your SIXFL dashboard sign-in link",
+    text: appendSIXFLTextSignature(textBody),
+    html: buildSIXFLEmailHtml({
+      body,
+      cta: {
+        label: LOGIN_CTA_LABEL,
+        url: loginLink.url,
+      },
+      branding: input.teamName
+        ? {
+            teamName: input.teamName,
+          }
+        : undefined,
+    }),
+  });
+
+  return loginLink;
+}


### PR DESCRIPTION
## Summary
- Adds a reusable helper to create and send secure SIXFL dashboard magic-link emails.
- Adds a captain-authorised API route that sends a login email to a player already linked to the team squad.
- Adds **Send login email** buttons on the admin squad page and captain squad page.
- Captains can send the email but never see the underlying magic link.

## Notes
- This is for linked squad members with saved email addresses.
- Pending activation prospects still use the existing activation email flow.

## Testing
- Not run locally; repository was edited through GitHub connector only.