### PR TITLE
Add shin pad checkbox to tally sheets

### DIFF
--- a/scripts/apply-issue-raised-confirmation-chase-fix.cjs
+++ b/scripts/apply-issue-raised-confirmation-chase-fix.cjs
@@ -9,7 +9,7 @@ function replaceOnce(filePath, before, after) {
 
   if (source.includes(after)) return;
   if (!source.includes(before)) {
-    throw new Error(`Expected confirmation chase source was not found in ${filePath}`);
+    throw new Error(`Expected source was not found in ${filePath}`);
   }
 
   fs.writeFileSync(absolutePath, source.replace(before, after), "utf8");
@@ -27,4 +27,10 @@ replaceOnce(
   '  if (\n    input.mode !== "manual" &&\n    existingConfirmation?.status === FixtureCaptainConfirmationStatus.ISSUE_RAISED\n  ) {\n    return { ok: false, status: "issue_raised", teamName: team.name };\n  }',
 );
 
-console.log("Applied manual fixture confirmation chase support for issue-raised teams.");
+replaceOnce(
+  "src/app/api/admin/night-board/pitch-tally-sheets/route.ts",
+  '  ctx.font = font(9.5, true);\n  write(\n    ctx,\n    fit(ctx, input.teamName, teamWidth - 27),\n    input.x + 23,\n    input.y + 25,\n    { font: font(9.5, true) },\n  );',
+  '  ctx.font = font(9, true);\n  write(\n    ctx,\n    fit(ctx, input.teamName, teamWidth - 27),\n    input.x + 23,\n    input.y + 17,\n    { font: font(9, true) },\n  );\n\n  const shinPadBoxX = input.x + 23;\n  const shinPadBoxY = input.y + 23;\n  ctx.fillStyle = "#ffffff";\n  ctx.strokeStyle = "#111111";\n  ctx.lineWidth = 0.8;\n  ctx.fillRect(shinPadBoxX, shinPadBoxY, 9, 9);\n  ctx.strokeRect(shinPadBoxX, shinPadBoxY, 9, 9);\n  write(ctx, "SHIN PADS", shinPadBoxX + 13, shinPadBoxY + 8, {\n    font: font(5.8, true),\n    fill: "#555555",\n  });',
+);
+
+console.log("Applied fixture confirmation chase support and tally-sheet shin pad checkbox.");


### PR DESCRIPTION
## What changed

- adds a printable **SHIN PADS** checkbox beneath each team name on the A5 pitch tally sheets
- keeps the existing tally and score areas at their current sizes
- gives the referee a separate checkbox for each team

## Validation

- confirmed the patch target still matches the current tally-sheet renderer on `main`
- checked the patch script syntax
- branch is based on the latest `main`