### PR TITLE
Add late payment admin fee controls

### DIFF
--- a/prisma/migrations/20260624120000_add_payment_late_admin_fee_fields/migration.sql
+++ b/prisma/migrations/20260624120000_add_payment_late_admin_fee_fields/migration.sql
@@ -1,0 +1,19 @@
+-- ========================================
+-- File: prisma/migrations/20260624120000_add_payment_late_admin_fee_fields/migration.sql
+-- ========================================
+
+CREATE TYPE "PaymentLateFeeStatus" AS ENUM ('NONE', 'WARNING', 'APPLIED', 'WAIVED');
+
+ALTER TABLE "PaymentCharge"
+  ADD COLUMN "latePaymentFeeStatus" "PaymentLateFeeStatus" NOT NULL DEFAULT 'NONE',
+  ADD COLUMN "latePaymentFeeAmountPence" INTEGER NOT NULL DEFAULT 1000,
+  ADD COLUMN "latePaymentFeeNote" TEXT,
+  ADD COLUMN "latePaymentFeeWarningAt" TIMESTAMP(3),
+  ADD COLUMN "latePaymentFeeAppliedAt" TIMESTAMP(3),
+  ADD COLUMN "latePaymentFeeWaivedAt" TIMESTAMP(3);
+
+CREATE INDEX "PaymentCharge_latePaymentFeeStatus_idx"
+  ON "PaymentCharge"("latePaymentFeeStatus");
+
+CREATE INDEX "PaymentCharge_dueDate_latePaymentFeeStatus_idx"
+  ON "PaymentCharge"("dueDate", "latePaymentFeeStatus");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -518,6 +518,13 @@ enum PaymentChargeStatus {
   VOID
 }
 
