### PR TITLE
Show building for small league team counts

### DIFF
--- a/src/app/(public)/leagues/page.tsx
+++ b/src/app/(public)/leagues/page.tsx
@@ -382,7 +382,10 @@ export default async function LeaguesPage() {
                     {league.name}
                   </h3>
                   <p className="mt-3 text-sm leading-6 text-white/65">
-                    {league.venue} · {league.teams} team{league.teams === 1 ? "" : "s"}
+                    {league.venue} ·{" "}
+                    {league.teams < 3
+                      ? "building"
+                      : `${league.teams} team${league.teams === 1 ? "" : "s"}`}
                   </p>
 
                   <div className={`mt-5 inline-flex rounded-full px-5 py-3 text-sm font-black text-black transition ${league.button}`}>


### PR DESCRIPTION
## What changed

- league cards now show **building** instead of `0 teams`, `1 team`, or `2 teams`
- normal team counts continue from 3 teams upwards

## Why

Very early-stage leagues look unfinished when the public card shows a tiny numeric count. **Building** communicates that recruitment is underway without exposing the low number.