### PR TITLE
[codex] Add late confirmation fee review

### DIFF
--- a/prisma/migrations/20260623150000_add_fixture_confirmation_late_fees/migration.sql
+++ b/prisma/migrations/20260623150000_add_fixture_confirmation_late_fees/migration.sql
@@ -1,0 +1,28 @@
+-- ========================================
+-- File: prisma/migrations/20260623150000_add_fixture_confirmation_late_fees/migration.sql
+-- ========================================
+
+CREATE TYPE "FixtureConfirmationLateFeeStatus" AS ENUM ('NONE', 'WARNING', 'APPLIED', 'WAIVED');
+
+CREATE TABLE "FixtureConfirmationLateFee" (
+  "id" TEXT NOT NULL,
+  "fixtureId" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "status" "FixtureConfirmationLateFeeStatus" NOT NULL DEFAULT 'NONE',
+  "amountPence" INTEGER NOT NULL DEFAULT 1000,
+  "note" TEXT,
+  "warningAt" TIMESTAMP(3),
+  "appliedAt" TIMESTAMP(3),
+  "waivedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "FixtureConfirmationLateFee_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "FixtureConfirmationLateFee_fixtureId_fkey" FOREIGN KEY ("fixtureId") REFERENCES "Fixture"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "FixtureConfirmationLateFee_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "FixtureConfirmationLateFee_fixtureId_teamId_key" ON "FixtureConfirmationLateFee"("fixtureId", "teamId");
+CREATE INDEX "FixtureConfirmationLateFee_fixtureId_status_idx" ON "FixtureConfirmationLateFee"("fixtureId", "status");
+CREATE INDEX "FixtureConfirmationLateFee_teamId_status_idx" ON "FixtureConfirmationLateFee"("teamId", "status");
+CREATE INDEX "FixtureConfirmationLateFee_status_idx" ON "FixtureConfirmationLateFee"("status");

--- a/src/app/(admin)/admin/fixtures/late-fees/actions.ts
+++ b/src/app/(admin)/admin/fixtures/late-fees/actions.ts
@@ -1,0 +1,291 @@
+// ========================================
+// File: src/app/(admin)/admin/fixtures/late-fees/actions.ts
+// ========================================
+
+"use server";
+
+import { randomUUID } from "crypto";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+type LateFeeDecision = "NONE" | "WARNING" | "APPLIED" | "WAIVED";
+
+const ALLOWED_DECISIONS = new Set<LateFeeDecision>([
+  "NONE",
+  "WARNING",
+  "APPLIED",
+  "WAIVED",
+]);
+
+function parseRequiredString(value: FormDataEntryValue | null, fieldName: string) {
+  const parsed = String(value ?? "").trim();
+
+  if (!parsed) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  return parsed;
+}
+
+function parseDecision(value: FormDataEntryValue | null): LateFeeDecision {
+  const parsed = String(value ?? "").trim().toUpperCase() as LateFeeDecision;
+
+  if (!ALLOWED_DECISIONS.has(parsed)) {
+    throw new Error("Late fee decision is invalid.");
+  }
+
+  return parsed;
+}
+
+function parseNote(value: FormDataEntryValue | null) {
+  const parsed = String(value ?? "").trim();
+  return parsed || null;
+}
+
+function buildRedirect(input: {
+  notice: "late_fee_saved" | "late_fee_error";
+  teamName?: string | null;
+  fixtureId?: string | null;
+}) {
+  const searchParams = new URLSearchParams();
+  searchParams.set("notice", input.notice);
+
+  if (input.teamName?.trim()) {
+    searchParams.set("teamName", input.teamName.trim());
+  }
+
+  const query = searchParams.toString();
+  const hash = input.fixtureId?.trim()
+    ? `#fixture-${input.fixtureId.trim()}`
+    : "";
+
+  return `/admin/fixtures/late-fees?${query}${hash}`;
+}
+
+async function getFixtureTeam(input: { fixtureId: string; teamId: string }) {
+  return prisma.fixture.findUnique({
+    where: { id: input.fixtureId },
+    select: {
+      id: true,
+      kickoffAt: true,
+      status: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+      captainConfirmations: {
+        where: { teamId: input.teamId },
+        select: {
+          status: true,
+          confirmedAt: true,
+          issueRaisedAt: true,
+        },
+        take: 1,
+      },
+    },
+  });
+}
+
+function isTeamInFixture(input: {
+  fixture: Awaited<ReturnType<typeof getFixtureTeam>>;
+  teamId: string;
+}) {
+  return (
+    input.fixture?.homeTeamId === input.teamId ||
+    input.fixture?.awayTeamId === input.teamId
+  );
+}
+
+function getTeamName(input: {
+  fixture: NonNullable<Awaited<ReturnType<typeof getFixtureTeam>>>;
+  teamId: string;
+}) {
+  return input.fixture.homeTeamId === input.teamId
+    ? input.fixture.homeTeam.name
+    : input.fixture.awayTeam.name;
+}
+
+export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
+  await requireAdmin();
+
+  const fixtureId = parseRequiredString(formData.get("fixtureId"), "Fixture");
+  const teamId = parseRequiredString(formData.get("teamId"), "Team");
+  const decision = parseDecision(formData.get("decision"));
+  const note = parseNote(formData.get("note"));
+  const now = new Date();
+
+  let teamName: string | null = null;
+
+  try {
+    const fixture = await getFixtureTeam({ fixtureId, teamId });
+
+    if (!fixture || !isTeamInFixture({ fixture, teamId })) {
+      throw new Error("Fixture/team combination was not found.");
+    }
+
+    teamName = getTeamName({ fixture, teamId });
+
+    if (fixture.status !== "SCHEDULED") {
+      throw new Error("Late confirmation fees can only be managed for scheduled fixtures.");
+    }
+
+    const confirmation = fixture.captainConfirmations[0] ?? null;
+
+    if (confirmation?.status === "ISSUE_RAISED" && decision === "APPLIED") {
+      throw new Error("A fee should not be applied while a captain issue is open.");
+    }
+
+    await prisma.$executeRaw`
+      INSERT INTO "FixtureConfirmationLateFee" (
+        "id",
+        "fixtureId",
+        "teamId",
+        "status",
+        "amountPence",
+        "note",
+        "warningAt",
+        "appliedAt",
+        "waivedAt",
+        "createdAt",
+        "updatedAt"
+      )
+      VALUES (
+        ${randomUUID()},
+        ${fixtureId},
+        ${teamId},
+        CAST(${decision} AS "FixtureConfirmationLateFeeStatus"),
+        1000,
+        ${note},
+        ${decision === "WARNING" ? now : null},
+        ${decision === "APPLIED" ? now : null},
+        ${decision === "WAIVED" ? now : null},
+        ${now},
+        ${now}
+      )
+      ON CONFLICT ("fixtureId", "teamId") DO UPDATE SET
+        "status" = CAST(${decision} AS "FixtureConfirmationLateFeeStatus"),
+        "amountPence" = 1000,
+        "note" = ${note},
+        "warningAt" = CASE
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'WARNING' THEN ${now}
+          ELSE "FixtureConfirmationLateFee"."warningAt"
+        END,
+        "appliedAt" = CASE
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'APPLIED' THEN ${now}
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'NONE' THEN NULL
+          ELSE "FixtureConfirmationLateFee"."appliedAt"
+        END,
+        "waivedAt" = CASE
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'WAIVED' THEN ${now}
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'APPLIED' THEN NULL
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'NONE' THEN NULL
+          ELSE "FixtureConfirmationLateFee"."waivedAt"
+        END,
+        "updatedAt" = ${now}
+    `;
+
+    revalidatePath("/admin/fixtures");
+    revalidatePath("/admin/fixtures/late-fees");
+    revalidatePath(`/captain/team/${teamId}`);
+    revalidatePath(`/captain/team/${teamId}/fixtures`);
+  } catch (error) {
+    console.error("Failed to set late confirmation fee decision", error);
+    redirect(buildRedirect({ notice: "late_fee_error", teamName, fixtureId }));
+  }
+
+  redirect(buildRedirect({ notice: "late_fee_saved", teamName, fixtureId }));
+}
+
+export type LateConfirmationFeeRow = {
+  fixtureId: string;
+  kickoffAt: Date;
+  fixtureStatus: string;
+  leagueName: string | null;
+  leagueSeason: string | null;
+  venueName: string | null;
+  homeTeamId: string;
+  homeTeamName: string;
+  awayTeamId: string;
+  awayTeamName: string;
+  homeConfirmationStatus: string | null;
+  homeConfirmedAt: Date | null;
+  homeIssueRaisedAt: Date | null;
+  homeLastChasedAt: Date | null;
+  homeLateFeeStatus: LateFeeDecision | null;
+  homeLateFeeAmountPence: number | null;
+  homeLateFeeNote: string | null;
+  homeLateFeeWarningAt: Date | null;
+  homeLateFeeAppliedAt: Date | null;
+  homeLateFeeWaivedAt: Date | null;
+  awayConfirmationStatus: string | null;
+  awayConfirmedAt: Date | null;
+  awayIssueRaisedAt: Date | null;
+  awayLastChasedAt: Date | null;
+  awayLateFeeStatus: LateFeeDecision | null;
+  awayLateFeeAmountPence: number | null;
+  awayLateFeeNote: string | null;
+  awayLateFeeWarningAt: Date | null;
+  awayLateFeeAppliedAt: Date | null;
+  awayLateFeeWaivedAt: Date | null;
+};
+
+export async function getLateConfirmationFeeRows() {
+  return prisma.$queryRaw<LateConfirmationFeeRow[]>(Prisma.sql`
+    SELECT
+      fixture."id" AS "fixtureId",
+      fixture."kickoffAt" AS "kickoffAt",
+      fixture."status"::text AS "fixtureStatus",
+      league."name" AS "leagueName",
+      league."season" AS "leagueSeason",
+      venue."name" AS "venueName",
+      fixture."homeTeamId" AS "homeTeamId",
+      home_team."name" AS "homeTeamName",
+      fixture."awayTeamId" AS "awayTeamId",
+      away_team."name" AS "awayTeamName",
+      home_confirmation."status"::text AS "homeConfirmationStatus",
+      home_confirmation."confirmedAt" AS "homeConfirmedAt",
+      home_confirmation."issueRaisedAt" AS "homeIssueRaisedAt",
+      home_confirmation."lastChasedAt" AS "homeLastChasedAt",
+      home_fee."status"::text AS "homeLateFeeStatus",
+      home_fee."amountPence" AS "homeLateFeeAmountPence",
+      home_fee."note" AS "homeLateFeeNote",
+      home_fee."warningAt" AS "homeLateFeeWarningAt",
+      home_fee."appliedAt" AS "homeLateFeeAppliedAt",
+      home_fee."waivedAt" AS "homeLateFeeWaivedAt",
+      away_confirmation."status"::text AS "awayConfirmationStatus",
+      away_confirmation."confirmedAt" AS "awayConfirmedAt",
+      away_confirmation."issueRaisedAt" AS "awayIssueRaisedAt",
+      away_confirmation."lastChasedAt" AS "awayLastChasedAt",
+      away_fee."status"::text AS "awayLateFeeStatus",
+      away_fee."amountPence" AS "awayLateFeeAmountPence",
+      away_fee."note" AS "awayLateFeeNote",
+      away_fee."warningAt" AS "awayLateFeeWarningAt",
+      away_fee."appliedAt" AS "awayLateFeeAppliedAt",
+      away_fee."waivedAt" AS "awayLateFeeWaivedAt"
+    FROM "Fixture" fixture
+    INNER JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+    INNER JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+    LEFT JOIN "League" league ON league."id" = fixture."leagueId"
+    LEFT JOIN "Venue" venue ON venue."id" = fixture."venueId"
+    LEFT JOIN "FixtureCaptainConfirmation" home_confirmation
+      ON home_confirmation."fixtureId" = fixture."id"
+      AND home_confirmation."teamId" = fixture."homeTeamId"
+    LEFT JOIN "FixtureCaptainConfirmation" away_confirmation
+      ON away_confirmation."fixtureId" = fixture."id"
+      AND away_confirmation."teamId" = fixture."awayTeamId"
+    LEFT JOIN "FixtureConfirmationLateFee" home_fee
+      ON home_fee."fixtureId" = fixture."id"
+      AND home_fee."teamId" = fixture."homeTeamId"
+    LEFT JOIN "FixtureConfirmationLateFee" away_fee
+      ON away_fee."fixtureId" = fixture."id"
+      AND away_fee."teamId" = fixture."awayTeamId"
+    WHERE fixture."status" = 'SCHEDULED'
+      AND fixture."kickoffAt" >= NOW() - INTERVAL '2 days'
+      AND fixture."kickoffAt" <= NOW() + INTERVAL '45 days'
+    ORDER BY fixture."kickoffAt" ASC, league."name" ASC, home_team."name" ASC
+  `);
+}

