### PR TITLE
Let captains add additional captains

### DIFF
--- a/src/app/api/captain/team/[teamid]/additional-captains/route.ts
+++ b/src/app/api/captain/team/[teamid]/additional-captains/route.ts
@@ -1,0 +1,162 @@
+// ========================================
+// File: src/app/api/captain/team/[teamid]/additional-captains/route.ts
+// ========================================
+
+import { revalidatePath } from "next/cache";
+import { TeamRole } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { sendDashboardLoginEmail } from "@/lib/auth/sendDashboardLoginEmail";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function cleanText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function cleanEmail(value: unknown) {
+  return cleanText(value).toLowerCase();
+}
+
+function isPlausibleEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const body = (await request.json().catch(() => null)) as {
+    name?: string;
+    email?: string;
+  } | null;
+
+  const name = cleanText(body?.name);
+  const email = cleanEmail(body?.email);
+
+  if (!teamid?.trim()) {
+    return NextResponse.json({ error: "Team not found." }, { status: 400 });
+  }
+
+  if (!name) {
+    return NextResponse.json(
+      { error: "Enter the new captain's name." },
+      { status: 400 },
+    );
+  }
+
+  if (!isPlausibleEmail(email)) {
+    return NextResponse.json(
+      { error: "Enter a valid email address for the new captain." },
+      { status: 400 },
+    );
+  }
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamid },
+    select: {
+      id: true,
+      name: true,
+      teamMode: true,
+      captainUserId: true,
+    },
+  });
+
+  if (!team) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  if (team.teamMode === "MANAGED") {
+    return NextResponse.json(
+      { error: "SIXFL manages captain access for this team." },
+      { status: 403 },
+    );
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const user = await tx.user.upsert({
+      where: { email },
+      update: { name },
+      create: { email, name },
+      select: { id: true, name: true, email: true },
+    });
+
+    const existingMembership = await tx.teamMember.findUnique({
+      where: {
+        userId_teamId: {
+          userId: user.id,
+          teamId: team.id,
+        },
+      },
+      select: { id: true, role: true },
+    });
+
+    const wasAlreadyCaptain = existingMembership?.role === TeamRole.CAPTAIN;
+
+    if (existingMembership) {
+      await tx.teamMember.update({
+        where: { id: existingMembership.id },
+        data: { role: TeamRole.CAPTAIN },
+      });
+    } else {
+      await tx.teamMember.create({
+        data: {
+          userId: user.id,
+          teamId: team.id,
+          role: TeamRole.CAPTAIN,
+        },
+      });
+    }
+
+    if (!team.captainUserId) {
+      await tx.team.update({
+        where: { id: team.id },
+        data: {
+          captainUserId: user.id,
+          captainLinkedAt: new Date(),
+          captainLinkedSource: "captain-added-captain",
+        },
+      });
+    }
+
+    return { user, wasAlreadyCaptain };
+  });
+
+  let emailSent = true;
+
+  try {
+    await sendDashboardLoginEmail({
+      email,
+      displayName: result.user.name,
+      teamName: team.name,
+      callbackPath: `/captain/team/${team.id}`,
+    });
+  } catch (error) {
+    emailSent = false;
+    console.error("Failed to send additional captain login email", error);
+  }
+
+  revalidatePath(`/captain/team/${team.id}`);
+  revalidatePath(`/captain/team/${team.id}/captain-squad`);
+  revalidatePath(`/captain/team/${team.id}/squad`);
+  revalidatePath(`/admin/teams/${team.id}`);
+  revalidatePath(`/admin/teams/${team.id}/squad`);
+
+  const accessMessage = result.wasAlreadyCaptain
+    ? `${name} already had captain access.`
+    : `${name} now has captain access.`;
+
+  return NextResponse.json({
+    ok: true,
+    emailSent,
+    message: emailSent
+      ? `${accessMessage} A dashboard sign-in email has been sent to ${email}.`
+      : `${accessMessage} The sign-in email could not be sent, but they can use the normal SIXFL sign-in page with ${email}.`,
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import NightBoardPitchSheetsLink from "@/components/admin/night-board/NightBoard
 import NightBoardTeamIssuesPanel from "@/components/admin/night-board/NightBoardTeamIssuesPanel";
 import NightBoardWarningsPositionBridge from "@/components/admin/night-board/NightBoardWarningsPositionBridge";
 import AdminPaymentsPageBridge from "@/components/admin/payments/AdminPaymentsPageBridge";
+import CaptainAdditionalCaptainBridge from "@/components/captain/CaptainAdditionalCaptainBridge";
 import CaptainFixturesDeduplicateBridge from "@/components/captain/CaptainFixturesDeduplicateBridge";
 import CaptainHeaderLeaguePositionBridge from "@/components/captain/CaptainHeaderLeaguePositionBridge";
 import HideImpossibleLeaguePositionBridge from "@/components/captain/HideImpossibleLeaguePositionBridge";
@@ -115,6 +116,7 @@ export default function RootLayout({
             <NightBoardPitchSheetsLink />
             <NightBoardWarningsPositionBridge />
             <AdminPaymentsPageBridge />
+            <CaptainAdditionalCaptainBridge />
             <CaptainFixturesDeduplicateBridge />
             <CaptainHeaderLeaguePositionBridge />
             <HideImpossibleLeaguePositionBridge />

--- a/src/components/captain/CaptainAdditionalCaptainBridge.tsx
+++ b/src/components/captain/CaptainAdditionalCaptainBridge.tsx
@@ -1,0 +1,171 @@
+// ========================================
+// File: src/components/captain/CaptainAdditionalCaptainBridge.tsx
+// ========================================
+
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+function getCaptainSquadTeamId(pathname: string) {
+  return /^\/captain\/team\/([^/]+)\/captain-squad\/?$/.exec(pathname)?.[1] ?? null;
+}
+
+function findHeading(text: string) {
+  return Array.from(document.querySelectorAll<HTMLHeadingElement>("h2")).find(
+    (heading) => heading.textContent?.trim() === text,
+  );
+}
+
+function installAdditionalCaptainForm(teamId: string) {
+  if (document.querySelector("[data-additional-captain-panel]")) return true;
+
+  const addPlayerHeading = findHeading("Add a player to your squad");
+  const addPlayerSection = addPlayerHeading?.closest<HTMLElement>("section");
+
+  if (!addPlayerSection) {
+    const managedHeading = findHeading("Player additions are managed by SIXFL");
+    return Boolean(managedHeading);
+  }
+
+  const panel = document.createElement("section");
+  panel.dataset.additionalCaptainPanel = "true";
+  panel.className =
+    "rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.2)]";
+
+  panel.innerHTML = `
+    <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">
+      Team access
+    </p>
+    <h2 class="mt-2 text-xl font-semibold text-white">Add another captain</h2>
+    <p class="mt-2 text-sm leading-6 text-amber-50/70">
+      Add someone you trust to share the captain dashboard. They will be able to manage fixtures, availability, squad information and team payments just like you.
+    </p>
+    <div class="mt-4 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/55">
+      Captains cannot remove or demote other captains from this screen, so the team cannot accidentally be left without a captain.
+    </div>
+    <form class="mt-5 space-y-4" data-additional-captain-form>
+      <label class="block space-y-2 text-sm text-white/65">
+        <span>Captain name</span>
+        <input
+          name="name"
+          required
+          autocomplete="name"
+          placeholder="e.g. Alex Smith"
+          class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50"
+        />
+      </label>
+      <label class="block space-y-2 text-sm text-white/65">
+        <span>Email</span>
+        <input
+          name="email"
+          type="email"
+          required
+          autocomplete="email"
+          placeholder="captain@example.com"
+          class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50"
+        />
+      </label>
+      <div class="hidden rounded-xl border px-4 py-3 text-sm" data-additional-captain-status></div>
+      <button
+        type="submit"
+        class="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200 disabled:cursor-wait disabled:opacity-60"
+      >
+        Add captain and send login
+      </button>
+    </form>
+  `;
+
+  addPlayerSection.insertAdjacentElement("beforebegin", panel);
+
+  const form = panel.querySelector<HTMLFormElement>("[data-additional-captain-form]");
+  const status = panel.querySelector<HTMLElement>("[data-additional-captain-status]");
+  const button = form?.querySelector<HTMLButtonElement>('button[type="submit"]');
+
+  if (!form || !status || !button) return true;
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const name = String(formData.get("name") ?? "").trim();
+    const email = String(formData.get("email") ?? "").trim();
+
+    button.disabled = true;
+    button.textContent = "Adding captain…";
+    status.className =
+      "rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65";
+    status.textContent = "Creating captain access and sending the login email…";
+
+    try {
+      const response = await fetch(
+        `/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, email }),
+        },
+      );
+
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+        message?: string;
+      } | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error || "The captain could not be added.");
+      }
+
+      status.className =
+        "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm leading-6 text-emerald-100";
+      status.textContent = payload?.message || "Captain access has been added.";
+      button.textContent = "Captain added";
+
+      window.setTimeout(() => window.location.reload(), 1200);
+    } catch (error) {
+      status.className =
+        "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm leading-6 text-red-100";
+      status.textContent =
+        error instanceof Error ? error.message : "The captain could not be added.";
+      button.disabled = false;
+      button.textContent = "Add captain and send login";
+    }
+  });
+
+  return true;
+}
+
+export default function CaptainAdditionalCaptainBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const teamId = getCaptainSquadTeamId(pathname);
+    if (!teamId) return;
+
+    let frame = 0;
+    let attempts = 0;
+    let disposed = false;
+
+    function install() {
+      if (disposed) return;
+      attempts += 1;
+
+      const installed = installAdditionalCaptainForm(teamId);
+      if (!installed && attempts < 30) {
+        frame = window.requestAnimationFrame(install);
+      }
+    }
+
+    frame = window.requestAnimationFrame(install);
+
+    return () => {
+      disposed = true;
+      window.cancelAnimationFrame(frame);
+      document
+        .querySelectorAll<HTMLElement>("[data-additional-captain-panel]")
+        .forEach((panel) => panel.remove());
+    };
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## What changed

- adds an **Add another captain** panel to the captain squad screen for team-managed squads
- requires the new captain's name and email
- creates a new SIXFL user or promotes an existing squad member to `CAPTAIN`
- sends the new captain a dashboard sign-in email linking directly to the team captain dashboard
- keeps the existing primary captain record unless the team did not already have one
- does not expose any captain removal or demotion controls, so a captain cannot accidentally leave the team without captain access

## Security and behaviour

- the API is protected with `requireCaptain`
- SIXFL-managed teams cannot use the self-service captain invite
- duplicate captain invites do not create duplicate memberships
- existing players with the same email are promoted safely
- email failures do not undo the captain access; the new captain can still use normal SIXFL sign-in

## Validation

- no database migration
- no native select controls
- only three files changed