### PR TITLE
Support affiliated teams outside the active season

### DIFF
--- a/src/app/api/admin/leagues/[id]/season-teams/route.ts
+++ b/src/app/api/admin/leagues/[id]/season-teams/route.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from "next/cache";
 import { Prisma } from "@prisma/client";
 
 import {
+  getAffiliatedTeamsOutsideSeason,
   getLeagueSeasonTeams,
   setSeasonTeamDivision,
 } from "@/lib/league-season-teams";
@@ -44,6 +45,7 @@ function revalidateLeaguePaths(league: { id: string; slug: string }) {
   revalidatePath(`/admin/leagues/${league.id}`);
   revalidatePath(`/admin/leagues/${league.id}/communications`);
   revalidatePath(`/leagues/${league.slug}`);
+  revalidatePath("/admin/teams");
 }
 
 export async function GET(
@@ -53,17 +55,18 @@ export async function GET(
   await requireAdmin();
 
   const { id } = await params;
-  const [league, divisions, teams] = await Promise.all([
+  const [league, divisions, teams, affiliatedTeams] = await Promise.all([
     getLeague(id),
     getDivisions(id),
     getLeagueSeasonTeams({ leagueId: id }),
+    getAffiliatedTeamsOutsideSeason(id),
   ]);
 
   if (!league) {
     return NextResponse.json({ error: "League not found." }, { status: 404 });
   }
 
-  return NextResponse.json({ league, divisions, teams });
+  return NextResponse.json({ league, divisions, teams, affiliatedTeams });
 }
 
 export async function POST(
@@ -89,6 +92,9 @@ export async function POST(
   await setSeasonTeamDivision({ leagueId: id, teamId, divisionId });
 
   revalidateLeaguePaths(league);
+  revalidatePath(`/admin/teams/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}/player-pool`);
 
   return NextResponse.json({ ok: true });
 }
@@ -123,6 +129,9 @@ export async function DELETE(
   `);
 
   revalidateLeaguePaths(league);
+  revalidatePath(`/admin/teams/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}/player-pool`);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/components/admin/leagues/AdminLeagueSeasonTeamsBridge.tsx
+++ b/src/components/admin/leagues/AdminLeagueSeasonTeamsBridge.tsx
@@ -28,6 +28,7 @@ type Payload = {
   league?: { id: string; name: string; season: string | null; slug: string };
   divisions?: Division[];
   teams?: SeasonTeam[];
+  affiliatedTeams?: SeasonTeam[];
 };
 
 function getLeagueIdFromPathname(pathname: string | null) {
@@ -60,6 +61,54 @@ function removeButtonClass() {
   return "rounded-xl border border-red-400/25 bg-red-500/10 px-3 py-2 text-sm font-semibold text-red-100 transition hover:bg-red-500/15";
 }
 
+function enterButtonClass() {
+  return "rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15";
+}
+
+function createTeamIdentity(team: SeasonTeam) {
+  const link = document.createElement("a");
+  link.href = `/admin/teams/${team.teamId}`;
+  link.className = "flex min-w-0 items-center gap-3 transition hover:text-emerald-300";
+
+  const badge = document.createElement("div");
+  badge.className = "flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-white/10 bg-black/30 text-xs font-black text-white/70";
+  badge.textContent = getInitials(team.teamName);
+
+  const text = document.createElement("div");
+  text.className = "min-w-0";
+  const name = document.createElement("div");
+  name.className = "truncate text-sm font-medium text-white";
+  name.textContent = team.teamName;
+  const contact = document.createElement("div");
+  contact.className = "truncate text-xs text-white/45";
+  contact.textContent = `${team.contactEmail || "No email"} · ${team.contactPhone || "No phone"}`;
+  text.append(name, contact);
+  link.append(badge, text);
+
+  return link;
+}
+
+async function sendSeasonTeamRequest(input: {
+  leagueId: string;
+  teamId: string;
+  method: "POST" | "DELETE";
+  divisionId?: string | null;
+}) {
+  const response = await fetch(`/api/admin/leagues/${input.leagueId}/season-teams`, {
+    method: input.method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      teamId: input.teamId,
+      ...(input.method === "POST" ? { divisionId: input.divisionId ?? null } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(payload?.error || "The season membership could not be updated.");
+  }
+}
+
 function renderTeamRow(input: {
   leagueId: string;
   team: SeasonTeam;
@@ -70,25 +119,7 @@ function renderTeamRow(input: {
 
   const layout = document.createElement("div");
   layout.className = "flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between";
-
-  const link = document.createElement("a");
-  link.href = `/admin/teams/${input.team.teamId}`;
-  link.className = "flex min-w-0 items-center gap-3 transition hover:text-emerald-300";
-
-  const badge = document.createElement("div");
-  badge.className = "flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-white/10 bg-black/30 text-xs font-black text-white/70";
-  badge.textContent = getInitials(input.team.teamName);
-
-  const text = document.createElement("div");
-  text.className = "min-w-0";
-  const name = document.createElement("div");
-  name.className = "truncate text-sm font-medium text-white";
-  name.textContent = input.team.teamName;
-  const contact = document.createElement("div");
-  contact.className = "truncate text-xs text-white/45";
-  contact.textContent = `${input.team.contactEmail || "No email"} · ${input.team.contactPhone || "No phone"}`;
-  text.append(name, contact);
-  link.append(badge, text);
+  const link = createTeamIdentity(input.team);
 
   const controls = document.createElement("div");
   controls.className = "flex flex-wrap gap-2 lg:justify-end";
@@ -101,16 +132,21 @@ function renderTeamRow(input: {
     button.className = divisionButtonClass(active);
     button.textContent = division.name;
     button.addEventListener("click", async () => {
+      button.disabled = true;
       button.textContent = "Saving…";
-      await fetch(`/api/admin/leagues/${input.leagueId}/season-teams`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+
+      try {
+        await sendSeasonTeamRequest({
+          leagueId: input.leagueId,
           teamId: input.team.teamId,
+          method: "POST",
           divisionId: division.id || null,
-        }),
-      });
-      window.location.reload();
+        });
+        window.location.reload();
+      } catch (error) {
+        button.disabled = false;
+        button.textContent = error instanceof Error ? error.message : "Could not save";
+      }
     });
     controls.appendChild(button);
   }
@@ -118,25 +154,70 @@ function renderTeamRow(input: {
   const removeButton = document.createElement("button");
   removeButton.type = "button";
   removeButton.className = removeButtonClass();
-  removeButton.textContent = "Remove from season";
+  removeButton.textContent = "Make affiliated only";
   removeButton.addEventListener("click", async () => {
     const confirmed = window.confirm(
-      `Remove ${input.team.teamName} from this season? This will not delete the team record.`,
+      `Remove ${input.team.teamName} from this season? The team will remain affiliated, retain its captain account and PlayerPool access, and can still receive league communications.`,
     );
 
     if (!confirmed) return;
 
-    removeButton.textContent = "Removing…";
-    await fetch(`/api/admin/leagues/${input.leagueId}/season-teams`, {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ teamId: input.team.teamId }),
-    });
-    window.location.reload();
+    removeButton.disabled = true;
+    removeButton.textContent = "Updating…";
+
+    try {
+      await sendSeasonTeamRequest({
+        leagueId: input.leagueId,
+        teamId: input.team.teamId,
+        method: "DELETE",
+      });
+      window.location.reload();
+    } catch (error) {
+      removeButton.disabled = false;
+      removeButton.textContent = error instanceof Error ? error.message : "Could not update";
+    }
   });
   controls.appendChild(removeButton);
 
   layout.append(link, controls);
+  row.appendChild(layout);
+  return row;
+}
+
+function renderAffiliatedTeamRow(input: {
+  leagueId: string;
+  team: SeasonTeam;
+}) {
+  const row = document.createElement("div");
+  row.className = "rounded-2xl border border-sky-400/15 bg-sky-500/[0.05] p-4";
+
+  const layout = document.createElement("div");
+  layout.className = "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between";
+  const link = createTeamIdentity(input.team);
+
+  const enterButton = document.createElement("button");
+  enterButton.type = "button";
+  enterButton.className = enterButtonClass();
+  enterButton.textContent = "Enter current season";
+  enterButton.addEventListener("click", async () => {
+    enterButton.disabled = true;
+    enterButton.textContent = "Adding…";
+
+    try {
+      await sendSeasonTeamRequest({
+        leagueId: input.leagueId,
+        teamId: input.team.teamId,
+        method: "POST",
+        divisionId: null,
+      });
+      window.location.reload();
+    } catch (error) {
+      enterButton.disabled = false;
+      enterButton.textContent = error instanceof Error ? error.message : "Could not add";
+    }
+  });
+
+  layout.append(link, enterButton);
   row.appendChild(layout);
   return row;
 }
@@ -146,6 +227,7 @@ function renderTeamsCard(card: HTMLElement, leagueId: string, payload: Payload) 
   card.dataset.seasonTeamsRendered = leagueId;
 
   const teams = payload.teams ?? [];
+  const affiliatedTeams = payload.affiliatedTeams ?? [];
   const divisions = payload.divisions ?? [];
 
   card.innerHTML = "";
@@ -159,13 +241,13 @@ function renderTeamsCard(card: HTMLElement, leagueId: string, payload: Payload) 
   title.textContent = "Teams in this season";
   const desc = document.createElement("p");
   desc.className = "mt-1 text-sm text-white/60";
-  desc.textContent = `${teams.length} team${teams.length === 1 ? "" : "s"} entered in ${payload.league?.season || "this season"}. Assign Premiership/Championship here.`;
+  desc.textContent = `${teams.length} active team${teams.length === 1 ? "" : "s"} in ${payload.league?.season || "this season"}. Only these teams appear in fixtures, season counts and the league table.`;
   copy.append(title, desc);
 
   const add = document.createElement("a");
   add.href = "/admin/teams/new";
   add.className = "inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15";
-  add.textContent = "Add team";
+  add.textContent = "Create new team";
 
   header.append(copy, add);
   card.appendChild(header);
@@ -185,6 +267,34 @@ function renderTeamsCard(card: HTMLElement, leagueId: string, payload: Payload) 
   }
 
   card.appendChild(list);
+
+  const affiliatedSection = document.createElement("section");
+  affiliatedSection.className = "mt-7 border-t border-white/10 pt-6";
+
+  const affiliatedTitle = document.createElement("h3");
+  affiliatedTitle.className = "text-base font-semibold text-white";
+  affiliatedTitle.textContent = "Affiliated teams not in this season";
+
+  const affiliatedDesc = document.createElement("p");
+  affiliatedDesc.className = "mt-1 text-sm leading-6 text-white/55";
+  affiliatedDesc.textContent = `${affiliatedTeams.length} affiliated team${affiliatedTeams.length === 1 ? "" : "s"}. They keep captain access, PlayerPool access and league communications, but stay out of fixtures and the table.`;
+
+  const affiliatedList = document.createElement("div");
+  affiliatedList.className = "mt-4 space-y-3";
+
+  if (affiliatedTeams.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "rounded-2xl border border-dashed border-white/10 bg-black/20 p-4 text-sm text-white/50";
+    empty.textContent = "No affiliated-only teams at the moment.";
+    affiliatedList.appendChild(empty);
+  } else {
+    for (const team of affiliatedTeams) {
+      affiliatedList.appendChild(renderAffiliatedTeamRow({ leagueId, team }));
+    }
+  }
+
+  affiliatedSection.append(affiliatedTitle, affiliatedDesc, affiliatedList);
+  card.appendChild(affiliatedSection);
 }
 
 async function injectSeasonTeams(pathname: string | null) {

--- a/src/lib/league-season-teams.ts
+++ b/src/lib/league-season-teams.ts
@@ -28,6 +28,16 @@ export type CompetitionOption = {
   currentSeason: string | null;
 };
 
+/**
+ * Backfill legacy Team.leagueId rows without changing an explicit season status.
+ *
+ * The key distinction is:
+ * - Team affiliation is long-lived (Team.competitionId / legacy Team.leagueId).
+ * - LeagueSeasonTeam.isActive controls whether the team is playing this season.
+ *
+ * A read must never reactivate a team that an admin deliberately removed from a
+ * season, so the conflict update intentionally leaves isActive untouched.
+ */
 export async function ensureSeasonTeamRowsForLeague(
   leagueId: string,
   client: RawDbClient = prisma,
@@ -56,7 +66,6 @@ export async function ensureSeasonTeamRowsForLeague(
     ON CONFLICT ("leagueId", "teamId") DO UPDATE
     SET
       "divisionId" = COALESCE("LeagueSeasonTeam"."divisionId", EXCLUDED."divisionId"),
-      "isActive" = true,
       "updatedAt" = NOW()
   `);
 }
@@ -114,6 +123,51 @@ export async function getLeagueSeasonTeams(input: {
   `);
 }
 
+/**
+ * Teams affiliated with the parent competition but not entered in this season.
+ * These teams retain captain access, PlayerPool visibility and league comms,
+ * while staying out of tables, fixtures and season counts.
+ */
+export async function getAffiliatedTeamsOutsideSeason(leagueId: string) {
+  await ensureSeasonTeamRowsForLeague(leagueId);
+
+  return prisma.$queryRaw<LeagueSeasonTeamRow[]>(Prisma.sql`
+    SELECT
+      COALESCE(lst."id", ${"affiliated_"} || md5(t."id" || ':' || target."id")) AS "id",
+      t."id" AS "teamId",
+      t."name" AS "teamName",
+      t."logoUrl",
+      t."contactEmail",
+      t."contactPhone",
+      lst."divisionId",
+      d."name" AS "divisionName"
+    FROM "League" target
+    JOIN "Team" t ON (
+      t."leagueId" = target."id"
+      OR (
+        target."competitionId" IS NOT NULL
+        AND (
+          t."competitionId" = target."competitionId"
+          OR EXISTS (
+            SELECT 1
+            FROM "League" team_league
+            WHERE team_league."id" = t."leagueId"
+              AND team_league."competitionId" = target."competitionId"
+          )
+        )
+      )
+    )
+    LEFT JOIN "LeagueSeasonTeam" lst
+      ON lst."leagueId" = target."id"
+     AND lst."teamId" = t."id"
+    LEFT JOIN "LeagueDivision" d ON d."id" = lst."divisionId"
+    WHERE target."id" = ${leagueId}
+      AND COALESCE(lst."isActive", false) = false
+      AND COALESCE(t."isFixturePlaceholder", false) = false
+    ORDER BY t."name" ASC
+  `);
+}
+
 export async function getLeagueSeasonTeamIds(input: {
   leagueId: string;
   divisionId?: string | null;
@@ -144,39 +198,45 @@ export async function setSeasonTeamDivision(input: {
     }
   }
 
-  await prisma.$executeRaw(Prisma.sql`
-    INSERT INTO "LeagueSeasonTeam" (
-      "id",
-      "leagueId",
-      "teamId",
-      "divisionId",
-      "isActive",
-      "createdAt",
-      "updatedAt"
-    )
-    VALUES (
-      ${randomUUID()},
-      ${input.leagueId},
-      ${input.teamId},
-      ${input.divisionId},
-      true,
-      NOW(),
-      NOW()
-    )
-    ON CONFLICT ("leagueId", "teamId") DO UPDATE
-    SET
-      "divisionId" = EXCLUDED."divisionId",
-      "isActive" = true,
-      "updatedAt" = NOW()
-  `);
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "LeagueSeasonTeam" (
+        "id",
+        "leagueId",
+        "teamId",
+        "divisionId",
+        "isActive",
+        "createdAt",
+        "updatedAt"
+      )
+      VALUES (
+        ${randomUUID()},
+        ${input.leagueId},
+        ${input.teamId},
+        ${input.divisionId},
+        true,
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT ("leagueId", "teamId") DO UPDATE
+      SET
+        "divisionId" = EXCLUDED."divisionId",
+        "isActive" = true,
+        "updatedAt" = NOW()
+    `);
 
-  await prisma.$executeRaw(Prisma.sql`
-    UPDATE "Team"
-    SET
-      "divisionId" = CASE WHEN "leagueId" = ${input.leagueId} THEN ${input.divisionId} ELSE "divisionId" END,
-      "updatedAt" = NOW()
-    WHERE "id" = ${input.teamId}
-  `);
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE "Team" t
+      SET
+        "leagueId" = l."id",
+        "competitionId" = COALESCE(l."competitionId", t."competitionId"),
+        "divisionId" = ${input.divisionId},
+        "updatedAt" = NOW()
+      FROM "League" l
+      WHERE t."id" = ${input.teamId}
+        AND l."id" = ${input.leagueId}
+    `);
+  });
 }
 
 export async function setTeamCompetitionFromLeague(input: {
@@ -226,6 +286,7 @@ export async function getTeamCompetitionData(teamId: string) {
     competitionName: string | null;
     currentLeagueId: string | null;
     currentSeason: string | null;
+    currentSeasonIsActive: boolean;
   }>>(Prisma.sql`
     SELECT
       t."id",
@@ -235,7 +296,14 @@ export async function getTeamCompetitionData(teamId: string) {
       COALESCE(t."competitionId", l."competitionId") AS "competitionId",
       c."name" AS "competitionName",
       c."currentLeagueId" AS "currentLeagueId",
-      current_l."season" AS "currentSeason"
+      current_l."season" AS "currentSeason",
+      EXISTS (
+        SELECT 1
+        FROM "LeagueSeasonTeam" current_lst
+        WHERE current_lst."teamId" = t."id"
+          AND current_lst."leagueId" = c."currentLeagueId"
+          AND current_lst."isActive" = true
+      ) AS "currentSeasonIsActive"
     FROM "Team" t
     LEFT JOIN "League" l ON l."id" = t."leagueId"
     LEFT JOIN "LeagueCompetition" c ON c."id" = COALESCE(t."competitionId", l."competitionId")
@@ -247,6 +315,11 @@ export async function getTeamCompetitionData(teamId: string) {
   return rows[0] ?? null;
 }
 
+/**
+ * Change long-term competition affiliation without automatically entering a
+ * season. Existing active entries within the same competition are preserved;
+ * entries from other competitions are deactivated.
+ */
 export async function updateTeamCompetition(input: {
   teamId: string;
   competitionId: string | null;
@@ -264,7 +337,11 @@ export async function updateTeamCompetition(input: {
       `);
 
       await tx.$executeRaw(Prisma.sql`
-        DELETE FROM "LeagueSeasonTeam"
+        UPDATE "LeagueSeasonTeam"
+        SET
+          "isActive" = false,
+          "divisionId" = NULL,
+          "updatedAt" = NOW()
         WHERE "teamId" = ${input.teamId}
       `);
     });
@@ -286,12 +363,15 @@ export async function updateTeamCompetition(input: {
 
   await prisma.$transaction(async (tx) => {
     await tx.$executeRaw(Prisma.sql`
-      UPDATE "Team"
+      UPDATE "LeagueSeasonTeam" lst
       SET
-        "competitionId" = ${competition.competitionId},
-        "leagueId" = ${competition.currentLeagueId},
+        "isActive" = false,
+        "divisionId" = NULL,
         "updatedAt" = NOW()
-      WHERE "id" = ${input.teamId}
+      FROM "League" l
+      WHERE lst."leagueId" = l."id"
+        AND lst."teamId" = ${input.teamId}
+        AND l."competitionId" IS DISTINCT FROM ${competition.competitionId}
     `);
 
     if (competition.currentLeagueId) {
@@ -300,6 +380,7 @@ export async function updateTeamCompetition(input: {
           "id",
           "leagueId",
           "teamId",
+          "divisionId",
           "isActive",
           "createdAt",
           "updatedAt"
@@ -308,13 +389,30 @@ export async function updateTeamCompetition(input: {
           ${randomUUID()},
           ${competition.currentLeagueId},
           ${input.teamId},
-          true,
+          NULL,
+          false,
           NOW(),
           NOW()
         )
-        ON CONFLICT ("leagueId", "teamId") DO UPDATE
-        SET "isActive" = true, "updatedAt" = NOW()
+        ON CONFLICT ("leagueId", "teamId") DO NOTHING
       `);
     }
+
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE "Team" t
+      SET
+        "competitionId" = ${competition.competitionId},
+        "leagueId" = ${competition.currentLeagueId},
+        "divisionId" = (
+          SELECT lst."divisionId"
+          FROM "LeagueSeasonTeam" lst
+          WHERE lst."teamId" = t."id"
+            AND lst."leagueId" = ${competition.currentLeagueId}
+            AND lst."isActive" = true
+          LIMIT 1
+        ),
+        "updatedAt" = NOW()
+      WHERE t."id" = ${input.teamId}
+    `);
   });
 }

--- a/src/lib/leagueTable.ts
+++ b/src/lib/leagueTable.ts
@@ -35,6 +35,10 @@ type TableTeamRow = {
   logoUrl: string | null;
 };
 
+type SeasonEntryPresenceRow = {
+  hasEntries: boolean;
+};
+
 function createRow(input: {
   id: string;
   name: string;
@@ -119,16 +123,28 @@ async function getLeagueTableTeams(
     return removeFixturePlaceholderTeams(selectedTeams);
   }
 
-  const seasonTeams = await prisma.$queryRaw<TableTeamRow[]>(Prisma.sql`
-    SELECT t."id", t."name", t."logoUrl"
-    FROM "LeagueSeasonTeam" lst
-    JOIN "Team" t ON t."id" = lst."teamId"
-    WHERE lst."leagueId" = ${leagueId}
-      AND lst."isActive" = true
-    ORDER BY t."name" ASC
-  `);
+  const [seasonTeams, seasonEntryPresence] = await Promise.all([
+    prisma.$queryRaw<TableTeamRow[]>(Prisma.sql`
+      SELECT t."id", t."name", t."logoUrl"
+      FROM "LeagueSeasonTeam" lst
+      JOIN "Team" t ON t."id" = lst."teamId"
+      WHERE lst."leagueId" = ${leagueId}
+        AND lst."isActive" = true
+      ORDER BY t."name" ASC
+    `),
+    prisma.$queryRaw<SeasonEntryPresenceRow[]>(Prisma.sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM "LeagueSeasonTeam"
+        WHERE "leagueId" = ${leagueId}
+      ) AS "hasEntries"
+    `),
+  ]);
 
-  if (seasonTeams.length > 0) {
+  // Once a league uses season-team entries, those entries are authoritative.
+  // An empty active set means the table should be empty, not that affiliated
+  // teams should leak back in through the legacy Team.leagueId fallback.
+  if (seasonTeams.length > 0 || seasonEntryPresence[0]?.hasEntries) {
     return removeFixturePlaceholderTeams(seasonTeams);
   }
 


### PR DESCRIPTION
## What changed

- separated long-term team affiliation from active season membership
- stopped season reads from reactivating teams that were deliberately removed
- added an **Affiliated teams not in this season** section to league administration
- renamed the removal action to **Make affiliated only** and clarified what access is retained
- added a one-click **Enter current season** action for returning teams
- made season-team entries authoritative for league tables so inactive affiliated teams cannot reappear through the legacy fallback
- preserved captain access, PlayerPool access and league communications for affiliated-only teams

## Why

Teams should be able to remain connected to a SIXFL competition without occupying a place in the current division. Previously, removing a team from a season could be undone by the legacy backfill helper, and an empty active season could fall back to `Team.leagueId` and show affiliated teams in the table.

## Behaviour after this change

- **Active season team:** fixtures, table, division assignment and normal season operations
- **Affiliated-only team:** captain account, PlayerPool and selected league communications, but no table row or fixtures
- **Unassigned team:** no competition affiliation or season entry

## Validation

- reviewed the full branch diff against the latest `main`
- branch is based on the current `main` commit and changes only four membership/table files
- ran a TypeScript syntax pass locally; unresolved-module errors were expected because the repository dependencies are not available in the execution environment, and no syntax errors were reported