--- a/src/app/(admin)/admin/fixtures/late-fees/actions.ts
+++ b/src/app/(admin)/admin/fixtures/late-fees/actions.ts
@@ -109,6 +109,10 @@ function getTeamName(input: {
     : input.fixture.awayTeam.name;
 }
 
+function getConfirmationDeadline(kickoffAt: Date) {
+  return new Date(kickoffAt.getTime() - 72 * 60 * 60 * 1000);
+}
+
 export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
   await requireAdmin();
 
@@ -116,6 +120,7 @@ export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
   const teamId = parseRequiredString(formData.get("teamId"), "Team");
   const decision = parseDecision(formData.get("decision"));
   const note = parseNote(formData.get("note"));
+  const decisionNote = decision === "NONE" ? null : note;
   const now = new Date();
 
   let teamName: string | null = null;
@@ -134,9 +139,20 @@ export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
     }
 
     const confirmation = fixture.captainConfirmations[0] ?? null;
+    const deadline = getConfirmationDeadline(fixture.kickoffAt);
+    const confirmedOnTime = Boolean(
+      confirmation?.status === "CONFIRMED" &&
+        confirmation.confirmedAt &&
+        confirmation.confirmedAt <= deadline,
+    );
+    const deadlineMissed = now > deadline && !confirmedOnTime;
 
     if (confirmation?.status === "ISSUE_RAISED" && decision === "APPLIED") {
       throw new Error("A fee should not be applied while a captain issue is open.");
+    }
+
+    if (decision === "APPLIED" && !deadlineMissed) {
+      throw new Error("A fee can only be applied after the 72-hour confirmation deadline has been missed.");
     }
 
     await prisma.$executeRaw`
@@ -159,7 +175,7 @@ export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
         ${teamId},
         CAST(${decision} AS "FixtureConfirmationLateFeeStatus"),
         1000,
-        ${note},
+        ${decisionNote},
         ${decision === "WARNING" ? now : null},
         ${decision === "APPLIED" ? now : null},
         ${decision === "WAIVED" ? now : null},
@@ -169,21 +185,21 @@ export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
       ON CONFLICT ("fixtureId", "teamId") DO UPDATE SET
         "status" = CAST(${decision} AS "FixtureConfirmationLateFeeStatus"),
         "amountPence" = 1000,
-        "note" = ${note},
+        "note" = ${decisionNote},
         "warningAt" = CASE
-          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'WARNING' THEN ${now}
-          ELSE "FixtureConfirmationLateFee"."warningAt"
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'WARNING'
+            THEN COALESCE("FixtureConfirmationLateFee"."warningAt", ${now})
+          ELSE NULL
         END,
         "appliedAt" = CASE
-          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'APPLIED' THEN ${now}
-          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'NONE' THEN NULL
-          ELSE "FixtureConfirmationLateFee"."appliedAt"
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'APPLIED'
+            THEN COALESCE("FixtureConfirmationLateFee"."appliedAt", ${now})
+          ELSE NULL
         END,
         "waivedAt" = CASE
-          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'WAIVED' THEN ${now}
-          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'APPLIED' THEN NULL
-          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'NONE' THEN NULL
-          ELSE "FixtureConfirmationLateFee"."waivedAt"
+          WHEN CAST(${decision} AS "FixtureConfirmationLateFeeStatus") = 'WAIVED'
+            THEN COALESCE("FixtureConfirmationLateFee"."waivedAt", ${now})
+          ELSE NULL
         END,
         "updatedAt" = ${now}
     `;

