### PR TITLE
Add North Yorkshire Heartlands launch and joining page

### DIFF
--- a/src/app/(public)/leagues/heartlands/actions.ts
+++ b/src/app/(public)/leagues/heartlands/actions.ts
@@ -1,0 +1,91 @@
+// ========================================
+// File: src/app/(public)/leagues/heartlands/actions.ts
+// ========================================
+
+"use server";
+
+import { InterestType, LeagueType } from "@prisma/client";
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { queueLeadWelcomeNotifications } from "@/lib/notifications/transactional";
+
+export async function createHeartlandsInterestLeadAction(formData: FormData) {
+  const contactName = String(formData.get("contactName") ?? "").trim();
+  const email = String(formData.get("email") ?? "").trim().toLowerCase();
+  const phone = String(formData.get("phone") ?? "").trim();
+  const teamName = String(formData.get("teamName") ?? "").trim();
+  const message = String(formData.get("message") ?? "").trim();
+  const leagueId = String(formData.get("leagueId") ?? "").trim();
+  const area = String(formData.get("area") ?? "").trim();
+  const source = String(formData.get("source") ?? "").trim();
+  const requestedType = String(formData.get("interestType") ?? "TEAM")
+    .trim()
+    .toUpperCase();
+  const interestType =
+    requestedType === InterestType.PLAYER
+      ? InterestType.PLAYER
+      : InterestType.TEAM;
+
+  if (!contactName) throw new Error("Contact name is required.");
+  if (!email) throw new Error("Email is required.");
+  if (!leagueId) throw new Error("League is required.");
+
+  const league = await prisma.league.findUnique({
+    where: { id: leagueId },
+    select: {
+      id: true,
+      area: true,
+      dayOfWeek: true,
+      leagueType: true,
+    },
+  });
+
+  if (!league) throw new Error("League is required.");
+
+  const lead = await prisma.interestLead.create({
+    data: {
+      interestType,
+      status: "NEW",
+      contactName,
+      email,
+      phone: phone || null,
+      teamName: interestType === InterestType.TEAM ? teamName || null : null,
+      area: league.area || area || null,
+      leagueType: league.leagueType ?? LeagueType.MENS,
+      message: message || null,
+      source: source || "heartlands-launch-page",
+      leagueId: league.id,
+      preferredNights: league.dayOfWeek
+        ? {
+            create: [
+              {
+                night: league.dayOfWeek,
+              },
+            ],
+          }
+        : undefined,
+    },
+    select: {
+      id: true,
+      contactName: true,
+      email: true,
+      phone: true,
+      interestType: true,
+      area: true,
+      teamName: true,
+      marketingConsent: true,
+    },
+  });
+
+  try {
+    await queueLeadWelcomeNotifications({
+      lead,
+      signupUrl: "https://www.sixfl.co.uk/leagues/heartlands",
+    });
+  } catch (error) {
+    console.error("Heartlands welcome queue failed:", error);
+  }
+
+  redirect(`/leagues/thanks?lead=${lead.id}`);
+}

--- a/src/app/(public)/leagues/heartlands/page.tsx
+++ b/src/app/(public)/leagues/heartlands/page.tsx
@@ -4,7 +4,7 @@
 
 import type { Metadata } from "next";
 import Image from "next/image";
-import { notFound, redirect } from "next/navigation";
+import { redirect } from "next/navigation";
 
 import { prisma } from "@/lib/prisma";
 import { createHeartlandsInterestLeadAction } from "./actions";
