### PR TITLE
Warn when a league team has no fixture this week

### DIFF
--- a/src/app/api/admin/night-board/missing-team-fixtures/route.ts
+++ b/src/app/api/admin/night-board/missing-team-fixtures/route.ts
@@ -1,0 +1,207 @@
+// ========================================
+// File: src/app/api/admin/night-board/missing-team-fixtures/route.ts
+// ========================================
+
+import { FixtureStatus } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const VISIBLE_FIXTURE_STATUSES: FixtureStatus[] = [
+  FixtureStatus.SCHEDULED,
+  FixtureStatus.COMPLETED,
+];
+
+function isDateInput(value: string) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function toLondonDateInput(value: Date) {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
+  const year = parts.find((part) => part.type === "year")?.value ?? "1970";
+  const month = parts.find((part) => part.type === "month")?.value ?? "01";
+  const day = parts.find((part) => part.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+function dayRangeFromInput(dateInput: string) {
+  const start = new Date(`${dateInput}T00:00:00.000Z`);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { start, end };
+}
+
+function weekRangeFromInput(dateInput: string) {
+  const selectedDate = new Date(`${dateInput}T00:00:00.000Z`);
+  const mondayOffset = (selectedDate.getUTCDay() + 6) % 7;
+  const start = new Date(selectedDate);
+  start.setUTCDate(start.getUTCDate() - mondayOffset);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 7);
+  return { start, end };
+}
+
+function formatWeekBeginning(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+  }).format(value);
+}
+
+async function findNextFixtureDate(input: {
+  leagueId: string;
+  venueId: string;
+}) {
+  const baseWhere = {
+    publishedAt: { not: null },
+    kickoffAt: { gte: new Date() },
+    status: { in: VISIBLE_FIXTURE_STATUSES },
+    ...(input.leagueId ? { leagueId: input.leagueId } : {}),
+  };
+
+  let nextFixture = await prisma.fixture.findFirst({
+    where: {
+      ...baseWhere,
+      ...(input.venueId ? { venueId: input.venueId } : {}),
+    },
+    orderBy: { kickoffAt: "asc" },
+    select: { kickoffAt: true },
+  });
+
+  if (!nextFixture && input.venueId) {
+    nextFixture = await prisma.fixture.findFirst({
+      where: baseWhere,
+      orderBy: { kickoffAt: "asc" },
+      select: { kickoffAt: true },
+    });
+  }
+
+  return nextFixture?.kickoffAt ?? null;
+}
+
+export async function GET(request: Request) {
+  await requireAdmin();
+
+  const url = new URL(request.url);
+  const requestedDate = url.searchParams.get("date")?.trim() ?? "";
+  const leagueId = url.searchParams.get("leagueId")?.trim() ?? "";
+  const venueId = url.searchParams.get("venueId")?.trim() ?? "";
+
+  let selectedDate = isDateInput(requestedDate) ? requestedDate : "";
+  if (!selectedDate) {
+    const nextKickoffAt = await findNextFixtureDate({ leagueId, venueId });
+    selectedDate = toLondonDateInput(nextKickoffAt ?? new Date());
+  }
+
+  const dayRange = dayRangeFromInput(selectedDate);
+  const dayFixtureWhere = {
+    publishedAt: { not: null },
+    kickoffAt: { gte: dayRange.start, lt: dayRange.end },
+    status: { in: VISIBLE_FIXTURE_STATUSES },
+    ...(leagueId ? { leagueId } : {}),
+  };
+
+  let boardFixtures = await prisma.fixture.findMany({
+    where: {
+      ...dayFixtureWhere,
+      ...(venueId ? { venueId } : {}),
+    },
+    select: { leagueId: true },
+  });
+
+  if (boardFixtures.length === 0 && venueId) {
+    boardFixtures = await prisma.fixture.findMany({
+      where: dayFixtureWhere,
+      select: { leagueId: true },
+    });
+  }
+
+  const relevantLeagueIds = leagueId
+    ? [leagueId]
+    : Array.from(new Set(boardFixtures.map((fixture) => fixture.leagueId)));
+
+  if (relevantLeagueIds.length === 0) {
+    return NextResponse.json(
+      { selectedDate, warnings: [] },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  const weekRange = weekRangeFromInput(selectedDate);
+  const [leagues, weeklyFixtures] = await Promise.all([
+    prisma.league.findMany({
+      where: { id: { in: relevantLeagueIds } },
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        name: true,
+        teams: {
+          orderBy: { name: "asc" },
+          select: {
+            id: true,
+            name: true,
+            division: { select: { name: true } },
+          },
+        },
+      },
+    }),
+    prisma.fixture.findMany({
+      where: {
+        leagueId: { in: relevantLeagueIds },
+        publishedAt: { not: null },
+        kickoffAt: { gte: weekRange.start, lt: weekRange.end },
+        status: { in: VISIBLE_FIXTURE_STATUSES },
+      },
+      select: {
+        leagueId: true,
+        homeTeamId: true,
+        awayTeamId: true,
+      },
+    }),
+  ]);
+
+  const scheduledTeamIdsByLeague = new Map<string, Set<string>>();
+  for (const fixture of weeklyFixtures) {
+    const teamIds = scheduledTeamIdsByLeague.get(fixture.leagueId) ?? new Set<string>();
+    teamIds.add(fixture.homeTeamId);
+    teamIds.add(fixture.awayTeamId);
+    scheduledTeamIdsByLeague.set(fixture.leagueId, teamIds);
+  }
+
+  const weekBeginning = formatWeekBeginning(weekRange.start);
+  const warnings = leagues.flatMap((league) => {
+    const scheduledTeamIds = scheduledTeamIdsByLeague.get(league.id) ?? new Set<string>();
+
+    return league.teams
+      .filter((team) => !scheduledTeamIds.has(team.id))
+      .map((team) => {
+        const leagueLabel = team.division?.name
+          ? `${league.name} · ${team.division.name}`
+          : league.name;
+
+        return {
+          key: `missing-weekly-fixture:${league.id}:${team.id}`,
+          leagueId: league.id,
+          teamId: team.id,
+          teamName: team.name,
+          message: `Potential issue – no fixture this week: ${team.name} has no published scheduled or completed fixture in ${leagueLabel} for the week beginning ${weekBeginning}. This may be intentional, for example a bye, but it is worth checking.`,
+        };
+      });
+  });
+
+  return NextResponse.json(
+    { selectedDate, warnings },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/components/admin/night-board/NightBoardWarningsPositionBridge.tsx
+++ b/src/components/admin/night-board/NightBoardWarningsPositionBridge.tsx
@@ -7,6 +7,15 @@
 import { useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
+type MissingFixtureWarning = {
+  key: string;
+  message: string;
+};
+
+type MissingFixtureResponse = {
+  warnings?: MissingFixtureWarning[];
+};
+
 function findHeading(texts: string[]) {
   return Array.from(document.querySelectorAll<HTMLHeadingElement>("h2")).find((heading) =>
     texts.includes(heading.textContent?.trim() ?? ""),
@@ -155,6 +164,72 @@ function ensureTeamIssuesButton(issueCards: HTMLElement[], onViewIssue: () => vo
   );
 }
 
+function clearMissingFixtureWarnings() {
+  document
+    .querySelectorAll<HTMLElement>("[data-night-board-missing-fixture-warning]")
+    .forEach((warning) => warning.remove());
+  document
+    .querySelectorAll<HTMLElement>("[data-night-board-missing-fixture-note]")
+    .forEach((note) => note.remove());
+  document
+    .querySelectorAll<HTMLElement>("[data-night-board-hidden-no-warnings]")
+    .forEach((message) => {
+      message.style.display = message.dataset.nightBoardPreviousDisplay ?? "";
+      delete message.dataset.nightBoardPreviousDisplay;
+      delete message.dataset.nightBoardHiddenNoWarnings;
+    });
+}
+
+function renderMissingFixtureWarnings(warnings: MissingFixtureWarning[]) {
+  clearMissingFixtureWarnings();
+  if (warnings.length === 0) return;
+
+  const warningsHeading = findHeading(["Warnings", "Warnings and potential issues"]);
+  const warningsCard = warningsHeading?.closest<HTMLElement>("section");
+  const warningsList = warningsHeading?.nextElementSibling;
+  if (!warningsCard || !(warningsList instanceof HTMLElement)) return;
+
+  const noWarningsMessage = Array.from(warningsList.children).find((element) =>
+    element.textContent?.trim().startsWith("No obvious pitch"),
+  );
+  if (noWarningsMessage instanceof HTMLElement) {
+    noWarningsMessage.dataset.nightBoardPreviousDisplay = noWarningsMessage.style.display;
+    noWarningsMessage.dataset.nightBoardHiddenNoWarnings = "true";
+    noWarningsMessage.style.display = "none";
+  }
+
+  for (const warning of warnings) {
+    const warningElement = document.createElement("div");
+    warningElement.dataset.nightBoardMissingFixtureWarning = warning.key;
+    warningElement.className =
+      "rounded-2xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-100";
+    warningElement.textContent = warning.message;
+    warningsList.appendChild(warningElement);
+  }
+
+  const note = document.createElement("p");
+  note.dataset.nightBoardMissingFixtureNote = "true";
+  note.className = "mt-2 text-xs leading-5 text-white/45";
+  note.textContent =
+    "The missing-fixture check looks across the full Monday-to-Sunday week and ignores venue filters. A bye or planned week off may be intentional.";
+  warningsCard.appendChild(note);
+}
+
+async function loadMissingFixtureWarnings(searchKey: string, signal: AbortSignal) {
+  const query = searchKey ? `?${searchKey}` : "";
+  const response = await fetch(
+    `/api/admin/night-board/missing-team-fixtures${query}`,
+    {
+      cache: "no-store",
+      signal,
+    },
+  );
+  if (!response.ok) throw new Error("Missing fixture warnings could not be loaded.");
+
+  const payload = (await response.json()) as MissingFixtureResponse;
+  return Array.isArray(payload.warnings) ? payload.warnings : [];
+}
+
 export default function NightBoardWarningsPositionBridge() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -163,6 +238,8 @@ export default function NightBoardWarningsPositionBridge() {
   useEffect(() => {
     if (pathname !== "/admin/night-board") return;
 
+    const controller = new AbortController();
+    let disposed = false;
     let issueIndex = 0;
     let frame = 0;
 
@@ -184,10 +261,30 @@ export default function NightBoardWarningsPositionBridge() {
       });
     }
 
-    frame = window.requestAnimationFrame(refreshLayout);
+    async function refreshMissingFixtureWarnings() {
+      try {
+        const warnings = await loadMissingFixtureWarnings(
+          searchKey,
+          controller.signal,
+        );
+        if (!disposed) renderMissingFixtureWarnings(warnings);
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error(error);
+        if (!disposed) clearMissingFixtureWarnings();
+      }
+    }
+
+    frame = window.requestAnimationFrame(() => {
+      refreshLayout();
+      void refreshMissingFixtureWarnings();
+    });
 
     return () => {
+      disposed = true;
+      controller.abort();
       window.cancelAnimationFrame(frame);
+      clearMissingFixtureWarnings();
       document.querySelectorAll<HTMLElement>("[data-night-board-team-raised-issue-highlighted]").forEach((card) => {
         delete card.dataset.nightBoardTeamRaisedIssueHighlighted;
         clearIssueHighlight(card);


### PR DESCRIPTION
## What changed

- adds an admin-only Night Board check for league teams with no published scheduled/completed fixture in the selected Monday-to-Sunday week
- shows one clear amber warning per missing team in the existing **Warnings and potential issues** card
- checks the whole week rather than only the selected night, so rearranged fixtures on another day still count
- ignores venue filters for the weekly check, while limiting the warning to the selected league or leagues visible on the board
- explains that a bye or planned week off may be intentional

## Why

This gives operations a backup check against accidentally leaving a team out of the weekly fixture schedule without preventing intentional byes.

## Validation

- no database migration
- endpoint is protected with `requireAdmin`
- only published `SCHEDULED` or `COMPLETED` fixtures count as a weekly fixture
- warnings are advisory and do not block saving matches