--- a/src/app/(admin)/admin/fixtures/late-fees/page.tsx
+++ b/src/app/(admin)/admin/fixtures/late-fees/page.tsx
@@ -1,0 +1,228 @@
+// ========================================
+// File: src/app/(admin)/admin/fixtures/late-fees/page.tsx
+// ========================================
+
+import Link from "next/link";
+
+import AdminCard from "@/components/admin/AdminCard";
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { requireAdmin } from "@/lib/requireAdmin";
+import {
+  getLateConfirmationFeeRows,
+  setLateConfirmationFeeDecisionAction,
+  type LateConfirmationFeeRow,
+} from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Late Confirmation Review | SIXFL Admin",
+};
+
+type SearchParams = {
+  notice?: string;
+  teamName?: string;
+};
+
+function cx(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+function formatDate(value: Date | null) {
+  if (!value) return "—";
+
+  return formatDateTimeInLondon(value, {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getDeadline(kickoffAt: Date) {
+  return new Date(kickoffAt.getTime() - 72 * 60 * 60 * 1000);
+}
+
+function getFixtureLabel(row: LateConfirmationFeeRow) {
+  return `${row.homeTeamName} vs ${row.awayTeamName}`;
+}
+
+function getNotice(input: SearchParams) {
+  const teamName = input.teamName?.trim() || "that team";
+
+  if (input.notice === "late_fee_saved") {
+    return {
+      tone: "success" as const,
+      message: `Decision saved for ${teamName}.`,
+    };
+  }
+
+  if (input.notice === "late_fee_error") {
+    return {
+      tone: "error" as const,
+      message: `The decision could not be saved for ${teamName}.`,
+    };
+  }
+
+  return null;
+}
+
+function getDecisionLabel(status: string | null) {
+  switch (status) {
+    case "APPLIED":
+      return "Applied";
+    case "WAIVED":
+      return "Waived";
+    case "WARNING":
+      return "Warning";
+    default:
+      return "No decision";
+  }
+}
+
+function getConfirmationLabel(status: string | null, confirmedAt: Date | null, deadline: Date) {
+  if (status === "CONFIRMED" && confirmedAt && confirmedAt > deadline) {
+    return "Confirmed late";
+  }
+
+  if (status === "CONFIRMED") return "Confirmed";
+  if (status === "ISSUE_RAISED") return "Issue raised";
+  if (status === "PENDING") return "Awaiting confirmation";
+  return "No confirmation";
+}
+
+function DecisionForm({
+  fixtureId,
+  teamId,
+  note,
+}: {
+  fixtureId: string;
+  teamId: string;
+  note: string | null;
+}) {
+  return (
+    <form action={setLateConfirmationFeeDecisionAction} className="space-y-3">
+      <input type="hidden" name="fixtureId" value={fixtureId} />
+      <input type="hidden" name="teamId" value={teamId} />
+      <textarea
+        name="note"
+        rows={2}
+        defaultValue={note ?? ""}
+        placeholder="Admin note"
+        className="w-full rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
+      />
+      <div className="grid gap-2 sm:grid-cols-4">
+        <button name="decision" value="WARNING" className="rounded-xl border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100">
+          Warning
+        </button>
+        <button name="decision" value="APPLIED" className="rounded-xl border border-red-400/25 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">
+          Apply charge
+        </button>
+        <button name="decision" value="WAIVED" className="rounded-xl border border-sky-400/25 bg-sky-500/10 px-3 py-2 text-xs font-semibold text-sky-100">
+          Waive
+        </button>
+        <button name="decision" value="NONE" className="rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-semibold text-white/75">
+          Clear
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function TeamRow({
+  fixtureId,
+  kickoffAt,
+  teamId,
+  teamName,
+  confirmationStatus,
+  confirmedAt,
+  lastChasedAt,
+  decisionStatus,
+  decisionNote,
+}: {
+  fixtureId: string;
+  kickoffAt: Date;
+  teamId: string;
+  teamName: string;
+  confirmationStatus: string | null;
+  confirmedAt: Date | null;
+  lastChasedAt: Date | null;
+  decisionStatus: string | null;
+  decisionNote: string | null;
+}) {
+  const deadline = getDeadline(kickoffAt);
+  const confirmedOnTime = confirmationStatus === "CONFIRMED" && confirmedAt && confirmedAt <= deadline;
+  const issueRaised = confirmationStatus === "ISSUE_RAISED";
+  const needsDecision = new Date() > deadline && !confirmedOnTime && !issueRaised;
+
+  return (
+    <div className={cx("rounded-3xl border p-5", needsDecision ? "border-red-400/25 bg-red-500/[0.06]" : "border-white/10 bg-black/20")}>
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-lg font-semibold text-white">{teamName}</h3>
+            {needsDecision ? <span className="rounded-full border border-red-400/25 bg-red-500/10 px-3 py-1 text-xs font-semibold text-red-100">72h missed</span> : null}
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold">
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/70">
+              {getConfirmationLabel(confirmationStatus, confirmedAt, deadline)}
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/70">
+              {getDecisionLabel(decisionStatus)}
+            </span>
+          </div>
+          <div className="mt-4 grid gap-2 text-sm text-white/55 sm:grid-cols-2">
+            <div>Deadline: {formatDate(deadline)}</div>
+            <div>Confirmed: {formatDate(confirmedAt)}</div>
+            <div>Last chased: {formatDate(lastChasedAt)}</div>
+            <div>Charge: £10</div>
+          </div>
+          {decisionNote ? <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65">{decisionNote}</div> : null}
+        </div>
+        <DecisionForm fixtureId={fixtureId} teamId={teamId} note={decisionNote} />
+      </div>
+    </div>
+  );
+}
+
+export default async function LateConfirmationFeesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
+  await requireAdmin();
+
+  const [rows, resolvedSearchParams] = await Promise.all([
+    getLateConfirmationFeeRows(),
+    searchParams ? searchParams : Promise.resolve({}),
+  ]);
+  const notice = getNotice(resolvedSearchParams);
+
+  return (
+    <div className="w-full space-y-8 px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+      <section className="rounded-3xl border border-emerald-400/15 bg-white/[0.03] p-6 md:p-8">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">Fixture confirmation policy</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">Late confirmation review</h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">Review teams that have not confirmed at least 72 hours before kick-off. Record a warning, apply the admin charge, or waive it with a note.</p>
+        <Link href="/admin/fixtures" className="mt-5 inline-flex rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 hover:bg-white/5">Back to fixtures</Link>
+      </section>
+
+      {notice ? <section className={cx("rounded-2xl border px-4 py-3 text-sm", notice.tone === "success" ? "border-emerald-400/20 bg-emerald-500/10 text-emerald-100" : "border-red-400/20 bg-red-500/10 text-red-100")}>{notice.message}</section> : null}
+
+      <AdminCard className="space-y-5 rounded-3xl border border-white/10 bg-white/[0.03] p-5 md:p-6">
+        {rows.length === 0 ? <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-sm text-white/55">No scheduled fixtures are inside the review window.</div> : null}
+        {rows.map((row) => (
+          <section key={row.fixtureId} id={`fixture-${row.fixtureId}`} className="scroll-mt-6 space-y-4 rounded-3xl border border-white/10 bg-black/20 p-4 md:p-5">
+            <div className="border-b border-white/10 pb-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/35">{row.leagueName ?? "No league"}{row.leagueSeason ? ` · ${row.leagueSeason}` : ""}</p>
+              <h2 className="mt-2 text-xl font-semibold text-white">{getFixtureLabel(row)}</h2>
+              <p className="mt-1 text-sm text-white/55">{formatDate(row.kickoffAt)} · {row.venueName ?? "Venue TBC"}</p>
+            </div>
+            <div className="grid gap-4">
+              <TeamRow fixtureId={row.fixtureId} kickoffAt={row.kickoffAt} teamId={row.homeTeamId} teamName={row.homeTeamName} confirmationStatus={row.homeConfirmationStatus} confirmedAt={row.homeConfirmedAt} lastChasedAt={row.homeLastChasedAt} decisionStatus={row.homeLateFeeStatus} decisionNote={row.homeLateFeeNote} />
+              <TeamRow fixtureId={row.fixtureId} kickoffAt={row.kickoffAt} teamId={row.awayTeamId} teamName={row.awayTeamName} confirmationStatus={row.awayConfirmationStatus} confirmedAt={row.awayConfirmedAt} lastChasedAt={row.awayLastChasedAt} decisionStatus={row.awayLateFeeStatus} decisionNote={row.awayLateFeeNote} />
+            </div>
+          </section>
+        ))}
+      </AdminCard>
+    </div>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -72,6 +72,12 @@ const navigation = [
     description: "Schedule and results",
   },
   {
+    name: "Late Fees",
+    href: "/admin/fixtures/late-fees",
+    icon: ExclamationTriangleIcon,
+    description: "72h confirmation review",
+  },
+  {
     name: "Social",
     href: "/admin/social",
     icon: PhotoIcon,


### PR DESCRIPTION
## Summary

Adds a first-pass admin workflow for the 72-hour fixture confirmation policy.

- Adds a database migration for fixture confirmation late-fee decisions.
- Adds `/admin/fixtures/late-fees` for reviewing scheduled fixtures inside the review window.
- Adds the new Late Fees screen to the admin sidebar.
- Lets admins record a warning, apply the admin charge, waive it, or clear the decision with an audit note.
- Blocks applying the charge before the 72-hour deadline is actually missed.
- Clears stale decision timestamps when switching between warning/apply/waive/clear.
- Keeps this separate from Stripe/payment charges for now to avoid clashing with the existing match-fee charge model.

## Notes

This builds on the existing captain fixture confirmation flow rather than adding a duplicate confirmation button.

## Validation

Checked the PR diff and tightened the obvious decision-state issue. No GitHub Actions runs were available for the updated commit, so this remains a draft PR until it can be run/deployed in the normal environment.