@@ -74,7 +74,11 @@ async function getHeartlandsLeague() {
 
 export default async function HeartlandsLaunchPage() {
   const league = await getHeartlandsLeague();
-  if (!league) notFound();
+  if (!league) {
+    redirect(
+      "/register-interest?type=team&area=North%20Yorkshire%20Heartlands",
+    );
+  }
 
   if (league.fixtures.length > 0 && league.slug !== "heartlands") {
     redirect(`/leagues/${league.slug}`);

--- a/src/app/(public)/leagues/heartlands/page.tsx
+++ b/src/app/(public)/leagues/heartlands/page.tsx
@@ -1,0 +1,372 @@
+// ========================================
+// File: src/app/(public)/leagues/heartlands/page.tsx
+// ========================================
+
+import type { Metadata } from "next";
+import Image from "next/image";
+import { notFound, redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { createHeartlandsInterestLeadAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: "North Yorkshire Heartlands 6-a-side League | SIXFL",
+  description:
+    "Join the new North Yorkshire Heartlands 6-a-side league. Register a team or join as an individual player for properly organised weekly football.",
+};
+
+function formatPreferredNight(value?: string | null) {
+  if (!value) return "To be confirmed";
+  if (value === "ANY") return "Night to be confirmed";
+  return value.charAt(0) + value.slice(1).toLowerCase();
+}
+
+function normaliseImage(value?: string | null) {
+  if (!value?.trim()) return null;
+  const trimmed = value.trim();
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("http://")
+  ) {
+    return trimmed;
+  }
+  return `/${trimmed}`;
+}
+
+async function getHeartlandsLeague() {
+  return prisma.league.findFirst({
+    where: {
+      isActive: true,
+      OR: [
+        { slug: { contains: "heartlands", mode: "insensitive" } },
+        { name: { contains: "heartlands", mode: "insensitive" } },
+        { area: { contains: "heartlands", mode: "insensitive" } },
+      ],
+    },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      season: true,
+      area: true,
+      dayOfWeek: true,
+      venueName: true,
+      kickoffInfo: true,
+      format: true,
+      surface: true,
+      description: true,
+      heroImageUrl: true,
+      badgeUrl: true,
+      ctaText: true,
+      fixtures: {
+        where: { publishedAt: { not: null } },
+        select: { id: true },
+        take: 1,
+      },
+    },
+  });
+}
+
+export default async function HeartlandsLaunchPage() {
+  const league = await getHeartlandsLeague();
+  if (!league) notFound();
+
+  if (league.fixtures.length > 0 && league.slug !== "heartlands") {
+    redirect(`/leagues/${league.slug}`);
+  }
+
+  const nightLabel = formatPreferredNight(league.dayOfWeek);
+  const venueLabel = league.venueName || "North Yorkshire venue";
+  const heroImage =
+    normaliseImage(league.heroImageUrl) ||
+    "/venues/north-yorkshire-heartlands-hero.jpg";
+  const badgeImage = normaliseImage(league.badgeUrl) || "/sixfl-badge.png";
+  const intro =
+    league.description?.trim() ||
+    "A new SIXFL league for teams and players across Northallerton, Bedale, Richmond and the surrounding area. Proper weekly fixtures, qualified referees and a league that is easy to follow.";
+
+  const details = [
+    { label: "Match night", value: nightLabel },
+    { label: "Venue", value: venueLabel },
+    { label: "Season", value: league.season || "Founding season" },
+    { label: "Team fee", value: "£40 per week" },
+  ];
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <section className="relative isolate overflow-hidden border-b border-white/10">
+        <div className="absolute inset-0">
+          <Image
+            src={heroImage}
+            alt={venueLabel}
+            fill
+            priority
+            className="object-cover object-center"
+          />
+          <div className="absolute inset-0 bg-black/70" />
+          <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/55 to-black" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.24),transparent_38%)]" />
+        </div>
+
+        <div className="relative mx-auto max-w-6xl px-4 py-14 sm:px-6 sm:py-20 lg:px-8 lg:py-24">
+          <div className="max-w-4xl rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_28px_100px_rgba(0,0,0,0.48)] backdrop-blur-sm sm:p-9 lg:p-11">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
+              <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-3xl border border-emerald-400/25 bg-black/60 p-3 shadow-2xl sm:h-28 sm:w-28">
+                <Image
+                  src={badgeImage}
+                  alt={`${league.name} badge`}
+                  fill
+                  sizes="112px"
+                  className="object-contain p-2"
+                  unoptimized
+                />
+              </div>
+
+              <div>
+                <div className="flex flex-wrap gap-2">
+                  <span className="rounded-full border border-emerald-400/30 bg-emerald-500/15 px-3 py-1 text-[11px] font-black uppercase tracking-[0.2em] text-emerald-200">
+                    Founding season
+                  </span>
+                  <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] font-black uppercase tracking-[0.2em] text-white/80">
+                    Teams now registering
+                  </span>
+                </div>
+                <p className="mt-4 text-sm font-bold uppercase tracking-[0.2em] text-emerald-300">
+                  Northallerton • Bedale • Richmond
+                </p>
+              </div>
+            </div>
+
+            <h1 className="mt-7 max-w-3xl text-4xl font-black leading-[0.98] tracking-tight sm:text-5xl lg:text-6xl">
+              {league.name}
+            </h1>
+
+            <p className="mt-5 max-w-3xl text-base leading-8 text-white/75 sm:text-lg">
+              {intro}
+            </p>
+
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <a
+                href="#register"
+                className="inline-flex h-12 items-center justify-center rounded-full bg-emerald-500 px-6 text-sm font-extrabold text-black transition hover:bg-emerald-400"
+              >
+                Enter a team
+              </a>
+              <a
+                href="#register"
+                className="inline-flex h-12 items-center justify-center rounded-full border border-white/15 bg-white/10 px-6 text-sm font-extrabold text-white transition hover:bg-white/15"
+              >
+                Join as a player
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {details.map((detail) => (
+            <div
+              key={detail.label}
+              className="rounded-3xl border border-white/10 bg-white/[0.04] p-5"
+            >
+              <div className="text-[11px] font-bold uppercase tracking-[0.2em] text-emerald-300">
+                {detail.label}
+              </div>
+              <div className="mt-2 text-lg font-bold text-white">
+                {detail.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.72fr)] lg:items-start">
+          <div className="space-y-6">
+            <div className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 sm:p-8">
+              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-emerald-300">
+                6-a-side. Done properly.
+              </p>
+              <h2 className="mt-3 text-3xl font-black tracking-tight">
+                A better local league experience.
+              </h2>
+              <p className="mt-4 max-w-2xl text-base leading-8 text-white/65">
+                Built for teams who want reliable weekly football without the usual confusion. Everything important is kept together and updated throughout the season.
+              </p>
+
+              <div className="mt-7 grid gap-4 sm:grid-cols-3">
+                {[
+                  ["Reliable", "Fixed weekly fixtures and clear kick-off information."],
+                  ["Competitive", "A proper table, results and match-night structure."],
+                  ["Professional", "Qualified referees and organised league management."],
+                ].map(([title, copy]) => (
+                  <div
+                    key={title}
+                    className="rounded-2xl border border-white/10 bg-black/30 p-5"
+                  >
+                    <div className="font-bold text-emerald-300">{title}</div>
+                    <p className="mt-2 text-sm leading-6 text-white/60">{copy}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[2rem] border border-emerald-400/20 bg-emerald-500/[0.06] p-6 sm:p-8">
+              <h2 className="text-2xl font-black">The essentials</h2>
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                {[
+                  league.format || "6-a-side football",
+                  league.surface || "3G playing surface",
+                  league.kickoffInfo || "Weekly evening kick-offs",
+                  "Live fixtures, results and league table",
+                ].map((item) => (
+                  <div
+                    key={item}
+                    className="rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-sm font-semibold text-white/80"
+                  >
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <aside
+            id="register"
+            className="scroll-mt-24 rounded-[2rem] border border-white/10 bg-white/[0.055] p-6 shadow-[0_24px_90px_rgba(0,0,0,0.4)] sm:p-8"
+          >
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-emerald-300">
+              Join the league
+            </p>
+            <h2 className="mt-3 text-3xl font-black tracking-tight">
+              Register your interest
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-white/65">
+              No payment is taken now. Tell us whether you have a team or want to join as an individual player.
+            </p>
+
+            <form
+              action={createHeartlandsInterestLeadAction}
+              className="mt-6 space-y-5"
+            >
+              <input type="hidden" name="leagueId" value={league.id} />
+              <input
+                type="hidden"
+                name="area"
+                value={league.area || "North Yorkshire Heartlands"}
+              />
+              <input
+                type="hidden"
+                name="source"
+                value="heartlands-launch-page"
+              />
+
+              <fieldset>
+                <legend className="mb-3 text-sm font-semibold text-white/85">
+                  What are you registering?
+                </legend>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="flex cursor-pointer items-center gap-3 rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-4 text-sm font-bold text-white">
+                    <input
+                      type="radio"
+                      name="interestType"
+                      value="TEAM"
+                      defaultChecked
+                      required
+                      className="accent-emerald-500"
+                    />
+                    I have a team
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-3 rounded-2xl border border-white/10 bg-black/25 p-4 text-sm font-bold text-white">
+                    <input
+                      type="radio"
+                      name="interestType"
+                      value="PLAYER"
+                      required
+                      className="accent-emerald-500"
+                    />
+                    I am a player
+                  </label>
+                </div>
+              </fieldset>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-white/85">Your name</span>
+                <input
+                  name="contactName"
+                  type="text"
+                  required
+                  autoComplete="name"
+                  placeholder="Your full name"
+                  className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none placeholder:text-white/35 focus:border-emerald-400"
+                />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-white/85">Email</span>
+                <input
+                  name="email"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                  className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none placeholder:text-white/35 focus:border-emerald-400"
+                />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-white/85">Mobile</span>
+                <input
+                  name="phone"
+                  type="tel"
+                  autoComplete="tel"
+                  placeholder="Optional"
+                  className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none placeholder:text-white/35 focus:border-emerald-400"
+                />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-white/85">
+                  Team name
+                </span>
+                <input
+                  name="teamName"
+                  type="text"
+                  placeholder="Leave blank if joining as a player"
+                  className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none placeholder:text-white/35 focus:border-emerald-400"
+                />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-semibold text-white/85">
+                  Anything else?
+                </span>
+                <textarea
+                  name="message"
+                  rows={3}
+                  placeholder="Optional"
+                  className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none placeholder:text-white/35 focus:border-emerald-400"
+                />
+              </label>
+
+              <button
+                type="submit"
+                className="w-full rounded-xl bg-emerald-500 px-5 py-3.5 text-sm font-extrabold text-black transition hover:bg-emerald-400"
+              >
+                {league.ctaText?.trim() || "Join the Heartlands League"}
+              </button>
+            </form>
+
+            <p className="mt-4 text-xs leading-5 text-white/45">
+              We will use these details only to contact you about this league.
+            </p>
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -9,23 +9,29 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata = {
-  title: "SIXFL | Harrogate, Northallerton & Wetherby 6-a-side football leagues",
+  title: "SIXFL | North Yorkshire 6-a-side football leagues",
   description:
-    "Find local SIXFL 6-a-side football leagues in Harrogate, Wetherby at Boston Spa Academy and Northallerton. View fixtures, results, AI predictions and tables, or register interest as a team, player or referee.",
+    "Find local SIXFL 6-a-side football leagues across North Yorkshire, including Harrogate, Wetherby and the North Yorkshire Heartlands. View fixtures and tables or register as a team, player or referee.",
 };
 
 const harrogateLeagueLink = "/leagues/rossett-mens-tuesday";
+const heartlandsLeagueLink = "/leagues/heartlands";
 const generalRegisterLink = "/register-interest";
 const generalTeamLink = "/register-interest?type=team";
 const generalPlayerLink = "/register-interest?type=player";
 const generalRefereeLink = "/register-interest?type=referee";
-const northallertonTeamLink = "/register-interest?type=team&area=Northallerton&night=Wednesday";
-const northallertonPlayerLink = "/register-interest?type=player&area=Northallerton&night=Wednesday";
 const wetherbyTeamLink = "/register-interest?type=team&area=Wetherby&night=Wednesday";
 const wetherbyPlayerLink = "/register-interest?type=player&area=Wetherby&night=Wednesday";
 
 const leagueTypes = ["MEN’S LEAGUES", "WOMEN’S LEAGUES", "YOUTH LEAGUES"];
-const launchAreas = ["Harrogate", "Wetherby", "Northallerton", "Ripon", "York", "Leeds"];
+const launchAreas = [
+  "Harrogate",
+  "Wetherby",
+  "North Yorkshire Heartlands",
+  "Ripon",
+  "York",
+  "Leeds",
+];
 const predictorHomeTeamName = "Six Offenders";
 const predictorAwayTeamName = "Crescent United";
 
@@ -53,14 +59,14 @@ const areaCards = [
     featured: false,
   },
   {
-    eyebrow: "NORTHALLERTON LAUNCH",
-    title: "Northallerton Wednesday 6-a-side",
-    status: "Registrations open",
-    body: "Northallerton team entries are open for the upcoming Wednesday night 6-a-side league. Individual players and referees can also register interest.",
-    primaryLabel: "Register team",
-    primaryHref: northallertonTeamLink,
+    eyebrow: "NORTH YORKSHIRE HEARTLANDS",
+    title: "North Yorkshire Heartlands League",
+    status: "New league forming",
+    body: "A new SIXFL league for Northallerton, Bedale, Richmond and the surrounding area. Teams and individual players can view the details and register now.",
+    primaryLabel: "View & join",
+    primaryHref: heartlandsLeagueLink,
     secondaryLabel: "Join as player",
-    secondaryHref: northallertonPlayerLink,
+    secondaryHref: `${heartlandsLeagueLink}#register`,
     featured: false,
   },
 ];
@@ -123,8 +129,14 @@ async function getPredictorSampleTeamLogos(): Promise<PredictorSampleTeamLogos> 
       select: { name: true, logoUrl: true },
     });
 
-    const homeTeam = teams.find((team) => normaliseTeamName(team.name) === normaliseTeamName(predictorHomeTeamName));
-    const awayTeam = teams.find((team) => normaliseTeamName(team.name) === normaliseTeamName(predictorAwayTeamName));
+    const homeTeam = teams.find(
+      (team) =>
+        normaliseTeamName(team.name) === normaliseTeamName(predictorHomeTeamName),
+    );
+    const awayTeam = teams.find(
+      (team) =>
+        normaliseTeamName(team.name) === normaliseTeamName(predictorAwayTeamName),
+    );
 
     return {
       homeLogoUrl: homeTeam?.logoUrl ?? null,
@@ -155,11 +167,11 @@ export default async function HomePage() {
         <section className="rounded-[1.5rem] border border-white/10 bg-white/[0.045] p-4 shadow-[0_28px_100px_rgba(0,0,0,0.48)] backdrop-blur-xl sm:rounded-[2rem] sm:p-8 lg:p-10">
           <div className="max-w-5xl text-left">
             <div className="inline-flex max-w-full rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-center text-[10px] font-extrabold uppercase leading-5 tracking-[0.14em] text-emerald-300 sm:px-4 sm:text-xs sm:tracking-[0.22em]">
-              Harrogate live now • Wetherby at Boston Spa Academy
+              Harrogate live now • New Heartlands League forming
             </div>
 
             <h1 className="mt-6 max-w-4xl text-balance text-4xl font-extrabold leading-[0.98] tracking-tight sm:text-6xl sm:leading-[0.95] lg:text-7xl">
-              Local 6-a-side football in Harrogate, Wetherby and Northallerton.
+              Local 6-a-side football across North Yorkshire.
               <br />
               <span className="text-emerald-500 drop-shadow-[0_0_30px_rgba(16,185,129,0.55)]">
                 Easy to join. Easy to follow.
@@ -174,7 +186,9 @@ export default async function HomePage() {
               {leagueTypes.map((type, index) => (
                 <span key={type} className="inline-flex items-center">
                   {type}
-                  {index < leagueTypes.length - 1 && <span className="ml-4 text-white/25">•</span>}
+                  {index < leagueTypes.length - 1 && (
+                    <span className="ml-4 text-white/25">•</span>
+                  )}
                 </span>
               ))}
             </div>
@@ -197,7 +211,9 @@ export default async function HomePage() {
           </div>
 
           <div className="mt-10 grid gap-4 lg:grid-cols-3">
-            {areaCards.map((area) => <AreaCard key={area.title} {...area} />)}
+            {areaCards.map((area) => (
+              <AreaCard key={area.title} {...area} />
+            ))}
           </div>
         </section>
 
@@ -205,15 +221,25 @@ export default async function HomePage() {
 
         <section id="why-sixfl" className="mt-12 lg:mt-16">
           <div className="mb-6">
-            <div className="text-[11px] font-bold tracking-[0.24em] text-white/60">WHY SIXFL</div>
-            <h2 className="mt-2 text-3xl font-black tracking-tight sm:text-4xl">Local 6-a-side made easier to follow.</h2>
+            <div className="text-[11px] font-bold tracking-[0.24em] text-white/60">
+              WHY SIXFL
+            </div>
+            <h2 className="mt-2 text-3xl font-black tracking-tight sm:text-4xl">
+              Local 6-a-side made easier to follow.
+            </h2>
             <p className="mt-3 max-w-2xl text-sm leading-7 text-white/60 sm:text-base">
               From fixtures and results to registrations and league tables, SIXFL keeps the important details easy to find.
             </p>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
-            {whySixflPoints.map((point) => <PathwayCard key={point.title} title={point.title} desc={point.desc} />)}
+            {whySixflPoints.map((point) => (
+              <PathwayCard
+                key={point.title}
+                title={point.title}
+                desc={point.desc}
+              />
+            ))}
           </div>
         </section>
 
@@ -221,15 +247,22 @@ export default async function HomePage() {
           <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-5 shadow-[0_24px_90px_rgba(0,0,0,0.38)] backdrop-blur-xl sm:p-8">
             <div className="grid gap-8 lg:grid-cols-12 lg:items-center">
               <div className="lg:col-span-7">
-                <div className="text-[11px] font-bold tracking-[0.24em] text-emerald-300">JOIN A LEAGUE</div>
-                <h2 className="mt-2 text-2xl font-black tracking-tight sm:text-3xl">Get involved with SIXFL.</h2>
+                <div className="text-[11px] font-bold tracking-[0.24em] text-emerald-300">
+                  JOIN A LEAGUE
+                </div>
+                <h2 className="mt-2 text-2xl font-black tracking-tight sm:text-3xl">
+                  Get involved with SIXFL.
+                </h2>
                 <p className="mt-3 max-w-2xl text-sm leading-7 text-white/70 sm:text-base">
-                  Teams, individual players and referees can register interest for live leagues and new launch areas. Harrogate is live now, and Wetherby and Northallerton registrations are open.
+                  Teams, individual players and referees can register interest for live leagues and new launch areas. Harrogate is live now, while Wetherby and the North Yorkshire Heartlands are open for registrations.
                 </p>
 
                 <div className="mt-5 flex flex-wrap gap-2">
                   {launchAreas.map((area) => (
-                    <span key={area} className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-bold text-white/80">
+                    <span
+                      key={area}
+                      className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[11px] font-bold text-white/80"
+                    >
                       {area}
                     </span>
                   ))}
@@ -238,7 +271,14 @@ export default async function HomePage() {
 
               <div className="grid gap-3 lg:col-span-5">
                 {joinRoutes.map((route, index) => (
-                  <FunnelCard key={route.title} title={route.title} desc={route.desc} href={route.href} cta={route.cta} featured={index === 0} />
+                  <FunnelCard
+                    key={route.title}
+                    title={route.title}
+                    desc={route.desc}
+                    href={route.href}
+                    cta={route.cta}
+                    featured={index === 0}
+                  />
                 ))}
               </div>
             </div>
@@ -271,20 +311,46 @@ function AreaCard({
   featured: boolean;
 }) {
   return (
-    <article className={`rounded-[1.5rem] border p-4 shadow-[0_20px_80px_rgba(0,0,0,0.35)] sm:rounded-[1.75rem] sm:p-6 ${featured ? "border-emerald-500/25 bg-emerald-500/[0.08]" : "border-white/10 bg-black/35"}`}>
+    <article
+      className={`rounded-[1.5rem] border p-4 shadow-[0_20px_80px_rgba(0,0,0,0.35)] sm:rounded-[1.75rem] sm:p-6 ${
+        featured
+          ? "border-emerald-500/25 bg-emerald-500/[0.08]"
+          : "border-white/10 bg-black/35"
+      }`}
+    >
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="text-[11px] font-bold uppercase tracking-[0.22em] text-white/55">{eyebrow}</div>
-        <div className={`rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${featured ? "border-emerald-500/30 bg-emerald-500/15 text-emerald-300" : "border-white/10 bg-white/5 text-white/75"}`}>{status}</div>
+        <div className="text-[11px] font-bold uppercase tracking-[0.22em] text-white/55">
+          {eyebrow}
+        </div>
+        <div
+          className={`rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${
+            featured
+              ? "border-emerald-500/30 bg-emerald-500/15 text-emerald-300"
+              : "border-white/10 bg-white/5 text-white/75"
+          }`}
+        >
+          {status}
+        </div>
       </div>
 
-      <h2 className="mt-5 text-2xl font-black tracking-tight text-white sm:text-3xl">{title}</h2>
-      <p className="mt-3 text-sm leading-7 text-white/66 sm:text-base">{body}</p>
+      <h2 className="mt-5 text-2xl font-black tracking-tight text-white sm:text-3xl">
+        {title}
+      </h2>
+      <p className="mt-3 text-sm leading-7 text-white/66 sm:text-base">
+        {body}
+      </p>
 
       <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-        <Link href={primaryHref} className="inline-flex h-11 w-full items-center justify-center rounded-full bg-emerald-500 px-5 text-center text-sm font-extrabold tracking-wide text-black transition hover:scale-[1.02] hover:bg-emerald-400 sm:w-auto">
+        <Link
+          href={primaryHref}
+          className="inline-flex h-11 w-full items-center justify-center rounded-full bg-emerald-500 px-5 text-center text-sm font-extrabold tracking-wide text-black transition hover:scale-[1.02] hover:bg-emerald-400 sm:w-auto"
+        >
           {primaryLabel}
         </Link>
-        <Link href={secondaryHref} className="inline-flex h-11 w-full items-center justify-center rounded-full border border-white/10 bg-white/5 px-5 text-center text-sm font-extrabold tracking-wide text-white transition hover:bg-white/10 sm:w-auto">
+        <Link
+          href={secondaryHref}
+          className="inline-flex h-11 w-full items-center justify-center rounded-full border border-white/10 bg-white/5 px-5 text-center text-sm font-extrabold tracking-wide text-white transition hover:bg-white/10 sm:w-auto"
+        >
           {secondaryLabel}
         </Link>
       </div>
@@ -292,18 +358,28 @@ function AreaCard({
   );
 }
 
-function SixflAiPredictorSection({ teamLogos }: { teamLogos: PredictorSampleTeamLogos }) {
+function SixflAiPredictorSection({
+  teamLogos,
+}: {
+  teamLogos: PredictorSampleTeamLogos;
+}) {
   return (
     <section className="mt-12 lg:mt-16">
       <div className="overflow-hidden rounded-[1.5rem] border border-emerald-400/20 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.18),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.035))] p-5 shadow-[0_24px_90px_rgba(0,0,0,0.42)] backdrop-blur-xl sm:rounded-[2rem] sm:p-8 lg:p-10">
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] lg:items-center">
           <div>
-            <div className="inline-flex rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.22em] text-emerald-300">SIXFL AI Predictor</div>
-            <h2 className="mt-5 text-3xl font-black tracking-tight text-white sm:text-4xl">Match predictions, powered by SIXFL AI Predictor.</h2>
+            <div className="inline-flex rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.22em] text-emerald-300">
+              SIXFL AI Predictor
+            </div>
+            <h2 className="mt-5 text-3xl font-black tracking-tight text-white sm:text-4xl">
+              Match predictions, powered by SIXFL AI Predictor.
+            </h2>
             <p className="mt-4 max-w-2xl text-sm leading-7 text-white/68 sm:text-base">
               Before kick-off, SIXFL AI Predictor turns recent results, goals scored, goals conceded and league position into a simple match preview and win chance estimate.
             </p>
-            <p className="mt-3 max-w-2xl text-sm leading-7 text-white/55">It is just for fun. It gives teams something extra to check, compare and talk about before they play.</p>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-white/55">
+              It is just for fun. It gives teams something extra to check, compare and talk about before they play.
+            </p>
             <div className="mt-6 flex flex-wrap gap-2">
               <FeaturePill text="AI match previews" />
               <FeaturePill text="Win chance estimates" />
@@ -314,23 +390,47 @@ function SixflAiPredictorSection({ teamLogos }: { teamLogos: PredictorSampleTeam
           <div className="rounded-[1.5rem] border border-white/10 bg-black/45 p-4 shadow-[0_20px_70px_rgba(0,0,0,0.35)] sm:rounded-[2rem] sm:p-6">
             <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
               <div>
-                <div className="text-[11px] font-black uppercase tracking-[0.22em] text-emerald-300">Sample prediction</div>
-                <h3 className="mt-2 text-xl font-black text-white">{predictorHomeTeamName} vs {predictorAwayTeamName}</h3>
+                <div className="text-[11px] font-black uppercase tracking-[0.22em] text-emerald-300">
+                  Sample prediction
+                </div>
+                <h3 className="mt-2 text-xl font-black text-white">
+                  {predictorHomeTeamName} vs {predictorAwayTeamName}
+                </h3>
               </div>
-              <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-xs font-black text-emerald-200">SIXFL AI Predictor</span>
+              <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-xs font-black text-emerald-200">
+                SIXFL AI Predictor
+              </span>
             </div>
 
             <div className="mt-6 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-3xl border border-white/10 bg-white/[0.035] p-4 sm:gap-5 sm:p-5">
-              <SampleTeamBadge initials="SO" logoUrl={teamLogos.homeLogoUrl} name={predictorHomeTeamName} tone="emerald" />
-              <div className="rounded-full border border-white/10 bg-black/60 px-3 py-2 text-xs font-black tracking-[0.2em] text-white/55">VS</div>
-              <SampleTeamBadge initials="CU" logoUrl={teamLogos.awayLogoUrl} name={predictorAwayTeamName} tone="sky" />
+              <SampleTeamBadge
+                initials="SO"
+                logoUrl={teamLogos.homeLogoUrl}
+                name={predictorHomeTeamName}
+                tone="emerald"
+              />
+              <div className="rounded-full border border-white/10 bg-black/60 px-3 py-2 text-xs font-black tracking-[0.2em] text-white/55">
+                VS
+              </div>
+              <SampleTeamBadge
+                initials="CU"
+                logoUrl={teamLogos.awayLogoUrl}
+                name={predictorAwayTeamName}
+                tone="sky"
+              />
             </div>
 
-            <div className="mt-6 space-y-4">{predictorSample.map((item) => <PredictionBar key={item.label} {...item} />)}</div>
+            <div className="mt-6 space-y-4">
+              {predictorSample.map((item) => (
+                <PredictionBar key={item.label} {...item} />
+              ))}
+            </div>
             <div className="mt-6 rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm leading-6 text-white/62">
               SIXFL AI Predictor: Six Offenders edge the sample prediction after stronger recent scoring form, but Crescent United carry enough threat to make this a competitive fixture.
             </div>
-            <div className="mt-4 text-[11px] leading-5 text-white/35">Example only. Live predictions update from actual SIXFL fixture and results data.</div>
+            <div className="mt-4 text-[11px] leading-5 text-white/35">
+              Example only. Live predictions update from actual SIXFL fixture and results data.
+            </div>
           </div>
         </div>
       </div>
@@ -338,55 +438,136 @@ function SixflAiPredictorSection({ teamLogos }: { teamLogos: PredictorSampleTeam
   );
 }
 
-function SampleTeamBadge({ initials, logoUrl, name, tone }: { initials: string; logoUrl: string | null; name: string; tone: "emerald" | "sky" }) {
-  const badgeStyles = tone === "emerald"
-    ? { outer: "border-emerald-300/25 bg-gradient-to-b from-emerald-300/22 via-emerald-500/12 to-black/70 shadow-emerald-500/20", inner: "border-emerald-200/30 bg-emerald-400/15 text-emerald-100", accent: "bg-emerald-300/75" }
-    : { outer: "border-sky-300/25 bg-gradient-to-b from-sky-300/22 via-sky-500/12 to-black/70 shadow-sky-500/20", inner: "border-sky-200/30 bg-sky-400/15 text-sky-100", accent: "bg-sky-300/75" };
+function SampleTeamBadge({
+  initials,
+  logoUrl,
+  name,
+  tone,
+}: {
+  initials: string;
+  logoUrl: string | null;
+  name: string;
+  tone: "emerald" | "sky";
+}) {
+  const badgeStyles =
+    tone === "emerald"
+      ? {
+          outer:
+            "border-emerald-300/25 bg-gradient-to-b from-emerald-300/22 via-emerald-500/12 to-black/70 shadow-emerald-500/20",
+          inner:
+            "border-emerald-200/30 bg-emerald-400/15 text-emerald-100",
+          accent: "bg-emerald-300/75",
+        }
+      : {
+          outer:
+            "border-sky-300/25 bg-gradient-to-b from-sky-300/22 via-sky-500/12 to-black/70 shadow-sky-500/20",
+          inner: "border-sky-200/30 bg-sky-400/15 text-sky-100",
+          accent: "bg-sky-300/75",
+        };
 
   return (
     <div className="flex min-w-0 flex-col items-center text-center">
-      <div className={`relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-[2rem] border shadow-2xl sm:h-40 sm:w-40 ${badgeStyles.outer}`} aria-label={`${name} badge`} title={`${name} badge`}>
+      <div
+        className={`relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-[2rem] border shadow-2xl sm:h-40 sm:w-40 ${badgeStyles.outer}`}
+        aria-label={`${name} badge`}
+        title={`${name} badge`}
+      >
         {logoUrl ? (
           <div className="flex h-full w-full items-center justify-center bg-black/35 p-3 sm:p-4">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={logoUrl} alt={`${name} badge`} className="h-full w-full object-contain drop-shadow-[0_18px_24px_rgba(0,0,0,0.5)]" />
+            <img
+              src={logoUrl}
+              alt={`${name} badge`}
+              className="h-full w-full object-contain drop-shadow-[0_18px_24px_rgba(0,0,0,0.5)]"
+            />
           </div>
         ) : (
           <>
             <div className="absolute inset-3 rounded-[1.45rem] border border-white/10 bg-black/35" />
-            <div className={`absolute left-1/2 top-4 h-1.5 w-12 -translate-x-1/2 rounded-full sm:w-16 ${badgeStyles.accent}`} />
-            <div className={`relative flex h-16 w-16 items-center justify-center rounded-full border text-2xl font-black tracking-tight sm:h-20 sm:w-20 sm:text-3xl ${badgeStyles.inner}`}>{initials}</div>
+            <div
+              className={`absolute left-1/2 top-4 h-1.5 w-12 -translate-x-1/2 rounded-full sm:w-16 ${badgeStyles.accent}`}
+            />
+            <div
+              className={`relative flex h-16 w-16 items-center justify-center rounded-full border text-2xl font-black tracking-tight sm:h-20 sm:w-20 sm:text-3xl ${badgeStyles.inner}`}
+            >
+              {initials}
+            </div>
           </>
         )}
       </div>
-      <div className="mt-3 max-w-[9rem] text-sm font-black leading-5 text-white sm:text-base">{name}</div>
+      <div className="mt-3 max-w-[9rem] text-sm font-black leading-5 text-white sm:text-base">
+        {name}
+      </div>
     </div>
   );
 }
 
-function PredictionBar({ label, value, tone }: { label: string; value: number; tone: string }) {
-  const barClass = tone === "emerald" ? "bg-emerald-400" : tone === "sky" ? "bg-sky-400" : "bg-white/45";
+function PredictionBar({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: string;
+}) {
+  const barClass =
+    tone === "emerald"
+      ? "bg-emerald-400"
+      : tone === "sky"
+        ? "bg-sky-400"
+        : "bg-white/45";
   return (
     <div>
       <div className="mb-2 flex items-center justify-between gap-3 text-sm">
         <span className="font-semibold text-white">{label}</span>
         <span className="font-black text-white">{value}%</span>
       </div>
-      <div className="h-3 overflow-hidden rounded-full bg-white/10"><div className={`h-full rounded-full ${barClass}`} style={{ width: `${value}%` }} /></div>
+      <div className="h-3 overflow-hidden rounded-full bg-white/10">
+        <div
+          className={`h-full rounded-full ${barClass}`}
+          style={{ width: `${value}%` }}
+        />
+      </div>
     </div>
   );
 }
 
 function FeaturePill({ text }: { text: string }) {
-  return <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-bold tracking-[0.12em] text-emerald-200">{text}</span>;
+  return (
+    <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-bold tracking-[0.12em] text-emerald-200">
+      {text}
+    </span>
+  );
 }
 
-function FunnelCard({ title, desc, href, cta, featured = false }: { title: string; desc: string; href: string; cta: string; featured?: boolean }) {
+function FunnelCard({
+  title,
+  desc,
+  href,
+  cta,
+  featured = false,
+}: {
+  title: string;
+  desc: string;
+  href: string;
+  cta: string;
+  featured?: boolean;
+}) {
   return (
-    <Link href={href} className={`block rounded-2xl border p-4 transition ${featured ? "border-emerald-500/30 bg-emerald-500/[0.08] hover:bg-emerald-500/[0.12]" : "border-white/10 bg-black/40 hover:border-emerald-500/30 hover:bg-black/50"}`}>
+    <Link
+      href={href}
+      className={`block rounded-2xl border p-4 transition ${
+        featured
+          ? "border-emerald-500/30 bg-emerald-500/[0.08] hover:bg-emerald-500/[0.12]"
+          : "border-white/10 bg-black/40 hover:border-emerald-500/30 hover:bg-black/50"
+      }`}
+    >
       <div className="text-sm font-bold text-white">{title}</div>
       <div className="mt-1 text-sm text-white/60">{desc}</div>
-      <div className="mt-3 text-xs font-bold uppercase tracking-[0.18em] text-emerald-400">{cta} →</div>
+      <div className="mt-3 text-xs font-bold uppercase tracking-[0.18em] text-emerald-400">
+        {cta} →
+      </div>
     </Link>
   );
 }
@@ -394,8 +575,12 @@ function FunnelCard({ title, desc, href, cta, featured = false }: { title: strin
 function PathwayCard({ title, desc }: { title: string; desc: string }) {
   return (
     <div className="rounded-3xl border border-white/10 bg-white/[0.05] p-5 shadow-[0_18px_60px_rgba(0,0,0,0.28)] backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/[0.07] sm:p-6">
-      <div className="text-[11px] font-bold tracking-[0.24em] text-white/55">SIXFL BENEFIT</div>
-      <div className="mt-2 text-2xl font-black tracking-tight text-white">{title}</div>
+      <div className="text-[11px] font-bold tracking-[0.24em] text-white/55">
+        SIXFL BENEFIT
+      </div>
+      <div className="mt-2 text-2xl font-black tracking-tight text-white">
+        {title}
+      </div>
       <div className="mt-3 text-sm leading-7 text-white/60">{desc}</div>
       <div className="mt-6 h-px w-full bg-gradient-to-r from-transparent via-emerald-500/40 to-transparent" />
     </div>


### PR DESCRIPTION
## What changed

- added a dedicated `/leagues/heartlands` pre-launch page using the new venue hero image
- added a clear team/player choice so leads are saved with the correct interest type
- added a compact registration form with no payment taken at this stage
- replaced the old Northallerton homepage card with the North Yorkshire Heartlands League
- simplified the homepage headline to cover North Yorkshire without adding a fourth card
- redirects the Heartlands launch route to the normal live league page once published fixtures exist

## Why

The new league needs a polished joining page without making the homepage crowded. The launch page keeps registration prominent while hiding empty tables, fixtures and results during recruitment.

## Validation

- confirmed the Heartlands hero image already exists at `public/venues/north-yorkshire-heartlands-hero.jpg`
- confirmed `InterestType.PLAYER` is already used in the project
- checked the branch diff for unrelated changes

The branch is two non-conflicting commits behind `main`; those newer commits only affect the YouTube logo and SIXFL TV homepage component.