### PR TITLE
Stop TBC placeholder teams receiving notifications

### DIFF
--- a/prisma/migrations/20260726123000_suppress_fixture_placeholder_notifications/migration.sql
+++ b/prisma/migrations/20260726123000_suppress_fixture_placeholder_notifications/migration.sql
@@ -1,0 +1,120 @@
+-- Stop fixture placeholder teams (for example TBC) from inheriting or receiving
+-- messages that belonged to a real team previously converted into a placeholder.
+
+WITH placeholder_teams AS (
+  SELECT "id"
+  FROM "Team"
+  WHERE COALESCE("isFixturePlaceholder", false) = true
+)
+UPDATE "NotificationPreference"
+SET
+  "emailEnabled" = false,
+  "smsEnabled" = false,
+  "urgentSmsEnabled" = false,
+  "marketingEmailEnabled" = false,
+  "marketingSmsEnabled" = false,
+  "updatedAt" = NOW()
+WHERE "recipientId" IN (
+  SELECT nr."id"
+  FROM "NotificationRecipient" nr
+  JOIN placeholder_teams pt ON pt."id" = nr."sourceId"
+  WHERE nr."sourceType" = 'TEAM'
+);
+
+WITH placeholder_teams AS (
+  SELECT "id"
+  FROM "Team"
+  WHERE COALESCE("isFixturePlaceholder", false) = true
+)
+UPDATE "NotificationDispatch"
+SET
+  "status" = 'CANCELLED',
+  "cancelledAt" = NOW(),
+  "failureReason" = 'Fixture placeholder teams do not receive notifications.',
+  "updatedAt" = NOW()
+WHERE "recipientId" IN (
+  SELECT nr."id"
+  FROM "NotificationRecipient" nr
+  JOIN placeholder_teams pt ON pt."id" = nr."sourceId"
+  WHERE nr."sourceType" = 'TEAM'
+)
+  AND "status" IN ('QUEUED', 'PROCESSING');
+
+WITH placeholder_teams AS (
+  SELECT "id"
+  FROM "Team"
+  WHERE COALESCE("isFixturePlaceholder", false) = true
+)
+UPDATE "NotificationRecipient" nr
+SET
+  "displayName" = 'TBC placeholder',
+  "email" = NULL,
+  "phone" = NULL,
+  "emailNormalized" = NULL,
+  "phoneNormalized" = NULL,
+  "marketingEmailOptIn" = false,
+  "marketingSmsOptIn" = false,
+  "transactionalEmailOptIn" = false,
+  "transactionalSmsOptIn" = false,
+  "isSuppressed" = true,
+  "suppressionReason" = 'Fixture placeholder teams do not receive notifications.',
+  "lastSyncedAt" = NOW(),
+  "updatedAt" = NOW()
+FROM placeholder_teams pt
+WHERE nr."sourceType" = 'TEAM'
+  AND nr."sourceId" = pt."id";
+
+WITH placeholder_teams AS (
+  SELECT "id"
+  FROM "Team"
+  WHERE COALESCE("isFixturePlaceholder", false) = true
+)
+UPDATE "MessageThread" mt
+SET
+  "teamId" = NULL,
+  "status" = 'ARCHIVED',
+  "unreadForAdminCount" = 0,
+  "unreadForCaptainCount" = 0,
+  "updatedAt" = NOW()
+FROM placeholder_teams pt
+WHERE mt."teamId" = pt."id";
+
+DELETE FROM "TeamMember"
+WHERE "teamId" IN (
+  SELECT "id"
+  FROM "Team"
+  WHERE COALESCE("isFixturePlaceholder", false) = true
+);
+
+UPDATE "InterestLead"
+SET
+  "convertedTeamId" = NULL,
+  "updatedAt" = NOW()
+WHERE "convertedTeamId" IN (
+  SELECT "id"
+  FROM "Team"
+  WHERE COALESCE("isFixturePlaceholder", false) = true
+);
+
+UPDATE "Team"
+SET
+  "claimCode" = CASE
+    WHEN "claimCode" LIKE 'TBC-%' THEN "claimCode"
+    ELSE 'TBC-' || UPPER(SUBSTRING(MD5("id") FROM 1 FOR 12))
+  END,
+  "contactName" = NULL,
+  "contactEmail" = NULL,
+  "contactPhone" = NULL,
+  "secondaryContactName" = NULL,
+  "secondaryContactEmail" = NULL,
+  "secondaryContactPhone" = NULL,
+  "createdByUserId" = NULL,
+  "captainUserId" = NULL,
+  "captainLinkedAt" = NULL,
+  "captainLinkedSource" = NULL,
+  "captainInviteSentAt" = NULL,
+  "captainInviteSentTo" = NULL,
+  "captainClaimedAt" = NULL,
+  "captainClaimSource" = NULL,
+  "updatedAt" = NOW()
+WHERE COALESCE("isFixturePlaceholder", false) = true;

--- a/src/lib/teams/fixture-placeholders.ts
+++ b/src/lib/teams/fixture-placeholders.ts
@@ -101,6 +101,75 @@ export async function getLeagueFixturePlaceholderTeam(
   return rows[0] ?? null;
 }
 
