### PR TITLE
[codex] Add team credit pot for squad overpayments

### DIFF
--- a/prisma/migrations/20260702162500_add_team_credit_pot/migration.sql
+++ b/prisma/migrations/20260702162500_add_team_credit_pot/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "TeamCreditPotEntry" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "amountPence" INTEGER NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT NOT NULL,
+    "fixtureId" TEXT,
+    "chargeId" TEXT,
+    "description" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TeamCreditPotEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamCreditPotEntry_sourceType_sourceId_key" ON "TeamCreditPotEntry"("sourceType", "sourceId");
+
+-- CreateIndex
+CREATE INDEX "TeamCreditPotEntry_teamId_idx" ON "TeamCreditPotEntry"("teamId");
+
+-- CreateIndex
+CREATE INDEX "TeamCreditPotEntry_fixtureId_idx" ON "TeamCreditPotEntry"("fixtureId");
+
+-- CreateIndex
+CREATE INDEX "TeamCreditPotEntry_chargeId_idx" ON "TeamCreditPotEntry"("chargeId");
+
+-- CreateIndex
+CREATE INDEX "TeamCreditPotEntry_createdAt_idx" ON "TeamCreditPotEntry"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "TeamCreditPotEntry" ADD CONSTRAINT "TeamCreditPotEntry_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamCreditPotEntry" ADD CONSTRAINT "TeamCreditPotEntry_fixtureId_fkey" FOREIGN KEY ("fixtureId") REFERENCES "Fixture"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamCreditPotEntry" ADD CONSTRAINT "TeamCreditPotEntry_chargeId_fkey" FOREIGN KEY ("chargeId") REFERENCES "PaymentCharge"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/app/(admin)/admin/payments/team-pot/page.tsx
+++ b/src/app/(admin)/admin/payments/team-pot/page.tsx
@@ -1,0 +1,119 @@
+// ========================================
+// File: src/app/(admin)/admin/payments/team-pot/page.tsx
+// ========================================
+
+import Link from "next/link";
+
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Team Pots | SIXFL",
+};
+
+type TeamPotSummaryRow = {
+  teamId: string;
+  teamName: string;
+  leagueName: string | null;
+  leagueSeason: string | null;
+  balancePence: number | bigint | null;
+  entryCount: number | bigint;
+  lastEntryAt: Date | null;
+};
+
+type TeamPotEntryRow = {
+  id: string;
+  teamName: string;
+  amountPence: number | bigint;
+  sourceType: string;
+  description: string;
+  kickoffAt: Date | null;
+  createdAt: Date;
+};
+
+function toNumber(value: number | bigint | null | undefined) {
+  if (typeof value === "bigint") return Number(value);
+  return value ?? 0;
+}
+
+function formatMoney(amountPence: number) {
+  return new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(amountPence / 100);
+}
+
+function formatDate(value: Date | null) {
+  if (!value) return "No fixture date";
+  return formatDateTimeInLondon(value, { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function getLeagueLabel(row: TeamPotSummaryRow) {
+  return [row.leagueName, row.leagueSeason].filter(Boolean).join(" · ") || "No league linked";
+}
+
+export default async function AdminTeamPotPage() {
+  await requireAdmin();
+
+  const [teamRows, recentEntries] = await Promise.all([
+    prisma.$queryRaw<TeamPotSummaryRow[]>`
+      SELECT t."id" AS "teamId", t."name" AS "teamName", l."name" AS "leagueName", l."season" AS "leagueSeason", COALESCE(SUM(e."amountPence"), 0) AS "balancePence", COUNT(e."id") AS "entryCount", MAX(e."createdAt") AS "lastEntryAt"
+      FROM "Team" t
+      LEFT JOIN "League" l ON l."id" = t."leagueId"
+      LEFT JOIN "TeamCreditPotEntry" e ON e."teamId" = t."id"
+      GROUP BY t."id", t."name", l."name", l."season"
+      HAVING COALESCE(SUM(e."amountPence"), 0) <> 0
+      ORDER BY COALESCE(SUM(e."amountPence"), 0) DESC, t."name" ASC
+    `,
+    prisma.$queryRaw<TeamPotEntryRow[]>`
+      SELECT e."id", t."name" AS "teamName", e."amountPence", e."sourceType", e."description", f."kickoffAt", e."createdAt"
+      FROM "TeamCreditPotEntry" e
+      INNER JOIN "Team" t ON t."id" = e."teamId"
+      LEFT JOIN "Fixture" f ON f."id" = e."fixtureId"
+      ORDER BY e."createdAt" DESC
+      LIMIT 50
+    `,
+  ]);
+
+  const totalPotPence = teamRows.reduce((sum, row) => sum + toNumber(row.balancePence), 0);
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-8 px-6 py-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">Team pots</p>
+          <h1 className="text-3xl font-semibold text-white">Overpayment credit pots</h1>
+          <p className="max-w-3xl text-sm text-white/60">Squad payment overpayments are kept as team credit entries. This keeps the original player payments intact while making surplus money visible for future admin decisions.</p>
+        </div>
+        <Link href="/admin/payments" className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/75 transition hover:bg-white/10">Back to payments</Link>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5"><div className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-100/70">Total in pots</div><div className="mt-3 text-3xl font-semibold text-white">{formatMoney(totalPotPence)}</div><p className="mt-2 text-sm text-emerald-100/70">Current credit balance across teams.</p></div>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-5"><div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/45">Teams with credit</div><div className="mt-3 text-3xl font-semibold text-white">{teamRows.length}</div><p className="mt-2 text-sm text-white/50">Only non-zero balances are shown.</p></div>
+        <div className="rounded-3xl border border-sky-400/20 bg-sky-500/10 p-5"><div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-100/70">Recent entries</div><div className="mt-3 text-3xl font-semibold text-white">{recentEntries.length}</div><p className="mt-2 text-sm text-sky-100/70">Latest pot movements shown below.</p></div>
+      </div>
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+        <h2 className="text-xl font-semibold text-white">Team balances</h2>
+        <div className="mt-4 space-y-3">
+          {teamRows.length === 0 ? <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-6 text-sm text-white/55">No team pot balances yet.</div> : null}
+          {teamRows.map((row) => {
+            const balancePence = toNumber(row.balancePence);
+            const entryCount = toNumber(row.entryCount);
+            return <div key={row.teamId} className="rounded-2xl border border-white/10 bg-[#0d1428] p-4"><div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"><div><div className="text-base font-semibold text-white">{row.teamName}</div><div className="mt-1 text-sm text-white/50">{getLeagueLabel(row)}</div><div className="mt-2 text-xs text-white/35">{entryCount} pot entr{entryCount === 1 ? "y" : "ies"} · latest {formatDate(row.lastEntryAt)}</div></div><div className="text-left sm:text-right"><div className="text-2xl font-semibold text-emerald-100">{formatMoney(balancePence)}</div><div className="mt-1 text-xs uppercase tracking-[0.14em] text-white/40">Credit balance</div></div></div></div>;
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+        <h2 className="text-xl font-semibold text-white">Recent pot entries</h2>
+        <div className="mt-4 space-y-3">
+          {recentEntries.length === 0 ? <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-6 text-sm text-white/55">No pot entries have been recorded yet.</div> : null}
+          {recentEntries.map((entry) => <div key={entry.id} className="rounded-2xl border border-white/10 bg-[#0d1428] p-4"><div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"><div><div className="font-semibold text-white">{entry.teamName}</div><div className="mt-1 text-sm text-white/55">{entry.description}</div><div className="mt-2 flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-[0.14em]"><span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-white/45">{entry.sourceType.replaceAll("_", " ")}</span><span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-white/45">{formatDate(entry.kickoffAt)}</span></div></div><div className="text-left sm:text-right"><div className="text-xl font-semibold text-emerald-100">{formatMoney(toNumber(entry.amountPence))}</div><div className="mt-1 text-xs text-white/40">Added {formatDate(entry.createdAt)}</div></div></div></div>)}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/payments/player-match-fee-reconciliation.ts
+++ b/src/lib/payments/player-match-fee-reconciliation.ts
@@ -95,12 +95,14 @@ export async function reconcileFixtureChargeFromPlayerPayments(input: {
   if (paidTotalPence <= 0) return null;
 
   const fixtureDateKey = getLondonDateKey(fixture.kickoffAt);
-  const openStatuses: PaymentChargeStatus[] = ["OPEN", "PART_PAID"];
+  const chargeStatuses = Object.values(PaymentChargeStatus).filter(
+    (status) => status !== PaymentChargeStatus.VOID,
+  );
 
   const charges = await prisma.paymentCharge.findMany({
     where: {
       teamId: input.teamId,
-      status: { in: openStatuses },
+      status: { in: chargeStatuses },
       OR: [
         { fixtureId: input.fixtureId },
         ...(fixtureDateKey ? [{ dueDate: { not: null } }] : []),

--- a/src/lib/payments/player-match-fee-reconciliation.ts
+++ b/src/lib/payments/player-match-fee-reconciliation.ts
@@ -6,6 +6,7 @@ import { PaymentChargeStatus } from "@prisma/client";
 
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
 import { cancelQueuedMatchFeeNotificationDispatches } from "@/lib/payments/fixture-match-fees";
+import { syncFixtureOverpaymentCredit } from "@/lib/payments/team-credit-pot";
 import { prisma } from "@/lib/prisma";
 
 function getLondonDateKey(value: Date | null | undefined) {
@@ -24,6 +25,18 @@ function appendCoveredNote(description: string | null, paidTotalPence: number) {
 
   if (!cleaned) return note;
   if (cleaned.includes("Covered by player payments")) return cleaned;
+
+  return `${cleaned}\n${note}`;
+}
+
+function appendOverpaymentNote(description: string | null, overpaymentPence: number) {
+  if (overpaymentPence <= 0) return description;
+
+  const note = `Overpayment of £${(overpaymentPence / 100).toFixed(2)} added to team pot.`;
+  const cleaned = description?.trim();
+
+  if (!cleaned) return note;
+  if (cleaned.includes("added to team pot")) return cleaned;
 
   return `${cleaned}\n${note}`;
 }
@@ -108,11 +121,31 @@ export async function reconcileFixtureChargeFromPlayerPayments(input: {
     charges.find((charge) => getLondonDateKey(charge.dueDate) === fixtureDateKey) ??
     null;
 
-  if (!matchingCharge || paidTotalPence < matchingCharge.amountPence) {
+  if (!matchingCharge) {
     return {
-      chargeId: matchingCharge?.id ?? null,
+      chargeId: null,
       paidTotalPence,
       covered: false,
+      overpaymentPence: 0,
+    };
+  }
+
+  const overpaymentPence = Math.max(paidTotalPence - matchingCharge.amountPence, 0);
+
+  await syncFixtureOverpaymentCredit({
+    teamId: input.teamId,
+    fixtureId: input.fixtureId,
+    chargeId: matchingCharge.id,
+    paidTotalPence,
+    chargeAmountPence: matchingCharge.amountPence,
+  });
+
+  if (paidTotalPence < matchingCharge.amountPence) {
+    return {
+      chargeId: matchingCharge.id,
+      paidTotalPence,
+      covered: false,
+      overpaymentPence,
     };
   }
 
@@ -125,7 +158,10 @@ export async function reconcileFixtureChargeFromPlayerPayments(input: {
     where: { id: matchingCharge.id },
     data: {
       status: "PAID",
-      description: appendCoveredNote(matchingCharge.description, paidTotalPence),
+      description: appendOverpaymentNote(
+        appendCoveredNote(matchingCharge.description, paidTotalPence),
+        overpaymentPence,
+      ),
     },
   });
 
@@ -135,5 +171,6 @@ export async function reconcileFixtureChargeFromPlayerPayments(input: {
     chargeId: matchingCharge.id,
     paidTotalPence,
     covered: true,
+    overpaymentPence,
   };
 }

--- a/src/lib/payments/team-credit-pot.ts
+++ b/src/lib/payments/team-credit-pot.ts
@@ -1,0 +1,78 @@
+// ========================================
+// File: src/lib/payments/team-credit-pot.ts
+// ========================================
+
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@/lib/prisma";
+
+export const TEAM_CREDIT_SOURCE_PLAYER_OVERPAYMENT = "PLAYER_MATCH_FEE_OVERPAYMENT";
+
+function formatMoney(amountPence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(amountPence / 100);
+}
+
+export async function syncFixtureOverpaymentCredit(input: {
+  teamId: string;
+  fixtureId: string;
+  chargeId: string;
+  paidTotalPence: number;
+  chargeAmountPence: number;
+}) {
+  const surplusPence = Math.max(input.paidTotalPence - input.chargeAmountPence, 0);
+  const sourceId = `${input.teamId}:${input.fixtureId}`;
+
+  if (surplusPence <= 0) {
+    await prisma.$executeRaw`
+      DELETE FROM "TeamCreditPotEntry"
+      WHERE "sourceType" = ${TEAM_CREDIT_SOURCE_PLAYER_OVERPAYMENT}
+        AND "sourceId" = ${sourceId}
+    `;
+
+    return { surplusPence: 0 };
+  }
+
+  const description = [
+    "Squad payment overpayment added to team pot.",
+    `Players paid ${formatMoney(input.paidTotalPence)} against a ${formatMoney(input.chargeAmountPence)} team fee.`,
+  ].join(" ");
+
+  await prisma.$executeRaw`
+    INSERT INTO "TeamCreditPotEntry" (
+      "id",
+      "teamId",
+      "amountPence",
+      "sourceType",
+      "sourceId",
+      "fixtureId",
+      "chargeId",
+      "description",
+      "createdAt",
+      "updatedAt"
+    )
+    VALUES (
+      ${randomUUID()},
+      ${input.teamId},
+      ${surplusPence},
+      ${TEAM_CREDIT_SOURCE_PLAYER_OVERPAYMENT},
+      ${sourceId},
+      ${input.fixtureId},
+      ${input.chargeId},
+      ${description},
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT ("sourceType", "sourceId") DO UPDATE SET
+      "teamId" = EXCLUDED."teamId",
+      "amountPence" = EXCLUDED."amountPence",
+      "fixtureId" = EXCLUDED."fixtureId",
+      "chargeId" = EXCLUDED."chargeId",
+      "description" = EXCLUDED."description",
+      "updatedAt" = NOW()
+  `;
+
+  return { surplusPence };
+}


### PR DESCRIPTION
## Summary

- Adds a `TeamCreditPotEntry` ledger table for team overpayment credits.
- Records squad/player match fee surplus into the team pot during player-payment reconciliation.
- Adds `/admin/payments/team-pot` so admins can see total pot balances, teams with credit, and recent pot entries.

## Behaviour

For a £40 team fee where players pay £42 in total, the related team charge is marked paid as before and the extra £2 is stored as a team pot credit entry. The entry is keyed by team + fixture source so reconciliation is idempotent and does not duplicate the same overpayment.

## Notes

This PR stores and displays the pot. It does not automatically spend the pot against future charges yet; that can be added as a separate follow-up once you decide whether credits should auto-deduct or be manually applied by admin.

## Validation

- Compared branch against `main` and confirmed the intended files only are changed.
- No local build was run in this environment.