### PR TITLE
Add advance team week unavailability

### DIFF
--- a/src/app/(admin)/admin/team-unavailability/page.tsx
+++ b/src/app/(admin)/admin/team-unavailability/page.tsx
@@ -1,0 +1,216 @@
+// ========================================
+// File: src/app/(admin)/admin/team-unavailability/page.tsx
+// ========================================
+
+import Link from "next/link";
+
+import AdminCard from "@/components/admin/AdminCard";
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { requireAdmin } from "@/lib/requireAdmin";
+import {
+  addWeeks,
+  formatWeekLabel,
+  getCurrentWeekStart,
+} from "@/lib/team-week-unavailability";
+import { getTeamWeekUnavailabilityOverview } from "@/lib/team-week-unavailability-overview";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function formatFixtureDate(value: Date) {
+  return formatDateTimeInLondon(value, {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function statusCopy(status: "CLEAR" | "DRAFT_CONFLICT" | "PUBLISHED_CONFLICT") {
+  switch (status) {
+    case "PUBLISHED_CONFLICT":
+      return {
+        label: "Published fixture conflict",
+        classes: "border-red-400/30 bg-red-500/12 text-red-100",
+      };
+    case "DRAFT_CONFLICT":
+      return {
+        label: "Draft fixture conflict",
+        classes: "border-amber-400/30 bg-amber-500/12 text-amber-100",
+      };
+    default:
+      return {
+        label: "Advance week off recorded",
+        classes: "border-emerald-400/25 bg-emerald-500/10 text-emerald-100",
+      };
+  }
+}
+
+export default async function AdminTeamUnavailabilityPage() {
+  await requireAdmin();
+
+  const from = getCurrentWeekStart();
+  const to = addWeeks(from, 20);
+  const notices = await getTeamWeekUnavailabilityOverview({ from, to });
+
+  const publishedConflicts = notices.filter(
+    (notice) => notice.status === "PUBLISHED_CONFLICT",
+  ).length;
+  const draftConflicts = notices.filter(
+    (notice) => notice.status === "DRAFT_CONFLICT",
+  ).length;
+
+  const noticesByWeek = new Map<string, typeof notices>();
+  for (const notice of notices) {
+    const key = notice.weekStart.toISOString().slice(0, 10);
+    const existing = noticesByWeek.get(key) ?? [];
+    existing.push(notice);
+    noticesByWeek.set(key, existing);
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 px-4 pb-12 pt-6 sm:px-6 lg:px-8">
+      <div className="rounded-3xl border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_36%),rgba(255,255,255,0.03)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.34)] md:p-8">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-200">
+              Fixture planning
+            </div>
+            <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">
+              Advance team unavailability
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60 md:text-base">
+              Captains only report exceptions. Teams not shown here are assumed available. Check this page before generating or publishing fixtures.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/admin/fixtures/generate"
+              className="inline-flex h-11 items-center justify-center rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
+            >
+              Open fixture generator
+            </Link>
+            <Link
+              href="/admin/fixtures"
+              className="inline-flex h-11 items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-4 text-sm font-semibold text-white/80 transition hover:bg-white/[0.08]"
+            >
+              Back to fixtures
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <AdminCard className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
+          <div className="text-xs uppercase tracking-[0.16em] text-white/35">Future notices</div>
+          <div className="mt-2 text-3xl font-semibold text-white">{notices.length}</div>
+          <div className="mt-1 text-sm text-white/45">Next 20 weeks</div>
+        </AdminCard>
+        <AdminCard className="rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-5">
+          <div className="text-xs uppercase tracking-[0.16em] text-amber-100/55">Draft conflicts</div>
+          <div className="mt-2 text-3xl font-semibold text-white">{draftConflicts}</div>
+          <div className="mt-1 text-sm text-amber-100/60">Fix before publishing</div>
+        </AdminCard>
+        <AdminCard className="rounded-3xl border border-red-400/20 bg-red-500/[0.07] p-5">
+          <div className="text-xs uppercase tracking-[0.16em] text-red-100/55">Published conflicts</div>
+          <div className="mt-2 text-3xl font-semibold text-white">{publishedConflicts}</div>
+          <div className="mt-1 text-sm text-red-100/60">Needs direct contact</div>
+        </AdminCard>
+      </div>
+
+      {notices.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-white/10 bg-black/20 p-12 text-center">
+          <h2 className="text-xl font-semibold text-white">No advance unavailability reported</h2>
+          <p className="mt-2 text-sm leading-6 text-white/55">
+            All teams are currently assumed available for the next 20 weeks.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Array.from(noticesByWeek.entries()).map(([key, weekNotices]) => {
+            const weekStart = weekNotices[0].weekStart;
+            return (
+              <section key={key} className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 md:p-6">
+                <div className="flex flex-col gap-2 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/35">
+                      Week commencing {key.split("-").reverse().join("/")}
+                    </p>
+                    <h2 className="mt-2 text-xl font-semibold text-white">{formatWeekLabel(weekStart)}</h2>
+                  </div>
+                  <div className="text-sm text-white/45">
+                    {weekNotices.length} team{weekNotices.length === 1 ? "" : "s"} unavailable
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4">
+                  {weekNotices.map((notice) => {
+                    const status = statusCopy(notice.status);
+                    return (
+                      <article key={notice.id} className="rounded-2xl border border-white/10 bg-black/20 p-4 md:p-5">
+                        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                          <div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="text-lg font-semibold text-white">{notice.teamName}</h3>
+                              <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${status.classes}`}>
+                                {status.label}
+                              </span>
+                            </div>
+                            <p className="mt-2 text-sm text-white/55">
+                              {notice.leagueName ?? "League not recorded"}
+                              {notice.leagueSeason ? ` · ${notice.leagueSeason}` : ""}
+                              {notice.divisionName ? ` · ${notice.divisionName}` : ""}
+                            </p>
+                            {notice.note ? (
+                              <div className="mt-3 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-sm leading-6 text-white/70">
+                                {notice.note}
+                              </div>
+                            ) : null}
+                            <p className="mt-3 text-xs text-white/35">
+                              Last updated {formatFixtureDate(notice.updatedAt)}
+                              {notice.submittedByName || notice.submittedByEmail
+                                ? ` · by ${notice.submittedByName ?? notice.submittedByEmail}`
+                                : ""}
+                            </p>
+                          </div>
+
+                          {notice.fixtures.length > 0 ? (
+                            <div className="min-w-0 space-y-2 lg:max-w-md">
+                              {notice.fixtures.map((fixture) => (
+                                <Link
+                                  key={fixture.id}
+                                  href={`/admin/fixtures/${fixture.id}/edit`}
+                                  className={`block rounded-xl border px-3 py-2 text-sm transition hover:bg-white/[0.06] ${
+                                    fixture.publishedAt
+                                      ? "border-red-400/25 bg-red-500/10 text-red-100"
+                                      : "border-amber-400/25 bg-amber-500/10 text-amber-100"
+                                  }`}
+                                >
+                                  <span className="font-semibold">
+                                    {fixture.homeTeamName} vs {fixture.awayTeamName}
+                                  </span>
+                                  <span className="mt-1 block text-xs opacity-70">
+                                    {formatFixtureDate(fixture.kickoffAt)} · {fixture.publishedAt ? "published" : "draft"}
+                                  </span>
+                                </Link>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="text-sm text-emerald-100/65 lg:text-right">
+                              No scheduled fixture currently conflicts with this notice.
+                            </div>
+                          )}
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/night-board/missing-team-fixtures/route.ts
+++ b/src/app/api/admin/night-board/missing-team-fixtures/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
+import { getTeamWeekUnavailabilityOverview } from "@/lib/team-week-unavailability-overview";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -139,7 +140,7 @@ export async function GET(request: Request) {
   }
 
   const weekRange = weekRangeFromInput(selectedDate);
-  const [leagues, weeklyFixtures] = await Promise.all([
+  const [leagues, weeklyFixtures, advanceNotices] = await Promise.all([
     prisma.league.findMany({
       where: { id: { in: relevantLeagueIds } },
       orderBy: { name: "asc" },
@@ -169,6 +170,11 @@ export async function GET(request: Request) {
         awayTeamId: true,
       },
     }),
+    getTeamWeekUnavailabilityOverview({
+      from: weekRange.start,
+      to: weekRange.end,
+      leagueIds: relevantLeagueIds,
+    }),
   ]);
 
   const scheduledTeamIdsByLeague = new Map<string, Set<string>>();
@@ -179,12 +185,52 @@ export async function GET(request: Request) {
     scheduledTeamIdsByLeague.set(fixture.leagueId, teamIds);
   }
 
+  const noticeByTeamId = new Map(
+    advanceNotices.map((notice) => [notice.teamId, notice]),
+  );
   const weekBeginning = formatWeekBeginning(weekRange.start);
-  const warnings = leagues.flatMap((league) => {
+
+  const advanceWarnings = advanceNotices.map((notice) => {
+    if (notice.status === "PUBLISHED_CONFLICT") {
+      return {
+        key: `advance-unavailability-published-conflict:${notice.id}`,
+        level: "red" as const,
+        leagueId: notice.leagueId,
+        teamId: notice.teamId,
+        teamName: notice.teamName,
+        message: `Advance unavailability conflict: ${notice.teamName} told SIXFL they cannot field a team for the week beginning ${weekBeginning}, but they have a published fixture. Contact the team and review the fixture.`,
+      };
+    }
+
+    if (notice.status === "DRAFT_CONFLICT") {
+      return {
+        key: `advance-unavailability-draft-conflict:${notice.id}`,
+        level: "amber" as const,
+        leagueId: notice.leagueId,
+        teamId: notice.teamId,
+        teamName: notice.teamName,
+        message: `Draft fixture conflict: ${notice.teamName} reported that they cannot field a team for the week beginning ${weekBeginning}, but a draft fixture still includes them. Fix it before publishing.`,
+      };
+    }
+
+    return {
+      key: `advance-unavailability-recorded:${notice.id}`,
+      level: "info" as const,
+      leagueId: notice.leagueId,
+      teamId: notice.teamId,
+      teamName: notice.teamName,
+      message: `Advance notice recorded: ${notice.teamName} cannot field a team for the week beginning ${weekBeginning}. No fixture is expected for them this week.`,
+    };
+  });
+
+  const missingFixtureWarnings = leagues.flatMap((league) => {
     const scheduledTeamIds = scheduledTeamIdsByLeague.get(league.id) ?? new Set<string>();
 
     return league.teams
-      .filter((team) => !scheduledTeamIds.has(team.id))
+      .filter(
+        (team) =>
+          !scheduledTeamIds.has(team.id) && !noticeByTeamId.has(team.id),
+      )
       .map((team) => {
         const leagueLabel = team.division?.name
           ? `${league.name} · ${team.division.name}`
@@ -192,6 +238,7 @@ export async function GET(request: Request) {
 
         return {
           key: `missing-weekly-fixture:${league.id}:${team.id}`,
+          level: "amber" as const,
           leagueId: league.id,
           teamId: team.id,
           teamName: team.name,
@@ -201,7 +248,7 @@ export async function GET(request: Request) {
   });
 
   return NextResponse.json(
-    { selectedDate, warnings },
+    { selectedDate, warnings: [...advanceWarnings, ...missingFixtureWarnings] },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/src/app/api/admin/team-week-unavailability/route.ts
+++ b/src/app/api/admin/team-week-unavailability/route.ts
@@ -1,0 +1,48 @@
+// ========================================
+// File: src/app/api/admin/team-week-unavailability/route.ts
+// ========================================
+
+import { NextResponse } from "next/server";
+
+import { requireAdmin } from "@/lib/requireAdmin";
+import {
+  addWeeks,
+  getCurrentWeekStart,
+} from "@/lib/team-week-unavailability";
+import { getTeamWeekUnavailabilityOverview } from "@/lib/team-week-unavailability-overview";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  await requireAdmin();
+
+  const from = getCurrentWeekStart();
+  const to = addWeeks(from, 20);
+  const notices = await getTeamWeekUnavailabilityOverview({ from, to });
+
+  return NextResponse.json(
+    {
+      notices: notices.map((notice) => ({
+        id: notice.id,
+        teamId: notice.teamId,
+        teamName: notice.teamName,
+        leagueName: notice.leagueName,
+        leagueSeason: notice.leagueSeason,
+        divisionName: notice.divisionName,
+        weekStart: notice.weekStart.toISOString(),
+        note: notice.note,
+        updatedAt: notice.updatedAt.toISOString(),
+        status: notice.status,
+        fixtures: notice.fixtures.map((fixture) => ({
+          id: fixture.id,
+          kickoffAt: fixture.kickoffAt.toISOString(),
+          publishedAt: fixture.publishedAt?.toISOString() ?? null,
+          homeTeamName: fixture.homeTeamName,
+          awayTeamName: fixture.awayTeamName,
+        })),
+      })),
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/app/captain/team/[teamid]/weeks-unavailable/actions.ts
+++ b/src/app/captain/team/[teamid]/weeks-unavailable/actions.ts
@@ -1,0 +1,100 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/weeks-unavailable/actions.ts
+// ========================================
+
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { getCaptainRelatedTeamContext } from "@/lib/captain/related-teams";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import {
+  addWeeks,
+  deleteTeamWeekUnavailability,
+  getCurrentWeekStart,
+  isMondayWeekStart,
+  parseDateInput,
+  upsertTeamWeekUnavailability,
+} from "@/lib/team-week-unavailability";
+
+function redirectToPage(teamId: string, query: string) {
+  redirect(`/captain/team/${teamId}/weeks-unavailable${query}`);
+}
+
+function normaliseNote(value: FormDataEntryValue | null) {
+  const note = String(value ?? "").trim();
+  return note ? note.slice(0, 500) : null;
+}
+
+export async function saveTeamWeekUnavailabilityAction(formData: FormData) {
+  const teamId = String(formData.get("teamId") ?? "").trim();
+  const weekStartInput = String(formData.get("weekStart") ?? "").trim();
+  const unavailable = formData.get("unavailable") === "on";
+  const note = normaliseNote(formData.get("note"));
+
+  if (!teamId) redirect("/captain");
+
+  const access = await requireCaptain(teamId);
+  const context = await getCaptainRelatedTeamContext(teamId);
+  if (!context) redirect("/captain");
+
+  const weekStart = parseDateInput(weekStartInput);
+  const currentWeekStart = getCurrentWeekStart();
+  const latestAllowedWeek = addWeeks(currentWeekStart, 52);
+
+  if (
+    !weekStart ||
+    !isMondayWeekStart(weekStart) ||
+    weekStart < currentWeekStart ||
+    weekStart > latestAllowedWeek
+  ) {
+    redirectToPage(teamId, "?error=That%20week%20could%20not%20be%20saved.");
+  }
+
+  const weekEnd = addWeeks(weekStart, 1);
+  const currentLeagueId = context.currentLeagueId;
+  const publishedFixtureCount = currentLeagueId
+    ? await prisma.fixture.count({
+        where: {
+          leagueId: currentLeagueId,
+          publishedAt: { not: null },
+          kickoffAt: { gte: weekStart, lt: weekEnd },
+          status: { in: ["SCHEDULED", "COMPLETED"] },
+        },
+      })
+    : 0;
+
+  if (publishedFixtureCount > 0) {
+    redirectToPage(
+      teamId,
+      "?error=Fixtures%20for%20that%20week%20have%20already%20been%20published.%20Please%20contact%20SIXFL%20instead.",
+    );
+  }
+
+  if (unavailable) {
+    await upsertTeamWeekUnavailability({
+      teamId,
+      leagueId: currentLeagueId,
+      weekStart,
+      note,
+      submittedByUserId: access.user?.id ?? null,
+    });
+  } else {
+    await deleteTeamWeekUnavailability({ teamId, weekStart });
+  }
+
+  revalidatePath(`/captain/team/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}/weeks-unavailable`);
+  revalidatePath("/admin/team-unavailability");
+  revalidatePath("/admin/fixtures/generate");
+  revalidatePath("/admin/night-board");
+
+  redirectToPage(
+    teamId,
+    unavailable
+      ? "?saved=Team%20unavailability%20saved."
+      : "?saved=The%20week%20has%20been%20removed%20from%20team%20unavailability.",
+  );
+}

--- a/src/app/captain/team/[teamid]/weeks-unavailable/page.tsx
+++ b/src/app/captain/team/[teamid]/weeks-unavailable/page.tsx
@@ -1,0 +1,230 @@
+// ========================================
+// File: src/app/captain/team/[teamid]/weeks-unavailable/page.tsx
+// ========================================
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { getCaptainRelatedTeamContext } from "@/lib/captain/related-teams";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import {
+  addWeeks,
+  formatWeekLabel,
+  getCurrentWeekStart,
+  getWeekStartForDate,
+  listTeamWeekUnavailability,
+} from "@/lib/team-week-unavailability";
+
+import { saveTeamWeekUnavailabilityAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Weeks unavailable | SIXFL",
+};
+
+type SearchParams = {
+  saved?: string;
+  error?: string;
+};
+
+function decodeMessage(value?: string) {
+  return value ? decodeURIComponent(value) : null;
+}
+
+function weekKey(value: Date) {
+  return value.toISOString().slice(0, 10);
+}
+
+export default async function TeamWeeksUnavailablePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ teamid: string }>;
+  searchParams?: Promise<SearchParams>;
+}) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const [context, filters] = await Promise.all([
+    getCaptainRelatedTeamContext(teamid),
+    searchParams ? searchParams : Promise.resolve({} as SearchParams),
+  ]);
+
+  if (!context) notFound();
+
+  const currentWeekStart = getCurrentWeekStart();
+  const finalWeekEnd = addWeeks(currentWeekStart, 12);
+  const weeks = Array.from({ length: 12 }, (_, index) =>
+    addWeeks(currentWeekStart, index),
+  );
+
+  const [notices, publishedFixtures] = await Promise.all([
+    listTeamWeekUnavailability({
+      teamIds: [teamid],
+      from: currentWeekStart,
+      to: finalWeekEnd,
+    }),
+    context.currentLeagueId
+      ? prisma.fixture.findMany({
+          where: {
+            leagueId: context.currentLeagueId,
+            publishedAt: { not: null },
+            kickoffAt: { gte: currentWeekStart, lt: finalWeekEnd },
+            status: { in: ["SCHEDULED", "COMPLETED"] },
+          },
+          select: { kickoffAt: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const noticeByWeek = new Map(
+    notices.map((notice) => [weekKey(notice.weekStart), notice]),
+  );
+  const publishedWeekKeys = new Set(
+    publishedFixtures.map((fixture) => weekKey(getWeekStartForDate(fixture.kickoffAt))),
+  );
+
+  const savedMessage = decodeMessage(filters.saved);
+  const errorMessage = decodeMessage(filters.error);
+  const noticeCount = notices.length;
+
+  return (
+    <div className="space-y-8">
+      <section className="overflow-hidden rounded-3xl border border-emerald-400/15 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.18),transparent_38%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.03))] shadow-[0_24px_80px_rgba(0,0,0,0.3)]">
+        <div className="grid gap-6 px-6 py-7 lg:grid-cols-[1fr_auto] lg:items-end lg:px-8 lg:py-9">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
+              Advance fixture planning
+            </p>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Tell us when your team cannot play
+            </h1>
+            <p className="mt-4 max-w-3xl text-sm leading-6 text-white/70 sm:text-base">
+              Your team is assumed available every week. Only tick a week when you already know you will not be able to field a team. No action is needed when you are available.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-2">
+              <span className="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs font-medium text-white/75">
+                {context.currentLeague?.name ?? context.team.league?.name ?? "No league assigned"}
+              </span>
+              <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-100">
+                {noticeCount} future unavailable week{noticeCount === 1 ? "" : "s"}
+              </span>
+            </div>
+          </div>
+          <Link
+            href={`/captain/team/${teamid}/fixtures`}
+            className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-white/10 bg-black/20 px-5 text-sm font-semibold text-white/80 transition hover:border-white/20 hover:bg-white/5 hover:text-white"
+          >
+            Open published fixtures
+          </Link>
+        </div>
+      </section>
+
+      {savedMessage ? (
+        <div className="rounded-2xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+          {savedMessage}
+        </div>
+      ) : null}
+      {errorMessage ? (
+        <div className="rounded-2xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-5 sm:p-6">
+        <h2 className="text-xl font-semibold text-white">How this works</h2>
+        <p className="mt-2 max-w-4xl text-sm leading-6 text-amber-50/75">
+          SIXFL will see your notice while preparing draft fixtures. You can change it until fixtures for that league week are published. Once published, contact SIXFL rather than using this page as a late cancellation tool.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        {weeks.map((weekStart) => {
+          const key = weekKey(weekStart);
+          const notice = noticeByWeek.get(key) ?? null;
+          const locked = publishedWeekKeys.has(key);
+
+          return (
+            <form
+              key={key}
+              action={saveTeamWeekUnavailabilityAction}
+              className={`rounded-3xl border p-5 sm:p-6 ${
+                notice
+                  ? "border-red-400/25 bg-red-500/[0.08]"
+                  : locked
+                    ? "border-white/10 bg-white/[0.025]"
+                    : "border-white/10 bg-white/[0.04]"
+              }`}
+            >
+              <input type="hidden" name="teamId" value={teamid} />
+              <input type="hidden" name="weekStart" value={key} />
+
+              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.65fr)_auto] lg:items-center">
+                <label className={`flex items-start gap-4 ${locked ? "cursor-not-allowed" : "cursor-pointer"}`}>
+                  <input
+                    type="checkbox"
+                    name="unavailable"
+                    defaultChecked={Boolean(notice)}
+                    disabled={locked}
+                    className="mt-1 h-5 w-5 rounded border-white/20 bg-black/30 text-emerald-400 accent-emerald-400"
+                  />
+                  <span>
+                    <span className="block text-base font-semibold text-white">
+                      Week commencing {key.split("-").reverse().join("/")}
+                    </span>
+                    <span className="mt-1 block text-sm text-white/55">
+                      {formatWeekLabel(weekStart)}
+                    </span>
+                    <span className={`mt-2 inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${
+                      notice
+                        ? "border-red-400/25 bg-red-500/10 text-red-100"
+                        : locked
+                          ? "border-white/10 bg-white/5 text-white/50"
+                          : "border-emerald-400/20 bg-emerald-500/10 text-emerald-100"
+                    }`}>
+                      {notice
+                        ? "Team marked unavailable"
+                        : locked
+                          ? "Fixtures published - locked"
+                          : "Assumed available"}
+                    </span>
+                  </span>
+                </label>
+
+                <div>
+                  <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+                    Optional note
+                  </label>
+                  <input
+                    name="note"
+                    defaultValue={notice?.note ?? ""}
+                    disabled={locked}
+                    maxLength={500}
+                    placeholder="Example: several players away"
+                    className="h-12 w-full rounded-2xl border border-white/10 bg-black/30 px-4 text-sm text-white outline-none placeholder:text-white/30 focus:border-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-50"
+                  />
+                </div>
+
+                {locked ? (
+                  <div className="max-w-xs text-sm leading-6 text-white/45 lg:text-right">
+                    Fixtures for this week have already been published. Contact SIXFL if circumstances have changed.
+                  </div>
+                ) : (
+                  <button
+                    type="submit"
+                    className="inline-flex min-h-12 items-center justify-center rounded-2xl bg-emerald-400 px-5 text-sm font-semibold text-black transition hover:bg-emerald-300"
+                  >
+                    Save this week
+                  </button>
+                )}
+              </div>
+            </form>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ import HideImpossibleLeaguePositionBridge from "@/components/captain/HideImpossi
 import TeamAutoPayCopyBridge from "@/components/captain/TeamAutoPayCopyBridge";
 import NorthallertonWaitingListCopyBridge from "@/components/public/NorthallertonWaitingListCopyBridge";
 import SixflTvFixtureBridge from "@/components/SixflTvFixtureBridge";
+import TeamWeekUnavailabilityBridge from "@/components/TeamWeekUnavailabilityBridge";
 import Providers from "./providers";
 
 export const metadata = {
@@ -121,6 +122,7 @@ export default function RootLayout({
             <TeamAutoPayCopyBridge />
             <NorthallertonWaitingListCopyBridge />
             <SixflTvFixtureBridge />
+            <TeamWeekUnavailabilityBridge />
           </Suspense>
           {children}
         </Providers>

--- a/src/components/TeamWeekUnavailabilityBridge.tsx
+++ b/src/components/TeamWeekUnavailabilityBridge.tsx
@@ -1,0 +1,277 @@
+// ========================================
+// File: src/components/TeamWeekUnavailabilityBridge.tsx
+// ========================================
+
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+type AdminNotice = {
+  id: string;
+  teamName: string;
+  leagueName: string | null;
+  leagueSeason: string | null;
+  divisionName: string | null;
+  weekStart: string;
+  note: string | null;
+  status: "CLEAR" | "DRAFT_CONFLICT" | "PUBLISHED_CONFLICT";
+  fixtures: Array<{
+    id: string;
+    kickoffAt: string;
+    publishedAt: string | null;
+    homeTeamName: string;
+    awayTeamName: string;
+  }>;
+};
+
+type AdminResponse = {
+  notices?: AdminNotice[];
+};
+
+function getCaptainTeamId(pathname: string) {
+  return /^\/captain\/team\/([^/]+)(?:\/|$)/.exec(pathname)?.[1] ?? null;
+}
+
+function addCaptainNavLink(pathname: string) {
+  const teamId = getCaptainTeamId(pathname);
+  if (!teamId) return false;
+
+  const nav = document.querySelector<HTMLElement>(".captain-team-nav");
+  if (!nav) return false;
+  if (nav.querySelector("[data-team-week-unavailability-nav]")) return true;
+
+  const availabilityLink = Array.from(nav.querySelectorAll<HTMLAnchorElement>("a")).find(
+    (link) => link.textContent?.trim() === "Availability",
+  );
+  if (!availabilityLink) return false;
+
+  const link = document.createElement("a");
+  link.dataset.teamWeekUnavailabilityNav = "true";
+  link.href = `/captain/team/${encodeURIComponent(teamId)}/weeks-unavailable`;
+  link.textContent = "Weeks unavailable";
+  link.className = availabilityLink.className;
+  availabilityLink.insertAdjacentElement("afterend", link);
+  return true;
+}
+
+function addCaptainOverviewCallout(pathname: string) {
+  const teamId = getCaptainTeamId(pathname);
+  if (!teamId || pathname !== `/captain/team/${teamId}`) return false;
+  if (document.querySelector("[data-team-week-unavailability-callout]")) return true;
+
+  const pageRoot = document.querySelector<HTMLElement>(
+    ".captain-team-main > div.space-y-8",
+  );
+  if (!pageRoot) return false;
+
+  const section = document.createElement("section");
+  section.dataset.teamWeekUnavailabilityCallout = "true";
+  section.className =
+    "rounded-3xl border border-amber-400/20 bg-amber-500/[0.08] p-5 sm:p-6";
+
+  const row = document.createElement("div");
+  row.className =
+    "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between";
+
+  const copy = document.createElement("div");
+  const eyebrow = document.createElement("p");
+  eyebrow.className =
+    "text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-100/65";
+  eyebrow.textContent = "Advance fixture planning";
+  const title = document.createElement("h2");
+  title.className = "mt-2 text-xl font-semibold text-white";
+  title.textContent = "Know a week when your team cannot play?";
+  const description = document.createElement("p");
+  description.className = "mt-2 max-w-3xl text-sm leading-6 text-amber-50/70";
+  description.textContent =
+    "Your team is assumed available. Only tell SIXFL about weeks when you already know you cannot field a team, before fixtures are published.";
+  copy.append(eyebrow, title, description);
+
+  const link = document.createElement("a");
+  link.href = `/captain/team/${encodeURIComponent(teamId)}/weeks-unavailable`;
+  link.className =
+    "inline-flex min-h-12 shrink-0 items-center justify-center rounded-2xl bg-emerald-400 px-5 text-sm font-semibold text-black transition hover:bg-emerald-300";
+  link.textContent = "Tell SIXFL";
+
+  row.append(copy, link);
+  section.appendChild(row);
+
+  const firstSection = pageRoot.querySelector(":scope > section");
+  if (firstSection?.nextSibling) {
+    pageRoot.insertBefore(section, firstSection.nextSibling);
+  } else {
+    pageRoot.appendChild(section);
+  }
+  return true;
+}
+
+function formatWeekStart(value: string) {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "UTC",
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+  }).format(date);
+}
+
+function statusLabel(status: AdminNotice["status"]) {
+  if (status === "PUBLISHED_CONFLICT") return "Published conflict";
+  if (status === "DRAFT_CONFLICT") return "Draft conflict";
+  return "Week off recorded";
+}
+
+function statusClasses(status: AdminNotice["status"]) {
+  if (status === "PUBLISHED_CONFLICT") {
+    return "border-red-400/30 bg-red-500/12 text-red-100";
+  }
+  if (status === "DRAFT_CONFLICT") {
+    return "border-amber-400/30 bg-amber-500/12 text-amber-100";
+  }
+  return "border-emerald-400/25 bg-emerald-500/10 text-emerald-100";
+}
+
+function renderAdminGeneratorPanel(notices: AdminNotice[]) {
+  document
+    .querySelectorAll<HTMLElement>("[data-team-week-unavailability-admin-panel]")
+    .forEach((panel) => panel.remove());
+
+  const heading = Array.from(document.querySelectorAll<HTMLHeadingElement>("h1")).find(
+    (item) => item.textContent?.trim() === "Bulk Fixture Generator",
+  );
+  const container = heading?.closest<HTMLElement>(".max-w-5xl");
+  const headingBlock = heading?.parentElement;
+  if (!container || !headingBlock) return false;
+
+  const panel = document.createElement("section");
+  panel.dataset.teamWeekUnavailabilityAdminPanel = "true";
+  panel.className =
+    "rounded-3xl border border-amber-400/25 bg-amber-500/[0.07] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.22)] md:p-6";
+
+  const header = document.createElement("div");
+  header.className =
+    "flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between";
+  const titleWrap = document.createElement("div");
+  const eyebrow = document.createElement("p");
+  eyebrow.className =
+    "text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200/75";
+  eyebrow.textContent = "Check before generating";
+  const title = document.createElement("h2");
+  title.className = "mt-2 text-2xl font-semibold text-white";
+  title.textContent = "Advance team unavailability";
+  const description = document.createElement("p");
+  description.className = "mt-2 max-w-3xl text-sm leading-6 text-amber-50/70";
+  description.textContent =
+    notices.length === 0
+      ? "No teams have reported a future week off. Teams are assumed available."
+      : `${notices.length} future team notice${notices.length === 1 ? "" : "s"} recorded. Resolve draft conflicts before publishing.`;
+  titleWrap.append(eyebrow, title, description);
+
+  const openLink = document.createElement("a");
+  openLink.href = "/admin/team-unavailability";
+  openLink.className =
+    "inline-flex min-h-11 shrink-0 items-center justify-center rounded-xl border border-amber-300/25 bg-black/20 px-4 text-sm font-semibold text-amber-50 transition hover:bg-black/30";
+  openLink.textContent = "Open full list";
+  header.append(titleWrap, openLink);
+  panel.appendChild(header);
+
+  if (notices.length > 0) {
+    const list = document.createElement("div");
+    list.className = "mt-5 grid gap-3";
+
+    for (const notice of notices.slice(0, 8)) {
+      const item = document.createElement("div");
+      item.className =
+        "flex flex-col gap-3 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between";
+
+      const copy = document.createElement("div");
+      const name = document.createElement("div");
+      name.className = "font-semibold text-white";
+      name.textContent = notice.teamName;
+      const meta = document.createElement("div");
+      meta.className = "mt-1 text-xs leading-5 text-white/50";
+      meta.textContent = `Week commencing ${formatWeekStart(notice.weekStart)} · ${notice.leagueName ?? "League not recorded"}${notice.divisionName ? ` · ${notice.divisionName}` : ""}${notice.note ? ` · ${notice.note}` : ""}`;
+      copy.append(name, meta);
+
+      const status = document.createElement("span");
+      status.className = `inline-flex shrink-0 rounded-full border px-3 py-1 text-xs font-semibold ${statusClasses(notice.status)}`;
+      status.textContent = statusLabel(notice.status);
+      item.append(copy, status);
+      list.appendChild(item);
+    }
+
+    if (notices.length > 8) {
+      const more = document.createElement("p");
+      more.className = "text-xs text-white/45";
+      more.textContent = `${notices.length - 8} more notice${notices.length - 8 === 1 ? "" : "s"} on the full list.`;
+      list.appendChild(more);
+    }
+
+    panel.appendChild(list);
+  }
+
+  headingBlock.insertAdjacentElement("afterend", panel);
+  return true;
+}
+
+async function loadAdminNotices(signal: AbortSignal) {
+  const response = await fetch("/api/admin/team-week-unavailability", {
+    cache: "no-store",
+    signal,
+  });
+  if (!response.ok) throw new Error("Team unavailability could not be loaded.");
+  const payload = (await response.json()) as AdminResponse;
+  return Array.isArray(payload.notices) ? payload.notices : [];
+}
+
+export default function TeamWeekUnavailabilityBridge() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let disposed = false;
+    let frame = 0;
+    let attempts = 0;
+
+    async function install() {
+      if (disposed) return;
+      attempts += 1;
+
+      const captainInstalled = getCaptainTeamId(pathname)
+        ? addCaptainNavLink(pathname) && addCaptainOverviewCallout(pathname)
+        : true;
+
+      let adminInstalled = true;
+      if (pathname === "/admin/fixtures/generate") {
+        try {
+          const notices = await loadAdminNotices(controller.signal);
+          if (!disposed) adminInstalled = renderAdminGeneratorPanel(notices);
+        } catch (error) {
+          if (!controller.signal.aborted) console.error(error);
+        }
+      }
+
+      if ((!captainInstalled || !adminInstalled) && attempts < 20) {
+        frame = window.requestAnimationFrame(() => void install());
+      }
+    }
+
+    frame = window.requestAnimationFrame(() => void install());
+
+    return () => {
+      disposed = true;
+      controller.abort();
+      window.cancelAnimationFrame(frame);
+      document
+        .querySelectorAll<HTMLElement>(
+          "[data-team-week-unavailability-nav], [data-team-week-unavailability-callout], [data-team-week-unavailability-admin-panel]",
+        )
+        .forEach((element) => element.remove());
+    };
+  }, [pathname, searchKey]);
+
+  return null;
+}

--- a/src/components/admin/night-board/NightBoardWarningsPositionBridge.tsx
+++ b/src/components/admin/night-board/NightBoardWarningsPositionBridge.tsx
@@ -10,6 +10,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 type MissingFixtureWarning = {
   key: string;
   message: string;
+  level?: "info" | "amber" | "red";
 };
 
 type MissingFixtureResponse = {
@@ -180,6 +181,16 @@ function clearMissingFixtureWarnings() {
     });
 }
 
+function getWarningClasses(level: MissingFixtureWarning["level"]) {
+  if (level === "red") {
+    return "border-red-400/30 bg-red-500/12 text-red-100";
+  }
+  if (level === "info") {
+    return "border-sky-400/25 bg-sky-500/10 text-sky-100";
+  }
+  return "border-amber-400/25 bg-amber-500/10 text-amber-100";
+}
+
 function renderMissingFixtureWarnings(warnings: MissingFixtureWarning[]) {
   clearMissingFixtureWarnings();
   if (warnings.length === 0) return;
@@ -201,8 +212,7 @@ function renderMissingFixtureWarnings(warnings: MissingFixtureWarning[]) {
   for (const warning of warnings) {
     const warningElement = document.createElement("div");
     warningElement.dataset.nightBoardMissingFixtureWarning = warning.key;
-    warningElement.className =
-      "rounded-2xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-100";
+    warningElement.className = `rounded-2xl border px-4 py-3 text-sm ${getWarningClasses(warning.level)}`;
     warningElement.textContent = warning.message;
     warningsList.appendChild(warningElement);
   }
@@ -211,7 +221,7 @@ function renderMissingFixtureWarnings(warnings: MissingFixtureWarning[]) {
   note.dataset.nightBoardMissingFixtureNote = "true";
   note.className = "mt-2 text-xs leading-5 text-white/45";
   note.textContent =
-    "The missing-fixture check looks across the full Monday-to-Sunday week and ignores venue filters. A bye or planned week off may be intentional.";
+    "The weekly check covers Monday to Sunday and ignores venue filters. Advance weeks off are identified separately, while unreported missing fixtures remain potential issues.";
   warningsCard.appendChild(note);
 }
 

--- a/src/lib/team-week-unavailability-overview.ts
+++ b/src/lib/team-week-unavailability-overview.ts
@@ -1,0 +1,88 @@
+// ========================================
+// File: src/lib/team-week-unavailability-overview.ts
+// ========================================
+
+import { prisma } from "@/lib/prisma";
+import {
+  getWeekStartForDate,
+  listUpcomingTeamWeekUnavailability,
+  type TeamWeekUnavailabilityAdminRow,
+} from "@/lib/team-week-unavailability";
+
+export type TeamWeekUnavailabilityFixture = {
+  id: string;
+  kickoffAt: Date;
+  publishedAt: Date | null;
+  homeTeamName: string;
+  awayTeamName: string;
+};
+
+export type TeamWeekUnavailabilityOverviewRow = TeamWeekUnavailabilityAdminRow & {
+  status: "CLEAR" | "DRAFT_CONFLICT" | "PUBLISHED_CONFLICT";
+  fixtures: TeamWeekUnavailabilityFixture[];
+};
+
+function weekKey(value: Date) {
+  return value.toISOString().slice(0, 10);
+}
+
+export async function getTeamWeekUnavailabilityOverview(input: {
+  from: Date;
+  to: Date;
+  leagueIds?: string[];
+}) {
+  const notices = await listUpcomingTeamWeekUnavailability(input);
+  const teamIds = Array.from(new Set(notices.map((notice) => notice.teamId)));
+  if (teamIds.length === 0) return [] as TeamWeekUnavailabilityOverviewRow[];
+
+  const fixtures = await prisma.fixture.findMany({
+    where: {
+      kickoffAt: { gte: input.from, lt: input.to },
+      status: "SCHEDULED",
+      OR: [
+        { homeTeamId: { in: teamIds } },
+        { awayTeamId: { in: teamIds } },
+      ],
+    },
+    select: {
+      id: true,
+      kickoffAt: true,
+      publishedAt: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      homeTeam: { select: { name: true } },
+      awayTeam: { select: { name: true } },
+    },
+    orderBy: { kickoffAt: "asc" },
+  });
+
+  return notices.map((notice) => {
+    const noticeWeekKey = weekKey(notice.weekStart);
+    const matchingFixtures = fixtures
+      .filter(
+        (fixture) =>
+          (fixture.homeTeamId === notice.teamId ||
+            fixture.awayTeamId === notice.teamId) &&
+          weekKey(getWeekStartForDate(fixture.kickoffAt)) === noticeWeekKey,
+      )
+      .map((fixture) => ({
+        id: fixture.id,
+        kickoffAt: fixture.kickoffAt,
+        publishedAt: fixture.publishedAt,
+        homeTeamName: fixture.homeTeam.name,
+        awayTeamName: fixture.awayTeam.name,
+      }));
+
+    const status = matchingFixtures.some((fixture) => fixture.publishedAt)
+      ? "PUBLISHED_CONFLICT"
+      : matchingFixtures.length > 0
+        ? "DRAFT_CONFLICT"
+        : "CLEAR";
+
+    return {
+      ...notice,
+      status,
+      fixtures: matchingFixtures,
+    } satisfies TeamWeekUnavailabilityOverviewRow;
+  });
+}

--- a/src/lib/team-week-unavailability.ts
+++ b/src/lib/team-week-unavailability.ts
@@ -1,0 +1,241 @@
+// ========================================
+// File: src/lib/team-week-unavailability.ts
+// ========================================
+
+import { randomUUID } from "crypto";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type TeamWeekUnavailability = {
+  id: string;
+  teamId: string;
+  leagueId: string | null;
+  weekStart: Date;
+  note: string | null;
+  submittedByUserId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type TeamWeekUnavailabilityAdminRow = TeamWeekUnavailability & {
+  teamName: string;
+  leagueName: string | null;
+  leagueSeason: string | null;
+  divisionName: string | null;
+  submittedByName: string | null;
+  submittedByEmail: string | null;
+};
+
+let ensureTablePromise: Promise<void> | null = null;
+
+export async function ensureTeamWeekUnavailabilityTable() {
+  if (!ensureTablePromise) {
+    ensureTablePromise = (async () => {
+      await prisma.$executeRawUnsafe(`
+        CREATE TABLE IF NOT EXISTS "TeamWeekUnavailability" (
+          "id" TEXT PRIMARY KEY,
+          "teamId" TEXT NOT NULL REFERENCES "Team"("id") ON DELETE CASCADE,
+          "leagueId" TEXT REFERENCES "League"("id") ON DELETE SET NULL,
+          "weekStart" TIMESTAMP(3) NOT NULL,
+          "note" TEXT,
+          "submittedByUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL,
+          "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          CONSTRAINT "TeamWeekUnavailability_teamId_weekStart_key" UNIQUE ("teamId", "weekStart")
+        )
+      `);
+      await prisma.$executeRawUnsafe(`
+        CREATE INDEX IF NOT EXISTS "TeamWeekUnavailability_weekStart_idx"
+        ON "TeamWeekUnavailability"("weekStart")
+      `);
+      await prisma.$executeRawUnsafe(`
+        CREATE INDEX IF NOT EXISTS "TeamWeekUnavailability_leagueId_weekStart_idx"
+        ON "TeamWeekUnavailability"("leagueId", "weekStart")
+      `);
+    })();
+  }
+
+  try {
+    await ensureTablePromise;
+  } catch (error) {
+    ensureTablePromise = null;
+    throw error;
+  }
+}
+
+export function toLondonDateInput(value: Date) {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
+  const year = parts.find((part) => part.type === "year")?.value ?? "1970";
+  const month = parts.find((part) => part.type === "month")?.value ?? "01";
+  const day = parts.find((part) => part.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+export function parseDateInput(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function getWeekStartFromDateInput(value: string) {
+  const parsed = parseDateInput(value);
+  if (!parsed) return null;
+  const mondayOffset = (parsed.getUTCDay() + 6) % 7;
+  parsed.setUTCDate(parsed.getUTCDate() - mondayOffset);
+  return parsed;
+}
+
+export function getWeekStartForDate(value: Date) {
+  return getWeekStartFromDateInput(toLondonDateInput(value)) ?? new Date(0);
+}
+
+export function getCurrentWeekStart() {
+  return getWeekStartForDate(new Date());
+}
+
+export function addWeeks(value: Date, weeks: number) {
+  return new Date(value.getTime() + weeks * 7 * DAY_MS);
+}
+
+export function isMondayWeekStart(value: Date) {
+  return value.getUTCDay() === 1;
+}
+
+export function formatWeekLabel(value: Date) {
+  const end = new Date(value.getTime() + 6 * DAY_MS);
+  const startLabel = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "UTC",
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+  }).format(value);
+  const endLabel = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "UTC",
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+  }).format(end);
+  return `${startLabel} to ${endLabel}`;
+}
+
+export async function listTeamWeekUnavailability(input: {
+  teamIds: string[];
+  from: Date;
+  to: Date;
+}) {
+  await ensureTeamWeekUnavailabilityTable();
+  const teamIds = Array.from(new Set(input.teamIds.filter(Boolean)));
+  if (teamIds.length === 0) return [] as TeamWeekUnavailability[];
+
+  return prisma.$queryRaw<TeamWeekUnavailability[]>(Prisma.sql`
+    SELECT
+      "id",
+      "teamId",
+      "leagueId",
+      "weekStart",
+      "note",
+      "submittedByUserId",
+      "createdAt",
+      "updatedAt"
+    FROM "TeamWeekUnavailability"
+    WHERE "teamId" IN (${Prisma.join(teamIds)})
+      AND "weekStart" >= ${input.from}
+      AND "weekStart" < ${input.to}
+    ORDER BY "weekStart" ASC, "updatedAt" DESC
+  `);
+}
+
+export async function listUpcomingTeamWeekUnavailability(input: {
+  from: Date;
+  to: Date;
+  leagueIds?: string[];
+}) {
+  await ensureTeamWeekUnavailabilityTable();
+  const leagueIds = Array.from(new Set((input.leagueIds ?? []).filter(Boolean)));
+
+  return prisma.$queryRaw<TeamWeekUnavailabilityAdminRow[]>(Prisma.sql`
+    SELECT
+      u."id",
+      u."teamId",
+      u."leagueId",
+      u."weekStart",
+      u."note",
+      u."submittedByUserId",
+      u."createdAt",
+      u."updatedAt",
+      t."name" AS "teamName",
+      l."name" AS "leagueName",
+      l."season" AS "leagueSeason",
+      d."name" AS "divisionName",
+      usr."name" AS "submittedByName",
+      usr."email" AS "submittedByEmail"
+    FROM "TeamWeekUnavailability" u
+    JOIN "Team" t ON t."id" = u."teamId"
+    LEFT JOIN "League" l ON l."id" = COALESCE(u."leagueId", t."leagueId")
+    LEFT JOIN "LeagueDivision" d ON d."id" = t."divisionId"
+    LEFT JOIN "User" usr ON usr."id" = u."submittedByUserId"
+    WHERE u."weekStart" >= ${input.from}
+      AND u."weekStart" < ${input.to}
+      ${leagueIds.length > 0 ? Prisma.sql`AND COALESCE(u."leagueId", t."leagueId") IN (${Prisma.join(leagueIds)})` : Prisma.empty}
+    ORDER BY u."weekStart" ASC, l."name" ASC, t."name" ASC
+  `);
+}
+
+export async function upsertTeamWeekUnavailability(input: {
+  teamId: string;
+  leagueId: string | null;
+  weekStart: Date;
+  note: string | null;
+  submittedByUserId: string | null;
+}) {
+  await ensureTeamWeekUnavailabilityTable();
+  const id = randomUUID();
+
+  await prisma.$executeRaw(Prisma.sql`
+    INSERT INTO "TeamWeekUnavailability" (
+      "id",
+      "teamId",
+      "leagueId",
+      "weekStart",
+      "note",
+      "submittedByUserId",
+      "createdAt",
+      "updatedAt"
+    ) VALUES (
+      ${id},
+      ${input.teamId},
+      ${input.leagueId},
+      ${input.weekStart},
+      ${input.note},
+      ${input.submittedByUserId},
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT ("teamId", "weekStart")
+    DO UPDATE SET
+      "leagueId" = EXCLUDED."leagueId",
+      "note" = EXCLUDED."note",
+      "submittedByUserId" = EXCLUDED."submittedByUserId",
+      "updatedAt" = NOW()
+  `);
+}
+
+export async function deleteTeamWeekUnavailability(input: {
+  teamId: string;
+  weekStart: Date;
+}) {
+  await ensureTeamWeekUnavailabilityTable();
+  await prisma.$executeRaw(Prisma.sql`
+    DELETE FROM "TeamWeekUnavailability"
+    WHERE "teamId" = ${input.teamId}
+      AND "weekStart" = ${input.weekStart}
+  `);
+}


### PR DESCRIPTION
## What changed

- adds a captain page where teams can tick future Monday-to-Sunday weeks when they know they cannot field a side
- keeps availability assumed by default, so captains do not have to confirm every week
- allows an optional note and lets captains remove a notice until that league week's fixtures are published
- locks published weeks and directs the captain to contact SIXFL instead of using it as a late cancellation tool
- adds a prominent captain-dashboard prompt and a **Weeks unavailable** navigation item
- adds an admin overview showing all future notices, draft fixture conflicts and published fixture conflicts
- surfaces advance notices directly on the Bulk Fixture Generator page
- updates Night Board weekly checks so a reported week off is distinguished from an accidentally omitted team, while fixture conflicts are highlighted

## Storage

The feature uses a safely-created `TeamWeekUnavailability` table with a unique team/week record. No database reset is required.

## Behaviour

- no captain action means the team is available
- notices cover a full Monday-to-Sunday week
- a notice can be edited or removed before that week's fixtures are published
- draft conflicts are amber
- published conflicts are red
- a reported week off with no fixture is shown as an informational notice rather than an unexplained missing-fixture warning

## Validation notes

- captain writes are protected with `requireCaptain`
- admin views and APIs are protected with `requireAdmin`
- notes are trimmed and limited to 500 characters
- weeks must be valid Mondays, cannot be in the past, and are limited to the next year
- no payment, confirmation or cancellation behaviour is changed automatically