### PR TITLE
Fix AI predictor result history matching

### DIFF
--- a/src/app/api/captain/team/[teamid]/fixture-badges/route.ts
+++ b/src/app/api/captain/team/[teamid]/fixture-badges/route.ts
@@ -6,10 +6,11 @@ import { NextResponse } from "next/server";
 
 import { getCaptainRelatedTeamContext } from "@/lib/captain/related-teams";
 import { getFallbackFixtureAiPreview } from "@/lib/fixtures/aiPredictor";
+import { getStoredAiPreviewsByFixtureIds } from "@/lib/fixtures/storedAiPredictions";
 import {
-  getStoredAiPreviewsByFixtureIds,
-  refreshStoredAiPreviewsForLeague,
-} from "@/lib/fixtures/storedAiPredictions";
+  buildNameAwareWinChanceFixtures,
+  shouldIgnoreStaleTooEarlyPreview,
+} from "@/lib/fixtures/winChanceHistory";
 import { calculateFixtureWinChance } from "@/lib/fixtures/winChance";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
@@ -104,28 +105,13 @@ export async function GET(
       },
     });
 
-    const scheduledFixtureIds = fixtures
-      .filter((fixture) => fixture.status === "SCHEDULED")
-      .map((fixture) => fixture.id);
+    const scheduledFixtures = fixtures.filter((fixture) => fixture.status === "SCHEDULED");
 
-    if (context.currentLeagueId && scheduledFixtureIds.length > 0) {
-      await refreshStoredAiPreviewsForLeague(context.currentLeagueId, {
-        fixtureIds: scheduledFixtureIds,
-      });
-    }
-
-    const predictorTeamIds = Array.from(
-      new Set(fixtures.flatMap((fixture) => [fixture.homeTeamId, fixture.awayTeamId])),
-    );
-    const predictionHistory = predictorTeamIds.length
+    const leagueHistory = context.currentLeagueId
       ? await prisma.fixture.findMany({
           where: {
-            status: "COMPLETED",
-            result: { isNot: null },
-            OR: [
-              { homeTeamId: { in: predictorTeamIds } },
-              { awayTeamId: { in: predictorTeamIds } },
-            ],
+            leagueId: context.currentLeagueId,
+            publishedAt: { not: null },
           },
           orderBy: [{ kickoffAt: "asc" }],
           take: 500,
@@ -133,12 +119,17 @@ export async function GET(
             id: true,
             kickoffAt: true,
             status: true,
-            homeTeam: { select: { id: true } },
-            awayTeam: { select: { id: true } },
+            homeTeam: { select: { id: true, name: true } },
+            awayTeam: { select: { id: true, name: true } },
             result: { select: { homeScore: true, awayScore: true } },
           },
         })
       : [];
+
+    const predictionHistory = buildNameAwareWinChanceFixtures({
+      historyFixtures: leagueHistory,
+      targetFixtures: scheduledFixtures,
+    });
 
     const storedPreviews = await getStoredAiPreviewsByFixtureIds(
       fixtures.map((fixture) => fixture.id),
@@ -175,18 +166,25 @@ export async function GET(
           awayTeamId: fixture.awayTeamId,
           fixtures: predictionHistory,
         });
+        const storedPreview = storedPreviews.get(fixture.id) ?? null;
+        const fallbackPreview = getFallbackFixtureAiPreview({
+          homeTeamName: fixture.homeTeam.name,
+          awayTeamName: fixture.awayTeam.name,
+          winChance,
+        });
 
         return {
           ...base,
           winChance: {
             ...winChance,
             aiPreview:
-              storedPreviews.get(fixture.id) ??
-              getFallbackFixtureAiPreview({
-                homeTeamName: fixture.homeTeam.name,
-                awayTeamName: fixture.awayTeam.name,
-                winChance,
-              }),
+              !storedPreview ||
+              shouldIgnoreStaleTooEarlyPreview({
+                preview: storedPreview,
+                predictedResultLabel: winChance.predictedResult.label,
+              })
+                ? fallbackPreview
+                : storedPreview,
           },
         };
       }),

--- a/src/app/api/leagues/[slug]/win-chances/route.ts
+++ b/src/app/api/leagues/[slug]/win-chances/route.ts
@@ -5,10 +5,11 @@
 import { NextResponse } from "next/server";
 
 import { getFallbackFixtureAiPreview } from "@/lib/fixtures/aiPredictor";
+import { getStoredAiPreviewsByFixtureIds } from "@/lib/fixtures/storedAiPredictions";
 import {
-  getStoredAiPreviewsByFixtureIds,
-  refreshStoredAiPreviewsForLeague,
-} from "@/lib/fixtures/storedAiPredictions";
+  buildNameAwareWinChanceFixtures,
+  shouldIgnoreStaleTooEarlyPreview,
+} from "@/lib/fixtures/winChanceHistory";
 import { calculateFixtureWinChance } from "@/lib/fixtures/winChance";
 import { prisma } from "@/lib/prisma";
 
@@ -73,37 +74,10 @@ export async function GET(
       (fixture) => fixture.status === "SCHEDULED",
     );
 
