### PR TITLE
Add direct team changes for player prospects

### DIFF
--- a/src/app/api/admin/player-prospects/change-team/route.ts
+++ b/src/app/api/admin/player-prospects/change-team/route.ts
@@ -1,0 +1,336 @@
+// ========================================
+// File: src/app/api/admin/player-prospects/change-team/route.ts
+// ========================================
+
+import {
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+} from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import {
+  ensureManagedSquadJoinConfirmationTemplate,
+  getManagedSquadJoinConfirmationUrl,
+  MANAGED_SQUAD_JOIN_CONFIRMATION_TEMPLATE_KEY,
+} from "@/lib/managed-squad/prospectJoinConfirmation";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function routeError(error: unknown) {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : "Something went wrong.";
+}
+
+function getDisplayName(input: {
+  firstName: string;
+  lastName: string | null;
+  email: string | null;
+}) {
+  return (
+    [input.firstName, input.lastName].filter(Boolean).join(" ").trim() ||
+    input.email?.trim() ||
+    "Player"
+  );
+}
+
+function getFirstName(value: string) {
+  return value.trim().split(/\s+/)[0] ?? "";
+}
+
+function formatPreferredNight(value: string | null | undefined) {
+  if (!value || value === "ANY") return null;
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+}
+
+function getTeamContextLine(team: {
+  name: string;
+  league: {
+    dayOfWeek: string | null;
+    venueName: string | null;
+  } | null;
+}) {
+  const night = formatPreferredNight(team.league?.dayOfWeek);
+  const venueName = team.league?.venueName?.trim();
+
+  if (night && venueName) return `${team.name} plays on a ${night} night at ${venueName}.`;
+  if (night) return `${team.name} plays on a ${night} night.`;
+  if (venueName) return `${team.name} plays at ${venueName}.`;
+  return `${team.name} is a SIXFL squad.`;
+}
+
+async function queueFreshSquadInvite(input: {
+  prospect: {
+    id: string;
+    firstName: string;
+    lastName: string | null;
+    email: string;
+    phone: string | null;
+  };
+  team: {
+    id: string;
+    name: string;
+    logoUrl: string | null;
+    league: {
+      name: string;
+      season: string | null;
+      dayOfWeek: string | null;
+      venueName: string | null;
+    } | null;
+  };
+  createdByUserId: string | null;
+}) {
+  await ensureManagedSquadJoinConfirmationTemplate();
+
+  const displayName = getDisplayName(input.prospect);
+  const joinConfirmationUrl = getManagedSquadJoinConfirmationUrl(input.prospect.id);
+  const leagueName = input.team.league
+    ? `${input.team.league.name}${
+        input.team.league.season ? ` · ${input.team.league.season}` : ""
+      }`
+    : "";
+
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.GENERAL,
+    sourceId: `team-prospect:${input.prospect.id}`,
+    audience: NotificationAudience.PLAYER,
+    displayName,
+    email: input.prospect.email,
+    phone: input.prospect.phone,
+    transactionalEmailOptIn: true,
+    transactionalSmsOptIn: true,
+    marketingEmailOptIn: true,
+    marketingSmsOptIn: true,
+    metadata: {
+      teamId: input.team.id,
+      teamName: input.team.name,
+      prospectId: input.prospect.id,
+      contactName: displayName,
+      entityType: "TEAM_PLAYER_PROSPECT",
+    },
+  });
+
+  const dispatch = await queueNotificationFromTemplate({
+    templateKey: MANAGED_SQUAD_JOIN_CONFIRMATION_TEMPLATE_KEY,
+    recipientId: recipient.id,
+    variables: {
+      firstName: getFirstName(displayName) || "there",
+      fullName: displayName,
+      teamName: input.team.name,
+      leagueName,
+      venueName: input.team.league?.venueName ?? "",
+      preferredNight: formatPreferredNight(input.team.league?.dayOfWeek) ?? "",
+      teamContextLine: getTeamContextLine(input.team),
+      joinConfirmationUrl,
+      teamJoinUrl: joinConfirmationUrl,
+    },
+    sourceType: "MANAGED_SQUAD_JOIN_CONFIRMATION",
+    sourceId: input.prospect.id,
+    metadata: {
+      origin: "squad_invite_team_change",
+      originLabel: "Fresh squad invite after team change",
+      teamId: input.team.id,
+      prospectId: input.prospect.id,
+      contactName: displayName,
+      templateKey: MANAGED_SQUAD_JOIN_CONFIRMATION_TEMPLATE_KEY,
+      joinConfirmationUrl,
+    },
+    emailBranding: {
+      teamName: input.team.name,
+      teamLogoUrl: input.team.logoUrl,
+      leagueName,
+    },
+    createdByUserId: input.createdByUserId,
+  });
+
+  await logNotificationDispatchToThread({ dispatch, recipient });
+  return dispatch;
+}
+
+function revalidateTeamSurfaces(teamId: string | null) {
+  if (!teamId) return;
+  revalidatePath(`/admin/teams/${teamId}`);
+  revalidatePath(`/admin/teams/${teamId}/squad`);
+  revalidatePath(`/admin/teams/${teamId}/prospects`);
+  revalidatePath(`/admin/teams/${teamId}/communications`);
+  revalidatePath(`/captain/team/${teamId}/squad`);
+  revalidatePath(`/captain/team/${teamId}/prospects`);
+}
+
+export async function GET() {
+  try {
+    await requireAdmin();
+
+    const teams = await prisma.team.findMany({
+      orderBy: [{ league: { name: "asc" } }, { name: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        teamMode: true,
+        league: {
+          select: {
+            name: true,
+            season: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({
+      items: teams.map((team) => ({
+        id: team.id,
+        label: `${team.name}${team.league?.name ? ` · ${team.league.name}` : ""}${
+          team.league?.season ? ` ${team.league.season}` : ""
+        } · ${team.teamMode}`,
+      })),
+    });
+  } catch (error) {
+    return NextResponse.json({ error: routeError(error) }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await requireAdmin();
+    const body = (await request.json().catch(() => null)) as {
+      prospectId?: unknown;
+      teamId?: unknown;
+      sendInvite?: unknown;
+    } | null;
+
+    const prospectId = typeof body?.prospectId === "string" ? body.prospectId.trim() : "";
+    const teamId = typeof body?.teamId === "string" ? body.teamId.trim() : "";
+    const sendInvite = body?.sendInvite === true;
+
+    if (!prospectId || !teamId) {
+      return NextResponse.json(
+        { error: "Choose the player and their new team." },
+        { status: 400 },
+      );
+    }
+
+    const [prospect, team] = await Promise.all([
+      prisma.teamPlayerProspect.findUnique({
+        where: { id: prospectId },
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          phone: true,
+          teamId: true,
+          status: true,
+        },
+      }),
+      prisma.team.findUnique({
+        where: { id: teamId },
+        select: {
+          id: true,
+          name: true,
+          logoUrl: true,
+          league: {
+            select: {
+              name: true,
+              season: true,
+              dayOfWeek: true,
+              venueName: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    if (!prospect) {
+      return NextResponse.json({ error: "Prospect not found." }, { status: 404 });
+    }
+    if (!team) {
+      return NextResponse.json({ error: "Team not found." }, { status: 404 });
+    }
+    if (prospect.status === "DECLINED" || prospect.status === "DUPLICATE") {
+      return NextResponse.json(
+        { error: "Closed prospect records cannot be moved to another team." },
+        { status: 409 },
+      );
+    }
+    if (prospect.status === "ACTIVE_SQUAD") {
+      return NextResponse.json(
+        { error: "This player is already active. Move their squad membership from the team squad page instead." },
+        { status: 409 },
+      );
+    }
+    if (prospect.teamId === team.id) {
+      return NextResponse.json(
+        { error: "This player is already held under that team." },
+        { status: 409 },
+      );
+    }
+
+    const previousTeamId = prospect.teamId;
+
+    await prisma.teamPlayerProspect.update({
+      where: { id: prospect.id },
+      data: { teamId: team.id },
+    });
+
+    let inviteQueued = false;
+    let warning: string | null = null;
+
+    if (sendInvite) {
+      const email = prospect.email?.trim().toLowerCase() ?? "";
+
+      if (!email) {
+        warning = "The team was changed, but no fresh squad invite was sent because the player has no email address.";
+      } else {
+        try {
+          await queueFreshSquadInvite({
+            prospect: {
+              id: prospect.id,
+              firstName: prospect.firstName,
+              lastName: prospect.lastName,
+              email,
+              phone: prospect.phone,
+            },
+            team,
+            createdByUserId: user?.id ?? null,
+          });
+          inviteQueued = true;
+
+          await prisma.teamPlayerProspect.update({
+            where: { id: prospect.id },
+            data: {
+              lastContactedAt: new Date(),
+              status: prospect.status === "NEW" ? "CONTACTED" : undefined,
+            },
+          });
+        } catch (error) {
+          warning = `The team was changed, but the fresh squad invite could not be queued: ${routeError(error)}`;
+        }
+      }
+    }
+
+    revalidatePath("/admin/player-prospects");
+    revalidatePath(`/admin/player-prospects/${prospect.id}/communications`);
+    revalidatePath("/admin/messaging");
+    revalidateTeamSurfaces(previousTeamId);
+    revalidateTeamSurfaces(team.id);
+
+    return NextResponse.json({
+      ok: true,
+      previousTeamId,
+      teamId: team.id,
+      teamName: team.name,
+      inviteQueued,
+      warning,
+    });
+  } catch (error) {
+    return NextResponse.json({ error: routeError(error) }, { status: 500 });
+  }
+}

--- a/src/components/admin/player-prospects/PlayerProspectsNotInterestedBridge.tsx
+++ b/src/components/admin/player-prospects/PlayerProspectsNotInterestedBridge.tsx
@@ -7,6 +7,26 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 
+type TeamOption = {
+  id: string;
+  label: string;
+};
+
+type TeamOptionsResponse = {
+  items?: TeamOption[];
+  error?: string;
+};
+
+type ChangeTeamResponse = {
+  ok?: boolean;
+  teamName?: string;
+  inviteQueued?: boolean;
+  warning?: string | null;
+  error?: string;
+};
+
+let teamOptionsPromise: Promise<TeamOption[]> | null = null;
+
 function getProspectIdFromCommsHref(href: string) {
   return href.match(/\/prospects\/([^/]+)\/communications(?:\?|#|$)/)?.[1] ?? null;
 }
@@ -32,8 +52,12 @@ function getProspectIds() {
 }
 
 function getCardForProspectId(prospectId: string) {
-  const input = document.querySelector<HTMLInputElement>(`form input[name="prospectId"][value="${CSS.escape(prospectId)}"]`);
-  const link = document.querySelector<HTMLAnchorElement>(`a[href*="/prospects/${CSS.escape(prospectId)}/communications"]`);
+  const input = document.querySelector<HTMLInputElement>(
+    `form input[name="prospectId"][value="${CSS.escape(prospectId)}"]`,
+  );
+  const link = document.querySelector<HTMLAnchorElement>(
+    `a[href*="/prospects/${CSS.escape(prospectId)}/communications"]`,
+  );
   const start = input ?? link;
 
   if (!start) return null;
@@ -43,7 +67,10 @@ function getCardForProspectId(prospectId: string) {
   while (current && current.tagName !== "MAIN") {
     const className = typeof current.className === "string" ? current.className : "";
 
-    if (current.tagName === "ARTICLE" || (className.includes("rounded-3xl") && className.includes("p-5"))) {
+    if (
+      current.tagName === "ARTICLE" ||
+      (className.includes("rounded-3xl") && className.includes("p-5"))
+    ) {
       return current;
     }
 
@@ -54,13 +81,17 @@ function getCardForProspectId(prospectId: string) {
 }
 
 function getActionArea(card: HTMLElement) {
-  const assignForm = card.querySelector<HTMLFormElement>('form input[name="prospectId"]')?.closest("form");
+  const assignForm = card
+    .querySelector<HTMLFormElement>('form input[name="prospectId"]')
+    ?.closest("form");
 
   if (assignForm?.parentElement instanceof HTMLElement) {
     return assignForm.parentElement;
   }
 
-  const commsLink = card.querySelector<HTMLAnchorElement>('a[href*="/prospects/"][href*="/communications"]');
+  const commsLink = card.querySelector<HTMLAnchorElement>(
+    'a[href*="/prospects/"][href*="/communications"]',
+  );
 
   if (commsLink?.parentElement instanceof HTMLElement) {
     return commsLink.parentElement;
@@ -69,14 +100,258 @@ function getActionArea(card: HTMLElement) {
   return null;
 }
 
+function getTeamPanel(card: HTMLElement) {
+  return (
+    Array.from(card.querySelectorAll<HTMLElement>(".rounded-2xl")).find((element) =>
+      element.textContent?.includes("Currently held under"),
+    ) ?? null
+  );
+}
+
+function getCurrentTeamId(card: HTMLElement) {
+  const squadLink = card.querySelector<HTMLAnchorElement>(
+    'a[href^="/admin/teams/"][href$="/squad"]',
+  );
+  const href = squadLink?.getAttribute("href") ?? "";
+  return href.match(/\/admin\/teams\/([^/]+)\/squad/)?.[1] ?? null;
+}
+
 function isClosedProspectCard(card: HTMLElement) {
   const text = card.textContent ?? "";
-  return text.includes("Not interested") || text.includes("Duplicated") || text.includes("Duplicate record");
+  return (
+    text.includes("Not interested") ||
+    text.includes("Duplicated") ||
+    text.includes("Duplicate record")
+  );
 }
 
 function isHeldUnderTeam(card: HTMLElement) {
   const text = card.textContent ?? "";
   return text.includes("Currently held under") || text.includes("Active team");
+}
+
+function canChangeTeam(card: HTMLElement) {
+  const text = card.textContent ?? "";
+  return text.includes("Currently held under") && !text.includes("Active player");
+}
+
+async function loadTeamOptions() {
+  if (!teamOptionsPromise) {
+    teamOptionsPromise = fetch("/api/admin/player-prospects/change-team", {
+      cache: "no-store",
+    })
+      .then(async (response) => {
+        const payload = (await response.json().catch(() => null)) as TeamOptionsResponse | null;
+
+        if (!response.ok) {
+          throw new Error(payload?.error || "The team list could not be loaded.");
+        }
+
+        return payload?.items ?? [];
+      })
+      .catch((error) => {
+        teamOptionsPromise = null;
+        throw error;
+      });
+  }
+
+  return teamOptionsPromise;
+}
+
+function addChangeTeamControls(input: {
+  card: HTMLElement;
+  panel: HTMLElement;
+  prospectId: string;
+  currentTeamId: string;
+}) {
+  if (input.card.querySelector(`[data-prospect-change-team="${input.prospectId}"]`)) {
+    return;
+  }
+
+  const wrapper = document.createElement("div");
+  wrapper.dataset.prospectChangeTeam = input.prospectId;
+  wrapper.className = "mt-3 space-y-2";
+
+  const toggleButton = document.createElement("button");
+  toggleButton.type = "button";
+  toggleButton.textContent = "Change team";
+  toggleButton.className =
+    "inline-flex w-full items-center justify-center rounded-xl border border-cyan-400/30 bg-cyan-500/10 px-4 py-2.5 text-sm font-medium text-cyan-100 transition hover:bg-cyan-500/15 disabled:cursor-not-allowed disabled:opacity-50";
+
+  const changePanel = document.createElement("div");
+  changePanel.hidden = true;
+  changePanel.className =
+    "space-y-3 rounded-2xl border border-cyan-400/20 bg-cyan-500/[0.08] p-3";
+
+  const label = document.createElement("label");
+  const selectId = `change-team-${input.prospectId}`;
+  label.htmlFor = selectId;
+  label.className = "block text-xs font-semibold text-cyan-100";
+  label.textContent = "Move player to";
+
+  const select = document.createElement("select");
+  select.id = selectId;
+  select.disabled = true;
+  select.className =
+    "h-11 w-full rounded-xl border border-white/15 bg-black/70 px-3 text-sm text-white outline-none transition focus:border-cyan-300 disabled:cursor-not-allowed disabled:opacity-50";
+
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.textContent = "Choose new team";
+  select.appendChild(placeholder);
+
+  const inviteLabel = document.createElement("label");
+  inviteLabel.className =
+    "flex cursor-pointer items-start gap-2 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs leading-5 text-white/70";
+
+  const inviteCheckbox = document.createElement("input");
+  inviteCheckbox.type = "checkbox";
+  inviteCheckbox.checked = true;
+  inviteCheckbox.className = "mt-1 h-4 w-4 accent-emerald-500";
+
+  const inviteText = document.createElement("span");
+  inviteText.textContent =
+    "Send a fresh squad invite for the new team. This is recommended when an earlier invite named the old team.";
+
+  inviteLabel.appendChild(inviteCheckbox);
+  inviteLabel.appendChild(inviteText);
+
+  const buttonRow = document.createElement("div");
+  buttonRow.className = "grid grid-cols-2 gap-2";
+
+  const confirmButton = document.createElement("button");
+  confirmButton.type = "button";
+  confirmButton.disabled = true;
+  confirmButton.textContent = "Confirm change";
+  confirmButton.className =
+    "inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/15 px-3 py-2.5 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50";
+
+  const cancelButton = document.createElement("button");
+  cancelButton.type = "button";
+  cancelButton.textContent = "Cancel";
+  cancelButton.className =
+    "inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm font-medium text-white/70 transition hover:bg-white/10";
+
+  buttonRow.appendChild(confirmButton);
+  buttonRow.appendChild(cancelButton);
+  changePanel.appendChild(label);
+  changePanel.appendChild(select);
+  changePanel.appendChild(inviteLabel);
+  changePanel.appendChild(buttonRow);
+  wrapper.appendChild(toggleButton);
+  wrapper.appendChild(changePanel);
+  input.panel.appendChild(wrapper);
+
+  let optionsLoaded = false;
+
+  toggleButton.addEventListener("click", async () => {
+    if (!changePanel.hidden) {
+      changePanel.hidden = true;
+      toggleButton.textContent = "Change team";
+      return;
+    }
+
+    if (!optionsLoaded) {
+      toggleButton.disabled = true;
+      toggleButton.textContent = "Loading teams…";
+
+      try {
+        const options = (await loadTeamOptions()).filter(
+          (option) => option.id !== input.currentTeamId,
+        );
+
+        if (options.length === 0) {
+          throw new Error("There are no other teams available.");
+        }
+
+        for (const option of options) {
+          const element = document.createElement("option");
+          element.value = option.id;
+          element.textContent = option.label;
+          select.appendChild(element);
+        }
+
+        select.disabled = false;
+        optionsLoaded = true;
+      } catch (error) {
+        alert(
+          error instanceof Error && error.message
+            ? error.message
+            : "The team list could not be loaded.",
+        );
+        toggleButton.disabled = false;
+        toggleButton.textContent = "Change team";
+        return;
+      }
+
+      toggleButton.disabled = false;
+    }
+
+    changePanel.hidden = false;
+    toggleButton.textContent = "Hide team change";
+  });
+
+  select.addEventListener("change", () => {
+    confirmButton.disabled = !select.value;
+  });
+
+  cancelButton.addEventListener("click", () => {
+    select.value = "";
+    confirmButton.disabled = true;
+    changePanel.hidden = true;
+    toggleButton.textContent = "Change team";
+  });
+
+  confirmButton.addEventListener("click", async () => {
+    const teamId = select.value.trim();
+    const selectedOption = select.selectedOptions[0];
+
+    if (!teamId || !selectedOption) return;
+
+    const inviteMessage = inviteCheckbox.checked
+      ? " A fresh squad invite will also be sent."
+      : " No new invite will be sent.";
+    const confirmed = window.confirm(
+      `Move this player to ${selectedOption.textContent ?? "the selected team"}?${inviteMessage}`,
+    );
+
+    if (!confirmed) return;
+
+    confirmButton.disabled = true;
+    cancelButton.disabled = true;
+    toggleButton.disabled = true;
+    select.disabled = true;
+    inviteCheckbox.disabled = true;
+    confirmButton.textContent = "Changing…";
+
+    const response = await fetch("/api/admin/player-prospects/change-team", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prospectId: input.prospectId,
+        teamId,
+        sendInvite: inviteCheckbox.checked,
+      }),
+    });
+    const payload = (await response.json().catch(() => null)) as ChangeTeamResponse | null;
+
+    if (!response.ok || !payload?.ok) {
+      alert(payload?.error || "The player's team could not be changed.");
+      confirmButton.disabled = false;
+      cancelButton.disabled = false;
+      toggleButton.disabled = false;
+      select.disabled = false;
+      inviteCheckbox.disabled = false;
+      confirmButton.textContent = "Confirm change";
+      return;
+    }
+
+    if (payload.warning) {
+      alert(payload.warning);
+    }
+
+    window.location.reload();
+  });
 }
 
 async function moveProspectToMainPool(input: {
@@ -106,9 +381,12 @@ async function moveProspectToNotInterested(input: {
   input.button.disabled = true;
   input.button.textContent = "Moving…";
 
-  const response = await fetch(`/api/admin/player-prospects/${input.prospectId}/not-interested`, {
-    method: "POST",
-  });
+  const response = await fetch(
+    `/api/admin/player-prospects/${input.prospectId}/not-interested`,
+    {
+      method: "POST",
+    },
+  );
 
   if (response.ok) {
     window.location.reload();
@@ -155,7 +433,24 @@ function addButtons() {
     const actionArea = getActionArea(card);
     if (!actionArea) continue;
 
-    if (isHeldUnderTeam(card) && !card.querySelector(`button[data-prospect-unassign="${prospectId}"]`)) {
+    if (canChangeTeam(card)) {
+      const teamPanel = getTeamPanel(card);
+      const currentTeamId = getCurrentTeamId(card);
+
+      if (teamPanel && currentTeamId) {
+        addChangeTeamControls({
+          card,
+          panel: teamPanel,
+          prospectId,
+          currentTeamId,
+        });
+      }
+    }
+
+    if (
+      isHeldUnderTeam(card) &&
+      !card.querySelector(`button[data-prospect-unassign="${prospectId}"]`)
+    ) {
       const poolButton = document.createElement("button");
       poolButton.type = "button";
       poolButton.textContent = "Move to main prospects";


### PR DESCRIPTION
## What changed
- adds a **Change team** control directly to prospects already held under a team
- lets admins choose the new team without moving the player through the main prospect pool
- excludes the current team from the selector
- prevents direct changes for closed or already-active squad records
- offers to send a fresh squad invite for the newly selected team, so an older email does not remain the only invite naming the previous team
- revalidates both the old and new team views after the move

## User flow
1. Click **Change team** on the prospect card.
2. Select the new team.
3. Leave the fresh-invite option selected when the player should receive a new team-specific squad invite.
4. Confirm the change.

## Notes
The existing prospect record and communications history are retained.