### PR TITLE
Add Player Pool as an email brand

### DIFF
--- a/src/components/admin/email-templates/EmailBrandOptionBridge.tsx
+++ b/src/components/admin/email-templates/EmailBrandOptionBridge.tsx
@@ -3,14 +3,20 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 
-import { SIXFL_TV_EMAIL_BRAND_MARKER } from "@/lib/email/buildEmail";
+import {
+  PLAYER_POOL_EMAIL_BRAND_MARKER,
+  SIXFL_TV_EMAIL_BRAND_MARKER,
+} from "@/lib/email/buildEmail";
 
 const CONTROL_ATTR = "data-sixfl-email-brand-control";
 const HIDDEN_NAME = "emailBrandKey";
 const SIXFL_EMAIL_LOGO_URL = "https://www.sixfl.co.uk/sixfl-email.png";
 const SIXFL_TV_LOGO_URL = "https://www.sixfl.co.uk/Sixfl-tv.png";
+const PLAYER_POOL_LOGO_URL =
+  "https://www.sixfl.co.uk/logos/sixfl%20player%20pool%20.png";
 
-type BrandKey = "sixfl" | "sixfl-tv";
+type BrandKey = "sixfl" | "sixfl-tv" | "player-pool";
+type BrandTone = "sixfl" | "tv" | "player-pool";
 
 function isTemplateBuilderPath(pathname: string | null) {
   return Boolean(
@@ -24,13 +30,16 @@ function getBuilderForm() {
   return body?.closest("form") ?? null;
 }
 
-function hasTvMarker(value: string) {
-  return value.includes(SIXFL_TV_EMAIL_BRAND_MARKER);
+function getBrandFromBody(value: string): BrandKey {
+  if (value.includes(PLAYER_POOL_EMAIL_BRAND_MARKER)) return "player-pool";
+  if (value.includes(SIXFL_TV_EMAIL_BRAND_MARKER)) return "sixfl-tv";
+  return "sixfl";
 }
 
-function removeTvMarker(value: string) {
+function removeBrandMarkers(value: string) {
   return value
     .replaceAll(SIXFL_TV_EMAIL_BRAND_MARKER, "")
+    .replaceAll(PLAYER_POOL_EMAIL_BRAND_MARKER, "")
     .replace(/^\s*\n/, "")
     .replace(/\n{3,}/g, "\n\n")
     .trimStart();
@@ -43,10 +52,14 @@ function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
 }
 
 function setBrandOnBody(textarea: HTMLTextAreaElement, brand: BrandKey) {
-  const cleanBody = removeTvMarker(textarea.value);
-  const next = brand === "sixfl-tv"
-    ? `${SIXFL_TV_EMAIL_BRAND_MARKER}\n\n${cleanBody}`.trimEnd()
-    : cleanBody;
+  const cleanBody = removeBrandMarkers(textarea.value);
+  const marker =
+    brand === "sixfl-tv"
+      ? SIXFL_TV_EMAIL_BRAND_MARKER
+      : brand === "player-pool"
+        ? PLAYER_POOL_EMAIL_BRAND_MARKER
+        : "";
+  const next = marker ? `${marker}\n\n${cleanBody}`.trimEnd() : cleanBody;
   setTextareaValue(textarea, next);
 }
 
@@ -56,12 +69,13 @@ function getPreviewRoot(form: HTMLFormElement) {
 
 function updatePreviewLogo(form: HTMLFormElement, brand: BrandKey) {
   const previewRoot = getPreviewRoot(form);
-  const logo = Array.from(previewRoot.querySelectorAll<HTMLImageElement>("img"))
-    .find((image) =>
+  const logo = Array.from(previewRoot.querySelectorAll<HTMLImageElement>("img")).find(
+    (image) =>
       image.src.includes("sixfl-email.png") ||
       image.src.includes("sixfl-tv.png") ||
-      image.src.includes("Sixfl-tv.png"),
-    );
+      image.src.includes("Sixfl-tv.png") ||
+      image.src.includes("sixfl%20player%20pool%20.png"),
+  );
 
   if (!logo) return;
 
@@ -70,6 +84,11 @@ function updatePreviewLogo(form: HTMLFormElement, brand: BrandKey) {
     logo.alt = "SIXFL TV";
     logo.style.width = "220px";
     logo.width = 220;
+  } else if (brand === "player-pool") {
+    logo.src = PLAYER_POOL_LOGO_URL;
+    logo.alt = "SIXFL Player Pool";
+    logo.style.width = "300px";
+    logo.width = 300;
   } else {
     logo.src = SIXFL_EMAIL_LOGO_URL;
     logo.alt = "SIXFL";
@@ -90,10 +109,13 @@ function ensureHiddenBrandInput(form: HTMLFormElement, brand: BrandKey) {
   return input;
 }
 
-function buttonClasses(active: boolean, tone: "sixfl" | "tv") {
-  const activeClasses = tone === "tv"
-    ? "border-fuchsia-400/50 bg-fuchsia-500/15 text-fuchsia-50"
-    : "border-emerald-400/50 bg-emerald-500/15 text-emerald-50";
+function buttonClasses(active: boolean, tone: BrandTone) {
+  const activeClasses =
+    tone === "tv"
+      ? "border-fuchsia-400/50 bg-fuchsia-500/15 text-fuchsia-50"
+      : tone === "player-pool"
+        ? "border-lime-400/50 bg-lime-500/15 text-lime-50"
+        : "border-emerald-400/50 bg-emerald-500/15 text-emerald-50";
 
   return [
     "rounded-2xl border px-4 py-4 text-left transition",
@@ -103,13 +125,23 @@ function buttonClasses(active: boolean, tone: "sixfl" | "tv") {
   ].join(" ");
 }
 
+function parseBrandKey(value: string | undefined): BrandKey {
+  if (value === "sixfl-tv" || value === "player-pool") return value;
+  return "sixfl";
+}
+
+function getBrandTone(brand: BrandKey): BrandTone {
+  if (brand === "sixfl-tv") return "tv";
+  return brand;
+}
+
 function injectBrandControl() {
   const maybeForm = getBuilderForm();
   const textarea = maybeForm?.querySelector<HTMLTextAreaElement>('textarea[name="body"]');
   if (!maybeForm || !textarea || maybeForm.querySelector(`[${CONTROL_ATTR}]`)) return;
 
   const form: HTMLFormElement = maybeForm;
-  let brand: BrandKey = hasTvMarker(textarea.value) ? "sixfl-tv" : "sixfl";
+  let brand: BrandKey = getBrandFromBody(textarea.value);
   const hiddenInput = ensureHiddenBrandInput(form, brand);
 
   const section = document.createElement("section");
@@ -118,9 +150,9 @@ function injectBrandControl() {
   section.innerHTML = `
     <div class="mb-5">
       <h2 class="text-lg font-semibold text-white">Email branding</h2>
-      <p class="mt-1 text-sm text-neutral-400">Choose the logo style used at the top of this email. SIXFL TV is for recorded fixture and Veo messages.</p>
+      <p class="mt-1 text-sm text-neutral-400">Choose the logo style used at the top of this email. SIXFL TV is for recorded fixture and Veo messages; Player Pool is for player recruitment and availability messages.</p>
     </div>
-    <div class="grid gap-3 md:grid-cols-2">
+    <div class="grid gap-3 md:grid-cols-3">
       <button type="button" data-brand="sixfl">
         <div class="text-sm font-semibold">SIXFL</div>
         <div class="mt-2 text-xs leading-5 text-neutral-400">Use the standard SIXFL email logo.</div>
@@ -129,13 +161,17 @@ function injectBrandControl() {
         <div class="text-sm font-semibold">SIXFL TV</div>
         <div class="mt-2 text-xs leading-5 text-neutral-400">Use the SIXFL TV logo for recorded match emails.</div>
       </button>
+      <button type="button" data-brand="player-pool">
+        <div class="text-sm font-semibold">Player Pool</div>
+        <div class="mt-2 text-xs leading-5 text-neutral-400">Use the Player Pool logo for player recruitment and availability emails.</div>
+      </button>
     </div>
   `;
 
   function refreshButtons() {
     section.querySelectorAll<HTMLButtonElement>("button[data-brand]").forEach((button) => {
-      const value = button.dataset.brand === "sixfl-tv" ? "sixfl-tv" : "sixfl";
-      button.className = buttonClasses(brand === value, value === "sixfl-tv" ? "tv" : "sixfl");
+      const value = parseBrandKey(button.dataset.brand);
+      button.className = buttonClasses(brand === value, getBrandTone(value));
     });
     hiddenInput.value = brand;
     updatePreviewLogo(form, brand);
@@ -143,14 +179,14 @@ function injectBrandControl() {
 
   section.querySelectorAll<HTMLButtonElement>("button[data-brand]").forEach((button) => {
     button.addEventListener("click", () => {
-      brand = button.dataset.brand === "sixfl-tv" ? "sixfl-tv" : "sixfl";
+      brand = parseBrandKey(button.dataset.brand);
       setBrandOnBody(textarea, brand);
       refreshButtons();
     });
   });
 
   textarea.addEventListener("input", () => {
-    const nextBrand: BrandKey = hasTvMarker(textarea.value) ? "sixfl-tv" : "sixfl";
+    const nextBrand = getBrandFromBody(textarea.value);
     if (nextBrand !== brand) {
       brand = nextBrand;
       refreshButtons();

--- a/src/lib/email/buildEmail.ts
+++ b/src/lib/email/buildEmail.ts
@@ -9,8 +9,11 @@ import {
 
 const SIXFL_LOGO_URL = "https://www.sixfl.co.uk/sixfl-email.png";
 const SIXFL_TV_LOGO_URL = "https://www.sixfl.co.uk/Sixfl-tv.png";
+const PLAYER_POOL_LOGO_URL =
+  "https://www.sixfl.co.uk/logos/sixfl%20player%20pool%20.png";
 
 export const SIXFL_TV_EMAIL_BRAND_MARKER = "{{emailBrand:sixfl-tv}}";
+export const PLAYER_POOL_EMAIL_BRAND_MARKER = "{{emailBrand:player-pool}}";
 
 const SIXFL_SIGNATURE_LINES = [
   "—",
@@ -25,7 +28,8 @@ const CTA_PLACEHOLDER = "{{cta}}";
 const RESPONSE_BUTTONS_PATTERN =
   /(?:^|\n)\s*YES,\s*I still want to play:\s*(https?:\/\/\S+)\s*\n\s*NO,\s*remove me from the squad list:\s*(https?:\/\/\S+)\s*(?:\n|$)/i;
 const POLL_BUTTONS_PATTERN = /(?:^|\n)\s*SIXFL_POLL_OPTIONS_START\s*\n([\s\S]*?)\n\s*SIXFL_POLL_OPTIONS_END\s*(?:\n|$)/i;
-const EMAIL_BRAND_MARKER_PATTERN = /(?:^|\n)\s*(?:\{\{\s*emailBrand\s*:\s*sixfl-tv\s*\}\}|SIXFL_EMAIL_BRAND\s*:\s*sixfl-tv)\s*(?:\n|$)/gi;
+const EMAIL_BRAND_MARKER_PATTERN =
+  /(?:^|\n)\s*(?:\{\{\s*emailBrand\s*:\s*(sixfl-tv|player-pool)\s*\}\}|SIXFL_EMAIL_BRAND\s*:\s*(sixfl-tv|player-pool))\s*(?:\n|$)/gi;
 
 export type SIXFLEmailCta = {
   label: string;
@@ -54,7 +58,7 @@ type PollButton = {
   url: string;
 };
 
-type EmailBrand = "sixfl" | "sixfl-tv";
+type EmailBrand = "sixfl" | "sixfl-tv" | "player-pool";
 
 type LogoDetails = {
   src: string;
@@ -86,10 +90,16 @@ function extractEmailBrand(body: string): { body: string; brand: EmailBrand } {
   const normalised = normalizeLineEndings(body);
 
   const bodyWithoutMarkers = normalised
-    .replace(EMAIL_BRAND_MARKER_PATTERN, (match) => {
-      brand = "sixfl-tv";
-      return match.startsWith("\n") ? "\n" : "";
-    })
+    .replace(
+      EMAIL_BRAND_MARKER_PATTERN,
+      (match, mustacheBrand: string | undefined, legacyBrand: string | undefined) => {
+        const selectedBrand = mustacheBrand || legacyBrand;
+        if (selectedBrand === "sixfl-tv" || selectedBrand === "player-pool") {
+          brand = selectedBrand;
+        }
+        return match.startsWith("\n") ? "\n" : "";
+      },
+    )
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 
@@ -102,6 +112,14 @@ function getLogoDetails(brand: EmailBrand): LogoDetails {
       src: SIXFL_TV_LOGO_URL,
       alt: "SIXFL TV",
       width: 220,
+    };
+  }
+
+  if (brand === "player-pool") {
+    return {
+      src: PLAYER_POOL_LOGO_URL,
+      alt: "SIXFL Player Pool",
+      width: 300,
     };
   }
 
@@ -449,8 +467,14 @@ function buildBodyHtmlWithOptionalCta(body: string, cta?: SIXFLEmailCta) {
   return `${bodyHtml}<div style="margin:28px 0 8px 0;">${ctaHtml}</div>${extraButtonsHtml}`.trim();
 }
 
+function getOuterBackground(brand: EmailBrand) {
+  if (brand === "sixfl-tv") return "#050505";
+  if (brand === "player-pool") return "#07130f";
+  return "#f3f4f6";
+}
+
 function buildResponsiveEmailDocument(contentHtml: string, brand: EmailBrand) {
-  const outerBackground = brand === "sixfl-tv" ? "#050505" : "#f3f4f6";
+  const outerBackground = getOuterBackground(brand);
 
   return `<!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
@@ -506,10 +530,15 @@ export function buildSIXFLEmailHtml(input: {
   const paymentHtml = buildPaymentSummaryHtml(input.payment);
   const showPaymentProviderNote = Boolean(input.payment);
   const isSixflTv = brandResult.brand === "sixfl-tv";
-  const outerBackground = isSixflTv ? "#050505" : "#f3f4f6";
-  const containerBorder = isSixflTv ? "#111827" : "#e5e7eb";
-  const logoBackground = isSixflTv ? "#050505" : "#ffffff";
-  const logoPadding = isSixflTv ? "30px 32px 28px 32px" : "34px 32px 20px 32px";
+  const isPlayerPool = brandResult.brand === "player-pool";
+  const outerBackground = getOuterBackground(brandResult.brand);
+  const containerBorder = isSixflTv ? "#111827" : isPlayerPool ? "#17483a" : "#e5e7eb";
+  const logoBackground = isSixflTv ? "#050505" : isPlayerPool ? "#07130f" : "#ffffff";
+  const logoPadding = isSixflTv
+    ? "30px 32px 28px 32px"
+    : isPlayerPool
+      ? "28px 32px 24px 32px"
+      : "34px 32px 20px 32px";
 
   const contentHtml = `
     <center role="article" aria-roledescription="email" lang="en" style="width:100%;background:${outerBackground};">


### PR DESCRIPTION
## What changed

- Added a third `Player Pool` option to the admin email-template brand selector.
- Added a dedicated `{{emailBrand:player-pool}}` marker alongside the existing SIXFL TV marker.
- Updated email rendering to use the existing SIXFL Player Pool artwork as the main header logo.
- Added a dark-green Player Pool header/background treatment while leaving standard SIXFL and SIXFL TV emails unchanged.
- Updated the live template preview to switch correctly between all three logos.

## Why

Player Pool recruitment and availability emails can now carry their own clear branding rather than using the standard SIXFL header or relying only on an optional in-message banner.

## Validation

- Confirmed the branch is based on the current `main` head.
- Reviewed the final two-file diff and verified marker selection, marker removal, preview switching, logo sizing, and brand-specific rendering paths.
- A full local build was not available in this connector-only environment; GitHub checks should provide the final build/lint validation.