+enum PaymentLateFeeStatus {
+  NONE
+  WARNING
+  APPLIED
+  WAIVED
+}
+
 enum PlayerMatchFeeStatus {
   OPEN
   PAID
@@ -547,6 +554,13 @@ model PaymentCharge {
 
   status PaymentChargeStatus @default(OPEN)
 
+  latePaymentFeeStatus      PaymentLateFeeStatus @default(NONE)
+  latePaymentFeeAmountPence Int                   @default(1000)
+  latePaymentFeeNote        String?
+  latePaymentFeeWarningAt   DateTime?
+  latePaymentFeeAppliedAt   DateTime?
+  latePaymentFeeWaivedAt    DateTime?
+
   paymentToken                  String?   @unique
   lastStripeCheckoutUrl         String?
   lastStripeCheckoutSessionId   String?   @unique
@@ -568,6 +582,8 @@ model PaymentCharge {
   @@index([fixtureId])
   @@index([status])
   @@index([dueDate])
+  @@index([latePaymentFeeStatus])
+  @@index([dueDate, latePaymentFeeStatus])
 }
 
 model PaymentTransaction {

--- a/src/app/(admin)/admin/fixtures/late-fees/actions.ts
+++ b/src/app/(admin)/admin/fixtures/late-fees/actions.ts
@@ -13,6 +13,11 @@ import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 type LateFeeDecision = "NONE" | "WARNING" | "APPLIED" | "WAIVED";
+type LateFeeNotice =
+  | "late_fee_saved"
+  | "late_fee_error"
+  | "payment_late_fee_saved"
+  | "payment_late_fee_error";
 
 const ALLOWED_DECISIONS = new Set<LateFeeDecision>([
   "NONE",
@@ -20,6 +25,9 @@ const ALLOWED_DECISIONS = new Set<LateFeeDecision>([
   "APPLIED",
   "WAIVED",
 ]);
+
+const PAYMENT_LATE_FEE_GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_PAYMENT_LATE_FEE_PENCE = 1000;
 
 function parseRequiredString(value: FormDataEntryValue | null, fieldName: string) {
   const parsed = String(value ?? "").trim();
@@ -47,9 +55,10 @@ function parseNote(value: FormDataEntryValue | null) {
 }
 
 function buildRedirect(input: {
-  notice: "late_fee_saved" | "late_fee_error";
+  notice: LateFeeNotice;
   teamName?: string | null;
   fixtureId?: string | null;
+  sectionId?: string | null;
 }) {
   const searchParams = new URLSearchParams();
   searchParams.set("notice", input.notice);
@@ -59,9 +68,11 @@ function buildRedirect(input: {
   }
 
   const query = searchParams.toString();
-  const hash = input.fixtureId?.trim()
-    ? `#fixture-${input.fixtureId.trim()}`
-    : "";
+  const hash = input.sectionId?.trim()
+    ? `#${input.sectionId.trim()}`
+    : input.fixtureId?.trim()
+      ? `#fixture-${input.fixtureId.trim()}`
+      : "";
 
   return `/admin/fixtures/late-fees?${query}${hash}`;
 }
@@ -111,6 +122,14 @@ function getTeamName(input: {
 
 function getConfirmationDeadline(kickoffAt: Date) {
   return new Date(kickoffAt.getTime() - 72 * 60 * 60 * 1000);
+}
+
+function getChargeStatus(input: { amountPence: number; paidTotalPence: number }) {
+  const outstandingPence = input.amountPence - input.paidTotalPence;
+
+  if (outstandingPence <= 0) return "PAID";
+  if (input.paidTotalPence > 0) return "PART_PAID";
+  return "OPEN";
 }
 
 export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
@@ -215,6 +234,219 @@ export async function setLateConfirmationFeeDecisionAction(formData: FormData) {
   }
 
   redirect(buildRedirect({ notice: "late_fee_saved", teamName, fixtureId }));
+}
+
+export async function setLatePaymentAdminFeeDecisionAction(formData: FormData) {
+  await requireAdmin();
+
+  const chargeId = parseRequiredString(formData.get("chargeId"), "Charge");
+  const decision = parseDecision(formData.get("decision"));
+  const note = parseNote(formData.get("note"));
+  const decisionNote = decision === "NONE" ? null : note;
+  const now = new Date();
+  let teamName: string | null = null;
+
+  try {
+    const [charge] = await prisma.$queryRaw<
+      Array<{
+        id: string;
+        teamId: string;
+        teamName: string;
+        status: string;
+        amountPence: number;
+        dueDate: Date | null;
+        paidTotalPence: number;
+        latePaymentFeeStatus: LateFeeDecision;
+        latePaymentFeeAmountPence: number;
+      }>
+    >(Prisma.sql`
+      SELECT
+        charge."id",
+        charge."teamId",
+        team."name" AS "teamName",
+        charge."status"::text AS "status",
+        charge."amountPence",
+        charge."dueDate",
+        COALESCE(SUM(transaction."amountPence"), 0)::int AS "paidTotalPence",
+        charge."latePaymentFeeStatus"::text AS "latePaymentFeeStatus",
+        charge."latePaymentFeeAmountPence" AS "latePaymentFeeAmountPence"
+      FROM "PaymentCharge" charge
+      INNER JOIN "Team" team ON team."id" = charge."teamId"
+      LEFT JOIN "PaymentTransaction" transaction ON transaction."chargeId" = charge."id"
+      WHERE charge."id" = ${chargeId}
+      GROUP BY charge."id", team."name"
+      LIMIT 1
+    `);
+
+    if (!charge || charge.status === "PAID" || charge.status === "VOID") {
+      throw new Error("Charge is not open for late payment fee management.");
+    }
+
+    teamName = charge.teamName;
+    const overdueAt = charge.dueDate
+      ? new Date(charge.dueDate.getTime() + PAYMENT_LATE_FEE_GRACE_PERIOD_MS)
+      : null;
+    const isLateFeeEligible = Boolean(overdueAt && overdueAt <= now);
+    const outstandingBeforeDecision = charge.amountPence - charge.paidTotalPence;
+
+    if (decision === "APPLIED" && (!isLateFeeEligible || outstandingBeforeDecision <= 0)) {
+      throw new Error("A payment admin fee can only be applied to an outstanding charge more than 7 days after the due date.");
+    }
+
+    const feeAmountPence =
+      charge.latePaymentFeeAmountPence > 0
+        ? charge.latePaymentFeeAmountPence
+        : DEFAULT_PAYMENT_LATE_FEE_PENCE;
+    const wasApplied = charge.latePaymentFeeStatus === "APPLIED";
+    const willBeApplied = decision === "APPLIED";
+    const amountDeltaPence =
+      !wasApplied && willBeApplied
+        ? feeAmountPence
+        : wasApplied && !willBeApplied
+          ? -feeAmountPence
+          : 0;
+    const nextAmountPence = Math.max(0, charge.amountPence + amountDeltaPence);
+    const nextStatus = getChargeStatus({
+      amountPence: nextAmountPence,
+      paidTotalPence: charge.paidTotalPence,
+    });
+
+    await prisma.$executeRaw`
+      UPDATE "PaymentCharge"
+      SET
+        "amountPence" = ${nextAmountPence},
+        "status" = CAST(${nextStatus} AS "PaymentChargeStatus"),
+        "latePaymentFeeStatus" = CAST(${decision} AS "PaymentLateFeeStatus"),
+        "latePaymentFeeAmountPence" = ${feeAmountPence},
+        "latePaymentFeeNote" = ${decisionNote},
+        "latePaymentFeeWarningAt" = CASE
+          WHEN CAST(${decision} AS "PaymentLateFeeStatus") = 'WARNING'
+            THEN COALESCE("latePaymentFeeWarningAt", ${now})
+          ELSE NULL
+        END,
+        "latePaymentFeeAppliedAt" = CASE
+          WHEN CAST(${decision} AS "PaymentLateFeeStatus") = 'APPLIED'
+            THEN COALESCE("latePaymentFeeAppliedAt", ${now})
+          ELSE NULL
+        END,
+        "latePaymentFeeWaivedAt" = CASE
+          WHEN CAST(${decision} AS "PaymentLateFeeStatus") = 'WAIVED'
+            THEN COALESCE("latePaymentFeeWaivedAt", ${now})
+          ELSE NULL
+        END,
+        "lastStripeCheckoutUrl" = CASE WHEN ${amountDeltaPence} <> 0 THEN NULL ELSE "lastStripeCheckoutUrl" END,
+        "lastStripeCheckoutSessionId" = CASE WHEN ${amountDeltaPence} <> 0 THEN NULL ELSE "lastStripeCheckoutSessionId" END,
+        "lastStripeCheckoutCreatedAt" = CASE WHEN ${amountDeltaPence} <> 0 THEN NULL ELSE "lastStripeCheckoutCreatedAt" END,
+        "lastStripeCheckoutAmountPence" = CASE WHEN ${amountDeltaPence} <> 0 THEN NULL ELSE "lastStripeCheckoutAmountPence" END,
+        "updatedAt" = ${now}
+      WHERE "id" = ${chargeId}
+    `;
+
+    revalidatePath("/admin/payments");
+    revalidatePath("/admin/fixtures/late-fees");
+    revalidatePath(`/captain/team/${charge.teamId}`);
+    revalidatePath(`/captain/team/${charge.teamId}/payments`);
+  } catch (error) {
+    console.error("Failed to set late payment admin fee decision", error);
+    redirect(
+      buildRedirect({
+        notice: "payment_late_fee_error",
+        teamName,
+        sectionId: `payment-charge-${chargeId}`,
+      }),
+    );
+  }
+
+  redirect(
+    buildRedirect({
+      notice: "payment_late_fee_saved",
+      teamName,
+      sectionId: `payment-charge-${chargeId}`,
+    }),
+  );
+}
+
+export type PaymentLateFeeRow = {
+  chargeId: string;
+  teamId: string;
+  teamName: string;
+  title: string;
+  description: string | null;
+  chargeStatus: string;
+  amountPence: number;
+  paidTotalPence: number;
+  outstandingPence: number;
+  dueDate: Date | null;
+  createdAt: Date;
+  daysLate: number | null;
+  lateFeeEligibleAt: Date | null;
+  paymentLateFeeStatus: LateFeeDecision;
+  paymentLateFeeAmountPence: number;
+  paymentLateFeeNote: string | null;
+  paymentLateFeeWarningAt: Date | null;
+  paymentLateFeeAppliedAt: Date | null;
+  paymentLateFeeWaivedAt: Date | null;
+  fixtureId: string | null;
+  kickoffAt: Date | null;
+  homeTeamName: string | null;
+  awayTeamName: string | null;
+};
+
+export async function getPaymentLateFeeRows() {
+  return prisma.$queryRaw<PaymentLateFeeRow[]>(Prisma.sql`
+    WITH charge_totals AS (
+      SELECT
+        charge."id" AS "chargeId",
+        charge."teamId" AS "teamId",
+        team."name" AS "teamName",
+        charge."title" AS "title",
+        charge."description" AS "description",
+        charge."status"::text AS "chargeStatus",
+        charge."amountPence" AS "amountPence",
+        COALESCE(SUM(transaction."amountPence"), 0)::int AS "paidTotalPence",
+        (charge."amountPence" - COALESCE(SUM(transaction."amountPence"), 0))::int AS "outstandingPence",
+        charge."dueDate" AS "dueDate",
+        charge."createdAt" AS "createdAt",
+        CASE
+          WHEN charge."dueDate" IS NULL THEN NULL
+          ELSE FLOOR(EXTRACT(EPOCH FROM (NOW() - charge."dueDate")) / 86400)::int
+        END AS "daysLate",
+        CASE
+          WHEN charge."dueDate" IS NULL THEN NULL
+          ELSE charge."dueDate" + INTERVAL '7 days'
+        END AS "lateFeeEligibleAt",
+        charge."latePaymentFeeStatus"::text AS "paymentLateFeeStatus",
+        charge."latePaymentFeeAmountPence" AS "paymentLateFeeAmountPence",
+        charge."latePaymentFeeNote" AS "paymentLateFeeNote",
+        charge."latePaymentFeeWarningAt" AS "paymentLateFeeWarningAt",
+        charge."latePaymentFeeAppliedAt" AS "paymentLateFeeAppliedAt",
+        charge."latePaymentFeeWaivedAt" AS "paymentLateFeeWaivedAt",
+        charge."fixtureId" AS "fixtureId",
+        fixture."kickoffAt" AS "kickoffAt",
+        home_team."name" AS "homeTeamName",
+        away_team."name" AS "awayTeamName"
+      FROM "PaymentCharge" charge
+      INNER JOIN "Team" team ON team."id" = charge."teamId"
+      LEFT JOIN "PaymentTransaction" transaction ON transaction."chargeId" = charge."id"
+      LEFT JOIN "Fixture" fixture ON fixture."id" = charge."fixtureId"
+      LEFT JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+      LEFT JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+      WHERE charge."status" NOT IN ('PAID', 'VOID')
+      GROUP BY charge."id", team."name", fixture."id", home_team."name", away_team."name"
+    )
+    SELECT *
+    FROM charge_totals
+    WHERE "outstandingPence" > 0
+      AND (
+        ("dueDate" IS NOT NULL AND "lateFeeEligibleAt" <= NOW())
+        OR "paymentLateFeeStatus" <> 'NONE'
+      )
+    ORDER BY
+      CASE WHEN "paymentLateFeeStatus" = 'APPLIED' THEN 1 ELSE 0 END ASC,
+      "lateFeeEligibleAt" ASC NULLS LAST,
+      "teamName" ASC,
+      "title" ASC
+  `);
 }
 
 export type LateConfirmationFeeRow = {

--- a/src/app/(admin)/admin/fixtures/late-fees/page.tsx
+++ b/src/app/(admin)/admin/fixtures/late-fees/page.tsx
@@ -9,15 +9,18 @@ import { formatDateTimeInLondon } from "@/lib/datetime/london";
 import { requireAdmin } from "@/lib/requireAdmin";
 import {
   getLateConfirmationFeeRows,
+  getPaymentLateFeeRows,
   setLateConfirmationFeeDecisionAction,
+  setLatePaymentAdminFeeDecisionAction,
   type LateConfirmationFeeRow,
+  type PaymentLateFeeRow,
 } from "./actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata = {
-  title: "Late Confirmation Review | SIXFL Admin",
+  title: "Late Fees | SIXFL Admin",
 };
 
 type SearchParams = {
@@ -27,6 +30,13 @@ type SearchParams = {
 
 function cx(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
+}
+
+function formatMoney(amountPence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(amountPence / 100);
 }
 
 function formatDate(value: Date | null) {
@@ -49,20 +59,42 @@ function getFixtureLabel(row: LateConfirmationFeeRow) {
   return `${row.homeTeamName} vs ${row.awayTeamName}`;
 }
 
+function getPaymentFixtureLabel(row: PaymentLateFeeRow) {
+  if (row.homeTeamName && row.awayTeamName && row.kickoffAt) {
+    return `${row.homeTeamName} vs ${row.awayTeamName} · ${formatDate(row.kickoffAt)}`;
+  }
+
+  return "Manual charge";
+}
+
 function getNotice(input: SearchParams) {
   const teamName = input.teamName?.trim() || "that team";
 
   if (input.notice === "late_fee_saved") {
     return {
       tone: "success" as const,
-      message: `Decision saved for ${teamName}.`,
+      message: `Confirmation fee decision saved for ${teamName}.`,
+    };
+  }
+
+  if (input.notice === "payment_late_fee_saved") {
+    return {
+      tone: "success" as const,
+      message: `Payment admin fee decision saved for ${teamName}.`,
     };
   }
 
   if (input.notice === "late_fee_error") {
     return {
       tone: "error" as const,
-      message: `The decision could not be saved for ${teamName}.`,
+      message: `The confirmation fee decision could not be saved for ${teamName}.`,
+    };
+  }
+
+  if (input.notice === "payment_late_fee_error") {
+    return {
+      tone: "error" as const,
+      message: `The payment admin fee decision could not be saved for ${teamName}.`,
     };
   }
 
@@ -77,8 +109,23 @@ function getDecisionLabel(status: string | null) {
       return "Waived";
     case "WARNING":
       return "Warning";
+    case "NONE":
+      return "No decision";
     default:
       return "No decision";
+  }
+}
+
+function getDecisionTone(status: string | null) {
+  switch (status) {
+    case "APPLIED":
+      return "border-red-400/25 bg-red-500/10 text-red-100";
+    case "WAIVED":
+      return "border-sky-400/25 bg-sky-500/10 text-sky-100";
+    case "WARNING":
+      return "border-amber-400/25 bg-amber-500/10 text-amber-100";
+    default:
+      return "border-white/10 bg-white/5 text-white/70";
   }
 }
 
@@ -93,7 +140,42 @@ function getConfirmationLabel(status: string | null, confirmedAt: Date | null, d
   return "No confirmation";
 }
 
-function DecisionForm({
+function PaymentLateFeeDecisionForm({
+  chargeId,
+  note,
+}: {
+  chargeId: string;
+  note: string | null;
+}) {
+  return (
+    <form action={setLatePaymentAdminFeeDecisionAction} className="space-y-3">
+      <input type="hidden" name="chargeId" value={chargeId} />
+      <textarea
+        name="note"
+        rows={2}
+        defaultValue={note ?? ""}
+        placeholder="Admin note shown only internally"
+        className="w-full rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/25 focus:border-emerald-400/50"
+      />
+      <div className="grid gap-2 sm:grid-cols-4">
+        <button name="decision" value="WARNING" className="rounded-xl border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100">
+          Warning
+        </button>
+        <button name="decision" value="APPLIED" className="rounded-xl border border-red-400/25 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">
+          Add £10
+        </button>
+        <button name="decision" value="WAIVED" className="rounded-xl border border-sky-400/25 bg-sky-500/10 px-3 py-2 text-xs font-semibold text-sky-100">
+          Waive
+        </button>
+        <button name="decision" value="NONE" className="rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-semibold text-white/75">
+          Clear
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ConfirmationDecisionForm({
   fixtureId,
   teamId,
   note,
@@ -136,6 +218,63 @@ function HistoryPill({ label, value }: { label: string; value: number }) {
     <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs font-semibold text-white/65">
       {label}: {value}
     </span>
+  );
+}
+
+function PaymentLateFeeRowCard({ row }: { row: PaymentLateFeeRow }) {
+  const feeAmount = row.paymentLateFeeAmountPence || 1000;
+  const baseChargeAmount =
+    row.paymentLateFeeStatus === "APPLIED"
+      ? Math.max(0, row.amountPence - feeAmount)
+      : row.amountPence;
+
+  return (
+    <div id={`payment-charge-${row.chargeId}`} className={cx("scroll-mt-6 rounded-3xl border p-5", row.paymentLateFeeStatus === "APPLIED" ? "border-red-400/25 bg-red-500/[0.06]" : "border-amber-400/25 bg-amber-500/[0.05]")}> 
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Link href={`/admin/teams/${row.teamId}`} className="text-lg font-semibold text-white underline-offset-4 hover:text-emerald-200 hover:underline">
+              {row.teamName}
+            </Link>
+            <span className="rounded-full border border-red-400/25 bg-red-500/10 px-3 py-1 text-xs font-semibold text-red-100">
+              {row.daysLate ?? 0} days late
+            </span>
+            <span className={cx("rounded-full border px-3 py-1 text-xs font-semibold", getDecisionTone(row.paymentLateFeeStatus))}>
+              {getDecisionLabel(row.paymentLateFeeStatus)}
+            </span>
+          </div>
+
+          <h3 className="mt-3 text-base font-semibold text-white">{row.title}</h3>
+          <p className="mt-1 text-sm text-white/55">{row.description || getPaymentFixtureLabel(row)}</p>
+
+          <div className="mt-4 grid gap-2 text-sm text-white/55 sm:grid-cols-2 xl:grid-cols-3">
+            <div>Due: {formatDate(row.dueDate)}</div>
+            <div>Late fee eligible: {formatDate(row.lateFeeEligibleAt)}</div>
+            <div>Admin fee: {formatMoney(feeAmount)}</div>
+            <div>Base charge: {formatMoney(baseChargeAmount)}</div>
+            <div>Paid: {formatMoney(row.paidTotalPence)}</div>
+            <div>Outstanding: {formatMoney(row.outstandingPence)}</div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link href={`/admin/payments?paymentChargeId=${encodeURIComponent(row.chargeId)}#record-payment`} className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 hover:bg-emerald-500/15">
+              Record payment
+            </Link>
+            <Link href="/admin/payments" className="rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-semibold text-white/75 hover:bg-white/[0.08]">
+              Open payments
+            </Link>
+          </div>
+
+          {row.paymentLateFeeNote ? (
+            <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65">
+              {row.paymentLateFeeNote}
+            </div>
+          ) : null}
+        </div>
+
+        <PaymentLateFeeDecisionForm chargeId={row.chargeId} note={row.paymentLateFeeNote} />
+      </div>
+    </div>
   );
 }
 
@@ -189,7 +328,7 @@ function TeamRow({
             <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/70">
               {getConfirmationLabel(confirmationStatus, confirmedAt, deadline)}
             </span>
-            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/70">
+            <span className={cx("rounded-full border px-3 py-1", getDecisionTone(decisionStatus))}>
               {getDecisionLabel(decisionStatus)}
             </span>
           </div>
@@ -218,35 +357,88 @@ function TeamRow({
 
           {decisionNote ? <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65">{decisionNote}</div> : null}
         </div>
-        <DecisionForm fixtureId={fixtureId} teamId={teamId} note={decisionNote} />
+        <ConfirmationDecisionForm fixtureId={fixtureId} teamId={teamId} note={decisionNote} />
       </div>
     </div>
   );
 }
 
-export default async function LateConfirmationFeesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
+export default async function LateFeesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
   await requireAdmin();
 
-  const [rows, resolvedSearchParams] = await Promise.all([
+  const [paymentRows, confirmationRows, resolvedSearchParams] = await Promise.all([
+    getPaymentLateFeeRows(),
     getLateConfirmationFeeRows(),
     searchParams ? searchParams : Promise.resolve({}),
   ]);
   const notice = getNotice(resolvedSearchParams);
+  const paymentFeeOutstanding = paymentRows.reduce((sum, row) => sum + row.outstandingPence, 0);
+  const appliedPaymentFees = paymentRows.filter((row) => row.paymentLateFeeStatus === "APPLIED").length;
 
   return (
     <div className="w-full space-y-8 px-4 pb-10 pt-6 sm:px-6 lg:px-8">
       <section className="rounded-3xl border border-emerald-400/15 bg-white/[0.03] p-6 md:p-8">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">Fixture confirmation policy</p>
-        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">Late confirmation review</h1>
-        <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">Review teams that have not confirmed at least 72 hours before kick-off. Each row now shows the team’s previous warnings, charges, waived decisions and late confirmations to help you decide fairly.</p>
-        <Link href="/admin/fixtures" className="mt-5 inline-flex rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 hover:bg-white/5">Back to fixtures</Link>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">Late fee control centre</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">Late fees</h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">
+          Manage payment admin fees for charges more than 7 days overdue and fixture confirmation fees for teams that miss the 72-hour confirmation deadline. Decisions stay manual so you can warn, apply, waive or clear fairly.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <Link href="/admin/payments" className="inline-flex rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 hover:bg-white/5">Open payments</Link>
+          <Link href="/admin/fixtures" className="inline-flex rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 hover:bg-white/5">Open fixtures</Link>
+        </div>
       </section>
 
       {notice ? <section className={cx("rounded-2xl border px-4 py-3 text-sm", notice.tone === "success" ? "border-emerald-400/20 bg-emerald-500/10 text-emerald-100" : "border-red-400/20 bg-red-500/10 text-red-100")}>{notice.message}</section> : null}
 
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-3xl border border-red-400/20 bg-red-500/10 p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-red-100/70">Payment fee decisions</div>
+          <div className="mt-3 text-3xl font-semibold text-white">{paymentRows.length}</div>
+          <p className="mt-2 text-sm text-red-100/70">Charges more than 7 days overdue.</p>
+        </div>
+        <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-100/70">Outstanding in review</div>
+          <div className="mt-3 text-3xl font-semibold text-white">{formatMoney(paymentFeeOutstanding)}</div>
+          <p className="mt-2 text-sm text-amber-100/70">Current outstanding balances shown below.</p>
+        </div>
+        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/45">£10 fees added</div>
+          <div className="mt-3 text-3xl font-semibold text-white">{appliedPaymentFees}</div>
+          <p className="mt-2 text-sm text-white/50">Applied but still unpaid.</p>
+        </div>
+      </div>
+
+      <AdminCard className="space-y-5 rounded-3xl border border-red-400/20 bg-red-500/[0.04] p-5 md:p-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-red-100/70">Payment admin fees</p>
+            <h2 className="mt-3 text-2xl font-semibold text-white">Fees paid more than 7 days late</h2>
+            <p className="mt-2 max-w-3xl text-sm text-white/65">
+              Use this section to manually add the £10 admin fee to the existing outstanding charge, waive it, or send a warning decision. Applying the fee increases the outstanding balance and resets any stale Stripe checkout session.
+            </p>
+          </div>
+          <span className="rounded-2xl border border-red-400/25 bg-black/20 px-4 py-3 text-sm font-semibold text-red-100">
+            {paymentRows.length} charge{paymentRows.length === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {paymentRows.length === 0 ? <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-sm text-white/55">No payment charges are more than 7 days overdue.</div> : null}
+        <div className="space-y-4">
+          {paymentRows.map((row) => <PaymentLateFeeRowCard key={row.chargeId} row={row} />)}
+        </div>
+      </AdminCard>
+
       <AdminCard className="space-y-5 rounded-3xl border border-white/10 bg-white/[0.03] p-5 md:p-6">
-        {rows.length === 0 ? <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-sm text-white/55">No scheduled fixtures are inside the review window.</div> : null}
-        {rows.map((row) => (
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300/80">Fixture confirmation policy</p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">72-hour confirmation review</h2>
+          <p className="mt-2 max-w-3xl text-sm text-white/65">
+            Review teams that have not confirmed at least 72 hours before kick-off. Each row shows previous warnings, charges, waived decisions and late confirmations to help you decide fairly.
+          </p>
+        </div>
+        {confirmationRows.length === 0 ? <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-sm text-white/55">No scheduled fixtures are inside the review window.</div> : null}
+        {confirmationRows.map((row) => (
           <section key={row.fixtureId} id={`fixture-${row.fixtureId}`} className="scroll-mt-6 space-y-4 rounded-3xl border border-white/10 bg-black/20 p-4 md:p-5">
             <div className="border-b border-white/10 pb-4">
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/35">{row.leagueName ?? "No league"}{row.leagueSeason ? ` · ${row.leagueSeason}` : ""}</p>


### PR DESCRIPTION
Adds manual late payment admin fee controls to the existing Late Fees admin page.

Changes:
- Adds database fields for payment late fee status.
- Shows charges more than 7 days overdue.
- Lets admin add £10, waive, warn, or clear.
- Applying the fee updates the existing charge balance.

Testing: not run locally.