### PR TITLE
Make support topic buttons update prompts

### DIFF
--- a/src/components/captain/CaptainSupportPanel.tsx
+++ b/src/components/captain/CaptainSupportPanel.tsx
@@ -17,19 +17,19 @@ type HelpContext = {
   options: string[];
 };
 
+type OptionPrompt = {
+  title: string;
+  helper: string;
+  placeholder: string;
+};
+
 function getContext(pathname: string): HelpContext | null {
   if (/\/player-payments\/?$/.test(pathname)) {
     return {
       topic: "Squad payments",
       title: "Need help with squad payments?",
       body: "Use this page to split the team fee between players and send secure payment links. Player links only work if player emails are saved.",
-      options: [
-        "How do squad payments work?",
-        "My player did not get a payment link",
-        "I need to change a player amount",
-        "A player has paid me directly",
-        "I still need help",
-      ],
+      options: ["How do squad payments work?", "My player did not get a payment link", "I need to change a player amount", "A player has paid me directly", "I still need help"],
     };
   }
 
@@ -38,13 +38,7 @@ function getContext(pathname: string): HelpContext | null {
       topic: "Fixture availability",
       title: "Need help with availability?",
       body: "Availability should be confirmed at least 72 hours before kick-off. If you cannot play or are unsure, raise it early so SIXFL can help.",
-      options: [
-        "I can confirm we can play",
-        "I am short of players",
-        "I need to raise an availability issue",
-        "I am not sure what to do",
-        "I still need help",
-      ],
+      options: ["I can confirm we can play", "I am short of players", "I need to raise an availability issue", "I am not sure what to do", "I still need help"],
     };
   }
 
@@ -53,13 +47,7 @@ function getContext(pathname: string): HelpContext | null {
       topic: "Results, scorers and Player of the Match",
       title: "Need help with results?",
       body: "Use this page to check scores, add scorers, add Player of the Match where available, or raise an issue if something is wrong.",
-      options: [
-        "The score is wrong",
-        "I need to add scorers",
-        "I need to add Player of the Match",
-        "I want to raise a result issue",
-        "I still need help",
-      ],
+      options: ["The score is wrong", "I need to add scorers", "I need to add Player of the Match", "I want to raise a result issue", "I still need help"],
     };
   }
 
@@ -68,13 +56,7 @@ function getContext(pathname: string): HelpContext | null {
       topic: "Matchday squad",
       title: "Need help with the matchday squad?",
       body: "Use this page to organise who is playing in a fixture and keep track of availability before matchday.",
-      options: [
-        "I need to pick the matchday squad",
-        "I have maybes or no responses",
-        "A player is missing",
-        "I am not sure what to do",
-        "I still need help",
-      ],
+      options: ["I need to pick the matchday squad", "I have maybes or no responses", "A player is missing", "I am not sure what to do", "I still need help"],
     };
   }
 
@@ -83,13 +65,7 @@ function getContext(pathname: string): HelpContext | null {
       topic: "Team payments",
       title: "Need help with team payments?",
       body: "The team payment ledger shows the actual team charges. Squad payments help you collect from players, but the captain remains responsible for the team fee being covered.",
-      options: [
-        "I do not understand the balance",
-        "A player has paid but the team still shows outstanding",
-        "I need a payment link",
-        "I have a payment problem",
-        "I still need help",
-      ],
+      options: ["I do not understand the balance", "A player has paid but the team still shows outstanding", "I need a payment link", "I have a payment problem", "I still need help"],
     };
   }
 
@@ -98,17 +74,51 @@ function getContext(pathname: string): HelpContext | null {
       topic: "Squad management",
       title: "Need help with your squad?",
       body: "Keep player names and emails up to date so availability, matchday planning and squad payment links work properly.",
-      options: [
-        "I need to add a player",
-        "I need to edit a player email",
-        "A player has left",
-        "A player is missing from payments",
-        "I still need help",
-      ],
+      options: ["I need to add a player", "I need to edit a player email", "A player has left", "A player is missing from payments", "I still need help"],
     };
   }
 
   return null;
