### PR TITLE
Add SIXFL TV fixture recording flag

### DIFF
--- a/prisma/migrations/20260712153000_add_fixture_sixfl_tv_recorded/migration.sql
+++ b/prisma/migrations/20260712153000_add_fixture_sixfl_tv_recorded/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Fixture"
+ADD COLUMN IF NOT EXISTS "sixflTvRecorded" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS "Fixture_sixflTvRecorded_idx"
+ON "Fixture" ("sixflTvRecorded");

--- a/src/app/api/admin/fixtures/sixfl-tv/route.ts
+++ b/src/app/api/admin/fixtures/sixfl-tv/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type FlagRow = {
+  id: string;
+  sixflTvRecorded: boolean;
+};
+
+export async function GET() {
+  await requireAdmin();
+
+  const rows = await prisma.$queryRaw<FlagRow[]>(Prisma.sql`
+    SELECT "id", "sixflTvRecorded"
+    FROM "Fixture"
+    WHERE "sixflTvRecorded" = true
+  `);
+
+  return NextResponse.json({ fixtureIds: rows.map((row) => row.id) });
+}
+
+export async function POST(request: Request) {
+  await requireAdmin();
+
+  const body = (await request.json().catch(() => null)) as {
+    fixtureId?: string;
+    sixflTvRecorded?: boolean;
+  } | null;
+
+  const fixtureId = body?.fixtureId?.trim() ?? "";
+  if (!fixtureId) {
+    return NextResponse.json({ error: "Fixture ID is required." }, { status: 400 });
+  }
+
+  const sixflTvRecorded = body?.sixflTvRecorded === true;
+
+  const rows = await prisma.$queryRaw<FlagRow[]>(Prisma.sql`
+    UPDATE "Fixture"
+    SET "sixflTvRecorded" = ${sixflTvRecorded}, "updatedAt" = NOW()
+    WHERE "id" = ${fixtureId}
+    RETURNING "id", "sixflTvRecorded"
+  `);
+
+  if (!rows[0]) {
+    return NextResponse.json({ error: "Fixture not found." }, { status: 404 });
+  }
+
+  return NextResponse.json(rows[0]);
+}

