### PR TITLE
Show free-kit badges and fix team messages link

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -27,6 +27,7 @@ import RefereeNightFixtureSyncBridge from "@/components/admin/referee-nights/Ref
 import AdminRefereeCommsHistoryBridge from "@/components/admin/referees/AdminRefereeCommsHistoryBridge";
 import RefereeWelcomeInviteBridge from "@/components/admin/referees/RefereeWelcomeInviteBridge";
 import AdminSocialResultsGeneratorLinksBridge from "@/components/admin/social/AdminSocialResultsGeneratorLinksBridge";
+import FreeKitTeamBadgesBridge from "@/components/admin/teams/FreeKitTeamBadgesBridge";
 import TeamCompetitionPickerBridge from "@/components/admin/teams/TeamCompetitionPickerBridge";
 import TeamReplaceFixturesButtonBridge from "@/components/admin/teams/TeamReplaceFixturesButtonBridge";
 import TeamStandardMatchFeeBridge from "@/components/admin/teams/TeamStandardMatchFeeBridge";
@@ -64,6 +65,7 @@ export default async function AdminLayout({
       <AdminLeagueSeasonsBridge />
       <AdminLeagueSeasonTeamsBridge />
       <AdminDivisionSelectBridge />
+      <FreeKitTeamBadgesBridge />
       <TeamCompetitionPickerBridge />
       <TeamReplaceFixturesButtonBridge />
       <TeamStandardMatchFeeBridge />

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -28,6 +28,7 @@ import AdminRefereeCommsHistoryBridge from "@/components/admin/referees/AdminRef
 import RefereeWelcomeInviteBridge from "@/components/admin/referees/RefereeWelcomeInviteBridge";
 import AdminSocialResultsGeneratorLinksBridge from "@/components/admin/social/AdminSocialResultsGeneratorLinksBridge";
 import FreeKitTeamBadgesBridge from "@/components/admin/teams/FreeKitTeamBadgesBridge";
+import RemoveDuplicateLatestKickoffBridge from "@/components/admin/teams/RemoveDuplicateLatestKickoffBridge";
 import TeamCompetitionPickerBridge from "@/components/admin/teams/TeamCompetitionPickerBridge";
 import TeamReplaceFixturesButtonBridge from "@/components/admin/teams/TeamReplaceFixturesButtonBridge";
 import TeamStandardMatchFeeBridge from "@/components/admin/teams/TeamStandardMatchFeeBridge";
@@ -66,6 +67,7 @@ export default async function AdminLayout({
       <AdminLeagueSeasonTeamsBridge />
       <AdminDivisionSelectBridge />
       <FreeKitTeamBadgesBridge />
+      <RemoveDuplicateLatestKickoffBridge />
       <TeamCompetitionPickerBridge />
       <TeamReplaceFixturesButtonBridge />
       <TeamStandardMatchFeeBridge />

--- a/src/app/(admin)/admin/team-messages/page.tsx
+++ b/src/app/(admin)/admin/team-messages/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function LegacyTeamMessagesPage() {
+  redirect("/admin/messaging");
+}

--- a/src/app/api/admin/teams/free-kit/route.ts
+++ b/src/app/api/admin/teams/free-kit/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+type FreeKitTeamRow = {
+  id: string;
+};
+
+export async function GET() {
+  await requireAdmin();
+
+  const teams = await prisma.$queryRaw<FreeKitTeamRow[]>(Prisma.sql`
+    SELECT "id"
+    FROM "Team"
+    WHERE "wantsFreeKit" = true
+    ORDER BY "name" ASC
+  `);
+
+  return NextResponse.json({ teamIds: teams.map((team) => team.id) });
+}

--- a/src/components/admin/teams/FreeKitTeamBadgesBridge.tsx
+++ b/src/components/admin/teams/FreeKitTeamBadgesBridge.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+type FreeKitPayload = {
+  teamIds: string[];
+};
+
+function addBadge(teamId: string) {
+  const editLink = document.querySelector<HTMLAnchorElement>(
+    `a[href="/admin/teams/${CSS.escape(teamId)}"]`,
+  );
+  const row = editLink?.closest("div.grid");
+  const title = row?.querySelector<HTMLElement>(".text-base.font-semibold.text-white");
+
+  if (!title || title.parentElement?.querySelector('[data-free-kit-badge="true"]')) return;
+
+  const badge = document.createElement("span");
+  badge.dataset.freeKitBadge = "true";
+  badge.className =
+    "rounded-full border border-amber-400/30 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100";
+  badge.textContent = "Free kit";
+  title.insertAdjacentElement("afterend", badge);
+}
+
+async function injectBadges() {
+  try {
+    const response = await fetch("/api/admin/teams/free-kit", { cache: "no-store" });
+    if (!response.ok) return;
+
+    const payload = (await response.json()) as FreeKitPayload;
+    payload.teamIds.forEach(addBadge);
+  } catch {
+    // Leave the normal team list untouched if this enhancement cannot load.
+  }
+}
+
+export default function FreeKitTeamBadgesBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname !== "/admin/teams") return;
+
+    const frame = window.requestAnimationFrame(() => void injectBadges());
+    const timer = window.setTimeout(() => void injectBadges(), 500);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timer);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/admin/teams/RemoveDuplicateLatestKickoffBridge.tsx
+++ b/src/components/admin/teams/RemoveDuplicateLatestKickoffBridge.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+function removeDuplicateLatestKickoffField() {
+  const labels = Array.from(document.querySelectorAll<HTMLLabelElement>("label")).filter(
+    (label) => label.textContent?.trim() === "Latest kickoff time",
+  );
+
+  if (labels.length < 2) return;
+
+  // Keep the first working control and remove any duplicate blocks that follow it.
+  labels.slice(1).forEach((label) => {
+    label.closest("div.space-y-2")?.remove();
+  });
+}
+
+export default function RemoveDuplicateLatestKickoffBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname?.match(/^\/admin\/teams\/[^/]+\/?$/)) return;
+
+    removeDuplicateLatestKickoffField();
+    const timer = window.setTimeout(removeDuplicateLatestKickoffField, 400);
+
+    return () => window.clearTimeout(timer);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## What changed

- shows an amber **Free kit** badge beside opted-in teams on the normal Admin → Teams page
- adds an authenticated admin endpoint used only to load the opted-in team IDs
- fixes the broken `/admin/team-messages` route by redirecting it to the current Communications hub at `/admin/messaging`

## Why

The free-kit list is useful for fulfilment, but the entitlement also needs to be visible while working in the main team list. The Team messages navigation item was a legacy duplicate and currently led to a 404; team and captain email/SMS conversations are now handled by the main Communications page.

## Deployment

No new database migration is included in this follow-up. It relies on the free-kit migration already merged in PR #128.