### PR TITLE
Disable legacy bridges on main team pages

### DIFF
--- a/src/components/RouteScopedBridges.tsx
+++ b/src/components/RouteScopedBridges.tsx
@@ -83,6 +83,13 @@ const SixflTvFixtureBridge = dynamic(
 export default function RouteScopedBridges() {
   const pathname = usePathname();
 
+  // The main team dashboards are fully rendered by their native React pages.
+  // Do not mount any legacy DOM bridge here: a bridge that mutates the page
+  // after hydration must never be able to replace or hide the team dashboard.
+  const isCaptainTeamRoot = /^\/captain\/team\/[^/]+\/?$/.test(pathname);
+  const isPlayerTeamRoot = /^\/player\/team\/[^/]+\/?$/.test(pathname);
+  if (isCaptainTeamRoot || isPlayerTeamRoot) return null;
+
   const isCaptain = pathname.startsWith("/captain/");
   const isPlayer = pathname.startsWith("/player/");
   const isCaptainMatchFees = /^\/captain\/team\/[^/]+\/match-fees\/?$/.test(pathname);


### PR DESCRIPTION
Emergency stability fix: the native captain and player team dashboards no longer mount any legacy DOM bridge layer on their root pages. This prevents post-hydration bridge mutations from making a team page flash briefly and then disappear/black out. Subpages keep their route-scoped bridges.