### PR TITLE
Preserve player details for historic match fees

### DIFF
--- a/prisma/migrations/20260710183000_add_player_match_fee_snapshots/migration.sql
+++ b/prisma/migrations/20260710183000_add_player_match_fee_snapshots/migration.sql
@@ -1,0 +1,65 @@
+ALTER TABLE "PlayerMatchFee"
+  ADD COLUMN IF NOT EXISTS "playerNameSnapshot" TEXT,
+  ADD COLUMN IF NOT EXISTS "playerEmailSnapshot" TEXT,
+  ADD COLUMN IF NOT EXISTS "playerPhoneSnapshot" TEXT;
+
+-- Backfill from still-linked squad members.
+UPDATE "PlayerMatchFee" pmf
+SET
+  "playerNameSnapshot" = COALESCE(NULLIF(TRIM(u."name"), ''), u."email", pmf."playerNameSnapshot"),
+  "playerEmailSnapshot" = COALESCE(u."email", pmf."playerEmailSnapshot")
+FROM "TeamMember" tm
+JOIN "User" u ON u."id" = tm."userId"
+WHERE pmf."teamMemberId" = tm."id"
+  AND (pmf."playerNameSnapshot" IS NULL OR pmf."playerEmailSnapshot" IS NULL);
+
+-- Backfill from still-linked prospects.
+UPDATE "PlayerMatchFee" pmf
+SET
+  "playerNameSnapshot" = COALESCE(
+    NULLIF(TRIM(CONCAT_WS(' ', p."firstName", p."lastName")), ''),
+    p."email",
+    p."phone",
+    pmf."playerNameSnapshot"
+  ),
+  "playerEmailSnapshot" = COALESCE(p."email", pmf."playerEmailSnapshot"),
+  "playerPhoneSnapshot" = COALESCE(p."phone", pmf."playerPhoneSnapshot")
+FROM "TeamPlayerProspect" p
+WHERE pmf."prospectId" = p."id"
+  AND (
+    pmf."playerNameSnapshot" IS NULL OR
+    pmf."playerEmailSnapshot" IS NULL OR
+    pmf."playerPhoneSnapshot" IS NULL
+  );
+
+-- Recover orphaned fees from old player-fee notification recipients where possible.
+WITH latest_dispatch AS (
+  SELECT DISTINCT ON (nd."sourceId")
+    nd."sourceId" AS "feeId",
+    nr."displayName",
+    nr."email",
+    nr."phone"
+  FROM "NotificationDispatch" nd
+  JOIN "NotificationRecipient" nr ON nr."id" = nd."recipientId"
+  WHERE nd."sourceType" IN (
+    'PLAYER_MATCH_FEE_REQUEST',
+    'PLAYER_MATCH_FEE_CHASE_24H',
+    'PLAYER_MATCH_FEE_CHASE_72H'
+  )
+  ORDER BY nd."sourceId", COALESCE(nd."sentAt", nd."scheduledFor", nd."createdAt") DESC
+)
+UPDATE "PlayerMatchFee" pmf
+SET
+  "playerNameSnapshot" = COALESCE(NULLIF(TRIM(latest_dispatch."displayName"), ''), latest_dispatch."email", latest_dispatch."phone", pmf."playerNameSnapshot"),
+  "playerEmailSnapshot" = COALESCE(latest_dispatch."email", pmf."playerEmailSnapshot"),
+  "playerPhoneSnapshot" = COALESCE(latest_dispatch."phone", pmf."playerPhoneSnapshot")
+FROM latest_dispatch
+WHERE latest_dispatch."feeId" = pmf."id"
+  AND (
+    pmf."playerNameSnapshot" IS NULL OR
+    pmf."playerEmailSnapshot" IS NULL OR
+    pmf."playerPhoneSnapshot" IS NULL
+  );
+
+CREATE INDEX IF NOT EXISTS "PlayerMatchFee_playerNameSnapshot_idx" ON "PlayerMatchFee"("playerNameSnapshot");
+CREATE INDEX IF NOT EXISTS "PlayerMatchFee_playerEmailSnapshot_idx" ON "PlayerMatchFee"("playerEmailSnapshot");

--- a/scripts/find-orphaned-player-fee-owner.sql
+++ b/scripts/find-orphaned-player-fee-owner.sql
@@ -1,0 +1,45 @@
+-- Find likely original player details for orphaned PlayerMatchFee rows.
+-- Use this in Railway Postgres when an admin card shows "Unnamed player" / "No contact".
+
+SELECT
+  pmf."id" AS "playerMatchFeeId",
+  pmf."amountPence",
+  pmf."status",
+  pmf."createdAt" AS "feeCreatedAt",
+  pmf."lastChasedAt",
+  team."name" AS "teamName",
+  home."name" AS "homeTeam",
+  away."name" AS "awayTeam",
+  fixture."kickoffAt",
+  pmf."playerNameSnapshot",
+  pmf."playerEmailSnapshot",
+  pmf."playerPhoneSnapshot",
+  latest_recipient."displayName" AS "notificationDisplayName",
+  latest_recipient."email" AS "notificationEmail",
+  latest_recipient."phone" AS "notificationPhone",
+  latest_recipient."sentOrQueuedAt" AS "notificationSentOrQueuedAt"
+FROM "PlayerMatchFee" pmf
+JOIN "Team" team ON team."id" = pmf."teamId"
+JOIN "Fixture" fixture ON fixture."id" = pmf."fixtureId"
+JOIN "Team" home ON home."id" = fixture."homeTeamId"
+JOIN "Team" away ON away."id" = fixture."awayTeamId"
+LEFT JOIN LATERAL (
+  SELECT
+    nr."displayName",
+    nr."email",
+    nr."phone",
+    COALESCE(nd."sentAt", nd."scheduledFor", nd."createdAt") AS "sentOrQueuedAt"
+  FROM "NotificationDispatch" nd
+  JOIN "NotificationRecipient" nr ON nr."id" = nd."recipientId"
+  WHERE nd."sourceType" IN (
+    'PLAYER_MATCH_FEE_REQUEST',
+    'PLAYER_MATCH_FEE_CHASE_24H',
+    'PLAYER_MATCH_FEE_CHASE_72H'
+  )
+    AND nd."sourceId" = pmf."id"
+  ORDER BY COALESCE(nd."sentAt", nd."scheduledFor", nd."createdAt") DESC
+  LIMIT 1
+) latest_recipient ON TRUE
+WHERE pmf."teamMemberId" IS NULL
+  AND pmf."prospectId" IS NULL
+ORDER BY fixture."kickoffAt" DESC, pmf."createdAt" DESC;

