### PR TITLE
Restore normal PlayerPool tab and show logo on page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import CaptainAdditionalCaptainBridge from "@/components/captain/CaptainAddition
 import CaptainFixturesDeduplicateBridge from "@/components/captain/CaptainFixturesDeduplicateBridge";
 import CaptainHeaderLeaguePositionBridge from "@/components/captain/CaptainHeaderLeaguePositionBridge";
 import CaptainPlayerPoolNavBridge from "@/components/captain/CaptainPlayerPoolNavBridge";
+import CaptainPlayerPoolPageLogoBridge from "@/components/captain/CaptainPlayerPoolPageLogoBridge";
 import HideImpossibleLeaguePositionBridge from "@/components/captain/HideImpossibleLeaguePositionBridge";
 import TeamAutoPayCopyBridge from "@/components/captain/TeamAutoPayCopyBridge";
 import NorthallertonWaitingListCopyBridge from "@/components/public/NorthallertonWaitingListCopyBridge";
@@ -123,6 +124,7 @@ export default function RootLayout({
             <CaptainFixturesDeduplicateBridge />
             <CaptainHeaderLeaguePositionBridge />
             <CaptainPlayerPoolNavBridge />
+            <CaptainPlayerPoolPageLogoBridge />
             <HideImpossibleLeaguePositionBridge />
             <TeamAutoPayCopyBridge />
             <NorthallertonWaitingListCopyBridge />

--- a/src/components/captain/CaptainPlayerPoolNavBridge.tsx
+++ b/src/components/captain/CaptainPlayerPoolNavBridge.tsx
@@ -7,27 +7,6 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 
-const PLAYER_POOL_LOGO_URL = "/logos/sixfl%20player%20pool%20.png";
-
-function applyPlayerPoolLogo(link: HTMLAnchorElement) {
-  link.setAttribute("aria-label", "SIXFL PlayerPool");
-  link.title = "SIXFL PlayerPool";
-
-  let logo = link.querySelector<HTMLImageElement>(
-    'img[data-sixfl-player-pool-logo="true"]',
-  );
-
-  if (!logo) {
-    link.textContent = "";
-    logo = document.createElement("img");
-    logo.src = PLAYER_POOL_LOGO_URL;
-    logo.alt = "SIXFL PlayerPool";
-    logo.dataset.sixflPlayerPoolLogo = "true";
-    logo.className = "h-6 w-auto max-w-[7.5rem] object-contain";
-    link.appendChild(logo);
-  }
-}
-
 export default function CaptainPlayerPoolNavBridge() {
   const pathname = usePathname();
 
@@ -48,23 +27,27 @@ export default function CaptainPlayerPoolNavBridge() {
 
       if (existing) {
         existing.href = href;
-        applyPlayerPoolLogo(existing);
+        existing.textContent = "PlayerPool";
+        existing.setAttribute("aria-label", "PlayerPool");
+        existing.title = "PlayerPool";
         return;
       }
 
       const link = document.createElement("a");
       link.href = href;
+      link.textContent = "PlayerPool";
       link.dataset.sixflPlayerPoolNav = "true";
+      link.setAttribute("aria-label", "PlayerPool");
+      link.title = "PlayerPool";
       link.className =
-        "inline-flex min-h-10 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-500/10 px-3 py-1.5 transition hover:border-emerald-400/40 hover:bg-emerald-500/15";
-      applyPlayerPoolLogo(link);
+        "inline-flex min-h-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.035] px-4 py-2 text-sm font-semibold text-white/75 transition hover:border-white/20 hover:bg-white/[0.07] hover:text-white";
 
-      const squadLink = Array.from(nav.querySelectorAll("a")).find(
-        (item) => item.textContent?.trim() === "Squad",
+      const prospectsLink = Array.from(nav.querySelectorAll("a")).find(
+        (item) => item.textContent?.trim() === "Prospects",
       );
 
-      if (squadLink?.nextSibling) {
-        nav.insertBefore(link, squadLink.nextSibling);
+      if (prospectsLink) {
+        nav.insertBefore(link, prospectsLink);
       } else {
         nav.appendChild(link);
       }

--- a/src/components/captain/CaptainPlayerPoolPageLogoBridge.tsx
+++ b/src/components/captain/CaptainPlayerPoolPageLogoBridge.tsx
@@ -1,0 +1,53 @@
+// ========================================
+// File: src/components/captain/CaptainPlayerPoolPageLogoBridge.tsx
+// ========================================
+
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+const PLAYER_POOL_LOGO_URL = "/logos/sixfl%20player%20pool%20.png";
+
+export default function CaptainPlayerPoolPageLogoBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname?.match(/^\/captain\/team\/[^/]+\/player-pool(?:\/|$)/)) return;
+
+    function ensureLogo() {
+      if (document.querySelector('[data-sixfl-player-pool-page-logo="true"]')) return;
+
+      const heading = Array.from(document.querySelectorAll("h1")).find((item) =>
+        item.textContent?.includes("Available players for"),
+      );
+      const hero = heading?.closest("section");
+      if (!(hero instanceof HTMLElement)) return;
+
+      const wrapper = document.createElement("div");
+      wrapper.dataset.sixflPlayerPoolPageLogo = "true";
+      wrapper.className = "mb-6 flex justify-center sm:justify-start";
+
+      const image = document.createElement("img");
+      image.src = PLAYER_POOL_LOGO_URL;
+      image.alt = "SIXFL PlayerPool";
+      image.className = "h-auto w-full max-w-[34rem] object-contain";
+
+      wrapper.appendChild(image);
+      hero.insertBefore(wrapper, hero.firstChild);
+    }
+
+    ensureLogo();
+    const observer = new MutationObserver(ensureLogo);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      document
+        .querySelectorAll('[data-sixfl-player-pool-page-logo="true"]')
+        .forEach((item) => item.remove());
+    };
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
- restores PlayerPool as a normal text tab in the captain navigation
- removes the tiny unreadable logo from the tab
- displays the full PlayerPool logo prominently on the captain PlayerPool page