### PR TITLE
Add managed squad and lead actions for the player pool

### DIFF
--- a/src/app/(admin)/admin/leads/player-pool-actions.ts
+++ b/src/app/(admin)/admin/leads/player-pool-actions.ts
@@ -28,9 +28,9 @@ function splitLeadName(fullName: string | null | undefined) {
   };
 }
 
-function buildLeadRedirect(leadId: string, error: string) {
-  const query = new URLSearchParams({ playerPoolError: error });
-  return `/admin/leads/${leadId}?${query.toString()}`;
+function buildPlayerPoolErrorRedirect(error: string) {
+  const query = new URLSearchParams({ error });
+  return `/admin/player-prospects?${query.toString()}`;
 }
 
 export async function convertLeadToPlayerPoolAction(formData: FormData) {
@@ -69,7 +69,7 @@ export async function convertLeadToPlayerPoolAction(formData: FormData) {
     });
 
     if (!lead) {
-      redirect("/admin/leads");
+      throw new Error("Player lead not found.");
     }
 
     if (lead.interestType !== "PLAYER") {
@@ -189,7 +189,7 @@ export async function convertLeadToPlayerPoolAction(formData: FormData) {
         : "The player could not be added to the player pool.";
 
     console.error("Player-pool lead conversion failed", { leadId, error });
-    redirect(buildLeadRedirect(leadId, message));
+    redirect(buildPlayerPoolErrorRedirect(message));
   }
 
   revalidatePath("/admin/leads");

--- a/src/app/(admin)/admin/leads/player-pool-actions.ts
+++ b/src/app/(admin)/admin/leads/player-pool-actions.ts
@@ -1,0 +1,205 @@
+// ========================================
+// File: src/app/(admin)/admin/leads/player-pool-actions.ts
+// ========================================
+
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+function splitLeadName(fullName: string | null | undefined) {
+  const raw = fullName?.trim() ?? "";
+  const parts = raw.split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return { firstName: "Player", lastName: null as string | null };
+  }
+
+  if (parts.length === 1) {
+    return { firstName: parts[0], lastName: null as string | null };
+  }
+
+  return {
+    firstName: parts[0],
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+function buildLeadRedirect(leadId: string, error: string) {
+  const query = new URLSearchParams({ playerPoolError: error });
+  return `/admin/leads/${leadId}?${query.toString()}`;
+}
+
+export async function convertLeadToPlayerPoolAction(formData: FormData) {
+  await requireAdmin();
+
+  const leadId = String(formData.get("leadId") ?? "").trim();
+  const extraNotes = String(formData.get("notes") ?? "").trim();
+
+  if (!leadId) {
+    redirect("/admin/leads");
+  }
+
+  let prospectId = "";
+  let existingProspect = false;
+
+  try {
+    const lead = await prisma.interestLead.findUnique({
+      where: { id: leadId },
+      select: {
+        id: true,
+        interestType: true,
+        status: true,
+        contactName: true,
+        email: true,
+        phone: true,
+        area: true,
+        leagueType: true,
+        message: true,
+        source: true,
+        convertedAt: true,
+        preferredNights: {
+          orderBy: { createdAt: "asc" },
+          select: { night: true },
+        },
+      },
+    });
+
+    if (!lead) {
+      redirect("/admin/leads");
+    }
+
+    if (lead.interestType !== "PLAYER") {
+      throw new Error("Only player leads can be added to the player pool.");
+    }
+
+    const email = lead.email?.trim().toLowerCase() || null;
+    const phone = lead.phone?.trim() || null;
+    const duplicateWhere = [
+      ...(email
+        ? [
+            {
+              email: {
+                equals: email,
+                mode: "insensitive" as const,
+              },
+            },
+          ]
+        : []),
+      ...(phone ? [{ phone }] : []),
+    ];
+
+    const matchingProspect = duplicateWhere.length
+      ? await prisma.teamPlayerProspect.findFirst({
+          where: { OR: duplicateWhere },
+          orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+          select: {
+            id: true,
+            teamId: true,
+            status: true,
+            team: { select: { name: true } },
+          },
+        })
+      : null;
+
+    if (matchingProspect?.teamId || matchingProspect?.status === "ACTIVE_SQUAD") {
+      throw new Error(
+        matchingProspect.team?.name
+          ? `This player already has a squad record under ${matchingProspect.team.name}.`
+          : "This player already has an active squad record.",
+      );
+    }
+
+    const preferredNightSummary =
+      lead.preferredNights.length > 0
+        ? lead.preferredNights.map((entry) => entry.night).join(", ")
+        : null;
+    const { firstName, lastName } = splitLeadName(lead.contactName);
+    const source = ["LEAD_PLAYER_POOL", lead.source?.trim() || null]
+      .filter((value): value is string => Boolean(value))
+      .join(" • ");
+    const generatedNotes = [
+      extraNotes || null,
+      lead.message?.trim() ? `Lead message: ${lead.message.trim()}` : null,
+      lead.area?.trim() ? `Area: ${lead.area.trim()}` : null,
+      lead.leagueType ? `League type: ${lead.leagueType}` : null,
+      preferredNightSummary ? `Preferred nights: ${preferredNightSummary}` : null,
+      `Source lead ID: ${lead.id}`,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join("\n\n");
+
+    const result = await prisma.$transaction(async (tx) => {
+      const prospect = matchingProspect
+        ? await tx.teamPlayerProspect.update({
+            where: { id: matchingProspect.id },
+            data: {
+              teamId: null,
+              firstName,
+              lastName,
+              email,
+              phone,
+              availabilitySummary: preferredNightSummary,
+              source,
+              status:
+                matchingProspect.status === "DECLINED" || matchingProspect.status === "DUPLICATE"
+                  ? "NEW"
+                  : matchingProspect.status,
+              notes: generatedNotes || null,
+            },
+            select: { id: true },
+          })
+        : await tx.teamPlayerProspect.create({
+            data: {
+              teamId: null,
+              firstName,
+              lastName,
+              email,
+              phone,
+              availabilitySummary: preferredNightSummary,
+              source,
+              status: "NEW",
+              notes: generatedNotes || null,
+            },
+            select: { id: true },
+          });
+
+      await tx.interestLead.update({
+        where: { id: lead.id },
+        data: {
+          status: "CLOSED",
+          contactedAt: lead.status === "NEW" ? new Date() : undefined,
+          convertedAt: lead.convertedAt ?? new Date(),
+          closedAt: new Date(),
+        },
+      });
+
+      return prospect;
+    });
+
+    prospectId = result.id;
+    existingProspect = Boolean(matchingProspect);
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "The player could not be added to the player pool.";
+
+    console.error("Player-pool lead conversion failed", { leadId, error });
+    redirect(buildLeadRedirect(leadId, message));
+  }
+
+  revalidatePath("/admin/leads");
+  revalidatePath(`/admin/leads/${leadId}`);
+  revalidatePath("/admin/player-prospects");
+
+  const query = new URLSearchParams({
+    saved: existingProspect ? "lead-pool-reused" : "lead-pool-added",
+    prospect: prospectId,
+  });
+
+  redirect(`/admin/player-prospects?${query.toString()}`);
+}

--- a/src/components/admin/leads/ConvertLeadToManagedSquadForm.tsx
+++ b/src/components/admin/leads/ConvertLeadToManagedSquadForm.tsx
@@ -9,6 +9,7 @@ import { useFormStatus } from "react-dom";
 import { Listbox, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 import { convertLeadToManagedSquadPlayerAction } from "@/app/(admin)/admin/leads/managed-squad-actions";
+import { convertLeadToPlayerPoolAction } from "@/app/(admin)/admin/leads/player-pool-actions";
 import { convertLeadToStandardSquadPlayerAction } from "@/app/(admin)/admin/leads/standard-squad-actions";
 
 type TeamOption = {
@@ -134,6 +135,7 @@ export default function ConvertLeadToManagedSquadForm({
   const [standardTeams, setStandardTeams] = useState<TeamOption[]>([]);
   const [standardTeamsLoaded, setStandardTeamsLoaded] = useState(false);
   const [notes, setNotes] = useState("");
+  const [poolNotes, setPoolNotes] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -169,6 +171,38 @@ export default function ConvertLeadToManagedSquadForm({
 
   return (
     <div className="space-y-4">
+      <div className="rounded-2xl border border-violet-400/20 bg-violet-500/5 p-4">
+        <div className="mb-4">
+          <h3 className="text-sm font-semibold text-white">Add to player pool</h3>
+          <p className="mt-1 text-xs leading-5 text-white/50">
+            Keep this player available for any suitable SIXFL team without assigning them to a squad yet. Their lead details and preferred nights are copied into the pool record.
+          </p>
+        </div>
+
+        <form action={convertLeadToPlayerPoolAction} className="space-y-4">
+          <input type="hidden" name="leadId" value={leadId} />
+
+          <div className="space-y-2">
+            <label htmlFor="player-pool-notes" className="block text-sm text-white/70">
+              Player pool notes
+            </label>
+            <textarea
+              id="player-pool-notes"
+              name="notes"
+              value={poolNotes}
+              onChange={(event) => setPoolNotes(event.target.value)}
+              rows={3}
+              placeholder="Optional note, e.g. best suited to Leeds Wednesday or happy to travel."
+              className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-3 text-white placeholder:text-white/35 outline-none transition focus:border-violet-400/60"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <SubmitButton pendingLabel="Adding to pool..." label="Add to player pool" variant="secondary" />
+          </div>
+        </form>
+      </div>
+
       <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
         <div className="mb-4">
           <h3 className="text-sm font-semibold text-white">Add to managed squad</h3>

--- a/src/components/captain/ManagedSquadEditLinks.tsx
+++ b/src/components/captain/ManagedSquadEditLinks.tsx
@@ -274,12 +274,12 @@ async function movePlayerToProspects(input: {
   button: HTMLButtonElement;
 }) {
   const confirmed = window.confirm(
-    `Move ${input.playerName} to the Player Prospects list? This removes them from the active squad but keeps their details as a prospective player.`,
+    `Move ${input.playerName} to the player pool? This removes them from the active squad but keeps their details available for another suitable team.`,
   );
 
   if (!confirmed) return;
 
-  const originalText = input.button.textContent ?? "Move to prospects";
+  const originalText = input.button.textContent ?? "Move to player pool";
   input.button.disabled = true;
   input.button.textContent = "Moving…";
 
@@ -298,14 +298,14 @@ async function movePlayerToProspects(input: {
     } | null;
 
     if (!response.ok) {
-      throw new Error(payload?.error ?? "Player could not be moved to prospects.");
+      throw new Error(payload?.error ?? "Player could not be moved to the player pool.");
     }
 
     window.location.href = "/admin/player-prospects";
   } catch (error) {
     input.button.disabled = false;
     input.button.textContent = originalText;
-    window.alert(error instanceof Error ? error.message : "Player could not be moved to prospects.");
+    window.alert(error instanceof Error ? error.message : "Player could not be moved to the player pool.");
   }
 }
 
@@ -483,7 +483,7 @@ function addManagedSquadEditLinks(pathname: string) {
     if (!existingMoveToProspectsButton) {
       const moveButton = document.createElement("button");
       moveButton.type = "button";
-      moveButton.textContent = "Move to prospects";
+      moveButton.textContent = "Move to player pool";
       moveButton.dataset.managedSquadMoveToProspectsLink = membershipId;
       moveButton.className = moveToProspectsClassName;
       moveButton.addEventListener("click", () => {


### PR DESCRIPTION
## What changed

- Renames the managed-squad action from **Move to prospects** to **Move to player pool** and makes the confirmation clearer.
- Uses the existing safe unassignment flow, so the player is removed from the managed squad while their profile and contact details are retained as an unassigned player prospect.
- Adds an **Add to player pool** option on individual PLAYER lead pages.
- Copies the lead message, area, league type, preferred nights and optional admin notes into the player-pool record.
- Reuses an existing unassigned prospect where possible and prevents accidentally pulling an active or team-assigned record out of a squad.
- Closes the source lead after a successful conversion and opens the Player Prospects page.

## Validation

- Reviewed the existing squad-to-prospect helper and retained that data-preserving flow.
- Branch is up to date with `main` at PR creation.
- GitHub/Vercel checks should confirm lint, type and build compatibility.