-    if (scheduledFixtures.length > 0) {
-      await refreshStoredAiPreviewsForLeague(league.id, {
-        fixtureIds: scheduledFixtures.map((fixture) => fixture.id),
-      });
-    }
-
-    const predictorTeamIds = Array.from(
-      new Set(scheduledFixtures.flatMap((fixture) => [fixture.homeTeam.id, fixture.awayTeam.id])),
-    );
-    const predictionHistory = predictorTeamIds.length
-      ? await prisma.fixture.findMany({
-          where: {
-            status: "COMPLETED",
-            result: { isNot: null },
-            OR: [
-              { homeTeamId: { in: predictorTeamIds } },
-              { awayTeamId: { in: predictorTeamIds } },
-            ],
-          },
-          orderBy: [{ kickoffAt: "asc" }],
-          take: 500,
-          select: {
-            id: true,
-            kickoffAt: true,
-            status: true,
-            homeTeam: { select: { id: true } },
-            awayTeam: { select: { id: true } },
-            result: { select: { homeScore: true, awayScore: true } },
-          },
-        })
-      : [];
+    const predictionHistory = buildNameAwareWinChanceFixtures({
+      historyFixtures: league.fixtures,
+      targetFixtures: scheduledFixtures,
+    });
 
     const storedPreviews = await getStoredAiPreviewsByFixtureIds(
       scheduledFixtures.map((fixture) => fixture.id),
@@ -116,6 +90,12 @@ export async function GET(
           awayTeamId: fixture.awayTeam.id,
           fixtures: predictionHistory,
         });
+        const storedPreview = storedPreviews.get(fixture.id) ?? null;
+        const fallbackPreview = getFallbackFixtureAiPreview({
+          homeTeamName: fixture.homeTeam.name,
+          awayTeamName: fixture.awayTeam.name,
+          winChance,
+        });
 
         return {
           id: fixture.id,
@@ -126,12 +106,13 @@ export async function GET(
           winChance: {
             ...winChance,
             aiPreview:
-              storedPreviews.get(fixture.id) ??
-              getFallbackFixtureAiPreview({
-                homeTeamName: fixture.homeTeam.name,
-                awayTeamName: fixture.awayTeam.name,
-                winChance,
-              }),
+              !storedPreview ||
+              shouldIgnoreStaleTooEarlyPreview({
+                preview: storedPreview,
+                predictedResultLabel: winChance.predictedResult.label,
+              })
+                ? fallbackPreview
+                : storedPreview,
           },
         };
       }),

--- a/src/lib/fixtures/winChanceHistory.ts
+++ b/src/lib/fixtures/winChanceHistory.ts
@@ -1,0 +1,89 @@
+// ========================================
+// File: src/lib/fixtures/winChanceHistory.ts
+// ========================================
+
+import type { FixtureAiPreview } from "@/lib/fixtures/aiPredictor";
+import type { WinChanceFixture } from "@/lib/fixtures/winChance";
+
+type NamedTeam = {
+  id: string;
+  name: string;
+};
+
+type NamedFixtureSource = {
+  kickoffAt?: Date | string | null;
+  status: string;
+  homeTeam: NamedTeam;
+  awayTeam: NamedTeam;
+  result: {
+    homeScore: number;
+    awayScore: number;
+  } | null;
+};
+
+type TargetFixtureSource = {
+  homeTeam: NamedTeam;
+  awayTeam: NamedTeam;
+};
+
+export function normalisePredictorTeamName(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildCurrentTeamIdByName(targetFixtures: TargetFixtureSource[]) {
+  const currentTeamIdByName = new Map<string, string>();
+
+  for (const fixture of targetFixtures) {
+    for (const team of [fixture.homeTeam, fixture.awayTeam]) {
+      const key = normalisePredictorTeamName(team.name);
+      if (key && !currentTeamIdByName.has(key)) {
+        currentTeamIdByName.set(key, team.id);
+      }
+    }
+  }
+
+  return currentTeamIdByName;
+}
+
+function canonicalTeamId(input: { team: NamedTeam; currentTeamIdByName: Map<string, string> }) {
+  const nameKey = normalisePredictorTeamName(input.team.name);
+  return input.currentTeamIdByName.get(nameKey) ?? input.team.id;
+}
+
+export function buildNameAwareWinChanceFixtures(input: {
+  historyFixtures: NamedFixtureSource[];
+  targetFixtures: TargetFixtureSource[];
+}): WinChanceFixture[] {
+  const currentTeamIdByName = buildCurrentTeamIdByName(input.targetFixtures);
+
+  return input.historyFixtures.map((fixture) => ({
+    kickoffAt: fixture.kickoffAt,
+    status: fixture.status,
+    homeTeam: {
+      id: canonicalTeamId({ team: fixture.homeTeam, currentTeamIdByName }),
+    },
+    awayTeam: {
+      id: canonicalTeamId({ team: fixture.awayTeam, currentTeamIdByName }),
+    },
+    result: fixture.result,
+  }));
+}
+
+export function shouldIgnoreStaleTooEarlyPreview(input: {
+  preview?: FixtureAiPreview | null;
+  predictedResultLabel: string;
+}) {
+  const preview = input.preview;
+  if (!preview) return false;
+
+  if (input.predictedResultLabel === "Too early") return false;
+
+  const text = `${preview.headline} ${preview.summary}`.toLowerCase();
+
+  return /no completed results?|no usable match data|too early for a score prediction|too early to call|without completed results?|not enough completed/.test(text);
+}


### PR DESCRIPTION
## What changed

- matches prediction history by normalised team name as well as current team IDs
- fixes public league-page win chances so duplicated/recreated team records can still use previous completed results
- applies the same history fix to captain fixture badges
- ignores stale stored AI text that still says "no completed results" once the live prediction has usable results

## Why

The predictor was using exact Team IDs, so if a team had been recreated or carried across seasons/divisions under a different record, it could miss visible completed results and show the default 35/30/35 "too early" copy.

## Deployment

No database migration. Railway can deploy normally.