### PR TITLE
Fix AI predictor headline cut-off

### DIFF
--- a/src/components/captain/CaptainFixtureBadgesBridge.tsx
+++ b/src/components/captain/CaptainFixtureBadgesBridge.tsx
@@ -238,11 +238,11 @@ function createFullWinChancePanel(fixture: FixtureBadge) {
     preview.className = "mt-4 rounded-2xl border border-white/10 bg-black/20 p-4";
 
     const headline = document.createElement("div");
-    headline.className = "text-sm font-semibold text-white";
+    headline.className = "whitespace-normal break-words text-sm font-semibold leading-5 text-white";
     headline.textContent = chance.aiPreview.headline;
 
     const paragraph = document.createElement("p");
-    paragraph.className = "mt-2 text-sm leading-6 text-white/60";
+    paragraph.className = "mt-2 whitespace-normal break-words text-sm leading-6 text-white/60";
     paragraph.textContent = chance.aiPreview.summary;
 
     preview.appendChild(headline);

--- a/src/lib/fixtures/aiPredictor.ts
+++ b/src/lib/fixtures/aiPredictor.ts
@@ -36,6 +36,8 @@ const AI_PREVIEW_CACHE = new Map<
 >();
 
 const CACHE_TTL_MS = 1000 * 60 * 60 * 6;
+const HEADLINE_MAX_LENGTH = 68;
+const SUMMARY_MAX_LENGTH = 260;
 
 function getCacheKey(input: FixtureAiPreviewInput) {
   return JSON.stringify({
@@ -57,17 +59,38 @@ function cleanText(value: string) {
     .trim();
 }
 
+function stripBrokenHeadlineEnding(value: string) {
+  return cleanText(value)
+    .replace(/\s+(?:in|with)\s+(?:a\s+)?\d+\s*[-–]\s*\d+\s*(?:pred\w*)?(?:…|\.\.\.)?\.?$/i, "")
+    .replace(/\s+\S*(?:…|\.\.\.)$/i, "")
+    .replace(/[.,;:!?-]+$/, "")
+    .trim();
+}
+
 function truncateSentence(value: string, maxLength: number) {
   const cleaned = cleanText(value);
   if (cleaned.length <= maxLength) return cleaned;
 
-  const hardCut = cleaned.slice(0, maxLength - 1).trim();
+  const hardCut = cleaned.slice(0, maxLength).trim();
   const lastSpace = hardCut.lastIndexOf(" ");
-  const wordBoundaryCut = lastSpace > Math.floor(maxLength * 0.65)
+  const wordBoundaryCut = lastSpace > Math.floor(maxLength * 0.55)
     ? hardCut.slice(0, lastSpace).trim()
     : hardCut;
 
   return `${wordBoundaryCut.replace(/[.,;:!?-]+$/, "")}…`;
+}
+
+function cleanHeadline(value: string) {
+  const stripped = stripBrokenHeadlineEnding(value);
+  return truncateSentence(stripped || value, HEADLINE_MAX_LENGTH);
+}
+
+export function cleanFixtureAiPreviewForDisplay(preview: FixtureAiPreview): FixtureAiPreview {
+  return {
+    ...preview,
+    headline: cleanHeadline(preview.headline),
+    summary: truncateSentence(preview.summary, SUMMARY_MAX_LENGTH),
+  };
 }
 
 function getFavourite(input: FixtureAiPreviewInput) {
@@ -123,8 +146,8 @@ function parsePreviewText(text: string, input: FixtureAiPreviewInput): FixtureAi
   if (!cleaned) return getFallbackFixtureAiPreview(input);
 
   const [firstSentence, ...rest] = cleaned.split(/(?<=[.!?])\s+/);
-  const headline = truncateSentence(firstSentence || "SIXFL AI Predictor", 96);
-  const summary = truncateSentence(rest.join(" ") || cleaned, 260);
+  const headline = cleanHeadline(firstSentence || "SIXFL AI Predictor");
+  const summary = truncateSentence(rest.join(" ") || cleaned, SUMMARY_MAX_LENGTH);
 
   return {
     headline,
@@ -158,10 +181,10 @@ export async function getFixtureAiPreview(
       },
       body: JSON.stringify({
         model,
-        max_output_tokens: 170,
+        max_output_tokens: 150,
         instructions:
-          "You write short, fun, factual 6-a-side football match previews for SIXFL. Do not invent injuries, absences, player names or facts not provided. Keep it suitable for a public sports website. Mention that it is a prediction only if needed.",
-        input: `Write one punchy headline sentence and one short explanation sentence for this fixture. Use only this data: ${JSON.stringify({
+          "You write short, fun, factual 6-a-side football match previews for SIXFL. Do not invent injuries, absences, player names or facts not provided. Keep it suitable for a public sports website. The headline must be one short sentence under 65 characters and must not end with a partial word. Do not put the exact scoreline in the headline.",
+        input: `Write one short headline sentence and one short explanation sentence for this fixture. Use only this data: ${JSON.stringify({
           homeTeam: input.homeTeamName,
           awayTeam: input.awayTeamName,
           predictedResult: input.winChance.predictedResult.label,

--- a/src/lib/fixtures/storedAiPredictions.ts
+++ b/src/lib/fixtures/storedAiPredictions.ts
@@ -5,7 +5,11 @@
 import { createHash } from "crypto";
 import { Prisma } from "@prisma/client";
 
-import { getFixtureAiPreview, type FixtureAiPreview } from "@/lib/fixtures/aiPredictor";
+import {
+  cleanFixtureAiPreviewForDisplay,
+  getFixtureAiPreview,
+  type FixtureAiPreview,
+} from "@/lib/fixtures/aiPredictor";
 import { calculateFixtureWinChance, type FixtureWinChance, type WinChanceFixture } from "@/lib/fixtures/winChance";
 import { prisma } from "@/lib/prisma";
 
@@ -32,10 +36,14 @@ export type StoredFixtureAiPreview = FixtureAiPreview & {
 };
 
 function toStoredPreview(row: StoredPredictionRow): StoredFixtureAiPreview {
-  return {
+  const preview = cleanFixtureAiPreviewForDisplay({
     headline: row.headline,
     summary: row.summary,
     source: row.source === "openai" ? "openai" : "fallback",
+  });
+
+  return {
+    ...preview,
     inputHash: row.inputHash,
     generatedAt: row.generatedAt,
   };
@@ -91,11 +99,13 @@ async function savePrediction(input: {
   preview: FixtureAiPreview;
   inputHash: string;
 }) {
+  const preview = cleanFixtureAiPreviewForDisplay(input.preview);
+
   await prisma.$executeRaw`
     INSERT INTO "FixtureAiPrediction"
       ("fixtureId", "headline", "summary", "source", "inputHash", "generatedAt", "updatedAt")
     VALUES
-      (${input.fixtureId}, ${input.preview.headline}, ${input.preview.summary}, ${input.preview.source}, ${input.inputHash}, NOW(), NOW())
+      (${input.fixtureId}, ${preview.headline}, ${preview.summary}, ${preview.source}, ${input.inputHash}, NOW(), NOW())
     ON CONFLICT ("fixtureId") DO UPDATE SET
       "headline" = EXCLUDED."headline",
       "summary" = EXCLUDED."summary",
@@ -125,11 +135,13 @@ async function generateAndSave(input: {
     if (existing?.inputHash === inputHash) return toStoredPreview(existing);
   }
 
-  const preview = await getFixtureAiPreview({
-    homeTeamName: input.fixture.homeTeam.name,
-    awayTeamName: input.fixture.awayTeam.name,
-    winChance,
-  });
+  const preview = cleanFixtureAiPreviewForDisplay(
+    await getFixtureAiPreview({
+      homeTeamName: input.fixture.homeTeam.name,
+      awayTeamName: input.fixture.awayTeam.name,
+      winChance,
+    }),
+  );
 
   await savePrediction({ fixtureId: input.fixture.id, preview, inputHash });
 


### PR DESCRIPTION
## Summary
- Cleans future AI predictor headlines so they are shorter and end on complete words.
- Cleans existing stored AI prediction headlines before display so broken endings like partial words are removed.
- Lets the captain/dashboard AI preview headline and summary wrap instead of behaving like a clipped single line.

## Testing
- Not run locally; repository was edited through GitHub connector only.