### PR TITLE
Add team shirt colours to fixture displays

### DIFF
--- a/prisma/migrations/20260719180000_add_team_kit_primary_colour/migration.sql
+++ b/prisma/migrations/20260719180000_add_team_kit_primary_colour/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Team"
+ADD COLUMN "kitPrimaryColour" TEXT;

--- a/prisma/migrations/20260719180000_add_team_kit_primary_colour/migration.sql
+++ b/prisma/migrations/20260719180000_add_team_kit_primary_colour/migration.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "Team"
-ADD COLUMN "kitPrimaryColour" TEXT;

--- a/src/app/api/admin/teams/[id]/kit-colour/route.ts
+++ b/src/app/api/admin/teams/[id]/kit-colour/route.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 
+import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
@@ -12,10 +13,6 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-type StoredKitColourRow = {
-  kitPrimaryColour: string | null;
-};
-
 function normaliseColour(value: unknown) {
   if (value === null || value === undefined || value === "") return null;
   if (typeof value !== "string") return undefined;
@@ -24,15 +21,37 @@ function normaliseColour(value: unknown) {
   return /^#[0-9a-f]{6}$/i.test(trimmed) ? trimmed.toUpperCase() : undefined;
 }
 
-async function getStoredColour(teamId: string) {
-  const rows = await prisma.$queryRaw<StoredKitColourRow[]>`
-    SELECT "kitPrimaryColour"
-    FROM "Team"
-    WHERE "id" = ${teamId}
-    LIMIT 1
-  `;
+function getMetadataRecord(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {} as Record<string, Prisma.InputJsonValue | null>;
+  }
 
-  return rows[0]?.kitPrimaryColour ?? null;
+  return {
+    ...(metadata as Record<string, Prisma.InputJsonValue | null>),
+  };
+}
+
+function getStoredColour(metadata: unknown) {
+  const value = getMetadataRecord(metadata).kitPrimaryColour;
+  return normaliseColour(value) ?? null;
+}
+
+async function storeTeamColour(teamId: string, colour: string | null) {
+  const { recipient } = await upsertTeamNotificationRecipient(teamId);
+  const metadata = getMetadataRecord(recipient.metadata);
+
+  if (colour) {
+    metadata.kitPrimaryColour = colour;
+  } else {
+    delete metadata.kitPrimaryColour;
+  }
+
+  await prisma.notificationRecipient.update({
+    where: { id: recipient.id },
+    data: {
+      metadata: metadata as Prisma.InputJsonObject,
+    },
+  });
 }
 
 export async function GET(_request: Request, context: RouteContext) {
@@ -44,10 +63,21 @@ export async function GET(_request: Request, context: RouteContext) {
     return NextResponse.json({ error: "Team not found." }, { status: 404 });
   }
 
-  const team = await prisma.team.findUnique({
-    where: { id: teamId },
-    select: { id: true, name: true },
-  });
+  const [team, recipient] = await Promise.all([
+    prisma.team.findUnique({
+      where: { id: teamId },
+      select: { id: true, name: true },
+    }),
+    prisma.notificationRecipient.findFirst({
+      where: {
+        sourceType: "TEAM",
+        sourceId: teamId,
+      },
+      select: {
+        metadata: true,
+      },
+    }),
+  ]);
 
   if (!team) {
     return NextResponse.json({ error: "Team not found." }, { status: 404 });
@@ -56,7 +86,7 @@ export async function GET(_request: Request, context: RouteContext) {
   return NextResponse.json({
     teamId: team.id,
     teamName: team.name,
-    colour: normaliseColour(await getStoredColour(team.id)) ?? null,
+    colour: getStoredColour(recipient?.metadata),
   });
 }
 
@@ -129,12 +159,10 @@ export async function PATCH(request: Request, context: RouteContext) {
     new Set([team.id, ...relatedTeams.map((item) => item.id)]),
   );
 
-  await prisma.$executeRaw(
-    Prisma.sql`
-      UPDATE "Team"
-      SET "kitPrimaryColour" = ${colour}, "updatedAt" = CURRENT_TIMESTAMP
-      WHERE "id" IN (${Prisma.join(affectedTeamIds)})
-    `,
+  await Promise.all(
+    affectedTeamIds.map((affectedTeamId) =>
+      storeTeamColour(affectedTeamId, colour),
+    ),
   );
 
   revalidatePath("/admin/teams");

--- a/src/app/api/admin/teams/[id]/kit-colour/route.ts
+++ b/src/app/api/admin/teams/[id]/kit-colour/route.ts
@@ -1,0 +1,167 @@
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+type StoredKitColourRow = {
+  kitPrimaryColour: string | null;
+};
+
+function normaliseColour(value: unknown) {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") return undefined;
+
+  const trimmed = value.trim();
+  return /^#[0-9a-f]{6}$/i.test(trimmed) ? trimmed.toUpperCase() : undefined;
+}
+
+async function getStoredColour(teamId: string) {
+  const rows = await prisma.$queryRaw<StoredKitColourRow[]>`
+    SELECT "kitPrimaryColour"
+    FROM "Team"
+    WHERE "id" = ${teamId}
+    LIMIT 1
+  `;
+
+  return rows[0]?.kitPrimaryColour ?? null;
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  await requireAdmin();
+  const { id } = await context.params;
+  const teamId = id.trim();
+
+  if (!teamId) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: { id: true, name: true },
+  });
+
+  if (!team) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    teamId: team.id,
+    teamName: team.name,
+    colour: normaliseColour(await getStoredColour(team.id)) ?? null,
+  });
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  await requireAdmin();
+  const { id } = await context.params;
+  const teamId = id.trim();
+  const body = (await request.json().catch(() => null)) as {
+    colour?: unknown;
+  } | null;
+  const colour = normaliseColour(body?.colour);
+
+  if (!teamId) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  if (colour === undefined) {
+    return NextResponse.json(
+      { error: "Choose a valid six-digit shirt colour." },
+      { status: 400 },
+    );
+  }
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: {
+      id: true,
+      name: true,
+      leagueId: true,
+      league: {
+        select: {
+          competitionId: true,
+          slug: true,
+        },
+      },
+    },
+  });
+
+  if (!team) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  const relatedTeams = team.league?.competitionId
+    ? await prisma.team.findMany({
+        where: {
+          name: { equals: team.name, mode: "insensitive" },
+          league: {
+            is: {
+              competitionId: team.league.competitionId,
+            },
+          },
+        },
+        select: {
+          id: true,
+          league: { select: { slug: true } },
+        },
+      })
+    : await prisma.team.findMany({
+        where: {
+          name: { equals: team.name, mode: "insensitive" },
+          leagueId: team.leagueId,
+        },
+        select: {
+          id: true,
+          league: { select: { slug: true } },
+        },
+      });
+
+  const affectedTeamIds = Array.from(
+    new Set([team.id, ...relatedTeams.map((item) => item.id)]),
+  );
+
+  await prisma.$executeRaw(
+    Prisma.sql`
+      UPDATE "Team"
+      SET "kitPrimaryColour" = ${colour}, "updatedAt" = CURRENT_TIMESTAMP
+      WHERE "id" IN (${Prisma.join(affectedTeamIds)})
+    `,
+  );
+
+  revalidatePath("/admin/teams");
+  for (const affectedTeamId of affectedTeamIds) {
+    revalidatePath(`/admin/teams/${affectedTeamId}`);
+    revalidatePath(`/captain/team/${affectedTeamId}`);
+    revalidatePath(`/captain/team/${affectedTeamId}/fixtures`);
+    revalidatePath(`/captain/team/${affectedTeamId}/results`);
+  }
+
+  const leagueSlugs = new Set(
+    [team.league?.slug, ...relatedTeams.map((item) => item.league?.slug)].filter(
+      (value): value is string => Boolean(value),
+    ),
+  );
+
+  for (const slug of leagueSlugs) {
+    revalidatePath(`/leagues/${slug}`);
+    revalidatePath(`/leagues/${slug}/fixtures`);
+    revalidatePath(`/leagues/${slug}/results`);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    teamId: team.id,
+    teamName: team.name,
+    colour,
+    updatedTeams: affectedTeamIds.length,
+  });
+}

