### PR TITLE
Enlarge SIXFL TV tab logo

### DIFF
--- a/src/components/captain/CaptainOnboardingReminderBridge.tsx
+++ b/src/components/captain/CaptainOnboardingReminderBridge.tsx
@@ -84,7 +84,8 @@ function decorateSixflTvNav() {
     const image = document.createElement("img");
     image.src = "/Sixfl-tv.png";
     image.alt = "SIXFL TV";
-    image.className = "h-5 w-auto max-w-[6.5rem] object-contain";
+    image.className =
+      "h-5 w-auto max-w-[6.5rem] scale-[1.15] object-contain";
 
     link.appendChild(image);
   }


### PR DESCRIPTION
## What changed

- Enlarges the SIXFL TV logo inside the captain navigation tab by 15%.
- Uses a CSS transform so the logo appears larger without changing the tab's layout dimensions, padding, or pill size.

## Scope

Only `src/components/captain/CaptainOnboardingReminderBridge.tsx` is changed.