### PR TITLE
Track and backfill free-kit team requests

### DIFF
--- a/prisma/migrations/20260711170000_add_team_free_kit_tracking/migration.sql
+++ b/prisma/migrations/20260711170000_add_team_free_kit_tracking/migration.sql
@@ -1,0 +1,33 @@
+-- Store the free-kit choice on the team itself.
+ALTER TABLE "Team"
+ADD COLUMN IF NOT EXISTS "wantsFreeKit" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill converted teams using the exact lead-to-team relationship.
+UPDATE "Team" AS team
+SET "wantsFreeKit" = lead."wantsFreeKit"
+FROM "InterestLead" AS lead
+WHERE lead."convertedTeamId" = team."id"
+  AND team."wantsFreeKit" IS DISTINCT FROM lead."wantsFreeKit";
+
+-- Keep the Team value synchronized whenever a team lead is converted or edited.
+CREATE OR REPLACE FUNCTION sync_team_free_kit_from_lead()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW."interestType" = 'TEAM'
+     AND NEW."convertedTeamId" IS NOT NULL THEN
+    UPDATE "Team"
+    SET "wantsFreeKit" = NEW."wantsFreeKit"
+    WHERE "id" = NEW."convertedTeamId";
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "InterestLead_sync_team_free_kit" ON "InterestLead";
+
+CREATE TRIGGER "InterestLead_sync_team_free_kit"
+AFTER INSERT OR UPDATE OF "convertedTeamId", "wantsFreeKit"
+ON "InterestLead"
+FOR EACH ROW
+EXECUTE FUNCTION sync_team_free_kit_from_lead();

--- a/src/app/(admin)/admin/teams/free-kit/page.tsx
+++ b/src/app/(admin)/admin/teams/free-kit/page.tsx
@@ -1,0 +1,154 @@
+import Link from "next/link";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+type FreeKitTeamRow = {
+  id: string;
+  name: string;
+  contactName: string | null;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  createdAt: Date;
+  leadId: string | null;
+  leadContactName: string | null;
+  leadEmail: string | null;
+  leadPhone: string | null;
+  leadTeamName: string | null;
+  leadCreatedAt: Date | null;
+};
+
+function formatUkDate(value: Date | null) {
+  if (!value) return "—";
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "Europe/London",
+  }).format(value);
+}
+
+export default async function FreeKitTeamsPage() {
+  await requireAdmin();
+
+  const teams = await prisma.$queryRaw<FreeKitTeamRow[]>(Prisma.sql`
+    SELECT
+      team."id",
+      team."name",
+      team."contactName",
+      team."contactEmail",
+      team."contactPhone",
+      team."createdAt",
+      lead."id" AS "leadId",
+      lead."contactName" AS "leadContactName",
+      lead."email" AS "leadEmail",
+      lead."phone" AS "leadPhone",
+      lead."teamName" AS "leadTeamName",
+      lead."createdAt" AS "leadCreatedAt"
+    FROM "Team" AS team
+    LEFT JOIN "InterestLead" AS lead
+      ON lead."convertedTeamId" = team."id"
+    WHERE team."wantsFreeKit" = true
+    ORDER BY team."name" ASC
+  `);
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-8 px-6 py-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-sm font-bold uppercase tracking-[0.22em] text-amber-300">
+            Kit offer
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold text-white">Free-kit teams</h1>
+          <p className="mt-2 max-w-3xl text-sm text-white/60">
+            Teams whose original registration included the free-kit offer. Converted leads are
+            linked using their exact team id rather than a name or email match.
+          </p>
+        </div>
+
+        <Link
+          href="/admin/teams"
+          className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-white/10"
+        >
+          Back to teams
+        </Link>
+      </div>
+
+      <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
+        <div className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-200/70">
+          Opted in
+        </div>
+        <div className="mt-2 text-4xl font-semibold text-amber-100">{teams.length}</div>
+      </div>
+
+      <div className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03]">
+        {teams.length === 0 ? (
+          <div className="p-8 text-sm text-white/55">No converted teams have opted in.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[980px] text-left text-sm">
+              <thead className="border-b border-white/10 bg-black/25 text-xs uppercase tracking-[0.14em] text-white/40">
+                <tr>
+                  <th className="px-5 py-4 font-semibold">Team</th>
+                  <th className="px-5 py-4 font-semibold">Contact</th>
+                  <th className="px-5 py-4 font-semibold">Original lead</th>
+                  <th className="px-5 py-4 font-semibold">Registered</th>
+                  <th className="px-5 py-4 text-right font-semibold">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10">
+                {teams.map((team) => {
+                  const contactName = team.contactName || team.leadContactName || "—";
+                  const contactEmail = team.contactEmail || team.leadEmail || "—";
+                  const contactPhone = team.contactPhone || team.leadPhone || "—";
+
+                  return (
+                    <tr key={team.id} className="align-top hover:bg-white/[0.03]">
+                      <td className="px-5 py-4">
+                        <div className="font-semibold text-white">{team.name}</div>
+                        <span className="mt-2 inline-flex rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-amber-200">
+                          Free kit requested
+                        </span>
+                      </td>
+                      <td className="px-5 py-4 text-white/70">
+                        <div>{contactName}</div>
+                        <div className="mt-1 break-all text-white/55">{contactEmail}</div>
+                        <div className="mt-1 text-white/55">{contactPhone}</div>
+                      </td>
+                      <td className="px-5 py-4 text-white/65">
+                        <div>{team.leadTeamName || "—"}</div>
+                        {team.leadId ? (
+                          <Link
+                            href={`/admin/leads/${team.leadId}`}
+                            className="mt-2 inline-flex text-xs font-semibold text-emerald-300 hover:text-emerald-200"
+                          >
+                            Open original lead
+                          </Link>
+                        ) : (
+                          <div className="mt-2 text-xs text-white/35">No linked lead</div>
+                        )}
+                      </td>
+                      <td className="px-5 py-4 text-white/60">
+                        {formatUkDate(team.leadCreatedAt || team.createdAt)}
+                      </td>
+                      <td className="px-5 py-4 text-right">
+                        <Link
+                          href={`/admin/teams/${team.id}`}
+                          className="inline-flex rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-emerald-500"
+                        >
+                          Open team
+                        </Link>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

- adds `Team.wantsFreeKit` at database level with a safe default
- backfills converted teams using `InterestLead.convertedTeamId`, avoiding unreliable name/email matching
- adds a database trigger so future lead conversions and later lead edits keep the team value synchronized
- adds an admin view at `/admin/teams/free-kit` listing every opted-in team, contact details, and the original lead

## Why

The free-kit choice was stored only on `InterestLead`, so it was easy to lose sight of once a lead became a Team. This makes the choice part of the Team data and provides a clear operational list.

## Deployment note

Run the normal Prisma migration deployment before opening `/admin/teams/free-kit`, because the page reads the new database column.

## Validation

Reviewed the migration for repeat-safe trigger replacement and exact id-based backfill. The admin page uses raw Prisma SQL so it does not depend on generated Prisma client types for the newly added column.