### PR TITLE
Gate team match fees until match day

### DIFF
--- a/src/app/captain/team/[teamid]/payments/page.tsx
+++ b/src/app/captain/team/[teamid]/payments/page.tsx
@@ -126,6 +126,8 @@ function getSubscriptionMessage(state?: string) {
       return "Automatic payments are not configured yet. Ask an admin to add the Stripe subscription price ID.";
     case "missing_customer":
       return "A Stripe customer has not been created for this team yet.";
+    case "no_fixture":
+      return "Automatic payments can be set up once this team has a published upcoming match-fee fixture.";
     default:
       return null;
   }

--- a/src/app/captain/team/[teamid]/payments/page.tsx
+++ b/src/app/captain/team/[teamid]/payments/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { isMatchFeeChargePayable } from "@/lib/payments/match-day-billing";
 import {
   formatPaymentFixtureDate,
   formatPaymentMoney,
@@ -327,11 +328,13 @@ export default async function CaptainPaymentsPage({
             </div>
           ) : (
             ledger.entries.map((entry) => {
+              const isPayableOnMatchDay = isMatchFeeChargePayable(entry.dueDate);
               const canPayOnline =
                 Boolean(entry.paymentToken) &&
                 entry.displayStatus !== "PAID" &&
                 entry.displayStatus !== "VOID" &&
-                entry.outstandingPence > 0;
+                entry.outstandingPence > 0 &&
+                isPayableOnMatchDay;
               const context = [entry.leagueName, entry.leagueSeason, entry.divisionName]
                 .filter(Boolean)
                 .join(" · ");
@@ -415,7 +418,9 @@ export default async function CaptainPaymentsPage({
                         entry.displayStatus !== "VOID" &&
                         entry.outstandingPence > 0 ? (
                         <div className="text-xs text-white/45">
-                          Online payment link not ready yet.
+                          {isPayableOnMatchDay
+                            ? "Online payment link not ready yet."
+                            : "Payment opens on match day."}
                         </div>
                       ) : null}
                     </div>

--- a/src/app/captain/team/[teamid]/payments/start-subscription/route.ts
+++ b/src/app/captain/team/[teamid]/payments/start-subscription/route.ts
@@ -43,7 +43,7 @@ export async function POST(
     return NextResponse.redirect(buildReturnUrl(teamid, "missing_price"), 303);
   }
 
-  const [team, subscription, nextFixture] = await Promise.all([
+  const [team, subscription, nextCharge] = await Promise.all([
     prisma.team.findUnique({
       where: { id: teamid },
       select: {
@@ -61,16 +61,15 @@ export async function POST(
       },
     }),
     getTeamSubscriptionSnapshot(teamid),
-    prisma.fixture.findFirst({
+    prisma.paymentCharge.findFirst({
       where: {
-        publishedAt: { not: null },
-        status: "SCHEDULED",
-        matchFeePence: { gt: 0 },
-        kickoffAt: { gte: new Date() },
-        OR: [{ homeTeamId: teamid }, { awayTeamId: teamid }],
+        teamId: teamid,
+        fixtureId: { not: null },
+        status: { not: "VOID" },
+        dueDate: { gte: new Date() },
       },
-      orderBy: { kickoffAt: "asc" },
-      select: { kickoffAt: true },
+      orderBy: { dueDate: "asc" },
+      select: { dueDate: true },
     }),
   ]);
 
@@ -82,7 +81,7 @@ export async function POST(
     return NextResponse.redirect(buildReturnUrl(teamid, "active"), 303);
   }
 
-  if (!nextFixture) {
+  if (!nextCharge?.dueDate) {
     return NextResponse.redirect(buildReturnUrl(teamid, "no_fixture"), 303);
   }
 
@@ -94,7 +93,7 @@ export async function POST(
   const description = team.league?.name
     ? `${team.name} · ${team.league.name}${team.league.season ? ` ${team.league.season}` : ""}`
     : team.name;
-  const subscriptionStartsAt = getMatchFeePaymentRequestScheduledFor(nextFixture.kickoffAt);
+  const subscriptionStartsAt = getMatchFeePaymentRequestScheduledFor(nextCharge.dueDate);
   const trialEnd =
     subscriptionStartsAt.getTime() > Date.now() + 5 * 60 * 1000
       ? Math.floor(subscriptionStartsAt.getTime() / 1000)

--- a/src/app/captain/team/[teamid]/payments/start-subscription/route.ts
+++ b/src/app/captain/team/[teamid]/payments/start-subscription/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from "next/server";
 
+import { getMatchFeePaymentRequestScheduledFor } from "@/lib/payments/match-day-billing";
 import {
   getTeamSubscriptionPriceId,
   getTeamSubscriptionSnapshot,
@@ -14,7 +15,10 @@ import { getPublicSiteUrl, getStripeServerClient } from "@/lib/stripe/client";
 
 export const dynamic = "force-dynamic";
 
-function buildReturnUrl(teamId: string, state: "success" | "cancelled" | "active" | "missing_price") {
+function buildReturnUrl(
+  teamId: string,
+  state: "success" | "cancelled" | "active" | "missing_price" | "no_fixture",
+) {
   const url = new URL(`/captain/team/${teamId}/payments`, `${getPublicSiteUrl()}/`);
   url.searchParams.set("subscription", state);
   return url.toString();
@@ -39,7 +43,7 @@ export async function POST(
     return NextResponse.redirect(buildReturnUrl(teamid, "missing_price"), 303);
   }
 
-  const [team, subscription] = await Promise.all([
+  const [team, subscription, nextFixture] = await Promise.all([
     prisma.team.findUnique({
       where: { id: teamid },
       select: {
@@ -57,6 +61,17 @@ export async function POST(
       },
     }),
     getTeamSubscriptionSnapshot(teamid),
+    prisma.fixture.findFirst({
+      where: {
+        publishedAt: { not: null },
+        status: "SCHEDULED",
+        matchFeePence: { gt: 0 },
+        kickoffAt: { gte: new Date() },
+        OR: [{ homeTeamId: teamid }, { awayTeamId: teamid }],
+      },
+      orderBy: { kickoffAt: "asc" },
+      select: { kickoffAt: true },
+    }),
   ]);
 
   if (!team) {
@@ -67,6 +82,10 @@ export async function POST(
     return NextResponse.redirect(buildReturnUrl(teamid, "active"), 303);
   }
 
+  if (!nextFixture) {
+    return NextResponse.redirect(buildReturnUrl(teamid, "no_fixture"), 303);
+  }
+
   const stripe = getStripeServerClient();
   const returnUrl = buildReturnUrl(teamid, "success");
   const cancelUrl = buildReturnUrl(teamid, "cancelled");
@@ -75,6 +94,11 @@ export async function POST(
   const description = team.league?.name
     ? `${team.name} · ${team.league.name}${team.league.season ? ` ${team.league.season}` : ""}`
     : team.name;
+  const subscriptionStartsAt = getMatchFeePaymentRequestScheduledFor(nextFixture.kickoffAt);
+  const trialEnd =
+    subscriptionStartsAt.getTime() > Date.now() + 5 * 60 * 1000
+      ? Math.floor(subscriptionStartsAt.getTime() / 1000)
+      : undefined;
 
   const session = await stripe.checkout.sessions.create({
     mode: "subscription",
@@ -102,6 +126,7 @@ export async function POST(
         teamName: team.name,
       },
       description,
+      ...(trialEnd ? { trial_end: trialEnd } : {}),
     },
   });
 

--- a/src/app/pay/charge/[token]/page.tsx
+++ b/src/app/pay/charge/[token]/page.tsx
@@ -10,6 +10,7 @@ import {
   getChargeOutstandingPence,
   getChargePaidTotal,
 } from "@/lib/payments/charge-status";
+import { isMatchFeeChargePayable } from "@/lib/payments/match-day-billing";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
@@ -97,10 +98,12 @@ export default async function PayChargePage({
   const fixturesHref = charge.fixture?.league?.slug
     ? `/leagues/${charge.fixture.league.slug}/fixtures`
     : "/";
+  const isPayableOnMatchDay = isMatchFeeChargePayable(charge.dueDate);
   const canPay =
     charge.status !== "VOID" &&
     outstandingPence > 0 &&
-    Boolean(charge.paymentToken);
+    Boolean(charge.paymentToken) &&
+    isPayableOnMatchDay;
 
   return (
     <div className="min-h-screen bg-[#050816] px-4 py-10 text-white sm:px-6 lg:px-8">
@@ -180,6 +183,10 @@ export default async function PayChargePage({
             ) : charge.status === "VOID" ? (
               <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-4 text-sm text-amber-100">
                 This payment request is no longer active.
+              </div>
+            ) : !isPayableOnMatchDay ? (
+              <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-4 text-sm text-amber-100">
+                This payment will be available on match day.
               </div>
             ) : (
               <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 px-4 py-4 text-sm text-emerald-100">

--- a/src/app/pay/charge/[token]/start/route.ts
+++ b/src/app/pay/charge/[token]/start/route.ts
@@ -8,6 +8,7 @@ import {
   getChargeOutstandingPence,
   getChargePaidTotal,
 } from "@/lib/payments/charge-status";
+import { isMatchFeeChargePayable } from "@/lib/payments/match-day-billing";
 import { prisma } from "@/lib/prisma";
 import { getPublicSiteUrl, getStripeServerClient } from "@/lib/stripe/client";
 
@@ -16,7 +17,7 @@ export const dynamic = "force-dynamic";
 function buildReturnPath(input: {
   leagueSlug: string | null;
   paymentToken: string;
-  state: "success" | "cancelled" | "already_paid" | "not_available";
+  state: "success" | "cancelled" | "already_paid" | "not_available" | "not_due";
 }) {
   const path = input.leagueSlug ? `/leagues/${input.leagueSlug}/fixtures` : "/";
   const url = new URL(path, `${getPublicSiteUrl()}/`);
@@ -79,6 +80,17 @@ export async function POST(
         leagueSlug: charge.fixture?.league?.slug ?? null,
         paymentToken: token,
         state: "not_available",
+      }),
+      303,
+    );
+  }
+
+  if (!isMatchFeeChargePayable(charge.dueDate)) {
+    return NextResponse.redirect(
+      buildReturnPath({
+        leagueSlug: charge.fixture?.league?.slug ?? null,
+        paymentToken: token,
+        state: "not_due",
       }),
       303,
     );

--- a/src/lib/payments/fixture-match-fees.ts
+++ b/src/lib/payments/fixture-match-fees.ts
@@ -17,6 +17,7 @@ import {
   getChargePaidTotal,
   getChargeStatusFromAmounts,
 } from "@/lib/payments/charge-status";
+import { getMatchFeePaymentRequestScheduledFor } from "@/lib/payments/match-day-billing";
 
 type FixtureMatchFeeTeam = {
   id: string;
@@ -483,6 +484,7 @@ export async function queueFixtureMatchFeeEmails(
   });
 
   const shouldQueueInitialRequest = input.mode !== "reminders_only";
+  const initialRequestScheduledFor = getMatchFeePaymentRequestScheduledFor(input.kickoffAt);
 
   let requestQueued = 0;
   let requestSkipped = 0;
@@ -504,6 +506,7 @@ export async function queueFixtureMatchFeeEmails(
           recipientId: recipient.id,
           sourceType: "FIXTURE_MATCH_FEE",
           sourceId: charge.id,
+          scheduledFor: initialRequestScheduledFor,
           metadata: {
             kind: "fixture_match_fee_request",
             chargeId: charge.id,
@@ -542,6 +545,7 @@ export async function queueFixtureMatchFeeEmails(
         recipientId: recipient.id,
         sourceType: "FIXTURE_MATCH_FEE",
         sourceId: charge.id,
+        scheduledFor: initialRequestScheduledFor,
         metadata: {
           kind: "fixture_match_fee_request_sms",
           chargeId: charge.id,

--- a/src/lib/payments/match-day-billing.ts
+++ b/src/lib/payments/match-day-billing.ts
@@ -1,0 +1,44 @@
+// ========================================
+// File: src/lib/payments/match-day-billing.ts
+// ========================================
+
+import {
+  parseLondonDateTime,
+  toLondonDateInputValue,
+} from "@/lib/datetime/london";
+
+const MATCH_DAY_PAYMENT_REQUEST_TIME = "09:00";
+
+function getLondonDateKey(value: Date) {
+  return toLondonDateInputValue(value);
+}
+
+export function isMatchFeeChargePayable(
+  dueDate: Date | null | undefined,
+  now = new Date(),
+) {
+  if (!dueDate) return true;
+
+  return getLondonDateKey(dueDate) <= getLondonDateKey(now);
+}
+
+export function getMatchFeePaymentRequestScheduledFor(
+  kickoffAt: Date,
+  now = new Date(),
+) {
+  if (isMatchFeeChargePayable(kickoffAt, now)) return now;
+
+  return parseLondonDateTime(
+    getLondonDateKey(kickoffAt),
+    MATCH_DAY_PAYMENT_REQUEST_TIME,
+  );
+}
+
+export function getMatchFeePaymentUnavailableReason(
+  dueDate: Date | null | undefined,
+  now = new Date(),
+) {
+  if (isMatchFeeChargePayable(dueDate, now)) return null;
+
+  return "Match fee payments open on match day.";
+}

--- a/src/lib/payments/team-payment-ledger.ts
+++ b/src/lib/payments/team-payment-ledger.ts
@@ -5,6 +5,7 @@
 import { Prisma } from "@prisma/client";
 
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { isMatchFeeChargePayable } from "@/lib/payments/match-day-billing";
 import {
   getDirectChargePaidTotal,
   getDisplayChargeOutstandingPence,
@@ -47,6 +48,7 @@ export type TeamPaymentLedgerEntry = {
   overpaidPence: number;
   storedStatus: string;
   displayStatus: string;
+  isPayableNow: boolean;
 };
 
 export type TeamPaymentLedger = {
@@ -182,6 +184,7 @@ export async function getTeamPaymentLedger(teamId: string): Promise<TeamPaymentL
     const fixtureLabel = charge.fixture
       ? `${charge.fixture.homeTeam.name} vs ${charge.fixture.awayTeam.name}`
       : charge.title;
+    const isPayableNow = isMatchFeeChargePayable(charge.dueDate);
 
     return {
       chargeId: charge.id,
@@ -208,11 +211,16 @@ export async function getTeamPaymentLedger(teamId: string): Promise<TeamPaymentL
       overpaidPence,
       storedStatus: charge.status,
       displayStatus,
+      isPayableNow,
     };
   });
 
   const openEntries = entries
-    .filter((entry) => entry.displayStatus !== "PAID" && entry.outstandingPence > 0)
+    .filter((entry) =>
+      entry.displayStatus !== "PAID" &&
+      entry.outstandingPence > 0 &&
+      entry.isPayableNow,
+    )
     .sort((a, b) => {
       const aDate = a.dueDate ?? a.kickoffAt ?? new Date(8640000000000000);
       const bDate = b.dueDate ?? b.kickoffAt ?? new Date(8640000000000000);

--- a/src/lib/payments/team-subscriptions.ts
+++ b/src/lib/payments/team-subscriptions.ts
@@ -4,6 +4,7 @@
 
 import type Stripe from "stripe";
 
+import { isMatchFeeChargePayable } from "@/lib/payments/match-day-billing";
 import { prisma } from "@/lib/prisma";
 
 type TeamSubscriptionDb = Pick<
@@ -57,6 +58,7 @@ type OpenChargeRow = {
   id: string;
   amountPence: number;
   paidPence: number;
+  dueDate: Date | null;
 };
 
 function toDateFromUnix(value: number | null | undefined) {
@@ -232,6 +234,7 @@ async function findOldestOpenChargeForSubscriptionPayment(input: {
     SELECT
       pc."id",
       pc."amountPence"::int AS "amountPence",
+      pc."dueDate",
       COALESCE(SUM(tx."amountPence"), 0)::int AS "paidPence"
     FROM "PaymentCharge" pc
     LEFT JOIN "PaymentTransaction" tx ON tx."chargeId" = pc."id"
@@ -243,10 +246,9 @@ async function findOldestOpenChargeForSubscriptionPayment(input: {
       CASE WHEN (pc."amountPence" - COALESCE(SUM(tx."amountPence"), 0)) = ${input.amountPence} THEN 0 ELSE 1 END,
       COALESCE(pc."dueDate", pc."createdAt") ASC,
       pc."createdAt" ASC
-    LIMIT 1
   `;
 
-  return rows[0] ?? null;
+  return rows.find((row) => isMatchFeeChargePayable(row.dueDate)) ?? null;
 }
 
 async function refreshChargeStatus(input: {
@@ -410,7 +412,7 @@ export async function recordTeamSubscriptionInvoicePaid(input: {
       method: "STRIPE",
       reference: stripeInvoiceId,
       notes: targetCharge
-        ? "Recurring team subscription paid via Stripe and applied to the oldest open team charge."
+        ? "Recurring team subscription paid via Stripe and applied to the oldest payable team charge."
         : "Recurring team subscription paid via Stripe.",
       paidAt,
       stripePaymentIntentId: paymentIntentId,


### PR DESCRIPTION
## Summary

- Adds a shared match-day billing helper using the London fixture date.
- Keeps fixture charges available for the ledger, but delays initial match-fee email/SMS payment requests until 09:00 on the fixture match day.
- Blocks Stripe Checkout from starting for a future fixture charge, even if someone opens a payment URL early.
- Hides Pay now links and excludes future fixture fees from the current outstanding balance until match day.
- Prevents recurring team subscription payments from being allocated to future fixture charges, and aligns new automatic payment setup to the next published chargeable fixture where possible.

## Why

Publishing fixtures should announce the fixture and prepare the charge record, but teams should not be asked for or allocated match-fee payment before the actual match day.

## Validation

- Inspected the changed payment, ledger, checkout, subscription, and notification code paths.
- Could not run local `next build`/`eslint` from this environment because the repository is only available through the GitHub connector here.