--- a/src/app/api/team-kit-colours/route.ts
+++ b/src/app/api/team-kit-colours/route.ts
@@ -5,41 +5,72 @@ import { prisma } from "@/lib/prisma";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-type TeamKitColourRow = {
-  id: string;
-  name: string;
-  kitPrimaryColour: string | null;
-  updatedAt: Date;
-};
-
-function normaliseColour(value: string | null) {
-  const trimmed = value?.trim() ?? "";
+function normaliseColour(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
   return /^#[0-9a-f]{6}$/i.test(trimmed) ? trimmed.toUpperCase() : null;
 }
 
+function getMetadataColour(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+
+  return normaliseColour(
+    (metadata as Record<string, unknown>).kitPrimaryColour,
+  );
+}
+
 export async function GET() {
-  const rows = await prisma.$queryRaw<TeamKitColourRow[]>`
-    SELECT "id", "name", "kitPrimaryColour", "updatedAt"
-    FROM "Team"
-    ORDER BY "updatedAt" DESC
-  `;
+  const teams = await prisma.team.findMany({
+    orderBy: [{ updatedAt: "desc" }],
+    select: {
+      id: true,
+      name: true,
+      updatedAt: true,
+    },
+  });
+
+  const recipients = teams.length
+    ? await prisma.notificationRecipient.findMany({
+        where: {
+          sourceType: "TEAM",
+          sourceId: {
+            in: teams.map((team) => team.id),
+          },
+        },
+        select: {
+          sourceId: true,
+          metadata: true,
+        },
+      })
+    : [];
+
+  const colourByTeamId = new Map(
+    recipients
+      .filter((recipient) => Boolean(recipient.sourceId))
+      .map((recipient) => [
+        recipient.sourceId as string,
+        getMetadataColour(recipient.metadata),
+      ]),
+  );
 
   const teamsByName = new Map<
     string,
     { id: string; name: string; colour: string | null }
   >();
 
-  for (const row of rows) {
-    const key = row.name.trim().toLowerCase();
+  for (const team of teams) {
+    const key = team.name.trim().toLowerCase();
     if (!key) continue;
 
-    const colour = normaliseColour(row.kitPrimaryColour);
+    const colour = colourByTeamId.get(team.id) ?? null;
     const existing = teamsByName.get(key);
 
     if (!existing || (!existing.colour && colour)) {
       teamsByName.set(key, {
-        id: row.id,
-        name: row.name.trim(),
+        id: team.id,
+        name: team.name.trim(),
         colour,
       });
     }

--- a/src/app/api/team-kit-colours/route.ts
+++ b/src/app/api/team-kit-colours/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type TeamKitColourRow = {
+  id: string;
+  name: string;
+  kitPrimaryColour: string | null;
+  updatedAt: Date;
+};
+
+function normaliseColour(value: string | null) {
+  const trimmed = value?.trim() ?? "";
+  return /^#[0-9a-f]{6}$/i.test(trimmed) ? trimmed.toUpperCase() : null;
+}
+
+export async function GET() {
+  const rows = await prisma.$queryRaw<TeamKitColourRow[]>`
+    SELECT "id", "name", "kitPrimaryColour", "updatedAt"
+    FROM "Team"
+    ORDER BY "updatedAt" DESC
+  `;
+
+  const teamsByName = new Map<
+    string,
+    { id: string; name: string; colour: string | null }
+  >();
+
+  for (const row of rows) {
+    const key = row.name.trim().toLowerCase();
+    if (!key) continue;
+
+    const colour = normaliseColour(row.kitPrimaryColour);
+    const existing = teamsByName.get(key);
+
+    if (!existing || (!existing.colour && colour)) {
+      teamsByName.set(key, {
+        id: row.id,
+        name: row.name.trim(),
+        colour,
+      });
+    }
+  }
+
+  return NextResponse.json(
+    { teams: [...teamsByName.values()] },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/src/app/api/team-kit-colours/route.ts
+++ b/src/app/api/team-kit-colours/route.ts
@@ -27,7 +27,6 @@ export async function GET() {
     select: {
       id: true,
       name: true,
-      updatedAt: true,
     },
   });
 
@@ -46,14 +45,14 @@ export async function GET() {
       })
     : [];
 
-  const colourByTeamId = new Map(
-    recipients
-      .filter((recipient) => Boolean(recipient.sourceId))
-      .map((recipient) => [
-        recipient.sourceId as string,
-        getMetadataColour(recipient.metadata),
-      ]),
-  );
+  const colourByTeamId = new Map<string, string | null>();
+  for (const recipient of recipients) {
+    if (!recipient.sourceId) continue;
+    colourByTeamId.set(
+      recipient.sourceId,
+      getMetadataColour(recipient.metadata),
+    );
+  }
 
   const teamsByName = new Map<
     string,

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,6 +3,15 @@
 
 import { SessionProvider } from "next-auth/react";
 
+import TeamKitColourAdminBridge from "@/components/admin/teams/TeamKitColourAdminBridge";
+import FixtureKitShirtsBridge from "@/components/fixtures/FixtureKitShirtsBridge";
+
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <TeamKitColourAdminBridge />
+      <FixtureKitShirtsBridge />
+      {children}
+    </SessionProvider>
+  );
 }

--- a/src/components/admin/teams/TeamKitColourAdminBridge.tsx
+++ b/src/components/admin/teams/TeamKitColourAdminBridge.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { usePathname } from "next/navigation";
+
+const PRESET_COLOURS = [
+  { label: "Black", value: "#111827" },
+  { label: "White", value: "#FFFFFF" },
+  { label: "Red", value: "#DC2626" },
+  { label: "Royal blue", value: "#2563EB" },
+  { label: "Sky blue", value: "#38BDF8" },
+  { label: "Green", value: "#16A34A" },
+  { label: "Yellow", value: "#FACC15" },
+  { label: "Orange", value: "#F97316" },
+  { label: "Purple", value: "#9333EA" },
+  { label: "Pink", value: "#EC4899" },
+  { label: "Navy", value: "#172554" },
+];
+
+const DEFAULT_PICKER_COLOUR = "#16A34A";
+
+type KitColourResponse = {
+  teamId?: string;
+  teamName?: string;
+  colour?: string | null;
+  updatedTeams?: number;
+  error?: string;
+};
+
+function getTeamId(pathname: string) {
+  return pathname.match(/^\/admin\/teams\/([^/]+)\/?$/)?.[1] ?? null;
+}
+
+function findSettingsCard() {
+  const heading = Array.from(document.querySelectorAll("h2")).find(
+    (item) => item.textContent?.trim() === "Team settings",
+  );
+
+  let current = heading?.parentElement ?? null;
+  while (current && current.tagName !== "MAIN") {
+    if (
+      current.classList.contains("rounded-3xl") &&
+      current.querySelector("form")
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function ShirtPreview({ colour }: { colour: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block h-11 w-12 shrink-0 drop-shadow-[0_4px_8px_rgba(0,0,0,0.35)]"
+      style={{
+        backgroundColor: colour,
+        clipPath:
+          "polygon(20% 0,34% 0,40% 13%,60% 13%,66% 0,80% 0,100% 24%,84% 42%,77% 33%,77% 100%,23% 100%,23% 33%,16% 42%,0 24%)",
+      }}
+    />
+  );
+}
+
+export default function TeamKitColourAdminBridge() {
+  const pathname = usePathname();
+  const teamId = useMemo(() => getTeamId(pathname), [pathname]);
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const [teamName, setTeamName] = useState("Team");
+  const [storedColour, setStoredColour] = useState<string | null>(null);
+  const [pickerColour, setPickerColour] = useState(DEFAULT_PICKER_COLOUR);
+  const [status, setStatus] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!teamId) {
+      setHost(null);
+      return;
+    }
+
+    let mounted = true;
+    let createdHost: HTMLElement | null = null;
+
+    const install = () => {
+      if (!mounted) return true;
+
+      const card = findSettingsCard();
+      const form = card?.querySelector("form");
+      if (!card || !form) return false;
+
+      const existing = card.querySelector<HTMLElement>(
+        `[data-sixfl-kit-colour-host="${CSS.escape(teamId)}"]`,
+      );
+      createdHost = existing ?? document.createElement("div");
+      createdHost.dataset.sixflKitColourHost = teamId;
+
+      if (!existing) {
+        form.parentElement?.insertBefore(createdHost, form);
+      }
+
+      setHost(createdHost);
+      return true;
+    };
+
+    if (!install()) {
+      const observer = new MutationObserver(() => {
+        if (install()) observer.disconnect();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      return () => {
+        mounted = false;
+        observer.disconnect();
+        createdHost?.remove();
+      };
+    }
+
+    return () => {
+      mounted = false;
+      createdHost?.remove();
+    };
+  }, [teamId]);
+
+  useEffect(() => {
+    if (!teamId) return;
+
+    let cancelled = false;
+    setStatus("");
+
+    fetch(`/api/admin/teams/${encodeURIComponent(teamId)}/kit-colour`, {
+      cache: "no-store",
+    })
+      .then(async (response) => {
+        const data = (await response.json()) as KitColourResponse;
+        if (!response.ok) throw new Error(data.error || "Could not load shirt colour.");
+        return data;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setTeamName(data.teamName || "Team");
+        setStoredColour(data.colour ?? null);
+        setPickerColour(data.colour || DEFAULT_PICKER_COLOUR);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setStatus(error instanceof Error ? error.message : "Could not load shirt colour.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId]);
+
+  async function saveColour(colour: string | null) {
+    if (!teamId || loading) return;
+
+    setLoading(true);
+    setStatus("");
+
+    try {
+      const response = await fetch(
+        `/api/admin/teams/${encodeURIComponent(teamId)}/kit-colour`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ colour }),
+        },
+      );
+      const data = (await response.json()) as KitColourResponse;
+
+      if (!response.ok) {
+        throw new Error(data.error || "Could not save shirt colour.");
+      }
+
+      setStoredColour(data.colour ?? null);
+      if (data.colour) setPickerColour(data.colour);
+      setStatus(
+        data.updatedTeams && data.updatedTeams > 1
+          ? `Saved for ${data.updatedTeams} season records of ${teamName}.`
+          : "Shirt colour saved.",
+      );
+      window.dispatchEvent(new CustomEvent("sixfl:kit-colours-updated"));
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Could not save shirt colour.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!teamId || !host) return null;
+
+  return createPortal(
+    <div
+      data-sixfl-kit-colour-picker
+      className="mb-5 rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.06] p-4 sm:p-5"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <ShirtPreview colour={storedColour || pickerColour} />
+          <div>
+            <div className="text-sm font-semibold text-white">Primary shirt colour</div>
+            <p className="mt-1 text-xs leading-5 text-white/55">
+              This coloured shirt is shown beside {teamName} on fixture and result screens, including the captain view.
+            </p>
+          </div>
+        </div>
+
+        <label className="flex items-center gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-white/65">
+          Custom colour
+          <input
+            aria-label="Choose custom shirt colour"
+            type="color"
+            value={pickerColour}
+            onChange={(event) => setPickerColour(event.target.value.toUpperCase())}
+            className="h-9 w-12 cursor-pointer rounded border-0 bg-transparent p-0"
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {PRESET_COLOURS.map((preset) => {
+          const selected = pickerColour === preset.value;
+          return (
+            <button
+              key={preset.value}
+              type="button"
+              onClick={() => setPickerColour(preset.value)}
+              title={preset.label}
+              aria-label={`Choose ${preset.label}`}
+              className={`h-8 w-8 rounded-full border-2 transition ${
+                selected
+                  ? "scale-110 border-emerald-300"
+                  : "border-white/20 hover:scale-105 hover:border-white/50"
+              }`}
+              style={{ backgroundColor: preset.value }}
+            />
+          );
+        })}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => saveColour(pickerColour)}
+          disabled={loading}
+          className="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {loading ? "Saving…" : "Save shirt colour"}
+        </button>
+        <button
+          type="button"
+          onClick={() => saveColour(null)}
+          disabled={loading || storedColour === null}
+          className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white/70 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Clear colour
+        </button>
+        <span className="font-mono text-xs text-white/45">
+          {storedColour || "Not set — neutral shirt used"}
+        </span>
+      </div>
+
+      {status ? (
+        <div
+          className={`mt-3 text-sm ${
+            status.toLowerCase().includes("could not") || status.toLowerCase().includes("valid")
+              ? "text-red-200"
+              : "text-emerald-200"
+          }`}
+        >
+          {status}
+        </div>
+      ) : null}
+    </div>,
+    host,
+  );
+}

--- a/src/components/fixtures/FixtureKitShirtsBridge.tsx
+++ b/src/components/fixtures/FixtureKitShirtsBridge.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+const DEFAULT_KIT_COLOUR = "#64748B";
+const FIXTURE_PATH_PATTERN =
+  /(?:\/fixtures?(?:\/|$)|\/results?(?:\/|$)|\/referee\/fixture|\/admin\/night-board|\/admin\/fixtures)/i;
+const CAPTAIN_PATH_PATTERN = /^\/captain\/team\//i;
+
+type KitTeam = {
+  id: string;
+  name: string;
+  colour: string | null;
+};
+
+type KitColourResponse = {
+  teams?: KitTeam[];
+};
+
+function normaliseName(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function createShirtIcon(team: KitTeam) {
+  const icon = document.createElement("span");
+  const colour = team.colour || DEFAULT_KIT_COLOUR;
+
+  icon.dataset.sixflKitShirt = "1";
+  icon.dataset.sixflKitTeam = normaliseName(team.name);
+  icon.setAttribute("aria-hidden", "true");
+  icon.title = `${team.name} shirt colour`;
+  icon.style.display = "inline-block";
+  icon.style.width = "1.05em";
+  icon.style.height = "0.92em";
+  icon.style.marginRight = "0.34em";
+  icon.style.verticalAlign = "-0.08em";
+  icon.style.flex = "0 0 auto";
+  icon.style.backgroundColor = colour;
+  icon.style.clipPath =
+    "polygon(20% 0,34% 0,40% 13%,60% 13%,66% 0,80% 0,100% 24%,84% 42%,77% 33%,77% 100%,23% 100%,23% 33%,16% 42%,0 24%)";
+  icon.style.filter = "drop-shadow(0 1px 1px rgba(0,0,0,0.7))";
+
+  if (colour.toUpperCase() === "#FFFFFF") {
+    icon.style.outline = "1px solid rgba(148,163,184,0.8)";
+    icon.style.outlineOffset = "-1px";
+  }
+
+  return icon;
+}
+
+function isIgnoredTextNode(node: Text) {
+  const parent = node.parentElement;
+  if (!parent) return true;
+
+  return Boolean(
+    parent.closest(
+      "script,style,noscript,textarea,input,select,option,[data-sixfl-kit-shirt],[data-sixfl-kit-team-label],[data-sixfl-kit-colour-picker],nav,header",
+    ),
+  );
+}
+
+function hasFixtureContext(node: Text, pathname: string, teamName: string) {
+  const parent = node.parentElement;
+  if (!parent) return false;
+
+  const directText = node.data.trim();
+  const fixtureHeavyPath = FIXTURE_PATH_PATTERN.test(pathname);
+  const captainPath = CAPTAIN_PATH_PATTERN.test(pathname);
+
+  let current: HTMLElement | null = parent;
+  for (let depth = 0; current && depth < 5; depth += 1) {
+    const text = current.textContent?.replace(/\s+/g, " ").trim() ?? "";
+    const href = current instanceof HTMLAnchorElement ? current.href : "";
+
+    if (
+      /\bvs?\.?\b/i.test(text) ||
+      /\bfixture\b|\bkick-?off\b|\bopponent\b|\bnext up\b|\bmatch list\b/i.test(text) ||
+      /\b\d+\s*[-–:]\s*\d+\b/.test(text) ||
+      /\/fixtures?|\/results?|\/fixture\//i.test(href)
+    ) {
+      return true;
+    }
+
+    current = current.parentElement;
+  }
+
+  if (fixtureHeavyPath && directText.toLowerCase().includes(teamName.toLowerCase())) {
+    return true;
+  }
+
+  if (captainPath && directText.toLowerCase() === teamName.toLowerCase()) {
+    return true;
+  }
+
+  return false;
+}
+
+function decorateTextNode(node: Text, teams: KitTeam[], pathname: string) {
+  if (!node.data.trim() || isIgnoredTextNode(node)) return;
+
+  const matchingTeams = teams.filter(
+    (team) =>
+      team.name.trim() &&
+      node.data.toLowerCase().includes(team.name.trim().toLowerCase()) &&
+      hasFixtureContext(node, pathname, team.name),
+  );
+
+  if (matchingTeams.length === 0) return;
+
+  const teamsByName = new Map(
+    matchingTeams.map((team) => [normaliseName(team.name), team]),
+  );
+  const names = [...teamsByName.values()]
+    .map((team) => team.name.trim())
+    .sort((a, b) => b.length - a.length);
+  const matcher = new RegExp(`(${names.map(escapeRegExp).join("|")})`, "gi");
+  const pieces = node.data.split(matcher);
+
+  if (pieces.length < 2) return;
+
+  const fragment = document.createDocumentFragment();
+
+  for (const piece of pieces) {
+    const team = teamsByName.get(normaliseName(piece));
+
+    if (!team) {
+      fragment.appendChild(document.createTextNode(piece));
+      continue;
+    }
+
+    const label = document.createElement("span");
+    label.dataset.sixflKitTeamLabel = normaliseName(team.name);
+    label.style.display = "inline-flex";
+    label.style.alignItems = "baseline";
+    label.style.whiteSpace = "nowrap";
+    label.appendChild(createShirtIcon(team));
+    label.appendChild(document.createTextNode(piece));
+    fragment.appendChild(label);
+  }
+
+  node.parentNode?.replaceChild(fragment, node);
+}
+
+function updateExistingIcons(teams: KitTeam[]) {
+  const colours = new Map(
+    teams.map((team) => [normaliseName(team.name), team.colour || DEFAULT_KIT_COLOUR]),
+  );
+
+  document.querySelectorAll<HTMLElement>("[data-sixfl-kit-shirt]").forEach((icon) => {
+    const teamName = icon.dataset.sixflKitTeam ?? "";
+    const colour = colours.get(teamName) ?? DEFAULT_KIT_COLOUR;
+    icon.style.backgroundColor = colour;
+    icon.style.outline = colour.toUpperCase() === "#FFFFFF"
+      ? "1px solid rgba(148,163,184,0.8)"
+      : "none";
+  });
+}
+
+function decoratePage(teams: KitTeam[], pathname: string) {
+  if (teams.length === 0) return;
+
+  updateExistingIcons(teams);
+
+  const root = document.querySelector("main") ?? document.body;
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode as Text);
+  }
+
+  for (const node of nodes) {
+    decorateTextNode(node, teams, pathname);
+  }
+}
+
+async function loadKitColours() {
+  const response = await fetch("/api/team-kit-colours", { cache: "no-store" });
+  if (!response.ok) return [];
+  const data = (await response.json()) as KitColourResponse;
+  return data.teams ?? [];
+}
+
+export default function FixtureKitShirtsBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let cancelled = false;
+    let observer: MutationObserver | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let teams: KitTeam[] = [];
+
+    const scheduleDecorate = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => decoratePage(teams, pathname), 40);
+    };
+
+    const refresh = async () => {
+      const nextTeams = await loadKitColours();
+      if (cancelled) return;
+      teams = nextTeams;
+      scheduleDecorate();
+    };
+
+    void refresh();
+
+    observer = new MutationObserver((mutations) => {
+      const hasRelevantMutation = mutations.some((mutation) =>
+        Array.from(mutation.addedNodes).some(
+          (node) =>
+            node.nodeType === Node.TEXT_NODE ||
+            (node instanceof HTMLElement && !node.dataset.sixflKitShirt),
+        ),
+      );
+
+      if (hasRelevantMutation) scheduleDecorate();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    window.addEventListener("sixfl:kit-colours-updated", refresh);
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+      if (timer) clearTimeout(timer);
+      window.removeEventListener("sixfl:kit-colours-updated", refresh);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/src/lib/notifications/recipients.ts
+++ b/src/lib/notifications/recipients.ts
@@ -48,9 +48,8 @@ function mergeRecipientMetadata(
   incoming: Prisma.InputJsonValue | undefined,
 ): Prisma.InputJsonValue | undefined {
   if (incoming === undefined) {
-    return existing && existing !== Prisma.JsonNull
-      ? (existing as Prisma.InputJsonValue)
-      : undefined;
+    if (existing === null || existing === undefined) return undefined;
+    return existing as Prisma.InputJsonValue;
   }
 
   if (isJsonObject(existing) && isInputJsonObject(incoming)) {

--- a/src/lib/notifications/recipients.ts
+++ b/src/lib/notifications/recipients.ts
@@ -33,6 +33,36 @@ function normalizePhone(phone?: string | null) {
   return normalizePhoneNumber(phone);
 }
 
+function isJsonObject(value: unknown): value is Record<string, Prisma.JsonValue> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isInputJsonObject(
+  value: Prisma.InputJsonValue | undefined,
+): value is Prisma.InputJsonObject {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function mergeRecipientMetadata(
+  existing: Prisma.JsonValue | null | undefined,
+  incoming: Prisma.InputJsonValue | undefined,
+): Prisma.InputJsonValue | undefined {
+  if (incoming === undefined) {
+    return existing && existing !== Prisma.JsonNull
+      ? (existing as Prisma.InputJsonValue)
+      : undefined;
+  }
+
+  if (isJsonObject(existing) && isInputJsonObject(incoming)) {
+    return {
+      ...existing,
+      ...incoming,
+    } as Prisma.InputJsonObject;
+  }
+
+  return incoming;
+}
+
 export async function upsertNotificationRecipient(
   input: UpsertNotificationRecipientInput,
 ) {
@@ -49,6 +79,7 @@ export async function upsertNotificationRecipient(
     },
     select: {
       id: true,
+      metadata: true,
     },
   });
 
@@ -63,7 +94,7 @@ export async function upsertNotificationRecipient(
     marketingSmsOptIn: input.marketingSmsOptIn ?? false,
     transactionalEmailOptIn: input.transactionalEmailOptIn ?? true,
     transactionalSmsOptIn: input.transactionalSmsOptIn ?? true,
-    metadata: input.metadata,
+    metadata: mergeRecipientMetadata(existing?.metadata, input.metadata),
     lastSyncedAt: new Date(),
   };
 


### PR DESCRIPTION
## What changed
- added an admin colour picker with presets and a native custom colour control on each team admin screen
- stores the selected colour in the team’s existing notification-recipient metadata, so no database migration is needed
- preserves custom team metadata whenever contact details are re-synchronised
- syncs the chosen colour across matching season records for the same competition/team
- added a public read endpoint for fixture display colours
- added a small coloured shirt beside team names across fixture and result contexts, including captain views
- uses a neutral grey shirt until a team colour is selected

## Why
Captains and teams need to see which colour each side is expected to wear directly wherever fixtures are displayed, reducing kit clashes and matchday confusion.

## Validation
- reviewed the final six-file branch diff and route/component syntax
- colour input is validated as a six-digit hex value
- no Prisma schema or database migration is required
- fixture enhancement runs after hydration and observes dynamically updated fixture lists
- white shirts receive a visible outline against light backgrounds

## Follow-up checks on preview
- choose colours for two teams in Admin → Teams → Edit
- confirm shirts appear on public league fixtures and captain fixture/result screens
- confirm duplicate season records keep the same colour
- confirm later edits to team contact details do not remove the saved colour