--- a/src/app/(admin)/admin/payments/orphaned-player-fees/page.tsx
+++ b/src/app/(admin)/admin/payments/orphaned-player-fees/page.tsx
@@ -7,6 +7,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import {
+  getPlayerMatchFeeSnapshots,
+  recoverPlayerMatchFeeSnapshotFromNotifications,
+} from "@/lib/payments/player-match-fee-snapshots";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
@@ -41,11 +45,6 @@ function getString(formData: FormData, key: string) {
   return String(formData.get(key) ?? "").trim();
 }
 
-function appendParam(path: string, key: string, value: string) {
-  const separator = path.includes("?") ? "&" : "?";
-  return `${path}${separator}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
-}
-
 function getRepairHref(params: Record<string, string | null | undefined>) {
   const searchParams = new URLSearchParams();
 
@@ -77,13 +76,6 @@ async function attachOrphanedPlayerFeeAction(formData: FormData) {
       fixtureId: true,
       teamMemberId: true,
       prospectId: true,
-      fixture: {
-        select: {
-          id: true,
-          homeTeam: { select: { name: true } },
-          awayTeam: { select: { name: true } },
-        },
-      },
     },
   });
 
@@ -173,11 +165,37 @@ async function attachOrphanedPlayerFeeAction(formData: FormData) {
   );
 }
 
+async function recoverSnapshotAction(formData: FormData) {
+  "use server";
+
+  await requireAdmin();
+  const feeId = getString(formData, "feeId");
+  if (!feeId) redirect(getRepairHref({ error: "fee_not_found" }));
+
+  const snapshot = await recoverPlayerMatchFeeSnapshotFromNotifications(feeId);
+
+  revalidatePath("/admin/payments");
+  revalidatePath("/admin/payments/orphaned-player-fees");
+
+  if (!snapshot?.name && !snapshot?.email && !snapshot?.phone) {
+    redirect(getRepairHref({ error: "no_recovery", feeId }));
+  }
+
+  redirect(getRepairHref({ saved: "recovered", feeId, user: snapshot.name ?? snapshot.email ?? snapshot.phone }));
+}
+
 function getNotice(params: SearchParams) {
   if (params.saved === "reattached") {
     return {
       tone: "success" as const,
       text: `Payment reattached${params.user ? ` to ${params.user}` : ""}.`,
+    };
+  }
+
+  if (params.saved === "recovered") {
+    return {
+      tone: "success" as const,
+      text: `Original player details recovered${params.user ? `: ${params.user}` : ""}.`,
     };
   }
 
@@ -195,6 +213,8 @@ function getNotice(params: SearchParams) {
         tone: "error" as const,
         text: "That user already has a fee for this fixture. Do not attach this orphan until the duplicate fee is checked.",
       };
+    case "no_recovery":
+      return { tone: "error" as const, text: "No old notification recipient was found for that fee." };
     default:
       return null;
   }
@@ -229,6 +249,7 @@ export default async function OrphanedPlayerFeesPage({
       },
     },
   });
+  const snapshotByFeeId = await getPlayerMatchFeeSnapshots(orphanedFees.map((fee) => fee.id));
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 px-6 py-6">
@@ -239,7 +260,7 @@ export default async function OrphanedPlayerFeesPage({
           </Link>
           <h1 className="mt-4 text-3xl font-semibold text-white">Orphaned player fees</h1>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-            These are open player payment rows where the original squad player/prospect link has been lost, usually after a duplicate lead or prospect was deleted. Reattach the fee to the real user account.
+            These are open player payment rows where the original squad player/prospect link has been lost. If available, SIXFL now shows the saved or recovered player snapshot so historic charges still make sense.
           </p>
         </div>
         <span className="rounded-2xl border border-amber-400/20 bg-amber-500/10 px-4 py-3 text-sm font-semibold text-amber-100">
@@ -272,6 +293,9 @@ export default async function OrphanedPlayerFeesPage({
             orphanedFees.map((fee) => {
               const fixtureName = `${fee.fixture.homeTeam.name} vs ${fee.fixture.awayTeam.name}`;
               const highlighted = sp.feeId === fee.id;
+              const snapshot = snapshotByFeeId.get(fee.id);
+              const recoveredName = snapshot?.name || snapshot?.email || snapshot?.phone || null;
+              const recoveredContact = [snapshot?.email, snapshot?.phone].filter(Boolean).join(" · ");
 
               return (
                 <article
@@ -284,10 +308,13 @@ export default async function OrphanedPlayerFeesPage({
                   <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                     <div>
                       <div className="text-base font-semibold text-white">
-                        {fee.team.name} · {formatMoney(fee.amountPence)}
+                        {recoveredName ?? fee.team.name} · {formatMoney(fee.amountPence)}
                       </div>
+                      {recoveredContact ? (
+                        <div className="mt-1 text-sm text-emerald-100/70">Recovered contact: {recoveredContact}</div>
+                      ) : null}
                       <div className="mt-1 text-sm text-white/55">
-                        {fixtureName} · {formatFixtureDate(fee.fixture.kickoffAt)}
+                        {fee.team.name} · {fixtureName} · {formatFixtureDate(fee.fixture.kickoffAt)}
                       </div>
                       <div className="mt-2 flex flex-wrap gap-2 text-xs">
                         <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 font-mono text-white/55">
@@ -296,29 +323,48 @@ export default async function OrphanedPlayerFeesPage({
                         <span className="rounded-full border border-red-400/20 bg-red-500/10 px-2.5 py-1 text-red-100">
                           Missing player link
                         </span>
+                        {recoveredName ? (
+                          <span className="rounded-full border border-emerald-400/20 bg-emerald-500/10 px-2.5 py-1 text-emerald-100">
+                            Snapshot available
+                          </span>
+                        ) : null}
                       </div>
                     </div>
 
-                    <form action={attachOrphanedPlayerFeeAction} className="w-full max-w-xl rounded-2xl border border-white/10 bg-black/20 p-3">
-                      <input type="hidden" name="feeId" value={fee.id} />
-                      <label className="text-xs font-semibold uppercase tracking-[0.14em] text-white/45">
-                        Reattach to user ID / email / exact name
-                      </label>
-                      <div className="mt-2 flex flex-col gap-2 sm:flex-row">
-                        <input
-                          name="userLookup"
-                          defaultValue={sp.feeId === fee.id ? sp.user ?? "" : ""}
-                          placeholder="e.g. Liam Craig user ID or email"
-                          className="min-w-0 flex-1 rounded-xl border border-white/10 bg-black/30 px-3 py-2.5 text-sm text-white outline-none transition placeholder:text-white/30 focus:border-emerald-400/40"
-                        />
-                        <button
-                          type="submit"
-                          className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
-                        >
-                          Attach fee
-                        </button>
-                      </div>
-                    </form>
+                    <div className="flex w-full max-w-xl flex-col gap-3">
+                      {!recoveredName ? (
+                        <form action={recoverSnapshotAction} className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-3">
+                          <input type="hidden" name="feeId" value={fee.id} />
+                          <button
+                            type="submit"
+                            className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-2.5 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/15"
+                          >
+                            Recover from old notification
+                          </button>
+                        </form>
+                      ) : null}
+
+                      <form action={attachOrphanedPlayerFeeAction} className="rounded-2xl border border-white/10 bg-black/20 p-3">
+                        <input type="hidden" name="feeId" value={fee.id} />
+                        <label className="text-xs font-semibold uppercase tracking-[0.14em] text-white/45">
+                          Reattach to user ID / email / exact name
+                        </label>
+                        <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                          <input
+                            name="userLookup"
+                            defaultValue={sp.feeId === fee.id ? sp.user ?? recoveredContact ?? "" : recoveredContact ?? ""}
+                            placeholder="e.g. Liam Craig user ID or email"
+                            className="min-w-0 flex-1 rounded-xl border border-white/10 bg-black/30 px-3 py-2.5 text-sm text-white outline-none transition placeholder:text-white/30 focus:border-emerald-400/40"
+                          />
+                          <button
+                            type="submit"
+                            className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
+                          >
+                            Attach fee
+                          </button>
+                        </div>
+                      </form>
+                    </div>
                   </div>
                 </article>
               );

--- a/src/app/(admin)/admin/teams/[id]/match-fees/actions.ts
+++ b/src/app/(admin)/admin/teams/[id]/match-fees/actions.ts
@@ -8,8 +8,13 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { PlayerMatchFeeStatus } from "@prisma/client";
 
+import {
+  buildPlayerNameSnapshot,
+  setPlayerMatchFeeSnapshot,
+} from "@/lib/payments/player-match-fee-snapshots";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
+import { getTeamMemberProfilesByTeamMemberIds } from "@/lib/teamMemberProfiles";
 
 function getString(formData: FormData, key: string) {
   return String(formData.get(key) ?? "").trim();
@@ -121,6 +126,9 @@ export async function createPlayerMatchFeesAction(formData: FormData) {
     redirect(getMatchFeesPath(teamId, fixtureId, "&error=fixture_not_found"));
   }
 
+  const selectedMemberIds = players.filter((player) => player.type === "member").map((player) => player.id);
+  const profileByMemberId = await getTeamMemberProfilesByTeamMemberIds(selectedMemberIds);
+
   for (const player of players) {
     if (player.type === "member") {
       const member = await prisma.teamMember.findFirst({
@@ -128,10 +136,19 @@ export async function createPlayerMatchFeesAction(formData: FormData) {
           id: player.id,
           teamId,
         },
-        select: { id: true },
+        select: {
+          id: true,
+          user: { select: { name: true, email: true } },
+        },
       });
 
       if (!member) continue;
+
+      const snapshot = {
+        name: buildPlayerNameSnapshot({ name: member.user.name, email: member.user.email }),
+        email: member.user.email,
+        phone: profileByMemberId.get(player.id)?.phone ?? null,
+      };
 
       const existing = await prisma.playerMatchFee.findFirst({
         where: {
@@ -141,29 +158,31 @@ export async function createPlayerMatchFeesAction(formData: FormData) {
         select: { id: true },
       });
 
-      if (existing) {
-        await prisma.playerMatchFee.update({
-          where: { id: existing.id },
-          data: {
-            amountPence,
-            teamId,
-            note,
-            status: "OPEN",
-            cancelledAt: null,
-            waivedAt: null,
-          },
-        });
-      } else {
-        await prisma.playerMatchFee.create({
-          data: {
-            fixtureId,
-            teamId,
-            teamMemberId: player.id,
-            amountPence,
-            note,
-          },
-        });
-      }
+      const fee = existing
+        ? await prisma.playerMatchFee.update({
+            where: { id: existing.id },
+            data: {
+              amountPence,
+              teamId,
+              note,
+              status: "OPEN",
+              cancelledAt: null,
+              waivedAt: null,
+            },
+            select: { id: true },
+          })
+        : await prisma.playerMatchFee.create({
+            data: {
+              fixtureId,
+              teamId,
+              teamMemberId: player.id,
+              amountPence,
+              note,
+            },
+            select: { id: true },
+          });
+
+      await setPlayerMatchFeeSnapshot({ feeId: fee.id, snapshot });
     }
 
     if (player.type === "prospect") {
@@ -172,10 +191,21 @@ export async function createPlayerMatchFeesAction(formData: FormData) {
           id: player.id,
           teamId,
         },
-        select: { id: true },
+        select: { id: true, firstName: true, lastName: true, email: true, phone: true },
       });
 
       if (!prospect) continue;
+
+      const snapshot = {
+        name: buildPlayerNameSnapshot({
+          firstName: prospect.firstName,
+          lastName: prospect.lastName,
+          email: prospect.email,
+          phone: prospect.phone,
+        }),
+        email: prospect.email,
+        phone: prospect.phone,
+      };
 
       const existing = await prisma.playerMatchFee.findFirst({
         where: {
@@ -185,29 +215,31 @@ export async function createPlayerMatchFeesAction(formData: FormData) {
         select: { id: true },
       });
 
-      if (existing) {
-        await prisma.playerMatchFee.update({
-          where: { id: existing.id },
-          data: {
-            amountPence,
-            teamId,
-            note,
-            status: "OPEN",
-            cancelledAt: null,
-            waivedAt: null,
-          },
-        });
-      } else {
-        await prisma.playerMatchFee.create({
-          data: {
-            fixtureId,
-            teamId,
-            prospectId: player.id,
-            amountPence,
-            note,
-          },
-        });
-      }
+      const fee = existing
+        ? await prisma.playerMatchFee.update({
+            where: { id: existing.id },
+            data: {
+              amountPence,
+              teamId,
+              note,
+              status: "OPEN",
+              cancelledAt: null,
+              waivedAt: null,
+            },
+            select: { id: true },
+          })
+        : await prisma.playerMatchFee.create({
+            data: {
+              fixtureId,
+              teamId,
+              prospectId: player.id,
+              amountPence,
+              note,
+            },
+            select: { id: true },
+          });
+
+      await setPlayerMatchFeeSnapshot({ feeId: fee.id, snapshot });
     }
   }
 
@@ -295,37 +327,6 @@ export async function markPlayerMatchFeePaidAction(formData: FormData) {
         existingNote: existingFee.note,
         methodNote,
       }),
-    },
-  });
-
-  revalidatePath(getMatchFeesPath(teamId, fixtureId));
-  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
-}
-
-export async function updatePlayerMatchFeeAmountAction(formData: FormData) {
-  await requireAdmin();
-
-  const teamId = getString(formData, "teamId");
-  const fixtureId = getString(formData, "fixtureId");
-  const feeId = getString(formData, "feeId");
-  const amountPence = parseAmountPence(getString(formData, "amount"));
-
-  if (!teamId || !fixtureId || !feeId) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
-  }
-
-  if (!amountPence) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=invalid_amount"));
-  }
-
-  await prisma.playerMatchFee.updateMany({
-    where: {
-      id: feeId,
-      teamId,
-      fixtureId,
-    },
-    data: {
-      amountPence,
     },
   });
 

--- a/src/app/captain/team/[teamid]/match-fees/actions.ts
+++ b/src/app/captain/team/[teamid]/match-fees/actions.ts
@@ -10,6 +10,10 @@ import type { PlayerMatchFeeStatus } from "@prisma/client";
 
 import { publishedFixtureWhere } from "@/lib/fixtures/publishing";
 import { cancelQueuedPlayerMatchFeeNotificationDispatches } from "@/lib/payments/cancel-player-match-fee-notifications";
+import {
+  buildPlayerNameSnapshot,
+  setPlayerMatchFeeSnapshot,
+} from "@/lib/payments/player-match-fee-snapshots";
 import { queuePlayerMatchFeeReminder } from "@/lib/payments/player-match-fees";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
@@ -152,12 +156,16 @@ export async function createCaptainPlayerMatchFeesAction(formData: FormData) {
     if (player.type === "member") {
       const member = await prisma.teamMember.findFirst({
         where: { id: player.id, teamId },
-        select: { id: true },
+        select: {
+          id: true,
+          user: { select: { name: true, email: true } },
+        },
       });
 
       if (!member) continue;
 
-      const override = profileByMemberId.get(player.id)?.playerMatchFeePenceOverride;
+      const profile = profileByMemberId.get(player.id);
+      const override = profile?.playerMatchFeePenceOverride;
       const hasOverride = typeof override === "number";
       const amountPence = hasOverride ? override : defaultAmountPence;
       const status: PlayerMatchFeeStatus = amountPence === 0 ? "WAIVED" : "OPEN";
@@ -165,6 +173,11 @@ export async function createCaptainPlayerMatchFeesAction(formData: FormData) {
         ? appendNote({ existingNote: baseNote, note: getOverrideNote(amountPence) })
         : baseNote;
       const now = new Date();
+      const snapshot = {
+        name: buildPlayerNameSnapshot({ name: member.user.name, email: member.user.email }),
+        email: member.user.email,
+        phone: profile?.phone ?? null,
+      };
 
       const existing = await prisma.playerMatchFee.findFirst({
         where: { fixtureId, teamMemberId: player.id },
@@ -187,33 +200,46 @@ export async function createCaptainPlayerMatchFeesAction(formData: FormData) {
         paymentToken: amountPence === 0 ? null : undefined,
       };
 
-      if (existing) {
-        await prisma.playerMatchFee.update({
-          where: { id: existing.id },
-          data,
-        });
-      } else {
-        await prisma.playerMatchFee.create({
-          data: {
-            fixtureId,
-            teamId,
-            teamMemberId: player.id,
-            amountPence,
-            note,
-            status,
-            waivedAt: amountPence === 0 ? now : null,
-          },
-        });
-      }
+      const fee = existing
+        ? await prisma.playerMatchFee.update({
+            where: { id: existing.id },
+            data,
+            select: { id: true },
+          })
+        : await prisma.playerMatchFee.create({
+            data: {
+              fixtureId,
+              teamId,
+              teamMemberId: player.id,
+              amountPence,
+              note,
+              status,
+              waivedAt: amountPence === 0 ? now : null,
+            },
+            select: { id: true },
+          });
+
+      await setPlayerMatchFeeSnapshot({ feeId: fee.id, snapshot });
     }
 
     if (player.type === "prospect") {
       const prospect = await prisma.teamPlayerProspect.findFirst({
         where: { id: player.id, teamId },
-        select: { id: true },
+        select: { id: true, firstName: true, lastName: true, email: true, phone: true },
       });
 
       if (!prospect) continue;
+
+      const snapshot = {
+        name: buildPlayerNameSnapshot({
+          firstName: prospect.firstName,
+          lastName: prospect.lastName,
+          email: prospect.email,
+          phone: prospect.phone,
+        }),
+        email: prospect.email,
+        phone: prospect.phone,
+      };
 
       const existing = await prisma.playerMatchFee.findFirst({
         where: { fixtureId, prospectId: player.id },
@@ -224,30 +250,32 @@ export async function createCaptainPlayerMatchFeesAction(formData: FormData) {
         continue;
       }
 
-      if (existing) {
-        await prisma.playerMatchFee.update({
-          where: { id: existing.id },
-          data: {
-            amountPence: defaultAmountPence,
-            teamId,
-            note: baseNote,
-            status: "OPEN",
-            paidAt: null,
-            waivedAt: null,
-            cancelledAt: null,
-          },
-        });
-      } else {
-        await prisma.playerMatchFee.create({
-          data: {
-            fixtureId,
-            teamId,
-            prospectId: player.id,
-            amountPence: defaultAmountPence,
-            note: baseNote,
-          },
-        });
-      }
+      const fee = existing
+        ? await prisma.playerMatchFee.update({
+            where: { id: existing.id },
+            data: {
+              amountPence: defaultAmountPence,
+              teamId,
+              note: baseNote,
+              status: "OPEN",
+              paidAt: null,
+              waivedAt: null,
+              cancelledAt: null,
+            },
+            select: { id: true },
+          })
+        : await prisma.playerMatchFee.create({
+            data: {
+              fixtureId,
+              teamId,
+              prospectId: player.id,
+              amountPence: defaultAmountPence,
+              note: baseNote,
+            },
+            select: { id: true },
+          });
+
+      await setPlayerMatchFeeSnapshot({ feeId: fee.id, snapshot });
     }
   }
 
@@ -361,151 +389,15 @@ export async function updateCaptainPlayerMatchFeeStatusAction(formData: FormData
       paidAt: status === "PAID" ? now : null,
       waivedAt: status === "WAIVED" ? now : null,
       cancelledAt: status === "CANCELLED" ? now : null,
-      paymentUrl: status === "WAIVED" || status === "CANCELLED" ? null : undefined,
-      paymentToken: status === "WAIVED" || status === "CANCELLED" ? null : undefined,
     },
   });
 
-  if (status === "CANCELLED") {
-    await cancelQueuedPlayerMatchFeeNotificationDispatches([feeId]);
+  if (status !== "OPEN") {
+    await cancelQueuedPlayerMatchFeeNotificationDispatches(
+      [feeId],
+      `Player match fee status changed to ${status}.`,
+    );
   }
-
-  revalidatePath(getMatchFeesPath(teamId, fixtureId));
-  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
-}
-
-export async function sendCaptainPlayerMatchFeeReminderAction(formData: FormData) {
-  const teamId = getString(formData, "teamId");
-  const fixtureId = getString(formData, "fixtureId");
-  const feeId = getString(formData, "feeId");
-
-  const access = teamId ? await requireCaptain(teamId) : null;
-  redirectIfNotAdmin({ isAdmin: Boolean(access?.isAdmin), teamId, fixtureId });
-
-  if (!teamId || !fixtureId || !feeId) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
-  }
-
-  const fee = await prisma.playerMatchFee.findFirst({
-    where: { id: feeId, teamId, fixtureId },
-    select: { id: true, status: true },
-  });
-
-  if (!fee) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
-  }
-
-  if (fee.status !== "OPEN") {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=fee_not_open"));
-  }
-
-  const reminderModes = ["request", "chase24h", "chase72h"] as const;
-
-  for (const mode of reminderModes) {
-    const result = await queuePlayerMatchFeeReminder({
-      feeId: fee.id,
-      mode,
-      channels: ["SMS"],
-    });
-
-    if (result.queued > 0) {
-      revalidatePath(getMatchFeesPath(teamId, fixtureId));
-      redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_sms_queued"));
-    }
-
-    if (["no_contact", "not_open", "no_payment_url"].includes(result.status)) {
-      redirect(getMatchFeesPath(teamId, fixtureId, `&error=${result.status}`));
-    }
-  }
-
-  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_sms_already_sent"));
-}
-
-export async function voidCaptainFixturePlayerMatchFeesAction(formData: FormData) {
-  const teamId = getString(formData, "teamId");
-  const fixtureId = getString(formData, "fixtureId");
-  const reason = getString(formData, "reason") || "Game conceded / fixture not played";
-
-  const access = teamId ? await requireCaptain(teamId) : null;
-  redirectIfNotAdmin({ isAdmin: Boolean(access?.isAdmin), teamId, fixtureId });
-
-  if (!teamId || !fixtureId) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fixture"));
-  }
-
-  const fixtureOk = await assertFixtureBelongsToTeam({ fixtureId, teamId });
-
-  if (!fixtureOk) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=fixture_not_found"));
-  }
-
-  const fees = await prisma.playerMatchFee.findMany({
-    where: {
-      teamId,
-      fixtureId,
-      status: { in: ["OPEN", "WAIVED", "CANCELLED"] },
-    },
-    select: { id: true, note: true },
-  });
-
-  for (const fee of fees) {
-    await prisma.playerMatchFee.update({
-      where: { id: fee.id },
-      data: {
-        status: "CANCELLED",
-        paidAt: null,
-        waivedAt: null,
-        cancelledAt: new Date(),
-        paymentUrl: null,
-        paymentToken: null,
-        note: appendNote({ existingNote: fee.note, note: `Voided: ${reason}` }),
-      },
-    });
-  }
-
-  await cancelQueuedPlayerMatchFeeNotificationDispatches(
-    fees.map((fee) => fee.id),
-    `Player match fees voided: ${reason}`,
-  );
-
-  revalidatePath(getMatchFeesPath(teamId, fixtureId));
-  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
-}
-
-export async function updateCaptainPlayerMatchFeeAmountAction(formData: FormData) {
-  const teamId = getString(formData, "teamId");
-  const fixtureId = getString(formData, "fixtureId");
-  const feeId = getString(formData, "feeId");
-  const amountPence = parseAmountPence(getString(formData, "amount"));
-
-  const access = teamId ? await requireCaptain(teamId) : null;
-  redirectIfNotAdmin({ isAdmin: Boolean(access?.isAdmin), teamId, fixtureId });
-
-  if (!teamId || !fixtureId || !feeId) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
-  }
-
-  if (!amountPence) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=invalid_amount"));
-  }
-
-  const existingFee = await prisma.playerMatchFee.findFirst({
-    where: { id: feeId, teamId, fixtureId },
-    select: { id: true, status: true },
-  });
-
-  if (!existingFee) {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
-  }
-
-  if (existingFee.status === "PAID") {
-    redirect(getMatchFeesPath(teamId, fixtureId, "&error=fee_locked"));
-  }
-
-  await prisma.playerMatchFee.update({
-    where: { id: existingFee.id },
-    data: { amountPence },
-  });
 
   revalidatePath(getMatchFeesPath(teamId, fixtureId));
   redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));

--- a/src/app/captain/team/[teamid]/match-fees/actions.ts
+++ b/src/app/captain/team/[teamid]/match-fees/actions.ts
@@ -363,6 +363,46 @@ export async function markCaptainPlayerMatchFeePaidAction(formData: FormData) {
   redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
 }
 
+export async function updateCaptainPlayerMatchFeeAmountAction(formData: FormData) {
+  const teamId = getString(formData, "teamId");
+  const fixtureId = getString(formData, "fixtureId");
+  const feeId = getString(formData, "feeId");
+  const amountPence = parseAmountPence(getString(formData, "amount"));
+
+  const access = teamId ? await requireCaptain(teamId) : null;
+  redirectIfNotAdmin({ isAdmin: Boolean(access?.isAdmin), teamId, fixtureId });
+
+  if (!teamId || !fixtureId || !feeId) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
+  }
+
+  if (!amountPence) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=invalid_amount"));
+  }
+
+  const existingFee = await prisma.playerMatchFee.findFirst({
+    where: { id: feeId, teamId, fixtureId },
+    select: { id: true, status: true },
+  });
+
+  if (!existingFee) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
+  }
+
+  await prisma.playerMatchFee.update({
+    where: { id: existingFee.id },
+    data: {
+      amountPence,
+      status: existingFee.status === "WAIVED" ? "OPEN" : existingFee.status,
+      waivedAt: existingFee.status === "WAIVED" ? null : undefined,
+      cancelledAt: existingFee.status === "CANCELLED" ? null : undefined,
+    },
+  });
+
+  revalidatePath(getMatchFeesPath(teamId, fixtureId));
+  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
+}
+
 export async function updateCaptainPlayerMatchFeeStatusAction(formData: FormData) {
   const teamId = getString(formData, "teamId");
   const fixtureId = getString(formData, "fixtureId");

--- a/src/app/captain/team/[teamid]/match-fees/actions.ts
+++ b/src/app/captain/team/[teamid]/match-fees/actions.ts
@@ -402,3 +402,50 @@ export async function updateCaptainPlayerMatchFeeStatusAction(formData: FormData
   revalidatePath(getMatchFeesPath(teamId, fixtureId));
   redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_updated"));
 }
+
+export async function sendCaptainPlayerMatchFeeReminderAction(formData: FormData) {
+  const teamId = getString(formData, "teamId");
+  const fixtureId = getString(formData, "fixtureId");
+  const feeId = getString(formData, "feeId");
+
+  const access = teamId ? await requireCaptain(teamId) : null;
+  redirectIfNotAdmin({ isAdmin: Boolean(access?.isAdmin), teamId, fixtureId });
+
+  if (!teamId || !fixtureId || !feeId) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
+  }
+
+  const fee = await prisma.playerMatchFee.findFirst({
+    where: { id: feeId, teamId, fixtureId },
+    select: { id: true, status: true },
+  });
+
+  if (!fee) {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=missing_fee"));
+  }
+
+  if (fee.status !== "OPEN") {
+    redirect(getMatchFeesPath(teamId, fixtureId, "&error=fee_not_open"));
+  }
+
+  const reminderModes = ["request", "chase24h", "chase72h"] as const;
+
+  for (const mode of reminderModes) {
+    const result = await queuePlayerMatchFeeReminder({
+      feeId: fee.id,
+      mode,
+      channels: ["SMS"],
+    });
+
+    if (result.queued > 0) {
+      revalidatePath(getMatchFeesPath(teamId, fixtureId));
+      redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_sms_queued"));
+    }
+
+    if (["no_contact", "not_open", "no_payment_url"].includes(result.status)) {
+      redirect(getMatchFeesPath(teamId, fixtureId, `&error=${result.status}`));
+    }
+  }
+
+  redirect(getMatchFeesPath(teamId, fixtureId, "&saved=fee_sms_already_sent"));
+}

--- a/src/app/captain/team/[teamid]/player-payments/actions.ts
+++ b/src/app/captain/team/[teamid]/player-payments/actions.ts
@@ -9,6 +9,10 @@ import { redirect } from "next/navigation";
 import type { PlayerMatchFeeStatus } from "@prisma/client";
 
 import {
+  buildPlayerNameSnapshot,
+  setPlayerMatchFeeSnapshot,
+} from "@/lib/payments/player-match-fee-snapshots";
+import {
   ensurePlayerMatchFeePaymentDetailsForFees,
   queuePlayerMatchFeeReminder,
 } from "@/lib/payments/player-match-fees";
@@ -302,10 +306,20 @@ export async function createCaptainSquadPaymentCollectionAction(formData: FormDa
     if (player.type === "member") {
       const member = await prisma.teamMember.findFirst({
         where: { id: player.id, teamId },
-        select: { id: true },
+        select: {
+          id: true,
+          user: { select: { name: true, email: true } },
+        },
       });
 
       if (!member) continue;
+
+      const profile = profileByMemberId.get(player.id);
+      const snapshot = {
+        name: buildPlayerNameSnapshot({ name: member.user.name, email: member.user.email }),
+        email: member.user.email,
+        phone: profile?.phone ?? null,
+      };
 
       const existing = await prisma.playerMatchFee.findFirst({
         where: { fixtureId, teamMemberId: player.id },
@@ -341,16 +355,28 @@ export async function createCaptainSquadPaymentCollectionAction(formData: FormDa
             select: { id: true, status: true },
           });
 
+      await setPlayerMatchFeeSnapshot({ feeId: fee.id, snapshot });
       if (fee.status === "OPEN") createdOrUpdatedFeeIds.push(fee.id);
     }
 
     if (player.type === "prospect") {
       const prospect = await prisma.teamPlayerProspect.findFirst({
         where: { id: player.id, teamId },
-        select: { id: true },
+        select: { id: true, firstName: true, lastName: true, email: true, phone: true },
       });
 
       if (!prospect) continue;
+
+      const snapshot = {
+        name: buildPlayerNameSnapshot({
+          firstName: prospect.firstName,
+          lastName: prospect.lastName,
+          email: prospect.email,
+          phone: prospect.phone,
+        }),
+        email: prospect.email,
+        phone: prospect.phone,
+      };
 
       const existing = await prisma.playerMatchFee.findFirst({
         where: { fixtureId, prospectId: player.id },
@@ -386,6 +412,7 @@ export async function createCaptainSquadPaymentCollectionAction(formData: FormDa
             select: { id: true, status: true },
           });
 
+      await setPlayerMatchFeeSnapshot({ feeId: fee.id, snapshot });
       if (fee.status === "OPEN") createdOrUpdatedFeeIds.push(fee.id);
     }
   }

--- a/src/lib/payments/player-match-fee-snapshots.ts
+++ b/src/lib/payments/player-match-fee-snapshots.ts
@@ -2,6 +2,8 @@
 // File: src/lib/payments/player-match-fee-snapshots.ts
 // ========================================
 
+import { Prisma } from "@prisma/client";
+
 import { prisma } from "@/lib/prisma";
 
 export type PlayerMatchFeeSnapshot = {
@@ -68,7 +70,7 @@ export async function getPlayerMatchFeeSnapshots(feeIds: string[]) {
       "playerEmailSnapshot",
       "playerPhoneSnapshot"
     FROM "PlayerMatchFee"
-    WHERE "id" = ANY(${uniqueFeeIds})
+    WHERE "id" IN (${Prisma.join(uniqueFeeIds)})
   `;
 
   return new Map(

--- a/src/lib/payments/player-match-fee-snapshots.ts
+++ b/src/lib/payments/player-match-fee-snapshots.ts
@@ -1,0 +1,123 @@
+// ========================================
+// File: src/lib/payments/player-match-fee-snapshots.ts
+// ========================================
+
+import { prisma } from "@/lib/prisma";
+
+export type PlayerMatchFeeSnapshot = {
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+type SnapshotRow = {
+  id: string;
+  playerNameSnapshot: string | null;
+  playerEmailSnapshot: string | null;
+  playerPhoneSnapshot: string | null;
+};
+
+export function cleanSnapshotValue(value: string | null | undefined) {
+  const cleaned = value?.trim();
+  return cleaned || null;
+}
+
+export function buildPlayerNameSnapshot(input: {
+  name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+}) {
+  const fullName = [input.firstName, input.lastName]
+    .map((part) => cleanSnapshotValue(part))
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return (
+    cleanSnapshotValue(input.name) ||
+    cleanSnapshotValue(fullName) ||
+    cleanSnapshotValue(input.email) ||
+    cleanSnapshotValue(input.phone)
+  );
+}
+
+export async function setPlayerMatchFeeSnapshot(input: {
+  feeId: string;
+  snapshot: PlayerMatchFeeSnapshot;
+}) {
+  await prisma.$executeRaw`
+    UPDATE "PlayerMatchFee"
+    SET
+      "playerNameSnapshot" = COALESCE(${cleanSnapshotValue(input.snapshot.name)}, "playerNameSnapshot"),
+      "playerEmailSnapshot" = COALESCE(${cleanSnapshotValue(input.snapshot.email)}, "playerEmailSnapshot"),
+      "playerPhoneSnapshot" = COALESCE(${cleanSnapshotValue(input.snapshot.phone)}, "playerPhoneSnapshot")
+    WHERE "id" = ${input.feeId}
+  `;
+}
+
+export async function getPlayerMatchFeeSnapshots(feeIds: string[]) {
+  const uniqueFeeIds = Array.from(new Set(feeIds.filter(Boolean)));
+  if (uniqueFeeIds.length === 0) return new Map<string, PlayerMatchFeeSnapshot>();
+
+  const rows = await prisma.$queryRaw<SnapshotRow[]>`
+    SELECT
+      "id",
+      "playerNameSnapshot",
+      "playerEmailSnapshot",
+      "playerPhoneSnapshot"
+    FROM "PlayerMatchFee"
+    WHERE "id" = ANY(${uniqueFeeIds})
+  `;
+
+  return new Map(
+    rows.map((row) => [
+      row.id,
+      {
+        name: row.playerNameSnapshot,
+        email: row.playerEmailSnapshot,
+        phone: row.playerPhoneSnapshot,
+      },
+    ]),
+  );
+}
+
+export async function recoverPlayerMatchFeeSnapshotFromNotifications(feeId: string) {
+  const rows = await prisma.$queryRaw<Array<{
+    displayName: string | null;
+    email: string | null;
+    phone: string | null;
+  }>>`
+    SELECT
+      nr."displayName",
+      nr."email",
+      nr."phone"
+    FROM "NotificationDispatch" nd
+    JOIN "NotificationRecipient" nr ON nr."id" = nd."recipientId"
+    WHERE nd."sourceType" IN (
+      'PLAYER_MATCH_FEE_REQUEST',
+      'PLAYER_MATCH_FEE_CHASE_24H',
+      'PLAYER_MATCH_FEE_CHASE_72H'
+    )
+      AND nd."sourceId" = ${feeId}
+    ORDER BY COALESCE(nd."sentAt", nd."scheduledFor", nd."createdAt") DESC
+    LIMIT 1
+  `;
+
+  const row = rows[0];
+  if (!row) return null;
+
+  const snapshot = {
+    name: buildPlayerNameSnapshot({
+      name: row.displayName,
+      email: row.email,
+      phone: row.phone,
+    }),
+    email: cleanSnapshotValue(row.email),
+    phone: cleanSnapshotValue(row.phone),
+  };
+
+  await setPlayerMatchFeeSnapshot({ feeId, snapshot });
+  return snapshot;
+}


### PR DESCRIPTION
## Summary

- Adds persistent player detail snapshot columns for `PlayerMatchFee` rows: name, email and phone.
- Backfills snapshots from still-linked team members/prospects and, for existing orphaned rows, from old player-fee notification recipients where possible.
- Saves player snapshots when captains/admins create or update player match fees, including squad payment collection.
- Enhances the orphaned player fees admin page so it can show recovered details and recover from old notifications.
- Adds a Railway/Postgres helper query to identify likely original owners of orphaned player fee rows.

## Why

When a player/prospect is removed, the current relations use `onDelete: SetNull`, so the old fee can become `Unnamed player` / `No contact`. Historic fees should remain understandable even after squad changes.

## Notes

This PR uses a migration plus raw SQL helpers for the snapshot fields, so it can preserve/recover player information without relying on a live relation still existing.

## Validation

- Inspected the fee creation, orphaned-fee repair and notification-recovery paths.
- Could not run local build/lint from this environment because the repository is only accessible through the GitHub connector here.