### PR TITLE
Add Send to PlayerPool action to prospect cards

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -27,6 +27,7 @@ import QueuedSmsReasonHints from "@/components/admin/messages/QueuedSmsReasonHin
 import AdminPlayerFeePaymentLabelsBridge from "@/components/admin/payments/AdminPlayerFeePaymentLabelsBridge";
 import AdminVoidPaymentChargesBridge from "@/components/admin/payments/AdminVoidPaymentChargesBridge";
 import PlayerProspectsNotInterestedBridge from "@/components/admin/player-prospects/PlayerProspectsNotInterestedBridge";
+import PlayerProspectsPlayerPoolBridge from "@/components/admin/player-prospects/PlayerProspectsPlayerPoolBridge";
 import RefereeNightCashDistributionBridge from "@/components/admin/referee-nights/RefereeNightCashDistributionBridge";
 import RefereeNightFixtureSyncBridge from "@/components/admin/referee-nights/RefereeNightFixtureSyncBridge";
 import AdminRefereeCommsHistoryBridge from "@/components/admin/referees/AdminRefereeCommsHistoryBridge";
@@ -76,6 +77,7 @@ export default async function AdminLayout({
       <EmailTemplateListControlsBridge />
       <EmailBrandOptionBridge />
       <PlayerProspectsNotInterestedBridge />
+      <PlayerProspectsPlayerPoolBridge />
       <GenerateNextWeekFixturesBridge />
       <AdminSidebarDesktopColumnsBridge />
       <RemoveUnusedSettingsNavBridge />

--- a/src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts
+++ b/src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts
@@ -1,0 +1,251 @@
+// ========================================
+// File: src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts
+// ========================================
+
+import {
+  NotificationAudience,
+  NotificationRecipientSourceType,
+} from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import {
+  PLAYER_POOL_PROFILE_STATUSES,
+  createPlayerPoolId,
+  createPlayerPoolPublicCode,
+  createPlayerPoolToken,
+  ensurePlayerPoolTables,
+  getPlayerPoolBaseUrl,
+  normalizePlayerPoolEmail,
+} from "@/lib/player-pool/storage";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const PLAYER_POOL_PROFILE_INVITE_TEMPLATE_KEY =
+  "player-pool-profile-invite-email";
+const PLAYER_POOL_LOGO_PATH = "/logos/sixfl player pool .png";
+
+type ExistingProfileRow = {
+  id: string;
+  prospectId: string;
+  profileToken: string;
+  publicCode: string;
+};
+
+type RequestBody = {
+  leagueId?: unknown;
+};
+
+function routeError(error: unknown) {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : "Something went wrong.";
+}
+
+function fullName(firstName: string, lastName: string | null) {
+  return [firstName, lastName].filter(Boolean).join(" ").trim();
+}
+
+function extractArea(...values: Array<string | null | undefined>) {
+  const text = values.filter(Boolean).join(" ");
+  const match = text.match(
+    /\bArea:\s*(.+?)(?=\s+(?:League type|Preferred nights|Source lead ID|Lead message):|$)/i,
+  );
+
+  return match?.[1]?.trim() || null;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ prospectId: string }> },
+) {
+  const { prospectId } = await params;
+
+  try {
+    const { user } = await requireAdmin();
+    await ensurePlayerPoolTables();
+
+    const body = (await request.json().catch(() => null)) as RequestBody | null;
+    const requestedLeagueId =
+      typeof body?.leagueId === "string" ? body.leagueId.trim() : "";
+
+    const [prospect, league] = await Promise.all([
+      prisma.teamPlayerProspect.findUnique({
+        where: { id: prospectId },
+        select: {
+          id: true,
+          teamId: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          phone: true,
+          status: true,
+          notes: true,
+          availabilitySummary: true,
+        },
+      }),
+      requestedLeagueId
+        ? prisma.league.findUnique({
+            where: { id: requestedLeagueId },
+            select: { id: true, name: true, area: true },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    if (!prospect) {
+      return NextResponse.json({ error: "Prospect not found." }, { status: 404 });
+    }
+
+    if (prospect.teamId) {
+      return NextResponse.json(
+        { error: "Move this player out of their team before sending them to PlayerPool." },
+        { status: 409 },
+      );
+    }
+
+    if (["DECLINED", "DUPLICATE", "ACTIVE_SQUAD"].includes(prospect.status)) {
+      return NextResponse.json(
+        { error: "This record is not an open unassigned prospect." },
+        { status: 409 },
+      );
+    }
+
+    if (!prospect.email?.trim()) {
+      return NextResponse.json(
+        { error: "Add an email address before sending this player to PlayerPool." },
+        { status: 400 },
+      );
+    }
+
+    const email = normalizePlayerPoolEmail(prospect.email);
+    const displayName = fullName(prospect.firstName, prospect.lastName) || email;
+    const firstName = prospect.firstName.trim() || "there";
+    const area =
+      league?.area?.trim() ||
+      extractArea(prospect.notes, prospect.availabilitySummary);
+
+    const existingRows = await prisma.$queryRaw<ExistingProfileRow[]>`
+      SELECT "id", "prospectId", "profileToken", "publicCode"
+      FROM "PlayerPoolProfile"
+      WHERE "prospectId" = ${prospect.id}
+         OR "emailNormalized" = ${email}
+      ORDER BY CASE WHEN "prospectId" = ${prospect.id} THEN 0 ELSE 1 END
+      LIMIT 1
+    `;
+    const existingProfile = existingRows[0] ?? null;
+
+    const profileId = existingProfile?.id ?? createPlayerPoolId();
+    const profileToken = existingProfile?.profileToken ?? createPlayerPoolToken();
+    const publicCode = existingProfile?.publicCode ?? createPlayerPoolPublicCode();
+    const profileProspectId = existingProfile?.prospectId ?? prospect.id;
+
+    if (existingProfile) {
+      await prisma.$executeRaw`
+        UPDATE "PlayerPoolProfile"
+        SET
+          "emailNormalized" = ${email},
+          "area" = COALESCE("area", ${area}),
+          "leagueId" = COALESCE("leagueId", ${league?.id ?? null}),
+          "invitedAt" = NOW(),
+          "updatedAt" = NOW()
+        WHERE "id" = ${profileId}
+      `;
+    } else {
+      await prisma.$executeRaw`
+        INSERT INTO "PlayerPoolProfile" (
+          "id", "prospectId", "leadId", "profileToken", "publicCode",
+          "emailNormalized", "area", "leagueId", "status",
+          "invitedAt", "createdAt", "updatedAt"
+        ) VALUES (
+          ${profileId}, ${prospect.id}, NULL, ${profileToken}, ${publicCode},
+          ${email}, ${area}, ${league?.id ?? null}, ${PLAYER_POOL_PROFILE_STATUSES.INVITED},
+          NOW(), NOW(), NOW()
+        )
+      `;
+    }
+
+    const profileUrl = `${getPlayerPoolBaseUrl()}/player-pool/profile/${profileToken}`;
+    const leagueName = league?.name || "SIXFL PlayerPool";
+    const recipient = await upsertNotificationRecipient({
+      sourceType: NotificationRecipientSourceType.GENERAL,
+      sourceId: `player-pool-profile:${profileId}`,
+      audience: NotificationAudience.PLAYER,
+      displayName,
+      email,
+      phone: prospect.phone,
+      transactionalEmailOptIn: true,
+      transactionalSmsOptIn: true,
+      marketingEmailOptIn: false,
+      marketingSmsOptIn: false,
+      metadata: {
+        entityType: "PLAYER_POOL_PROFILE",
+        profileId,
+        prospectId: profileProspectId,
+        requestedProspectId: prospect.id,
+        publicCode,
+        leagueId: league?.id ?? null,
+      },
+    });
+
+    const dispatch = await queueNotificationFromTemplate({
+      templateKey: PLAYER_POOL_PROFILE_INVITE_TEMPLATE_KEY,
+      recipientId: recipient.id,
+      variables: {
+        firstName,
+        fullName: displayName,
+        profileUrl,
+        publicCode,
+        area: area || "",
+        leagueName,
+      },
+      emailBranding: {
+        teamName: "SIXFL PlayerPool",
+        teamLogoUrl: PLAYER_POOL_LOGO_PATH,
+        leagueName: "Private player matching",
+      },
+      sourceType: "PLAYER_POOL_PROFILE_INVITE",
+      sourceId: profileId,
+      metadata: {
+        origin: "player_pool_profile_invite_from_prospect",
+        originLabel: "PlayerPool profile invitation sent from player prospects",
+        profileId,
+        prospectId: profileProspectId,
+        requestedProspectId: prospect.id,
+        publicCode,
+        leagueId: league?.id ?? null,
+        ctaUrl: profileUrl,
+      },
+      createdByUserId: user?.id ?? null,
+    });
+
+    await logNotificationDispatchToThread({ dispatch, recipient });
+    await prisma.teamPlayerProspect.update({
+      where: { id: prospect.id },
+      data: {
+        lastContactedAt: new Date(),
+        status: prospect.status === "NEW" ? "CONTACTED" : undefined,
+      },
+    });
+
+    revalidatePath("/admin/player-prospects");
+    revalidatePath(`/admin/player-prospects/${prospect.id}/communications`);
+    revalidatePath("/admin/player-pool");
+    revalidatePath("/admin/messaging");
+
+    return NextResponse.json({
+      ok: true,
+      created: !existingProfile,
+      message: existingProfile
+        ? "PlayerPool profile form resent."
+        : "PlayerPool profile created and form sent.",
+    });
+  } catch (error) {
+    return NextResponse.json({ error: routeError(error) }, { status: 500 });
+  }
+}

--- a/src/components/admin/player-prospects/PlayerProspectsPlayerPoolBridge.tsx
+++ b/src/components/admin/player-prospects/PlayerProspectsPlayerPoolBridge.tsx
@@ -1,0 +1,189 @@
+// ========================================
+// File: src/components/admin/player-prospects/PlayerProspectsPlayerPoolBridge.tsx
+// ========================================
+
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+type SendToPlayerPoolResponse = {
+  ok?: boolean;
+  message?: string;
+  error?: string;
+};
+
+function getProspectIdFromCommsHref(href: string) {
+  return href.match(/\/prospects\/([^/]+)\/communications(?:\?|#|$)/)?.[1] ?? null;
+}
+
+function getProspectIds() {
+  const ids = new Set<string>();
+
+  document
+    .querySelectorAll<HTMLInputElement>('form input[name="prospectId"]')
+    .forEach((input) => {
+      const value = input.value.trim();
+      if (value) ids.add(value);
+    });
+
+  document
+    .querySelectorAll<HTMLAnchorElement>('a[href*="/prospects/"][href*="/communications"]')
+    .forEach((link) => {
+      const value = getProspectIdFromCommsHref(link.getAttribute("href") ?? "");
+      if (value) ids.add(value);
+    });
+
+  return Array.from(ids);
+}
+
+function getCardForProspectId(prospectId: string) {
+  const input = document.querySelector<HTMLInputElement>(
+    `form input[name="prospectId"][value="${CSS.escape(prospectId)}"]`,
+  );
+  const link = document.querySelector<HTMLAnchorElement>(
+    `a[href*="/prospects/${CSS.escape(prospectId)}/communications"]`,
+  );
+  const start = input ?? link;
+
+  if (!start) return null;
+
+  let current: HTMLElement | null = start;
+
+  while (current && current.tagName !== "MAIN") {
+    const className = typeof current.className === "string" ? current.className : "";
+
+    if (
+      current.tagName === "ARTICLE" ||
+      (className.includes("rounded-3xl") && className.includes("p-5"))
+    ) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function getActionArea(card: HTMLElement) {
+  const assignForm = Array.from(card.querySelectorAll<HTMLFormElement>("form")).find(
+    (form) => form.querySelector('input[name="prospectId"]'),
+  );
+
+  return assignForm?.parentElement instanceof HTMLElement
+    ? assignForm.parentElement
+    : null;
+}
+
+function isEligibleUnassignedCard(card: HTMLElement) {
+  const text = card.textContent ?? "";
+  const hasNoEmail = Array.from(card.querySelectorAll("span")).some(
+    (span) => span.textContent?.trim() === "No email",
+  );
+
+  return (
+    text.includes("Unassigned prospect") &&
+    !text.includes("Active player") &&
+    !text.includes("Not interested") &&
+    !text.includes("Duplicated") &&
+    !text.includes("Duplicate record") &&
+    !hasNoEmail
+  );
+}
+
+async function sendToPlayerPool(input: {
+  prospectId: string;
+  playerName: string;
+  button: HTMLButtonElement;
+}) {
+  const confirmed = window.confirm(
+    `Send ${input.playerName} a SIXFL PlayerPool profile form?`,
+  );
+
+  if (!confirmed) return;
+
+  const originalText = input.button.textContent || "Send to PlayerPool";
+  input.button.disabled = true;
+  input.button.textContent = "Sending…";
+
+  const leagueId = new URLSearchParams(window.location.search).get("leagueId");
+  const response = await fetch(
+    `/api/admin/player-prospects/${input.prospectId}/player-pool`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ leagueId }),
+    },
+  );
+  const payload = (await response.json().catch(() => null)) as
+    | SendToPlayerPoolResponse
+    | null;
+
+  if (!response.ok || !payload?.ok) {
+    alert(payload?.error || "The PlayerPool form could not be sent.");
+    input.button.disabled = false;
+    input.button.textContent = originalText;
+    return;
+  }
+
+  alert(payload.message || "PlayerPool form sent.");
+  window.location.reload();
+}
+
+function addPlayerPoolButtons() {
+  for (const prospectId of getProspectIds()) {
+    const card = getCardForProspectId(prospectId);
+    if (!card || !isEligibleUnassignedCard(card)) continue;
+
+    if (card.querySelector(`[data-prospect-player-pool="${prospectId}"]`)) {
+      continue;
+    }
+
+    const actionArea = getActionArea(card);
+    if (!actionArea) continue;
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "Send to PlayerPool";
+    button.dataset.prospectPlayerPool = prospectId;
+    button.className =
+      "inline-flex w-full items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15 disabled:cursor-not-allowed disabled:opacity-50";
+
+    const playerName =
+      card.querySelector("h3")?.textContent?.trim() || "this player";
+    button.addEventListener("click", () => {
+      void sendToPlayerPool({ prospectId, playerName, button });
+    });
+
+    const destructiveButton =
+      actionArea.querySelector<HTMLElement>(
+        `[data-prospect-not-interested="${prospectId}"]`,
+      ) ??
+      actionArea.querySelector<HTMLElement>(
+        `[data-prospect-duplicate="${prospectId}"]`,
+      );
+
+    actionArea.insertBefore(button, destructiveButton ?? null);
+  }
+}
+
+export default function PlayerProspectsPlayerPoolBridge() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname !== "/admin/player-prospects") return;
+
+    addPlayerPoolButtons();
+
+    const observer = new MutationObserver(addPlayerPoolButtons);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## What changed

- adds a **Send to PlayerPool** button to open, unassigned player prospect cards that have an email address
- asks for confirmation before sending
- creates a PlayerPool profile when the player does not already have one
- safely reuses and resends an existing PlayerPool profile when the email is already registered
- sends the normal branded PlayerPool profile form email
- keeps existing submitted/profile statuses intact when resending
- carries across the selected league context and extracts the recorded area from prospect notes when available
- updates the prospect's last-contacted date and records the email in communications

## Safety

- the action is admin-only
- it is not shown for active, team-assigned, closed, duplicated or email-less prospects
- the API rejects those records as well, so it cannot accidentally remove an active player from a team

## Validation

- branch is based on the latest `main`
- no database migration is required; it uses the existing PlayerPool tables and email template
- changes are limited to the admin bridge, its API endpoint and loading the bridge in the admin layout