### PR TITLE
Repair standings source and division memberships

### DIFF
--- a/prisma/migrations/20260807164000_repair_division_memberships_from_fixtures/migration.sql
+++ b/prisma/migrations/20260807164000_repair_division_memberships_from_fixtures/migration.sql
@@ -1,0 +1,79 @@
+-- Repair active season division memberships only where the team's fixtures in
+-- that same league consistently point to exactly one valid active division.
+-- This recovers memberships overwritten by the legacy Team.divisionId sync
+-- without guessing for teams whose fixture history is ambiguous.
+
+WITH team_fixture_divisions AS (
+  SELECT
+    lst."leagueId",
+    lst."teamId",
+    f."divisionId",
+    COUNT(*) AS fixture_count
+  FROM "LeagueSeasonTeam" lst
+  JOIN "Fixture" f
+    ON f."leagueId" = lst."leagueId"
+   AND (f."homeTeamId" = lst."teamId" OR f."awayTeamId" = lst."teamId")
+  JOIN "LeagueDivision" d
+    ON d."id" = f."divisionId"
+   AND d."leagueId" = lst."leagueId"
+   AND d."isActive" = TRUE
+  WHERE lst."isActive" = TRUE
+    AND f."divisionId" IS NOT NULL
+  GROUP BY lst."leagueId", lst."teamId", f."divisionId"
+),
+unambiguous AS (
+  SELECT
+    "leagueId",
+    "teamId",
+    MIN("divisionId") AS "divisionId"
+  FROM team_fixture_divisions
+  GROUP BY "leagueId", "teamId"
+  HAVING COUNT(*) = 1
+)
+UPDATE "LeagueSeasonTeam" lst
+SET
+  "divisionId" = u."divisionId",
+  "updatedAt" = NOW()
+FROM unambiguous u
+WHERE lst."leagueId" = u."leagueId"
+  AND lst."teamId" = u."teamId"
+  AND lst."isActive" = TRUE
+  AND lst."divisionId" IS DISTINCT FROM u."divisionId";
+
+-- Keep the legacy Team.divisionId aligned where the recovery signal is
+-- unambiguous. The replacement trigger no longer copies this field back into
+-- LeagueSeasonTeam, so this is compatibility only for older admin/UI code.
+WITH team_fixture_divisions AS (
+  SELECT
+    lst."leagueId",
+    lst."teamId",
+    f."divisionId"
+  FROM "LeagueSeasonTeam" lst
+  JOIN "Fixture" f
+    ON f."leagueId" = lst."leagueId"
+   AND (f."homeTeamId" = lst."teamId" OR f."awayTeamId" = lst."teamId")
+  JOIN "LeagueDivision" d
+    ON d."id" = f."divisionId"
+   AND d."leagueId" = lst."leagueId"
+   AND d."isActive" = TRUE
+  WHERE lst."isActive" = TRUE
+    AND f."divisionId" IS NOT NULL
+  GROUP BY lst."leagueId", lst."teamId", f."divisionId"
+),
+unambiguous AS (
+  SELECT
+    "leagueId",
+    "teamId",
+    MIN("divisionId") AS "divisionId"
+  FROM team_fixture_divisions
+  GROUP BY "leagueId", "teamId"
+  HAVING COUNT(*) = 1
+)
+UPDATE "Team" t
+SET
+  "divisionId" = u."divisionId",
+  "updatedAt" = NOW()
+FROM unambiguous u
+WHERE t."id" = u."teamId"
+  AND t."leagueId" = u."leagueId"
+  AND t."divisionId" IS DISTINCT FROM u."divisionId";

--- a/src/lib/leagueTable.ts
+++ b/src/lib/leagueTable.ts
@@ -175,8 +175,9 @@ export async function getLeagueTable(
     prisma.fixture.findMany({
       where: {
         leagueId,
-        ...(options.divisionId ? { divisionId: options.divisionId } : {}),
-        status: "COMPLETED",
+        // A saved result is the authoritative indication that a game was played.
+        // Do not trust legacy/stale Fixture.status or Fixture.divisionId here.
+        // Division membership is enforced below by allowedTeamIds.
         result: { isNot: null },
       },
       orderBy: { kickoffAt: "asc" },
@@ -191,8 +192,9 @@ export async function getLeagueTable(
   const table = new Map<string, LeagueTableRow>();
 
   // The selected/active team list is always authoritative, including when it
-  // is empty. Historic completed fixtures must never recreate a removed or
-  // affiliated-only team in the current league table.
+  // is empty. Historic fixtures must never recreate a removed or affiliated-only
+  // team in the current league table. For division tables, this also means a
+  // result counts only when both participating teams are active in that division.
   const allowedTeamIds = new Set(teams.map((team) => team.id));
 
   for (const team of teams) {


### PR DESCRIPTION
Makes membership-based result counting permanent in src/lib/leagueTable.ts instead of relying on a build-time rewrite. Adds a one-time migration that restores active LeagueSeasonTeam divisionId (and legacy Team.divisionId for compatibility) only when all of a team's fixtures in that season point to one clear valid active division. Ambiguous teams are deliberately left untouched.