### PR TITLE
Add admin fee amounts and warnings

### DIFF
--- a/src/app/captain/team/[teamid]/guide/page.tsx
+++ b/src/app/captain/team/[teamid]/guide/page.tsx
@@ -46,7 +46,8 @@ const guideSections = [
     items: [
       "Availability should be confirmed at least 72 hours before kick-off.",
       "If there is a problem, raise it early through the fixture tools rather than waiting until matchday.",
-      "We do not want to charge admin fees, but a £10 late availability admin fee may be added if avoidable late confirmation creates extra admin, fixture chasing or rearranging work.",
+      "We do not want to charge admin fees, but a £10 late confirmation admin fee may be added if avoidable late confirmation creates extra admin, fixture chasing or rearranging work.",
+      "SIXFL may send reminders or warnings first where practical, but captains should not rely on a warning before acting.",
     ],
   },
   {
@@ -55,7 +56,7 @@ const guideSections = [
       "The standard team fee is £40 per fixture unless SIXFL has agreed otherwise.",
       "The captain remains responsible for the team fee even when squad payments are used.",
       "We do not want to charge late payment admin fees, but a £10 late payment admin fee may be added if a team fee is more than 7 days overdue and SIXFL has to spend extra time chasing it.",
-      "Payment issues should be raised early so they can be sorted before they become a problem.",
+      "Payment reminders or warnings may be sent first where practical, but payment issues should still be raised early so they can be sorted before they become a problem.",
     ],
   },
   {

--- a/src/app/captain/team/[teamid]/help/page.tsx
+++ b/src/app/captain/team/[teamid]/help/page.tsx
@@ -41,7 +41,7 @@ const sections: HelpSection[] = [
   },
   {
     id: "squad",
-    title: "Squad management",
+    title: "Squd management",
     intro: "Keep your squad list tidy so availability, matchday planning and player payment links work properly.",
     steps: [
       "Add each regular player to your squad.",
@@ -96,8 +96,9 @@ const sections: HelpSection[] = [
     title: "Avoidable admin fees",
     intro: "Admin fees are not normal weekly charges. SIXFL does not want to charge them. They are only there when avoidable late action creates extra admin work.",
     steps: [
-      "The late payment admin fee may be added if a team fee is more than 7 days overdue and SIXFL has to spend extra time chasing it.",
-      "The late availability admin fee may be added if avoidable late confirmation creates extra fixture chasing or rearranging work.",
+      "The late payment admin fee is £10. It may be added if a team fee is more than 7 days overdue and SIXFL has to spend extra time chasing it.",
+      "The late confirmation admin fee is £10. It may be added if avoidable late availability confirmation creates extra fixture chasing or rearranging work.",
+      "SIXFL may send reminders or warnings first where practical, but repeated or avoidable late action can still lead to the admin fee being added.",
       "You can avoid both by confirming availability on time and keeping team fees up to date.",
     ],
   },
@@ -109,7 +110,7 @@ const sections: HelpSection[] = [
       "Open Fixtures or Availability when your next game appears.",
       "Confirm the fixture if your team can play.",
       "Raise an issue early if you cannot play or are not sure.",
-      "Do not wait until matchday if there is a problem.",
+      "Do not wait until matchday if there is a problem. Avoidable late confirmation may lead to a £10 late confirmation admin fee.",
     ],
     example: {
       title: "Dummy availability example",

--- a/src/app/captain/team/[teamid]/help/page.tsx
+++ b/src/app/captain/team/[teamid]/help/page.tsx
@@ -41,7 +41,7 @@ const sections: HelpSection[] = [
   },
   {
     id: "squad",
-    title: "Squd management",
+    title: "Squad management",
     intro: "Keep your squad list tidy so availability, matchday planning and player payment links work properly.",
     steps: [
       "Add each regular player to your squad.",

--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -8,6 +8,7 @@ import { notFound } from "next/navigation";
 import { TeamRole } from "@prisma/client";
 
 import AdminPlayerPreviewLinks from "@/components/captain/AdminPlayerPreviewLinks";
+import CaptainAdminFeeRouteNotice from "@/components/captain/CaptainAdminFeeRouteNotice";
 import CaptainFixtureBadgesBridge from "@/components/captain/CaptainFixtureBadgesBridge";
 import CaptainMatchdayAvailabilityBadgesBridge from "@/components/captain/CaptainMatchdayAvailabilityBadgesBridge";
 import CaptainOnboardingReminderBridge from "@/components/captain/CaptainOnboardingReminderBridge";
@@ -394,6 +395,7 @@ export default async function CaptainTeamLayout({
         <main className="captain-team-main min-w-0 space-y-8">
           <CaptainSupportPanel teamId={team.id} />
           {children}
+          <CaptainAdminFeeRouteNotice teamId={team.id} />
         </main>
       </div>
     </div>

--- a/src/components/captain/CaptainAdminFeeRouteNotice.tsx
+++ b/src/components/captain/CaptainAdminFeeRouteNotice.tsx
@@ -1,0 +1,81 @@
+// ========================================
+// File: src/components/captain/CaptainAdminFeeRouteNotice.tsx
+// ========================================
+
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type NoticeContent = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  items: string[];
+};
+
+function getNoticeContent(pathname: string): NoticeContent | null {
+  if (/\/payments\/?$/.test(pathname)) {
+    return {
+      eyebrow: "Payment deadline reminder",
+      title: "Avoid the £10 late payment admin fee",
+      body: "Team fees need to be kept up to date. SIXFL does not want to add admin fees, but late payment can create extra chasing and admin work.",
+      items: [
+        "A £10 late payment admin fee may be added if a team fee is more than 7 days overdue.",
+        "Warnings or reminders may be sent before this is added where practical.",
+        "Use the payment ledger or squad payments to make sure the team fee is covered on time.",
+      ],
+    };
+  }
+
+  if (/\/availability\/?$/.test(pathname) || /\/fixtures\/?$/.test(pathname)) {
+    return {
+      eyebrow: "Availability deadline reminder",
+      title: "Avoid the £10 late confirmation admin fee",
+      body: "Availability should be confirmed at least 72 hours before kick-off so fixtures can be planned properly.",
+      items: [
+        "A £10 late confirmation admin fee may be added if avoidable late confirmation creates extra chasing, fixture admin or rearranging work.",
+        "Warnings or reminders may be sent before this is added where practical.",
+        "Confirm availability on time, or raise an issue early if there is a genuine problem.",
+      ],
+    };
+  }
+
+  return null;
+}
+
+export default function CaptainAdminFeeRouteNotice({ teamId }: { teamId: string }) {
+  const pathname = usePathname();
+  const content = getNoticeContent(pathname);
+
+  if (!content) return null;
+
+  return (
+    <section className="rounded-3xl border border-amber-400/25 bg-amber-500/10 p-5">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">
+            {content.eyebrow}
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">{content.title}</h2>
+          <p className="mt-2 max-w-4xl text-sm leading-6 text-amber-50/75">{content.body}</p>
+          <ul className="mt-4 space-y-2 text-sm leading-6 text-white/68">
+            {content.items.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-200" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <Link
+          href={`/captain/team/${teamId}/help#admin-fees`}
+          className="inline-flex shrink-0 items-center justify-center rounded-full border border-amber-300/25 bg-black/20 px-5 py-3 text-sm font-semibold text-amber-50 transition hover:bg-black/30"
+        >
+          Read admin fee guide
+        </Link>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Spell out the £10 late payment admin fee and £10 late confirmation admin fee in the captain help and guide pages.
- Add warning/reminder wording so captains know SIXFL may warn first where practical, but avoidable late action can still lead to the fee.
- Add a bottom-of-page notice on Team payments and Availability/Fixtures pages that links back to the admin fee guide.

## Notes
- Content/UI change only.
- No database reset, migration, or destructive changes.