### PR TITLE
[codex] Add large badges to AI Predictor sample

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -3,6 +3,10 @@
 // ========================================
 
 import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export const metadata = {
   title: "SIXFL | Harrogate, Northallerton & Wetherby 6-a-side football leagues",
@@ -24,6 +28,8 @@ const generalPlayerLink = "/register-interest?type=player";
 const generalRefereeLink = "/register-interest?type=referee";
 
 const leagueTypes = ["MEN’S LEAGUES", "WOMEN’S LEAGUES", "YOUTH LEAGUES"];
+const predictorHomeTeamName = "Six Offenders";
+const predictorAwayTeamName = "Crescent United";
 
 const areaCards = [
   {
@@ -100,12 +106,56 @@ const joinRoutes = [
 const launchAreas = ["Harrogate", "Wetherby", "Northallerton", "Ripon", "York", "Leeds"];
 
 const predictorSample = [
-  { label: "Six Offenders", value: 58, tone: "emerald" },
+  { label: predictorHomeTeamName, value: 58, tone: "emerald" },
   { label: "Draw", value: 14, tone: "neutral" },
-  { label: "Crescent United", value: 28, tone: "sky" },
+  { label: predictorAwayTeamName, value: 28, tone: "sky" },
 ];
 
-export default function HomePage() {
+type PredictorSampleTeamLogos = {
+  homeLogoUrl: string | null;
+  awayLogoUrl: string | null;
+};
+
+function normaliseTeamName(name: string) {
+  return name.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+async function getPredictorSampleTeamLogos(): Promise<PredictorSampleTeamLogos> {
+  try {
+    const teams = await prisma.team.findMany({
+      where: {
+        name: {
+          in: [predictorHomeTeamName, predictorAwayTeamName],
+        },
+      },
+      select: {
+        name: true,
+        logoUrl: true,
+      },
+    });
+
+    const homeTeam = teams.find(
+      (team) => normaliseTeamName(team.name) === normaliseTeamName(predictorHomeTeamName),
+    );
+    const awayTeam = teams.find(
+      (team) => normaliseTeamName(team.name) === normaliseTeamName(predictorAwayTeamName),
+    );
+
+    return {
+      homeLogoUrl: homeTeam?.logoUrl ?? null,
+      awayLogoUrl: awayTeam?.logoUrl ?? null,
+    };
+  } catch {
+    return {
+      homeLogoUrl: null,
+      awayLogoUrl: null,
+    };
+  }
+}
+
+export default async function HomePage() {
+  const predictorSampleTeamLogos = await getPredictorSampleTeamLogos();
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-black text-white">
       <div className="pointer-events-none absolute inset-0">
@@ -175,7 +225,7 @@ export default function HomePage() {
           </div>
         </section>
 
-        <SixflAiPredictorSection />
+        <SixflAiPredictorSection teamLogos={predictorSampleTeamLogos} />
 
         <section id="why-sixfl" className="mt-12 lg:mt-16">
           <div className="mb-6">
@@ -319,7 +369,11 @@ function AreaCard({
   );
 }
 
-function SixflAiPredictorSection() {
+function SixflAiPredictorSection({
+  teamLogos,
+}: {
+  teamLogos: PredictorSampleTeamLogos;
+}) {
   return (
     <section className="mt-12 lg:mt-16">
       <div className="overflow-hidden rounded-[1.5rem] border border-emerald-400/20 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.18),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.035))] p-5 shadow-[0_24px_90px_rgba(0,0,0,0.42)] backdrop-blur-xl sm:rounded-[2rem] sm:p-8 lg:p-10">
@@ -354,7 +408,7 @@ function SixflAiPredictorSection() {
                   Sample prediction
                 </div>
                 <h3 className="mt-2 text-xl font-black text-white">
-                  Six Offenders vs Crescent United
+                  {predictorHomeTeamName} vs {predictorAwayTeamName}
                 </h3>
               </div>
               <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-xs font-black text-emerald-200">
@@ -363,11 +417,21 @@ function SixflAiPredictorSection() {
             </div>
 
             <div className="mt-6 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-3xl border border-white/10 bg-white/[0.035] p-4 sm:gap-5 sm:p-5">
-              <SampleTeamBadge initials="SO" name="Six Offenders" tone="emerald" />
+              <SampleTeamBadge
+                initials="SO"
+                logoUrl={teamLogos.homeLogoUrl}
+                name={predictorHomeTeamName}
+                tone="emerald"
+              />
               <div className="rounded-full border border-white/10 bg-black/60 px-3 py-2 text-xs font-black tracking-[0.2em] text-white/55">
                 VS
               </div>
-              <SampleTeamBadge initials="CU" name="Crescent United" tone="sky" />
+              <SampleTeamBadge
+                initials="CU"
+                logoUrl={teamLogos.awayLogoUrl}
+                name={predictorAwayTeamName}
+                tone="sky"
+              />
             </div>
 
             <div className="mt-6 space-y-4">
@@ -395,10 +459,12 @@ function SixflAiPredictorSection() {
 
 function SampleTeamBadge({
   initials,
+  logoUrl,
   name,
   tone,
 }: {
   initials: string;
+  logoUrl: string | null;
   name: string;
   tone: "emerald" | "sky";
 }) {
@@ -420,15 +486,28 @@ function SampleTeamBadge({
   return (
     <div className="flex min-w-0 flex-col items-center text-center">
       <div
-        className={`relative flex h-28 w-28 items-center justify-center rounded-[2rem] border shadow-2xl sm:h-36 sm:w-36 ${badgeStyles.outer}`}
+        className={`relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-[2rem] border shadow-2xl sm:h-40 sm:w-40 ${badgeStyles.outer}`}
         aria-label={`${name} badge`}
         title={`${name} badge`}
       >
-        <div className="absolute inset-3 rounded-[1.45rem] border border-white/10 bg-black/35" />
-        <div className={`absolute left-1/2 top-4 h-1.5 w-12 -translate-x-1/2 rounded-full sm:w-16 ${badgeStyles.accent}`} />
-        <div className={`relative flex h-16 w-16 items-center justify-center rounded-full border text-2xl font-black tracking-tight sm:h-20 sm:w-20 sm:text-3xl ${badgeStyles.inner}`}>
-          {initials}
-        </div>
+        {logoUrl ? (
+          <div className="flex h-full w-full items-center justify-center bg-black/35 p-3 sm:p-4">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={logoUrl}
+              alt={`${name} badge`}
+              className="h-full w-full object-contain drop-shadow-[0_18px_24px_rgba(0,0,0,0.5)]"
+            />
+          </div>
+        ) : (
+          <>
+            <div className="absolute inset-3 rounded-[1.45rem] border border-white/10 bg-black/35" />
+            <div className={`absolute left-1/2 top-4 h-1.5 w-12 -translate-x-1/2 rounded-full sm:w-16 ${badgeStyles.accent}`} />
+            <div className={`relative flex h-16 w-16 items-center justify-center rounded-full border text-2xl font-black tracking-tight sm:h-20 sm:w-20 sm:text-3xl ${badgeStyles.inner}`}>
+              {initials}
+            </div>
+          </>
+        )}
       </div>
       <div className="mt-3 max-w-[9rem] text-sm font-black leading-5 text-white sm:text-base">
         {name}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -362,7 +362,15 @@ function SixflAiPredictorSection() {
               </span>
             </div>
 
-            <div className="mt-5 space-y-4">
+            <div className="mt-6 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-3xl border border-white/10 bg-white/[0.035] p-4 sm:gap-5 sm:p-5">
+              <SampleTeamBadge initials="SO" name="Six Offenders" tone="emerald" />
+              <div className="rounded-full border border-white/10 bg-black/60 px-3 py-2 text-xs font-black tracking-[0.2em] text-white/55">
+                VS
+              </div>
+              <SampleTeamBadge initials="CU" name="Crescent United" tone="sky" />
+            </div>
+
+            <div className="mt-6 space-y-4">
               {predictorSample.map((item) => (
                 <PredictionBar key={item.label} {...item} />
               ))}
@@ -382,6 +390,50 @@ function SixflAiPredictorSection() {
         </div>
       </div>
     </section>
+  );
+}
+
+function SampleTeamBadge({
+  initials,
+  name,
+  tone,
+}: {
+  initials: string;
+  name: string;
+  tone: "emerald" | "sky";
+}) {
+  const badgeStyles =
+    tone === "emerald"
+      ? {
+          outer:
+            "border-emerald-300/25 bg-gradient-to-b from-emerald-300/22 via-emerald-500/12 to-black/70 shadow-emerald-500/20",
+          inner: "border-emerald-200/30 bg-emerald-400/15 text-emerald-100",
+          accent: "bg-emerald-300/75",
+        }
+      : {
+          outer:
+            "border-sky-300/25 bg-gradient-to-b from-sky-300/22 via-sky-500/12 to-black/70 shadow-sky-500/20",
+          inner: "border-sky-200/30 bg-sky-400/15 text-sky-100",
+          accent: "bg-sky-300/75",
+        };
+
+  return (
+    <div className="flex min-w-0 flex-col items-center text-center">
+      <div
+        className={`relative flex h-28 w-28 items-center justify-center rounded-[2rem] border shadow-2xl sm:h-36 sm:w-36 ${badgeStyles.outer}`}
+        aria-label={`${name} badge`}
+        title={`${name} badge`}
+      >
+        <div className="absolute inset-3 rounded-[1.45rem] border border-white/10 bg-black/35" />
+        <div className={`absolute left-1/2 top-4 h-1.5 w-12 -translate-x-1/2 rounded-full sm:w-16 ${badgeStyles.accent}`} />
+        <div className={`relative flex h-16 w-16 items-center justify-center rounded-full border text-2xl font-black tracking-tight sm:h-20 sm:w-20 sm:text-3xl ${badgeStyles.inner}`}>
+          {initials}
+        </div>
+      </div>
+      <div className="mt-3 max-w-[9rem] text-sm font-black leading-5 text-white sm:text-base">
+        {name}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds large real team badge visuals to the SIXFL AI Predictor homepage sample card.

- Looks up the real `logoUrl` values for Six Offenders and Crescent United from the Team table.
- Displays those badges prominently either side of a VS marker.
- Keeps a clean fallback only if a team badge is missing.
- Keeps the prediction bars and sample preview copy underneath.

## Notes

This now uses the actual team badge URLs stored against the teams rather than invented placeholder crests.

## Validation

Not run locally in this environment.