### PR TITLE
Reduce oversized Vercel image functions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,10 @@ const deploymentId = rawDeploymentId
 
 const nextConfig: NextConfig = {
   ...(deploymentId ? { deploymentId } : {}),
+  outputFileTracingExcludes: {
+    "/api/admin/night-board/night-fixtures": ["./public/Kits/**/*"],
+    "/api/social/image/[fixtureId]": ["./public/Kits/**/*"],
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
Excludes the unused public/Kits catalogue from the two Vercel serverless function traces that exceeded 250 MB: the social fixture image route and the night fixtures route. Neither function reads kit catalogue images, so this removes accidental packaging without changing generated graphics.