### PR TITLE
[codex] Add team late confirmation history

### DIFF
--- a/src/app/(admin)/admin/fixtures/late-fees/actions.ts
+++ b/src/app/(admin)/admin/fixtures/late-fees/actions.ts
@@ -206,6 +206,7 @@ export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
 
     revalidatePath("/admin/fixtures");
     revalidatePath("/admin/fixtures/late-fees");
+    revalidatePath(`/admin/teams/${teamId}/late-fees`);
     revalidatePath(`/captain/team/${teamId}`);
     revalidatePath(`/captain/team/${teamId}/fixtures`);
   } catch (error) {
@@ -237,6 +238,10 @@ export type LateConfirmationFeeRow = {
   homeLateFeeWarningAt: Date | null;
   homeLateFeeAppliedAt: Date | null;
   homeLateFeeWaivedAt: Date | null;
+  homeHistoryWarnings: number;
+  homeHistoryApplied: number;
+  homeHistoryWaived: number;
+  homeHistoryLateConfirms: number;
   awayConfirmationStatus: string | null;
   awayConfirmedAt: Date | null;
   awayIssueRaisedAt: Date | null;
@@ -247,6 +252,10 @@ export type LateConfirmationFeeRow = {
   awayLateFeeWarningAt: Date | null;
   awayLateFeeAppliedAt: Date | null;
   awayLateFeeWaivedAt: Date | null;
+  awayHistoryWarnings: number;
+  awayHistoryApplied: number;
+  awayHistoryWaived: number;
+  awayHistoryLateConfirms: number;
 };
 
 export async function getLateConfirmationFeeRows() {
@@ -272,6 +281,10 @@ export async function getLateConfirmationFeeRows() {
       home_fee."warningAt" AS "homeLateFeeWarningAt",
       home_fee."appliedAt" AS "homeLateFeeAppliedAt",
       home_fee."waivedAt" AS "homeLateFeeWaivedAt",
+      COALESCE(home_history."warnings", 0)::int AS "homeHistoryWarnings",
+      COALESCE(home_history."applied", 0)::int AS "homeHistoryApplied",
+      COALESCE(home_history."waived", 0)::int AS "homeHistoryWaived",
+      COALESCE(home_late_confirmations."lateConfirms", 0)::int AS "homeHistoryLateConfirms",
       away_confirmation."status"::text AS "awayConfirmationStatus",
       away_confirmation."confirmedAt" AS "awayConfirmedAt",
       away_confirmation."issueRaisedAt" AS "awayIssueRaisedAt",
@@ -281,7 +294,11 @@ export async function getLateConfirmationFeeRows() {
       away_fee."note" AS "awayLateFeeNote",
       away_fee."warningAt" AS "awayLateFeeWarningAt",
       away_fee."appliedAt" AS "awayLateFeeAppliedAt",
-      away_fee."waivedAt" AS "awayLateFeeWaivedAt"
+      away_fee."waivedAt" AS "awayLateFeeWaivedAt",
+      COALESCE(away_history."warnings", 0)::int AS "awayHistoryWarnings",
+      COALESCE(away_history."applied", 0)::int AS "awayHistoryApplied",
+      COALESCE(away_history."waived", 0)::int AS "awayHistoryWaived",
+      COALESCE(away_late_confirmations."lateConfirms", 0)::int AS "awayHistoryLateConfirms"
     FROM "Fixture" fixture
     INNER JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
     INNER JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
@@ -299,6 +316,38 @@ export async function getLateConfirmationFeeRows() {
     LEFT JOIN "FixtureConfirmationLateFee" away_fee
       ON away_fee."fixtureId" = fixture."id"
       AND away_fee."teamId" = fixture."awayTeamId"
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*) FILTER (WHERE fee."status" = 'WARNING') AS "warnings",
+        COUNT(*) FILTER (WHERE fee."status" = 'APPLIED') AS "applied",
+        COUNT(*) FILTER (WHERE fee."status" = 'WAIVED') AS "waived"
+      FROM "FixtureConfirmationLateFee" fee
+      WHERE fee."teamId" = fixture."homeTeamId"
+    ) home_history ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS "lateConfirms"
+      FROM "FixtureCaptainConfirmation" confirmation
+      INNER JOIN "Fixture" confirmation_fixture ON confirmation_fixture."id" = confirmation."fixtureId"
+      WHERE confirmation."teamId" = fixture."homeTeamId"
+        AND confirmation."status" = 'CONFIRMED'
+        AND confirmation."confirmedAt" > confirmation_fixture."kickoffAt" - INTERVAL '72 hours'
+    ) home_late_confirmations ON true
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*) FILTER (WHERE fee."status" = 'WARNING') AS "warnings",
+        COUNT(*) FILTER (WHERE fee."status" = 'APPLIED') AS "applied",
+        COUNT(*) FILTER (WHERE fee."status" = 'WAIVED') AS "waived"
+      FROM "FixtureConfirmationLateFee" fee
+      WHERE fee."teamId" = fixture."awayTeamId"
+    ) away_history ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS "lateConfirms"
+      FROM "FixtureCaptainConfirmation" confirmation
+      INNER JOIN "Fixture" confirmation_fixture ON confirmation_fixture."id" = confirmation."fixtureId"
+      WHERE confirmation."teamId" = fixture."awayTeamId"
+        AND confirmation."status" = 'CONFIRMED'
+        AND confirmation."confirmedAt" > confirmation_fixture."kickoffAt" - INTERVAL '72 hours'
+    ) away_late_confirmations ON true
     WHERE fixture."status" = 'SCHEDULED'
       AND fixture."kickoffAt" >= NOW() - INTERVAL '2 days'
       AND fixture."kickoffAt" <= NOW() + INTERVAL '45 days'

