### PR TITLE
Fix social image Vercel trace exclusion

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,7 @@ const nextConfig: NextConfig = {
   ...(deploymentId ? { deploymentId } : {}),
   outputFileTracingExcludes: {
     "/api/admin/night-board/night-fixtures": ["./public/Kits/**/*"],
-    "/api/social/image/[fixtureId]": ["./public/Kits/**/*"],
+    "/api/social/image/**": ["./public/Kits/**/*"],
   },
   async redirects() {
     return [


### PR DESCRIPTION
Uses a wildcard route matcher for the dynamic social image endpoint so Vercel excludes the unused public/Kits catalogue from that function trace. The previous [fixtureId] key was not matching in production.