--- a/src/app/api/captain/team/[teamid]/sixfl-tv-fixtures/route.ts
+++ b/src/app/api/captain/team/[teamid]/sixfl-tv-fixtures/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { getCaptainRelatedTeamContext } from "@/lib/captain/related-teams";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type TvFixtureRow = {
+  id: string;
+  homeTeamName: string;
+  awayTeamName: string;
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const context = await getCaptainRelatedTeamContext(teamid);
+  if (!context) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  const rows = await prisma.$queryRaw<TvFixtureRow[]>(Prisma.sql`
+    SELECT
+      f."id",
+      home."name" AS "homeTeamName",
+      away."name" AS "awayTeamName"
+    FROM "Fixture" f
+    JOIN "Team" home ON home."id" = f."homeTeamId"
+    JOIN "Team" away ON away."id" = f."awayTeamId"
+    WHERE f."sixflTvRecorded" = true
+      AND f."publishedAt" IS NOT NULL
+      AND (
+        f."homeTeamId" IN (${Prisma.join(context.relatedTeamIds)})
+        OR f."awayTeamId" IN (${Prisma.join(context.relatedTeamIds)})
+      )
+  `);
+
+  return NextResponse.json({
+    fixtures: rows.map((row) => ({
+      id: row.id,
+      fullLabel: `${row.homeTeamName} vs ${row.awayTeamName}`,
+      captainLabels: [`vs ${row.homeTeamName}`, `vs ${row.awayTeamName}`],
+    })),
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import "./team-badge-sizing.css";
 import "./hide-old-fixture-generator.css";
 import { Suspense, type ReactNode } from "react";
 import AdminPaymentsPageBridge from "@/components/admin/payments/AdminPaymentsPageBridge";
+import SixflTvFixtureBridge from "@/components/SixflTvFixtureBridge";
 import Providers from "./providers";
 
 export const metadata = {
@@ -101,6 +102,7 @@ export default function RootLayout({
         <Providers>
           <Suspense fallback={null}>
             <AdminPaymentsPageBridge />
+            <SixflTvFixtureBridge />
           </Suspense>
           {children}
         </Providers>

--- a/src/components/SixflTvFixtureBridge.tsx
+++ b/src/components/SixflTvFixtureBridge.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+type CaptainTvFixture = {
+  id: string;
+  fullLabel: string;
+  captainLabels: string[];
+};
+
+function normalise(value: string | null | undefined) {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+async function loadAdminFlags() {
+  const response = await fetch("/api/admin/fixtures/sixfl-tv", { cache: "no-store" });
+  if (!response.ok) return new Set<string>();
+  const payload = (await response.json().catch(() => null)) as { fixtureIds?: string[] } | null;
+  return new Set(payload?.fixtureIds ?? []);
+}
+
+async function saveAdminFlag(fixtureId: string, sixflTvRecorded: boolean) {
+  const response = await fetch("/api/admin/fixtures/sixfl-tv", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fixtureId, sixflTvRecorded }),
+  });
+  return response.ok;
+}
+
+function injectNightBoardCheckboxes(recordedIds: Set<string>) {
+  const forms = Array.from(
+    document.querySelectorAll<HTMLFormElement>('form input[name="fixtureId"]'),
+  )
+    .map((input) => input.closest("form"))
+    .filter((form): form is HTMLFormElement => Boolean(form));
+
+  for (const form of forms) {
+    if (form.querySelector("[data-sixfl-tv-control]")) continue;
+    const fixtureId = form.querySelector<HTMLInputElement>('input[name="fixtureId"]')?.value;
+    if (!fixtureId) continue;
+
+    const label = document.createElement("label");
+    label.dataset.sixflTvControl = "true";
+    label.className =
+      "flex items-center justify-between gap-3 rounded-xl border border-fuchsia-400/25 bg-fuchsia-500/10 px-3 py-2 text-xs font-semibold text-fuchsia-100";
+
+    const text = document.createElement("span");
+    text.textContent = "SIXFL TV recorded";
+
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = recordedIds.has(fixtureId);
+    input.className = "h-4 w-4 accent-fuchsia-500";
+
+    const status = document.createElement("span");
+    status.className = "text-[10px] font-normal text-fuchsia-100/60";
+    status.textContent = input.checked ? "Shown to captains" : "Not shown";
+
+    const left = document.createElement("span");
+    left.className = "flex flex-col";
+    left.appendChild(text);
+    left.appendChild(status);
+
+    input.addEventListener("change", async () => {
+      input.disabled = true;
+      status.textContent = "Saving…";
+      const ok = await saveAdminFlag(fixtureId, input.checked);
+      input.disabled = false;
+      if (!ok) {
+        input.checked = !input.checked;
+        status.textContent = "Could not save";
+        return;
+      }
+      status.textContent = input.checked ? "Shown to captains" : "Not shown";
+    });
+
+    label.appendChild(left);
+    label.appendChild(input);
+    form.querySelector('button[type="submit"]')?.insertAdjacentElement("beforebegin", label);
+  }
+}
+
+async function loadCaptainFixtures(teamId: string) {
+  const response = await fetch(`/api/captain/team/${teamId}/sixfl-tv-fixtures`, {
+    cache: "no-store",
+  });
+  if (!response.ok) return [];
+  const payload = (await response.json().catch(() => null)) as {
+    fixtures?: CaptainTvFixture[];
+  } | null;
+  return payload?.fixtures ?? [];
+}
+
+function createTvBadge(fixtureId: string) {
+  const badge = document.createElement("span");
+  badge.dataset.sixflTvFixture = fixtureId;
+  badge.className =
+    "inline-flex items-center rounded-full border border-fuchsia-400/30 bg-fuchsia-500/12 px-2.5 py-1 text-[11px] font-semibold text-fuchsia-100";
+  badge.textContent = "SIXFL TV";
+  badge.title = "This fixture is being recorded for SIXFL TV";
+  return badge;
+}
+
+function injectCaptainBadges(fixtures: CaptainTvFixture[]) {
+  if (fixtures.length === 0) return;
+  const candidates = Array.from(
+    document.querySelectorAll<HTMLElement>("h2, div.text-base.font-semibold.text-white, div.font-semibold.text-white"),
+  );
+
+  for (const element of candidates) {
+    const text = normalise(element.textContent);
+    const fixture = fixtures.find(
+      (item) =>
+        text === normalise(item.fullLabel) ||
+        item.captainLabels.some((label) => text === normalise(label)),
+    );
+    if (!fixture) continue;
+
+    const parent = element.parentElement ?? element;
+    if (parent.querySelector(`[data-sixfl-tv-fixture="${fixture.id}"]`)) continue;
+    parent.classList.add("flex", "flex-wrap", "items-center", "gap-2");
+    parent.appendChild(createTvBadge(fixture.id));
+  }
+}
+
+export default function SixflTvFixtureBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let cancelled = false;
+    let observer: MutationObserver | null = null;
+
+    if (pathname === "/admin/night-board") {
+      void loadAdminFlags().then((ids) => {
+        if (cancelled) return;
+        const run = () => injectNightBoardCheckboxes(ids);
+        run();
+        observer = new MutationObserver(run);
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+    }
+
+    const captainMatch = pathname.match(/^\/captain\/team\/([^/]+)(?:\/|$)/);
+    const teamId = captainMatch?.[1];
+    if (teamId) {
+      void loadCaptainFixtures(teamId).then((fixtures) => {
+        if (cancelled) return;
+        const run = () => injectCaptainBadges(fixtures);
+        run();
+        observer = new MutationObserver(run);
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+    };
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## What changed

- adds a `sixflTvRecorded` database field to fixtures
- adds a SIXFL TV recorded checkbox to each fixture on the Night board
- saves checkbox changes immediately through an authenticated admin endpoint
- shows a SIXFL TV badge on the captain dashboard for recorded fixtures

## Deployment

Railway will run the included Prisma migration on startup before the new field is used.