--- a/src/app/(admin)/admin/fixtures/late-fees/page.tsx
+++ b/src/app/(admin)/admin/fixtures/late-fees/page.tsx
@@ -131,6 +131,14 @@ function DecisionForm({
   );
 }
 
+function HistoryPill({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs font-semibold text-white/65">
+      {label}: {value}
+    </span>
+  );
+}
+
 function TeamRow({
   fixtureId,
   kickoffAt,
@@ -141,6 +149,10 @@ function TeamRow({
   lastChasedAt,
   decisionStatus,
   decisionNote,
+  historyWarnings,
+  historyApplied,
+  historyWaived,
+  historyLateConfirms,
 }: {
   fixtureId: string;
   kickoffAt: Date;
@@ -151,20 +163,28 @@ function TeamRow({
   lastChasedAt: Date | null;
   decisionStatus: string | null;
   decisionNote: string | null;
+  historyWarnings: number;
+  historyApplied: number;
+  historyWaived: number;
+  historyLateConfirms: number;
 }) {
   const deadline = getDeadline(kickoffAt);
   const confirmedOnTime = confirmationStatus === "CONFIRMED" && confirmedAt && confirmedAt <= deadline;
   const issueRaised = confirmationStatus === "ISSUE_RAISED";
   const needsDecision = new Date() > deadline && !confirmedOnTime && !issueRaised;
+  const hasHistory = historyWarnings + historyApplied + historyWaived + historyLateConfirms > 0;
 
   return (
     <div className={cx("rounded-3xl border p-5", needsDecision ? "border-red-400/25 bg-red-500/[0.06]" : "border-white/10 bg-black/20")}>
       <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
         <div>
           <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-lg font-semibold text-white">{teamName}</h3>
+            <Link href={`/admin/teams/${teamId}/late-fees`} className="text-lg font-semibold text-white underline-offset-4 hover:text-emerald-200 hover:underline">
+              {teamName}
+            </Link>
             {needsDecision ? <span className="rounded-full border border-red-400/25 bg-red-500/10 px-3 py-1 text-xs font-semibold text-red-100">72h missed</span> : null}
           </div>
+
           <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold">
             <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/70">
               {getConfirmationLabel(confirmationStatus, confirmedAt, deadline)}
@@ -173,12 +193,29 @@ function TeamRow({
               {getDecisionLabel(decisionStatus)}
             </span>
           </div>
+
           <div className="mt-4 grid gap-2 text-sm text-white/55 sm:grid-cols-2">
             <div>Deadline: {formatDate(deadline)}</div>
             <div>Confirmed: {formatDate(confirmedAt)}</div>
             <div>Last chased: {formatDate(lastChasedAt)}</div>
             <div>Charge: £10</div>
           </div>
+
+          <div className={cx("mt-4 rounded-2xl border p-3", hasHistory ? "border-amber-400/15 bg-amber-500/[0.04]" : "border-white/10 bg-white/[0.03]")}>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+              Team history
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <HistoryPill label="Warnings" value={historyWarnings} />
+              <HistoryPill label="Applied" value={historyApplied} />
+              <HistoryPill label="Waived" value={historyWaived} />
+              <HistoryPill label="Late confirms" value={historyLateConfirms} />
+            </div>
+            <Link href={`/admin/teams/${teamId}/late-fees`} className="mt-3 inline-flex text-xs font-semibold text-emerald-300 hover:text-emerald-200">
+              Open full team history →
+            </Link>
+          </div>
+
           {decisionNote ? <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65">{decisionNote}</div> : null}
         </div>
         <DecisionForm fixtureId={fixtureId} teamId={teamId} note={decisionNote} />
@@ -201,7 +238,7 @@ export default async function LateConfirmationFeesPage({ searchParams }: { searc
       <section className="rounded-3xl border border-emerald-400/15 bg-white/[0.03] p-6 md:p-8">
         <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">Fixture confirmation policy</p>
         <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">Late confirmation review</h1>
-        <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">Review teams that have not confirmed at least 72 hours before kick-off. Record a warning, apply the admin charge, or waive it with a note.</p>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">Review teams that have not confirmed at least 72 hours before kick-off. Each row now shows the team’s previous warnings, charges, waived decisions and late confirmations to help you decide fairly.</p>
         <Link href="/admin/fixtures" className="mt-5 inline-flex rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 hover:bg-white/5">Back to fixtures</Link>
       </section>
 
@@ -217,8 +254,8 @@ export default async function LateConfirmationFeesPage({ searchParams }: { searc
               <p className="mt-1 text-sm text-white/55">{formatDate(row.kickoffAt)} · {row.venueName ?? "Venue TBC"}</p>
             </div>
             <div className="grid gap-4">
-              <TeamRow fixtureId={row.fixtureId} kickoffAt={row.kickoffAt} teamId={row.homeTeamId} teamName={row.homeTeamName} confirmationStatus={row.homeConfirmationStatus} confirmedAt={row.homeConfirmedAt} lastChasedAt={row.homeLastChasedAt} decisionStatus={row.homeLateFeeStatus} decisionNote={row.homeLateFeeNote} />
-              <TeamRow fixtureId={row.fixtureId} kickoffAt={row.kickoffAt} teamId={row.awayTeamId} teamName={row.awayTeamName} confirmationStatus={row.awayConfirmationStatus} confirmedAt={row.awayConfirmedAt} lastChasedAt={row.awayLastChasedAt} decisionStatus={row.awayLateFeeStatus} decisionNote={row.awayLateFeeNote} />
+              <TeamRow fixtureId={row.fixtureId} kickoffAt={row.kickoffAt} teamId={row.homeTeamId} teamName={row.homeTeamName} confirmationStatus={row.homeConfirmationStatus} confirmedAt={row.homeConfirmedAt} lastChasedAt={row.homeLastChasedAt} decisionStatus={row.homeLateFeeStatus} decisionNote={row.homeLateFeeNote} historyWarnings={row.homeHistoryWarnings} historyApplied={row.homeHistoryApplied} historyWaived={row.homeHistoryWaived} historyLateConfirms={row.homeHistoryLateConfirms} />
+              <TeamRow fixtureId={row.fixtureId} kickoffAt={row.kickoffAt} teamId={row.awayTeamId} teamName={row.awayTeamName} confirmationStatus={row.awayConfirmationStatus} confirmedAt={row.awayConfirmedAt} lastChasedAt={row.awayLastChasedAt} decisionStatus={row.awayLateFeeStatus} decisionNote={row.awayLateFeeNote} historyWarnings={row.awayHistoryWarnings} historyApplied={row.awayHistoryApplied} historyWaived={row.awayHistoryWaived} historyLateConfirms={row.awayHistoryLateConfirms} />
             </div>
           </section>
         ))}

--- a/src/app/(admin)/admin/teams/[id]/late-fees/page.tsx
+++ b/src/app/(admin)/admin/teams/[id]/late-fees/page.tsx
@@ -1,0 +1,258 @@
+// ========================================
+// File: src/app/(admin)/admin/teams/[id]/late-fees/page.tsx
+// ========================================
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Prisma } from "@prisma/client";
+
+import AdminCard from "@/components/admin/AdminCard";
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Team Late Confirmations | SIXFL Admin",
+};
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+type LateConfirmationHistoryRow = {
+  fixtureId: string;
+  kickoffAt: Date;
+  leagueName: string | null;
+  leagueSeason: string | null;
+  venueName: string | null;
+  homeTeamName: string;
+  awayTeamName: string;
+  confirmationStatus: string | null;
+  confirmedAt: Date | null;
+  issueRaisedAt: Date | null;
+  lastChasedAt: Date | null;
+  lateFeeStatus: string | null;
+  lateFeeAmountPence: number | null;
+  lateFeeNote: string | null;
+  lateFeeWarningAt: Date | null;
+  lateFeeAppliedAt: Date | null;
+  lateFeeWaivedAt: Date | null;
+};
+
+function cx(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+function formatDate(value: Date | null) {
+  if (!value) return "—";
+
+  return formatDateTimeInLondon(value, {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getDeadline(kickoffAt: Date) {
+  return new Date(kickoffAt.getTime() - 72 * 60 * 60 * 1000);
+}
+
+function getMatchLabel(row: LateConfirmationHistoryRow) {
+  return `${row.homeTeamName} vs ${row.awayTeamName}`;
+}
+
+function getConfirmationLabel(row: LateConfirmationHistoryRow) {
+  const deadline = getDeadline(row.kickoffAt);
+
+  if (row.confirmationStatus === "CONFIRMED" && row.confirmedAt && row.confirmedAt > deadline) {
+    return "Confirmed late";
+  }
+
+  if (row.confirmationStatus === "CONFIRMED") return "Confirmed on time";
+  if (row.confirmationStatus === "ISSUE_RAISED") return "Issue raised";
+  if (row.confirmationStatus === "PENDING") return "Awaiting confirmation";
+  return "No confirmation";
+}
+
+function getDecisionLabel(status: string | null) {
+  switch (status) {
+    case "APPLIED":
+      return "Charge applied";
+    case "WAIVED":
+      return "Waived";
+    case "WARNING":
+      return "Warning";
+    default:
+      return "No decision";
+  }
+}
+
+function getDecisionTone(status: string | null) {
+  switch (status) {
+    case "APPLIED":
+      return "border-red-400/25 bg-red-500/10 text-red-100";
+    case "WAIVED":
+      return "border-sky-400/25 bg-sky-500/10 text-sky-100";
+    case "WARNING":
+      return "border-amber-400/25 bg-amber-500/10 text-amber-100";
+    default:
+      return "border-white/10 bg-white/5 text-white/55";
+  }
+}
+
+function formatMoney(amountPence: number | null) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format((amountPence ?? 1000) / 100);
+}
+
+async function getTeamLateConfirmationHistory(teamId: string) {
+  return prisma.$queryRaw<LateConfirmationHistoryRow[]>(Prisma.sql`
+    SELECT
+      fixture."id" AS "fixtureId",
+      fixture."kickoffAt" AS "kickoffAt",
+      league."name" AS "leagueName",
+      league."season" AS "leagueSeason",
+      venue."name" AS "venueName",
+      home_team."name" AS "homeTeamName",
+      away_team."name" AS "awayTeamName",
+      confirmation."status"::text AS "confirmationStatus",
+      confirmation."confirmedAt" AS "confirmedAt",
+      confirmation."issueRaisedAt" AS "issueRaisedAt",
+      confirmation."lastChasedAt" AS "lastChasedAt",
+      fee."status"::text AS "lateFeeStatus",
+      fee."amountPence" AS "lateFeeAmountPence",
+      fee."note" AS "lateFeeNote",
+      fee."warningAt" AS "lateFeeWarningAt",
+      fee."appliedAt" AS "lateFeeAppliedAt",
+      fee."waivedAt" AS "lateFeeWaivedAt"
+    FROM "Fixture" fixture
+    INNER JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+    INNER JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+    LEFT JOIN "League" league ON league."id" = fixture."leagueId"
+    LEFT JOIN "Venue" venue ON venue."id" = fixture."venueId"
+    LEFT JOIN "FixtureCaptainConfirmation" confirmation
+      ON confirmation."fixtureId" = fixture."id"
+      AND confirmation."teamId" = ${teamId}
+    LEFT JOIN "FixtureConfirmationLateFee" fee
+      ON fee."fixtureId" = fixture."id"
+      AND fee."teamId" = ${teamId}
+    WHERE fixture."homeTeamId" = ${teamId}
+       OR fixture."awayTeamId" = ${teamId}
+    ORDER BY fixture."kickoffAt" DESC
+    LIMIT 80
+  `);
+}
+
+export default async function TeamLateFeesPage({ params }: Props) {
+  await requireAdmin();
+
+  const { id } = await params;
+
+  const team = await prisma.team.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      league: {
+        select: {
+          name: true,
+          season: true,
+        },
+      },
+    },
+  });
+
+  if (!team) {
+    notFound();
+  }
+
+  const rows = await getTeamLateConfirmationHistory(team.id);
+  const warnings = rows.filter((row) => row.lateFeeStatus === "WARNING").length;
+  const applied = rows.filter((row) => row.lateFeeStatus === "APPLIED").length;
+  const waived = rows.filter((row) => row.lateFeeStatus === "WAIVED").length;
+  const lateConfirmations = rows.filter((row) => {
+    const deadline = getDeadline(row.kickoffAt);
+    return row.confirmedAt && row.confirmedAt > deadline;
+  }).length;
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+      <section className="rounded-3xl border border-emerald-400/15 bg-white/[0.03] p-6 md:p-8">
+        <Link href={`/admin/teams/${team.id}`} className="text-sm text-emerald-300 hover:text-emerald-200">
+          ← Back to team
+        </Link>
+        <p className="mt-5 text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
+          Team confirmation history
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          {team.name}
+        </h1>
+        <p className="mt-2 text-sm text-white/55">
+          {team.league ? `${team.league.name}${team.league.season ? ` · ${team.league.season}` : ""}` : "No league assigned"}
+        </p>
+        <p className="mt-4 max-w-3xl text-sm leading-6 text-white/65">
+          This is the team-level record for 72-hour fixture confirmations, warnings, waived decisions and applied admin charges.
+        </p>
+      </section>
+
+      <div className="grid gap-3 sm:grid-cols-4">
+        <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-amber-100">Warnings: {warnings}</div>
+        <div className="rounded-2xl border border-red-400/20 bg-red-500/10 p-4 text-red-100">Applied: {applied}</div>
+        <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sky-100">Waived: {waived}</div>
+        <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-white/70">Late confirms: {lateConfirmations}</div>
+      </div>
+
+      <AdminCard className="space-y-4 rounded-3xl border border-white/10 bg-white/[0.03] p-5 md:p-6">
+        {rows.length === 0 ? (
+          <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-sm text-white/55">
+            No fixtures found for this team yet.
+          </div>
+        ) : null}
+
+        {rows.map((row) => {
+          const deadline = getDeadline(row.kickoffAt);
+          const decisionAt = row.lateFeeAppliedAt ?? row.lateFeeWaivedAt ?? row.lateFeeWarningAt;
+
+          return (
+            <article key={row.fixtureId} className="rounded-3xl border border-white/10 bg-black/20 p-5">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/35">
+                    {row.leagueName ?? "No league"}{row.leagueSeason ? ` · ${row.leagueSeason}` : ""}
+                  </p>
+                  <h2 className="mt-2 text-xl font-semibold text-white">{getMatchLabel(row)}</h2>
+                  <p className="mt-1 text-sm text-white/55">{formatDate(row.kickoffAt)} · {row.venueName ?? "Venue TBC"}</p>
+                </div>
+                <span className={cx("rounded-full border px-3 py-1 text-xs font-semibold", getDecisionTone(row.lateFeeStatus))}>
+                  {getDecisionLabel(row.lateFeeStatus)}
+                </span>
+              </div>
+
+              <div className="mt-5 grid gap-2 text-sm text-white/55 md:grid-cols-2 xl:grid-cols-4">
+                <div>Deadline: {formatDate(deadline)}</div>
+                <div>Confirmation: {getConfirmationLabel(row)}</div>
+                <div>Confirmed: {formatDate(row.confirmedAt)}</div>
+                <div>Last chased: {formatDate(row.lastChasedAt)}</div>
+                <div>Decision date: {formatDate(decisionAt)}</div>
+                <div>Decision value: {formatMoney(row.lateFeeAmountPence)}</div>
+              </div>
+
+              {row.lateFeeNote ? (
+                <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm leading-6 text-white/65">
+                  {row.lateFeeNote}
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+      </AdminCard>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds team-level late confirmation history and shows that history during fixture late-fee decisions.

- Adds `/admin/teams/[id]/late-fees` as the full team record for warnings, applied charges, waived decisions and late confirmations.
- Adds team history counts directly onto `/admin/fixtures/late-fees` rows so admin can make a fair decision while reviewing a fixture.
- Links each team name and history panel from the fixture review to the full team record.

## Notes

This keeps the fixture review page useful for current decisions, while making the team history the source of truth over time.

## Validation

Not run locally in this environment.