### PR TITLE
Add £75 player team referral rewards

### DIFF
--- a/prisma/migrations/20260805002000_team_referral_rewards/migration.sql
+++ b/prisma/migrations/20260805002000_team_referral_rewards/migration.sql
@@ -1,0 +1,33 @@
+-- Player referral codes and £75 team referral rewards.
+CREATE TABLE IF NOT EXISTS "TeamReferralCode" (
+  "userId" TEXT NOT NULL,
+  "code" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "TeamReferralCode_pkey" PRIMARY KEY ("userId"),
+  CONSTRAINT "TeamReferralCode_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "TeamReferralCode_code_key" ON "TeamReferralCode"("code");
+
+CREATE TABLE IF NOT EXISTS "TeamReferral" (
+  "id" TEXT NOT NULL,
+  "referrerUserId" TEXT NOT NULL,
+  "interestLeadId" TEXT NOT NULL,
+  "rewardPence" INTEGER NOT NULL DEFAULT 7500,
+  "requiredMatches" INTEGER NOT NULL DEFAULT 3,
+  "paidAt" TIMESTAMP(3),
+  "paidByUserId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "TeamReferral_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "TeamReferral_referrerUserId_fkey" FOREIGN KEY ("referrerUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "TeamReferral_interestLeadId_fkey" FOREIGN KEY ("interestLeadId") REFERENCES "InterestLead"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "TeamReferral_paidByUserId_fkey" FOREIGN KEY ("paidByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "TeamReferral_interestLeadId_key" ON "TeamReferral"("interestLeadId");
+CREATE INDEX IF NOT EXISTS "TeamReferral_referrerUserId_idx" ON "TeamReferral"("referrerUserId");
+CREATE INDEX IF NOT EXISTS "TeamReferral_paidAt_idx" ON "TeamReferral"("paidAt");

--- a/scripts/apply-team-referral-rewards.cjs
+++ b/scripts/apply-team-referral-rewards.cjs
@@ -1,0 +1,91 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function update(relativePath, transform) {
+  const filePath = path.join(process.cwd(), relativePath);
+  const before = fs.readFileSync(filePath, "utf8");
+  const after = transform(before);
+  if (after === before) {
+    console.log(`[team-referrals] no change: ${relativePath}`);
+    return;
+  }
+  fs.writeFileSync(filePath, after);
+  console.log(`[team-referrals] updated: ${relativePath}`);
+}
+
+update("src/app/(public)/register-interest/actions.ts", (source) => {
+  let next = source;
+
+  if (!next.includes('from "@/lib/team-referrals"')) {
+    next = next.replace(
+      'import { queueLeadWelcomeNotifications } from "@/lib/notifications/transactional";',
+      'import { queueLeadWelcomeNotifications } from "@/lib/notifications/transactional";\nimport { attachReferralToLead } from "@/lib/team-referrals";',
+    );
+  }
+
+  if (!next.includes('const referralCode = String(formData.get("referralCode")')) {
+    next = next.replace(
+      '  const source = String(formData.get("source") ?? "").trim();',
+      '  const source = String(formData.get("source") ?? "").trim();\n  const referralCode = String(formData.get("referralCode") ?? "")\n    .trim()\n    .toUpperCase();',
+    );
+  }
+
+  if (!next.includes("attachReferralToLead({")) {
+    next = next.replace(
+      '  const logoUrl = "https://sixfl.co.uk/sixfl-email.png";',
+      `  if (interestType === "TEAM" && referralCode) {\n    try {\n      await attachReferralToLead({\n        interestLeadId: createdLead.id,\n        referralCode,\n        leadEmail: email,\n      });\n    } catch (error) {\n      console.error("Team referral could not be recorded:", error);\n    }\n  }\n\n  const logoUrl = "https://sixfl.co.uk/sixfl-email.png";`,
+    );
+  }
+
+  return next;
+});
+
+update("src/app/(public)/register-interest/page.tsx", (source) => {
+  let next = source;
+
+  if (!next.includes("  ref?: string;")) {
+    next = next.replace("  night?: string;\n}>;", "  night?: string;\n  ref?: string;\n}>;");
+  }
+
+  if (!next.includes("const referralCode = String(sp.ref")) {
+    next = next.replace(
+      "  const success = sp.success === \"1\";",
+      '  const success = sp.success === "1";\n  const referralCode = String(sp.ref ?? "").trim().toUpperCase();',
+    );
+  }
+
+  if (!next.includes('name="referralCode"')) {
+    const referralField = `\n              {leadType === "TEAM" ? (\n                <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">\n                  <label htmlFor="referralCode" className="block text-sm font-bold text-emerald-100">\n                    Player referral code <span className="font-normal text-emerald-100/60">(optional)</span>\n                  </label>\n                  <p className="mt-1 text-xs leading-5 text-emerald-100/65">\n                    Enter the code of the SIXFL player who referred your team. They receive £75 after your team completes three matches.\n                  </p>\n                  <input\n                    id="referralCode"\n                    name="referralCode"\n                    defaultValue={referralCode}\n                    autoCapitalize="characters"\n                    className="mt-3 h-12 w-full rounded-xl border border-white/10 bg-black/30 px-4 font-mono text-sm font-bold uppercase tracking-wider text-white outline-none placeholder:text-white/30 focus:border-emerald-400"\n                    placeholder="SIX-AB12CD34"\n                  />\n                </div>\n              ) : null}\n`;
+
+    next = next.replace(
+      /(<form\s+action=\{submitRegisterInterest\}[^>]*>)/,
+      `$1${referralField}`,
+    );
+  }
+
+  return next;
+});
+
+update("src/components/admin/AdminSidebar.tsx", (source) => {
+  if (source.includes('href: "/admin/referrals"')) return source;
+
+  return source.replace(
+    `      {\n        name: "Teams",\n        href: "/admin/teams",\n        icon: UserGroupIcon,\n        description: "Squads",\n      },`,
+    `      {\n        name: "Teams",\n        href: "/admin/teams",\n        icon: UserGroupIcon,\n        description: "Squads",\n      },\n      {\n        name: "Team referrals",\n        href: "/admin/referrals",\n        icon: CreditCardIcon,\n        description: "£75 rewards",\n      },`,
+  );
+});
+
+update("src/app/player/team/[teamid]/page.tsx", (source) => {
+  if (source.includes('href="/player/referrals"')) return source;
+
+  const marker = '<div className="min-h-screen';
+  const index = source.indexOf(marker);
+  if (index === -1) return source;
+
+  const openingEnd = source.indexOf(">", index);
+  if (openingEnd === -1) return source;
+
+  const referralLink = `\n      <div className="mx-auto max-w-7xl px-4 pt-4 sm:px-6 lg:px-8">\n        <Link\n          href="/player/referrals"\n          className="inline-flex items-center rounded-full border border-emerald-400/20 bg-emerald-500/10 px-4 py-2 text-sm font-black text-emerald-200 transition hover:bg-emerald-500/20"\n        >\n          Refer a team · Earn £75\n        </Link>\n      </div>`;
+
+  return source.slice(0, openingEnd + 1) + referralLink + source.slice(openingEnd + 1);
+});

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -39,6 +39,7 @@ require("./apply-extra-kit-incomplete-order-recovery.cjs");
 require("./apply-team-kit-badge-review-stage.cjs");
 require("./remove-duplicate-kit-allocation-panel.cjs");
 require("./apply-native-team-kit-save-v2.cjs");
+require("./apply-team-referral-rewards.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");
 const violations = [];

--- a/src/app/(admin)/admin/referrals/actions.ts
+++ b/src/app/(admin)/admin/referrals/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { getTeamReferrals } from "@/lib/team-referrals";
+
+export async function markReferralPaidAction(formData: FormData) {
+  const { user } = await requireAdmin();
+  const referralId = String(formData.get("referralId") ?? "").trim();
+  if (!referralId) return;
+
+  const referrals = await getTeamReferrals();
+  const referral = referrals.find((item) => item.id === referralId);
+
+  if (!referral || referral.paidAt || referral.completedMatches < referral.requiredMatches) {
+    return;
+  }
+
+  await prisma.$executeRaw`
+    UPDATE "TeamReferral"
+    SET
+      "paidAt" = CURRENT_TIMESTAMP,
+      "paidByUserId" = ${user?.id ?? null},
+      "updatedAt" = CURRENT_TIMESTAMP
+    WHERE "id" = ${referralId}
+      AND "paidAt" IS NULL
+  `;
+
+  revalidatePath("/admin/referrals");
+  revalidatePath("/player/referrals");
+}

--- a/src/app/(admin)/admin/referrals/page.tsx
+++ b/src/app/(admin)/admin/referrals/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { getTeamReferrals, referralStatus } from "@/lib/team-referrals";
+import { markReferralPaidAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = { title: "Team Referrals | SIXFL Admin" };
+
+function money(pence: number) {
+  return new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(pence / 100);
+}
+
+function date(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", { day: "2-digit", month: "short", year: "numeric" }).format(value);
+}
+
+export default async function AdminReferralsPage() {
+  await requireAdmin();
+  const referrals = await getTeamReferrals();
+  const readyCount = referrals.filter((row) => referralStatus(row) === "READY").length;
+  const unpaidValue = referrals
+    .filter((row) => referralStatus(row) === "READY")
+    .reduce((total, row) => total + row.rewardPence, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-600">Growth</p>
+          <h1 className="mt-2 text-3xl font-black tracking-tight text-slate-950">Team referral rewards</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+            Players earn £75 after a team they refer has completed three league matches.
+          </p>
+        </div>
+        <Link href="/admin/leads?type=TEAM" className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 shadow-sm hover:bg-slate-50">
+          View team leads
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Summary label="Total referrals" value={String(referrals.length)} />
+        <Summary label="Ready to pay" value={String(readyCount)} />
+        <Summary label="Amount due" value={money(unpaidValue)} />
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        {referrals.length === 0 ? (
+          <div className="p-8 text-center text-sm text-slate-500">No team referrals have been recorded yet.</div>
+        ) : (
+          <div className="divide-y divide-slate-100">
+            {referrals.map((row) => {
+              const status = referralStatus(row);
+              const displayedTeam = row.teamName ?? row.leadTeamName ?? "Unnamed team";
+              return (
+                <div key={row.id} className="grid gap-4 p-5 lg:grid-cols-[1.2fr_1.2fr_0.8fr_auto] lg:items-center">
+                  <div>
+                    <p className="font-black text-slate-950">{row.referrerName ?? row.referrerEmail ?? "Player"}</p>
+                    <p className="mt-1 text-xs text-slate-500">{row.referrerEmail ?? "No email"}</p>
+                  </div>
+                  <div>
+                    <p className="font-bold text-slate-900">{displayedTeam}</p>
+                    <p className="mt-1 text-xs text-slate-500">{row.leagueName ?? "Not assigned to a league yet"} · referred {date(row.createdAt)}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-black text-slate-900">{Math.min(row.completedMatches, row.requiredMatches)} of {row.requiredMatches} matches</p>
+                    <p className="mt-1 text-xs text-slate-500">Reward: {money(row.rewardPence)}</p>
+                  </div>
+                  <div className="min-w-36 text-left lg:text-right">
+                    {status === "PAID" ? (
+                      <span className="inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-black text-emerald-800">Paid</span>
+                    ) : status === "READY" ? (
+                      <form action={markReferralPaidAction}>
+                        <input type="hidden" name="referralId" value={row.id} />
+                        <button className="rounded-xl bg-emerald-600 px-4 py-2 text-sm font-black text-white hover:bg-emerald-500">
+                          Mark £75 paid
+                        </button>
+                      </form>
+                    ) : (
+                      <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-black text-amber-800">In progress</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Summary({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="text-xs font-bold uppercase tracking-[0.14em] text-slate-500">{label}</p>
+      <p className="mt-2 text-3xl font-black text-slate-950">{value}</p>
+    </div>
+  );
+}

--- a/src/app/player/referrals/page.tsx
+++ b/src/app/player/referrals/page.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { getOrCreateReferralCode, getTeamReferrals, referralStatus } from "@/lib/team-referrals";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata = { title: "Refer a Team | SIXFL" };
+
+function money(pence: number) {
+  return new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(pence / 100);
+}
+
+export default async function PlayerReferralsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    redirect(`/login?callbackUrl=${encodeURIComponent("/player/referrals")}`);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email.trim().toLowerCase() },
+    select: { id: true, name: true },
+  });
+  if (!user) redirect("/login");
+
+  const code = await getOrCreateReferralCode(user.id);
+  const referrals = await getTeamReferrals(user.id);
+  const referralUrl = `https://www.sixfl.co.uk/register-interest?type=team&ref=${encodeURIComponent(code)}`;
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-10 text-white">
+      <div className="mx-auto max-w-4xl space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-400">SIXFL rewards</p>
+            <h1 className="mt-2 text-3xl font-black tracking-tight sm:text-4xl">Refer a team and earn £75</h1>
+          </div>
+          <Link href="/dashboard" className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white hover:bg-white/10">
+            Back to dashboard
+          </Link>
+        </div>
+
+        <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-6 sm:p-8">
+          <h2 className="text-xl font-black">How it works</h2>
+          <p className="mt-3 max-w-2xl text-sm leading-7 text-emerald-50/90">
+            Share your personal link with a new team. Once that team joins any SIXFL league and completes three matches, your £75 reward becomes payable.
+          </p>
+          <div className="mt-6 grid gap-4 sm:grid-cols-[1fr_auto] sm:items-end">
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.14em] text-emerald-200">Your referral code</label>
+              <div className="mt-2 rounded-2xl border border-white/15 bg-black/20 px-5 py-4 font-mono text-xl font-black tracking-widest">{code}</div>
+            </div>
+            <a
+              href={`https://wa.me/?text=${encodeURIComponent(`Join a SIXFL league using my referral link: ${referralUrl}`)}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-14 items-center justify-center rounded-2xl bg-emerald-400 px-6 text-sm font-black text-slate-950 hover:bg-emerald-300"
+            >
+              Share on WhatsApp
+            </a>
+          </div>
+          <div className="mt-4 rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-white/80 break-all">{referralUrl}</div>
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 sm:p-8">
+          <h2 className="text-xl font-black">Your referrals</h2>
+          {referrals.length === 0 ? (
+            <p className="mt-4 text-sm leading-6 text-white/60">You have not referred a team yet. Share your link and their registration will appear here automatically.</p>
+          ) : (
+            <div className="mt-5 space-y-4">
+              {referrals.map((row) => {
+                const status = referralStatus(row);
+                const progress = Math.min(row.completedMatches, row.requiredMatches);
+                return (
+                  <div key={row.id} className="rounded-2xl border border-white/10 bg-black/20 p-5">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="font-black">{row.teamName ?? row.leadTeamName ?? "Referred team"}</p>
+                        <p className="mt-1 text-xs text-white/50">{row.leagueName ?? "Waiting to join a league"}</p>
+                      </div>
+                      <span className={`rounded-full px-3 py-1 text-xs font-black ${status === "PAID" ? "bg-emerald-400 text-slate-950" : status === "READY" ? "bg-sky-300 text-slate-950" : "bg-amber-300 text-slate-950"}`}>
+                        {status === "PAID" ? "£75 paid" : status === "READY" ? "£75 ready" : `${progress} of ${row.requiredMatches} matches`}
+                      </span>
+                    </div>
+                    <div className="mt-4 h-2 overflow-hidden rounded-full bg-white/10">
+                      <div className="h-full rounded-full bg-emerald-400" style={{ width: `${(progress / row.requiredMatches) * 100}%` }} />
+                    </div>
+                    <p className="mt-3 text-sm text-white/70">
+                      {status === "PAID"
+                        ? `Your ${money(row.rewardPence)} reward has been marked as paid.`
+                        : status === "READY"
+                          ? `The team has completed three matches. Your ${money(row.rewardPence)} reward is now due.`
+                          : `${row.requiredMatches - progress} more completed ${row.requiredMatches - progress === 1 ? "match" : "matches"} until your ${money(row.rewardPence)} reward.`}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <p className="text-xs leading-5 text-white/40">
+          The team must be new to SIXFL and use your referral code when registering. Cancelled or postponed fixtures do not count.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/team-referrals.ts
+++ b/src/lib/team-referrals.ts
@@ -1,0 +1,138 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { prisma } from "@/lib/prisma";
+
+export const TEAM_REFERRAL_REWARD_PENCE = 7500;
+export const TEAM_REFERRAL_REQUIRED_MATCHES = 3;
+
+type ReferralCodeRow = { code: string };
+
+function makeReferralCode() {
+  return `SIX-${randomBytes(4).toString("hex").toUpperCase()}`;
+}
+
+export async function getOrCreateReferralCode(userId: string) {
+  const existing = await prisma.$queryRaw<ReferralCodeRow[]>`
+    SELECT "code"
+    FROM "TeamReferralCode"
+    WHERE "userId" = ${userId}
+    LIMIT 1
+  `;
+
+  if (existing[0]?.code) return existing[0].code;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const code = makeReferralCode();
+    try {
+      await prisma.$executeRaw`
+        INSERT INTO "TeamReferralCode" ("userId", "code", "updatedAt")
+        VALUES (${userId}, ${code}, CURRENT_TIMESTAMP)
+        ON CONFLICT ("userId") DO NOTHING
+      `;
+
+      const created = await prisma.$queryRaw<ReferralCodeRow[]>`
+        SELECT "code"
+        FROM "TeamReferralCode"
+        WHERE "userId" = ${userId}
+        LIMIT 1
+      `;
+      if (created[0]?.code) return created[0].code;
+    } catch (error) {
+      if (attempt === 4) throw error;
+    }
+  }
+
+  throw new Error("Unable to create referral code");
+}
+
+export async function attachReferralToLead(input: {
+  interestLeadId: string;
+  referralCode: string;
+  leadEmail: string;
+}) {
+  const code = input.referralCode.trim().toUpperCase();
+  if (!code) return false;
+
+  const rows = await prisma.$queryRaw<Array<{ userId: string }>>`
+    SELECT rc."userId"
+    FROM "TeamReferralCode" rc
+    INNER JOIN "User" u ON u."id" = rc."userId"
+    WHERE UPPER(rc."code") = ${code}
+      AND (u."email" IS NULL OR LOWER(u."email") <> LOWER(${input.leadEmail}))
+    LIMIT 1
+  `;
+
+  const referrerUserId = rows[0]?.userId;
+  if (!referrerUserId) return false;
+
+  await prisma.$executeRaw`
+    INSERT INTO "TeamReferral" (
+      "id", "referrerUserId", "interestLeadId", "rewardPence", "requiredMatches", "updatedAt"
+    )
+    VALUES (
+      ${randomUUID()}, ${referrerUserId}, ${input.interestLeadId},
+      ${TEAM_REFERRAL_REWARD_PENCE}, ${TEAM_REFERRAL_REQUIRED_MATCHES}, CURRENT_TIMESTAMP
+    )
+    ON CONFLICT ("interestLeadId") DO NOTHING
+  `;
+
+  return true;
+}
+
+export type TeamReferralRow = {
+  id: string;
+  referrerUserId: string;
+  referrerName: string | null;
+  referrerEmail: string | null;
+  leadName: string;
+  leadEmail: string;
+  leadTeamName: string | null;
+  teamId: string | null;
+  teamName: string | null;
+  leagueName: string | null;
+  rewardPence: number;
+  requiredMatches: number;
+  completedMatches: number;
+  paidAt: Date | null;
+  createdAt: Date;
+};
+
+export async function getTeamReferrals(referrerUserId?: string) {
+  return prisma.$queryRaw<TeamReferralRow[]>`
+    SELECT
+      r."id",
+      r."referrerUserId",
+      u."name" AS "referrerName",
+      u."email" AS "referrerEmail",
+      l."contactName" AS "leadName",
+      l."email" AS "leadEmail",
+      l."teamName" AS "leadTeamName",
+      t."id" AS "teamId",
+      t."name" AS "teamName",
+      lg."name" AS "leagueName",
+      r."rewardPence",
+      r."requiredMatches",
+      COUNT(DISTINCT f."id")::int AS "completedMatches",
+      r."paidAt",
+      r."createdAt"
+    FROM "TeamReferral" r
+    INNER JOIN "User" u ON u."id" = r."referrerUserId"
+    INNER JOIN "InterestLead" l ON l."id" = r."interestLeadId"
+    LEFT JOIN "Team" t ON t."id" = l."convertedTeamId"
+    LEFT JOIN "League" lg ON lg."id" = t."leagueId"
+    LEFT JOIN "Fixture" f
+      ON (f."homeTeamId" = t."id" OR f."awayTeamId" = t."id")
+      AND f."status" = 'COMPLETED'
+    WHERE (${referrerUserId ?? null}::text IS NULL OR r."referrerUserId" = ${referrerUserId ?? null})
+    GROUP BY
+      r."id", r."referrerUserId", u."name", u."email", l."contactName", l."email",
+      l."teamName", t."id", t."name", lg."name", r."rewardPence",
+      r."requiredMatches", r."paidAt", r."createdAt"
+    ORDER BY r."createdAt" DESC
+  `;
+}
+
+export function referralStatus(row: Pick<TeamReferralRow, "paidAt" | "completedMatches" | "requiredMatches">) {
+  if (row.paidAt) return "PAID" as const;
+  if (row.completedMatches >= row.requiredMatches) return "READY" as const;
+  return "TRACKING" as const;
+}


### PR DESCRIPTION
## What changed
- gives each signed-in player a private referral code and shareable team-registration link
- records the referring player against a new team enquiry without exposing the player's email
- tracks completed fixtures for the converted team
- makes a single £75 reward due after three completed matches
- adds a player progress page and WhatsApp sharing
- adds an admin referral page with a guarded **Mark £75 paid** action
- adds database tables for referral codes and reward records
- adds registration and navigation wiring through the existing idempotent build-patch system

## Rules
- any SIXFL league qualifies
- the team must be new and use the code when registering
- the lead cannot use a referral code belonging to the same email address
- cancelled or postponed fixtures do not count
- payment is manual and only enabled after three completed fixtures

## Validation
- implementation uses existing authentication, admin guard and Prisma connection patterns
- database change is supplied as an additive Prisma migration
- build wiring is idempotent