### PR TITLE
Move Night Board warnings near the top

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Suspense, type ReactNode } from "react";
 import NightBoardFixtureIssuesLink from "@/components/admin/night-board/NightBoardFixtureIssuesLink";
 import NightBoardMatchFeeSyncBridge from "@/components/admin/night-board/NightBoardMatchFeeSyncBridge";
 import NightBoardTeamIssuesPanel from "@/components/admin/night-board/NightBoardTeamIssuesPanel";
+import NightBoardWarningsPositionBridge from "@/components/admin/night-board/NightBoardWarningsPositionBridge";
 import AdminPaymentsPageBridge from "@/components/admin/payments/AdminPaymentsPageBridge";
 import CaptainFixturesDeduplicateBridge from "@/components/captain/CaptainFixturesDeduplicateBridge";
 import CaptainHeaderLeaguePositionBridge from "@/components/captain/CaptainHeaderLeaguePositionBridge";
@@ -112,6 +113,7 @@ export default function RootLayout({
             <NightBoardMatchFeeSyncBridge />
             <NightBoardTeamIssuesPanel />
             <NightBoardFixtureIssuesLink />
+            <NightBoardWarningsPositionBridge />
             <AdminPaymentsPageBridge />
             <CaptainFixturesDeduplicateBridge />
             <CaptainHeaderLeaguePositionBridge />


### PR DESCRIPTION
## What changed

- mounts the existing `NightBoardWarningsPositionBridge` in the root layout
- moves the **Warnings and potential issues** card above the Pitch board on the Night Board
- keeps warnings advisory only; match saving behaviour is unchanged

## Why

The positioning bridge already existed but was not mounted, so the warning card remained near the bottom of the page and was easy to miss.