### PR TITLE
Preserve existing free kit entitlements

### DIFF
--- a/src/components/admin/leagues/LeagueFreeKitOfferBridge.tsx
+++ b/src/components/admin/leagues/LeagueFreeKitOfferBridge.tsx
@@ -108,7 +108,10 @@ async function applyCaptainOffer(teamId: string, signal: AbortSignal) {
   });
   if (!response.ok) return false;
   const data = (await response.json()) as { offerAvailable: boolean; existingEntitlement: boolean };
-  if (data.offerAvailable) return true;
+
+  // Closing a league's offer stops new teams qualifying; it must not remove an
+  // entitlement that was already granted to an existing team.
+  if (data.offerAvailable || data.existingEntitlement) return true;
 
   hideFreeOfferCopy();
 


### PR DESCRIPTION
Fixes the captain kit offer logic so closing a league's free-kit offer only prevents new teams from qualifying. Teams that already have an existing entitlement keep their included free-kit allocation and do not get switched to the paid-only notice. Uses the existing `existingEntitlement` value already returned by the kit-offer-status API.