+}
+
+function getOptionPrompt(option: string, context: HelpContext): OptionPrompt {
+  if (option.includes("payment") || option.includes("Payment") || option.includes("balance") || option.includes("paid")) {
+    return {
+      title: "Payment help selected",
+      helper: "Please include the fixture, the amount showing, who has paid and what looks wrong.",
+      placeholder: "Tell us which fixture/payment this relates to, what amount is showing, who has paid, and what needs checking.",
+    };
+  }
+
+  if (option.includes("Fixture") || option.includes("availability") || option.includes("short") || option.includes("confirm")) {
+    return {
+      title: "Fixture help selected",
+      helper: "Please include the fixture, whether you can play, and what support you need.",
+      placeholder: "Tell us which fixture this relates to, how many players you have available, and what you need help with.",
+    };
+  }
+
+  if (option.includes("Squad") || option.includes("player") || option.includes("Player") || option.includes("email")) {
+    return {
+      title: "Squad or player help selected",
+      helper: "Please include the player name, email if relevant, and what needs adding, editing or checking.",
+      placeholder: "Tell us which player this relates to, what the issue is, and what needs changing.",
+    };
+  }
+
+  if (option.includes("score") || option.includes("result") || option.includes("scorers") || option.includes("Match")) {
+    return {
+      title: "Result help selected",
+      helper: "Please include the fixture, score, scorer details or Player of the Match issue.",
+      placeholder: "Tell us which fixture this relates to, what the correct result/details should be, and what needs fixing.",
+    };
+  }
+
+  return {
+    title: `Selected: ${option}`,
+    helper: `Your message will be sent as ${context.topic} - ${option}.`,
+    placeholder: "Tell us what has happened, what you are stuck with, and what you need SIXFL to do.",
+  };
 }
 
 function isOverview(pathname: string, teamId: string) {
@@ -120,7 +130,7 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
   const searchParams = useSearchParams();
   const context = useMemo(() => getContext(pathname), [pathname]);
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState("I still need help");
+  const [selectedOption, setSelectedOption] = useState("Fixture issue");
 
   const sent = searchParams.get("support") === "sent";
   const missingMessage = searchParams.get("support") === "missing-message";
@@ -128,29 +138,19 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
   if (isOverview(pathname, teamId)) {
     return (
       <section className="grid gap-4 md:grid-cols-3">
-        <Link
-          href={`/captain/team/${teamId}/help`}
-          className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5 transition hover:bg-emerald-500/15"
-        >
+        <Link href={`/captain/team/${teamId}/help`} className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5 transition hover:bg-emerald-500/15">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/70">How-to help</p>
           <h2 className="mt-3 text-xl font-semibold text-white">How to use the captain area</h2>
           <p className="mt-2 text-sm leading-6 text-emerald-50/72">Step-by-step help for squad payments, availability, results, scorers and Player of the Match.</p>
         </Link>
 
-        <Link
-          href={`/captain/team/${teamId}/guide`}
-          className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 transition hover:border-white/20 hover:bg-white/[0.07]"
-        >
+        <Link href={`/captain/team/${teamId}/guide`} className="rounded-3xl border border-white/10 bg-white/[0.04] p-5 transition hover:border-white/20 hover:bg-white/[0.07]">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Rules</p>
           <h2 className="mt-3 text-xl font-semibold text-white">Rules and responsibilities</h2>
           <p className="mt-2 text-sm leading-6 text-white/62">Captain agreement, availability deadlines, payments, conduct and avoidable admin fees.</p>
         </Link>
 
-        <button
-          type="button"
-          onClick={() => setIsOpen((value) => !value)}
-          className="rounded-3xl border border-sky-400/20 bg-sky-500/10 p-5 text-left transition hover:bg-sky-500/15"
-        >
+        <button type="button" onClick={() => setIsOpen((value) => !value)} className="rounded-3xl border border-sky-400/20 bg-sky-500/10 p-5 text-left transition hover:bg-sky-500/15">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-100/70">Support</p>
           <h2 className="mt-3 text-xl font-semibold text-white">Contact SIXFL</h2>
           <p className="mt-2 text-sm leading-6 text-sky-50/72">Ask for help with a fixture, payment, squad issue, result or anything else.</p>
@@ -181,11 +181,7 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
   return (
     <section className="rounded-3xl border border-sky-400/20 bg-sky-500/10 p-5">
       {sent ? <SuccessNotice /> : null}
-      {missingMessage ? (
-        <div className="mb-4 rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">
-          Please add a short message before sending your request.
-        </div>
-      ) : null}
+      {missingMessage ? <div className="mb-4 rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">Please add a short message before sending your request.</div> : null}
 
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
@@ -193,73 +189,38 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
           <h2 className="mt-2 text-xl font-semibold text-white">{context.title}</h2>
           <p className="mt-2 max-w-4xl text-sm leading-6 text-sky-50/72">{context.body}</p>
         </div>
-        <button
-          type="button"
-          onClick={() => setIsOpen((value) => !value)}
-          className="inline-flex items-center justify-center rounded-full border border-sky-300/25 bg-sky-400/10 px-5 py-3 text-sm font-semibold text-sky-50 transition hover:bg-sky-400/15"
-        >
+        <button type="button" onClick={() => setIsOpen((value) => !value)} className="inline-flex items-center justify-center rounded-full border border-sky-300/25 bg-sky-400/10 px-5 py-3 text-sm font-semibold text-sky-50 transition hover:bg-sky-400/15">
           {isOpen ? "Close help" : "Open help"}
         </button>
       </div>
 
-      {isOpen ? (
-        <SupportForm
-          teamId={teamId}
-          pathname={pathname}
-          context={context}
-          selectedOption={selectedOption}
-          setSelectedOption={setSelectedOption}
-        />
-      ) : null}
+      {isOpen ? <SupportForm teamId={teamId} pathname={pathname} context={context} selectedOption={selectedOption} setSelectedOption={setSelectedOption} /> : null}
     </section>
   );
 }
 
 function SuccessNotice() {
-  return (
-    <div className="mb-4 rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
-      Thanks — your message has been sent to SIXFL. We’ll review it and get back to you.
-    </div>
-  );
+  return <div className="mb-4 rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">Thanks — your message has been sent to SIXFL. We’ll review it and get back to you.</div>;
 }
 
-function SupportForm({
-  teamId,
-  pathname,
-  context,
-  selectedOption,
-  setSelectedOption,
-}: {
-  teamId: string;
-  pathname: string;
-  context: HelpContext;
-  selectedOption: string;
-  setSelectedOption: (value: string) => void;
-}) {
+function SupportForm({ teamId, pathname, context, selectedOption, setSelectedOption }: { teamId: string; pathname: string; context: HelpContext; selectedOption: string; setSelectedOption: (value: string) => void }) {
+  const activeOption = context.options.includes(selectedOption) ? selectedOption : context.options[0] ?? "Other";
+  const prompt = getOptionPrompt(activeOption, context);
+
   return (
     <form action={sendCaptainSupportRequestAction} className="mt-5 space-y-4 rounded-2xl border border-white/10 bg-black/25 p-4">
       <input type="hidden" name="teamId" value={teamId} />
       <input type="hidden" name="pagePath" value={pathname} />
       <input type="hidden" name="topic" value={context.topic} />
-      <input type="hidden" name="quickOption" value={selectedOption} />
+      <input type="hidden" name="quickOption" value={activeOption} />
 
       <div>
         <p className="text-sm font-semibold text-white">What do you need help with?</p>
         <div className="mt-3 flex flex-wrap gap-2">
           {context.options.map((option) => {
-            const active = option === selectedOption;
+            const active = option === activeOption;
             return (
-              <button
-                key={option}
-                type="button"
-                onClick={() => setSelectedOption(option)}
-                className={[
-                  "rounded-full border px-3 py-2 text-xs font-semibold transition",
-                  active
-                    ? "border-sky-300/40 bg-sky-400/20 text-sky-50"
-                    : "border-white/10 bg-white/[0.04] text-white/65 hover:border-white/20 hover:bg-white/[0.07] hover:text-white",
-                ].join(" ")}
-              >
+              <button key={option} type="button" onClick={() => setSelectedOption(option)} className={["rounded-full border px-3 py-2 text-xs font-semibold transition", active ? "border-sky-300/40 bg-sky-400/20 text-sky-50" : "border-white/10 bg-white/[0.04] text-white/65 hover:border-white/20 hover:bg-white/[0.07] hover:text-white"].join(" ")}>
                 {option}
               </button>
             );
@@ -267,25 +228,19 @@ function SupportForm({
         </div>
       </div>
 
+      <div className="rounded-2xl border border-sky-300/15 bg-sky-400/10 p-4">
+        <p className="text-sm font-semibold text-sky-50">{prompt.title}</p>
+        <p className="mt-1 text-sm leading-6 text-sky-50/70">{prompt.helper}</p>
+      </div>
+
       <label className="block">
         <span className="text-sm font-semibold text-white">Message to SIXFL</span>
-        <textarea
-          name="message"
-          required
-          rows={4}
-          placeholder="Tell us what has happened or what you are stuck with."
-          className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none transition placeholder:text-white/35 focus:border-sky-300/40 focus:bg-black/40"
-        />
+        <textarea name="message" required rows={4} placeholder={prompt.placeholder} className="mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none transition placeholder:text-white/35 focus:border-sky-300/40 focus:bg-black/40" />
       </label>
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-xs leading-5 text-white/45">Your team, page and selected help topic will be included automatically.</p>
-        <button
-          type="submit"
-          className="inline-flex items-center justify-center rounded-full bg-sky-300 px-5 py-3 text-sm font-bold text-black transition hover:bg-sky-200"
-        >
-          Send to SIXFL
-        </button>
+        <button type="submit" className="inline-flex items-center justify-center rounded-full bg-sky-300 px-5 py-3 text-sm font-bold text-black transition hover:bg-sky-200">Send to SIXFL</button>
       </div>
     </form>
   );


### PR DESCRIPTION
Summary:
- Makes the support topic buttons feel active by changing the guidance text and textarea placeholder for the selected topic.
- Defaults the overview support form to Fixture issue.
- Sends the selected quick option reliably even when the selected state was from another page.

Result:
Clicking Fixture issue, Payment question, Squad/player issue, Result issue or Other now updates the message guidance instead of appearing to do nothing.