+async function suppressFixturePlaceholderNotifications(
+  teamId: string,
+  client: RawDbClient,
+) {
+  await client.$executeRaw(Prisma.sql`
+    UPDATE "NotificationPreference"
+    SET
+      "emailEnabled" = false,
+      "smsEnabled" = false,
+      "urgentSmsEnabled" = false,
+      "marketingEmailEnabled" = false,
+      "marketingSmsEnabled" = false,
+      "updatedAt" = NOW()
+    WHERE "recipientId" IN (
+      SELECT "id"
+      FROM "NotificationRecipient"
+      WHERE "sourceType" = 'TEAM'
+        AND "sourceId" = ${teamId}
+    )
+  `);
+
+  await client.$executeRaw(Prisma.sql`
+    UPDATE "NotificationDispatch"
+    SET
+      "status" = 'CANCELLED',
+      "cancelledAt" = NOW(),
+      "failureReason" = 'Fixture placeholder teams do not receive notifications.',
+      "updatedAt" = NOW()
+    WHERE "recipientId" IN (
+      SELECT "id"
+      FROM "NotificationRecipient"
+      WHERE "sourceType" = 'TEAM'
+        AND "sourceId" = ${teamId}
+    )
+      AND "status" IN ('QUEUED', 'PROCESSING')
+  `);
+
+  await client.$executeRaw(Prisma.sql`
+    UPDATE "NotificationRecipient"
+    SET
+      "displayName" = 'TBC placeholder',
+      "email" = NULL,
+      "phone" = NULL,
+      "emailNormalized" = NULL,
+      "phoneNormalized" = NULL,
+      "marketingEmailOptIn" = false,
+      "marketingSmsOptIn" = false,
+      "transactionalEmailOptIn" = false,
+      "transactionalSmsOptIn" = false,
+      "isSuppressed" = true,
+      "suppressionReason" = 'Fixture placeholder teams do not receive notifications.',
+      "lastSyncedAt" = NOW(),
+      "updatedAt" = NOW()
+    WHERE "sourceType" = 'TEAM'
+      AND "sourceId" = ${teamId}
+  `);
+
+  await client.$executeRaw(Prisma.sql`
+    UPDATE "MessageThread"
+    SET
+      "teamId" = NULL,
+      "status" = 'ARCHIVED',
+      "unreadForAdminCount" = 0,
+      "unreadForCaptainCount" = 0,
+      "updatedAt" = NOW()
+    WHERE "teamId" = ${teamId}
+  `);
+}
+
 export async function markTeamAsFixturePlaceholder(input: {
   teamId: string;
   leagueId: string;
@@ -113,9 +182,12 @@ export async function markTeamAsFixturePlaceholder(input: {
     throw new Error("This league already has a fixture placeholder team.");
   }
 
+  const placeholderClaimCode = `TBC-${randomUUID().slice(0, 12).toUpperCase()}`;
+
   await client.$executeRaw(Prisma.sql`
     UPDATE "Team"
     SET
+      "claimCode" = ${placeholderClaimCode},
       "isFixturePlaceholder" = true,
       "leagueId" = NULL,
       "divisionId" = NULL,
@@ -130,9 +202,32 @@ export async function markTeamAsFixturePlaceholder(input: {
       "secondaryContactEmail" = NULL,
       "secondaryContactPhone" = NULL,
       "latestKickoffTime" = NULL,
+      "createdByUserId" = NULL,
+      "captainUserId" = NULL,
+      "captainLinkedAt" = NULL,
+      "captainLinkedSource" = NULL,
+      "captainInviteSentAt" = NULL,
+      "captainInviteSentTo" = NULL,
+      "captainClaimedAt" = NULL,
+      "captainClaimSource" = NULL,
       "updatedAt" = NOW()
     WHERE "id" = ${input.teamId}
   `);
+
+  await client.$executeRaw(Prisma.sql`
+    DELETE FROM "TeamMember"
+    WHERE "teamId" = ${input.teamId}
+  `);
+
+  await client.$executeRaw(Prisma.sql`
+    UPDATE "InterestLead"
+    SET
+      "convertedTeamId" = NULL,
+      "updatedAt" = NOW()
+    WHERE "convertedTeamId" = ${input.teamId}
+  `);
+
+  await suppressFixturePlaceholderNotifications(input.teamId, client);
 
   await client.$executeRaw(Prisma.sql`
     INSERT INTO "LeagueSeasonTeam" (


### PR DESCRIPTION
## What changed

- Clears all real-team contact, captain, member, creator and converted-lead links when a team becomes a fixture placeholder.
- Suppresses and empties the placeholder's notification recipient.
- Disables email and SMS preferences for the placeholder.
- Cancels any queued or processing notifications already addressed to the placeholder.
- Archives and detaches the former team's message threads from TBC.
- Adds a migration that cleans the existing TBC placeholder immediately on deployment.

## Root cause

The team conversion cleared the visible contact fields on `Team`, but the separate `NotificationRecipient`, captain/member links and conversation thread remained. Contact resolution could therefore reuse the deleted team's old email and phone number for TBC.

## Expected result

The former captain/contact will not receive further email or SMS intended for TBC. Future teams converted into placeholders are cleaned and suppressed as part of the conversion.

## Validation

- Branch is based on the latest `main` and is not behind.
- Reviewed all affected database fields and notification opt-in checks.
- Migration and runtime conversion use the same cleanup rules.