### PR TITLE
Remove unused admin Settings link

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -7,6 +7,7 @@ import { requireAdmin } from "@/lib/requireAdmin";
 import { getAdminInboxSummary } from "@/lib/messaging/service";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 import AdminSidebarDesktopColumnsBridge from "@/components/admin/AdminSidebarDesktopColumnsBridge";
+import RemoveUnusedSettingsNavBridge from "@/components/admin/RemoveUnusedSettingsNavBridge";
 import AdminTeamContactPhoneFallbackBridge from "@/components/admin/communications/AdminTeamContactPhoneFallbackBridge";
 import ProspectCommunicationCtaBridge from "@/components/admin/communications/ProspectCommunicationCtaBridge";
 import EmailTemplateListControlsBridge from "@/components/admin/email-templates/EmailTemplateListControlsBridge";
@@ -63,6 +64,7 @@ export default async function AdminLayout({
       <PlayerProspectsNotInterestedBridge />
       <GenerateNextWeekFixturesBridge />
       <AdminSidebarDesktopColumnsBridge />
+      <RemoveUnusedSettingsNavBridge />
       <AdminLeagueSeasonsBridge />
       <AdminLeagueSeasonTeamsBridge />
       <AdminDivisionSelectBridge />

--- a/src/components/admin/RemoveUnusedSettingsNavBridge.tsx
+++ b/src/components/admin/RemoveUnusedSettingsNavBridge.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+function removeUnusedSettingsLink() {
+  document
+    .querySelectorAll<HTMLAnchorElement>('a[href="/admin/settings"]')
+    .forEach((link) => link.remove());
+}
+
+export default function RemoveUnusedSettingsNavBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    removeUnusedSettingsLink();
+
+    const observer = new MutationObserver(removeUnusedSettingsLink);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Removes the unused Settings item from the admin sidebar so it no longer leads to a 404. The link can be restored later when a real settings page exists.