### PR TITLE
Fix recent player fee payment labels

### DIFF
--- a/src/app/api/admin/payments/player-fee-labels/route.ts
+++ b/src/app/api/admin/payments/player-fee-labels/route.ts
@@ -81,6 +81,13 @@ function compact(value: string | null | undefined) {
   return trimmed || null;
 }
 
+function formatPaymentMethod(method: string) {
+  return method
+    .replaceAll("_", " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 function buildTitle(row: PlayerFeePaymentLabel) {
   return row.playerName
     ? `${row.playerName} · Player match fee`
@@ -91,7 +98,7 @@ function buildSubtitle(row: PlayerFeePaymentLabel) {
   const parts = [
     row.fixtureName,
     row.playerContact,
-    row.method.replaceAll("_", " "),
+    formatPaymentMethod(row.method),
   ]
     .map(compact)
     .filter((part): part is string => Boolean(part));

--- a/src/components/admin/payments/AdminPlayerFeePaymentLabelsBridge.tsx
+++ b/src/components/admin/payments/AdminPlayerFeePaymentLabelsBridge.tsx
@@ -20,14 +20,17 @@ type LabelsPayload = {
   labels?: PlayerFeePaymentLabel[];
 };
 
-function isUnlabelledPlayerFeePaymentCard(card: Element) {
+function formatMoney(amountPence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(amountPence / 100);
+}
+
+function isUnlabelledStripePaymentCard(card: Element) {
   const text = card.textContent ?? "";
 
-  return (
-    text.includes("Unlinked payment") &&
-    text.includes("Stripe") &&
-    text.includes("£6.00")
-  );
+  return text.includes("Unlinked payment") && text.includes("Stripe");
 }
 
 function getRecentPaymentsCards() {
@@ -40,31 +43,51 @@ function getRecentPaymentsCards() {
     if (!section) return [];
 
     return Array.from(section.querySelectorAll("div.rounded-2xl")).filter(
-      isUnlabelledPlayerFeePaymentCard,
+      isUnlabelledStripePaymentCard,
     );
   });
 }
 
+function getPaymentSubtitleElement(card: Element) {
+  return Array.from(card.querySelectorAll("div")).find(
+    (element) => element.textContent?.trim() === "Unlinked payment · Stripe",
+  );
+}
+
+function findLabelForCard(
+  card: Element,
+  labels: PlayerFeePaymentLabel[],
+  usedTransactionIds: Set<string>,
+) {
+  const cardText = card.textContent ?? "";
+
+  return labels.find(
+    (label) =>
+      !usedTransactionIds.has(label.transactionId) &&
+      cardText.includes(label.teamName) &&
+      cardText.includes(formatMoney(label.amountPence)),
+  );
+}
+
 function relabelPlayerFeePayments(labels: PlayerFeePaymentLabel[]) {
   const cards = getRecentPaymentsCards();
+  const usedTransactionIds = new Set<string>();
 
-  cards.forEach((card, index) => {
-    const label = labels[index];
+  cards.forEach((card) => {
+    const label = findLabelForCard(card, labels, usedTransactionIds);
     if (!label) return;
 
-    const subtitleElement = Array.from(card.querySelectorAll("div")).find(
-      (element) => element.textContent?.trim() === "Unlinked payment · Stripe",
-    );
-
+    const subtitleElement = getPaymentSubtitleElement(card);
     if (!subtitleElement) return;
 
     const titleElement = subtitleElement.previousElementSibling;
 
     if (titleElement) {
-      titleElement.textContent = label.title;
+      titleElement.textContent = `${label.teamName} · ${label.title}`;
     }
 
     subtitleElement.textContent = label.subtitle;
+    usedTransactionIds.add(label.transactionId);
   });
 }
 


### PR DESCRIPTION
This fixes the admin Payments page so Stripe player match fees do not stay labelled as “Unlinked payment”.

Changes:
- removes the hard-coded £6.00-only check in the admin payment label bridge
- matches recent payment cards by team and amount, so £4/£5/any player fee amount can be labelled
- shows the payment source as team + player match fee details instead of “Unlinked payment”
- formats the payment method label as “Stripe” rather than “STRIPE”

This should make the Recent payments list show where those Crescent United Stripe payments came from.