### PR TITLE
Clarify fixture generation tools

### DIFF
--- a/src/app/(admin)/admin/fixtures/generate/page.tsx
+++ b/src/app/(admin)/admin/fixtures/generate/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { FixtureStatus } from "@prisma/client";
 
 import AdminCard from "@/components/admin/AdminCard";
+import GenerateNextWeekFixturesPanel from "@/components/admin/fixtures/GenerateNextWeekFixturesPanel";
 import { getAllLeagueDivisionOptions } from "@/lib/league-divisions";
 import { getCurrentLeagueIds } from "@/lib/current-leagues";
 import { prisma } from "@/lib/prisma";
@@ -37,8 +38,10 @@ function refereeLabel(referee: { name: string | null; email: string | null }) {
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-const inputClass = "h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20";
-const labelClass = "mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45";
+const inputClass =
+  "h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20";
+const labelClass =
+  "mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45";
 
 type SearchParams = {
   standardFees?: string;
@@ -51,7 +54,7 @@ type SearchParams = {
   unpublishedDeleted?: string;
 };
 
-export default async function ImprovedFixtureGeneratorPage({
+export default async function FixtureGeneratorPage({
   searchParams,
 }: {
   searchParams?: Promise<SearchParams>;
@@ -62,11 +65,7 @@ export default async function ImprovedFixtureGeneratorPage({
 
   const [leagues, venues, referees, allDivisionOptions] = await Promise.all([
     prisma.league.findMany({
-      where: {
-        id: {
-          in: currentLeagueIds,
-        },
-      },
+      where: { id: { in: currentLeagueIds } },
       orderBy: [{ isActive: "desc" }, { name: "asc" }, { season: "asc" }],
       select: { id: true, name: true, season: true },
     }),
@@ -90,56 +89,75 @@ export default async function ImprovedFixtureGeneratorPage({
   const standardFeeCount = Number(sp.standardFees ?? "");
   const standardFeeChargeCount = Number(sp.standardFeeCharges ?? "");
   const paymentRequestCount = Number(sp.paymentRequests ?? "");
-  const hasStandardFeeNotice = Number.isFinite(standardFeeCount) && sp.standardFees !== undefined;
+  const hasStandardFeeNotice =
+    Number.isFinite(standardFeeCount) && sp.standardFees !== undefined;
 
   const backfilledCount = Number(sp.backfilled ?? "");
-  const hasLegacyBackfillNotice = Number.isFinite(backfilledCount) && sp.backfilled !== undefined;
+  const hasLegacyBackfillNotice =
+    Number.isFinite(backfilledCount) && sp.backfilled !== undefined;
 
   const refereeBackfilledCount = Number(sp.refBackfilled ?? "");
   const refereeAssignedCount = Number(sp.refAssigned ?? "");
   const refereeEmailCount = Number(sp.refEmails ?? "");
-  const hasRefereeBackfillNotice = Number.isFinite(refereeBackfilledCount) && sp.refBackfilled !== undefined;
+  const hasRefereeBackfillNotice =
+    Number.isFinite(refereeBackfilledCount) && sp.refBackfilled !== undefined;
 
   const unpublishedDeletedCount = Number(sp.unpublishedDeleted ?? "");
-  const hasUnpublishedDeletedNotice = Number.isFinite(unpublishedDeletedCount) && sp.unpublishedDeleted !== undefined;
+  const hasUnpublishedDeletedNotice =
+    Number.isFinite(unpublishedDeletedCount) && sp.unpublishedDeleted !== undefined;
 
   const noCurrentLeagues = leagues.length === 0;
+  const leagueOptions = leagues.map((league) => ({
+    id: league.id,
+    label: leagueLabel(league),
+  }));
 
   return (
     <div className="mx-auto max-w-5xl space-y-8 px-4 pb-12 pt-6 sm:px-6 lg:px-8">
       <div>
-        <Link href="/admin/fixtures" className="text-sm font-medium text-emerald-300 hover:text-emerald-200">
+        <Link
+          href="/admin/fixtures"
+          className="text-sm font-medium text-emerald-300 hover:text-emerald-200"
+        >
           ← Back to fixtures
         </Link>
         <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white md:text-4xl">
-          Bulk Fixture Generator
+          Generate fixtures
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60">
-          Generate a full draft schedule with pitch-specific referees. Only current competition seasons are available here, so archived seasons cannot accidentally receive new fixtures.
+          Use <strong className="text-white">Generate one week</strong> for the normal weekly job.
+          Use <strong className="text-white">Generate a full schedule</strong> only when setting up a new
+          league or rebuilding a complete round-robin schedule. The repair tools at the bottom are for
+          existing fixtures and are not part of normal weekly generation.
         </p>
       </div>
 
       {noCurrentLeagues ? (
         <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">
-          No current league seasons are available for fixture generation. Open a league and create or select the current season first.
+          No current league seasons are available. Open a league and create or select its current season first.
         </div>
       ) : null}
 
       {hasStandardFeeNotice ? (
         <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
-          Applied standard team fees to {standardFeeCount} fixture{standardFeeCount === 1 ? "" : "s"}. Created payment charges for {Number.isFinite(standardFeeChargeCount) ? standardFeeChargeCount : 0} published fixture{standardFeeChargeCount === 1 ? "" : "s"}. Queued {Number.isFinite(paymentRequestCount) ? paymentRequestCount : 0} payment message{paymentRequestCount === 1 ? "" : "s"}.
+          Applied standard team fees to {standardFeeCount} fixture{standardFeeCount === 1 ? "" : "s"}.
+          Created payment charges for {Number.isFinite(standardFeeChargeCount) ? standardFeeChargeCount : 0} published fixture{standardFeeChargeCount === 1 ? "" : "s"}.
+          Queued {Number.isFinite(paymentRequestCount) ? paymentRequestCount : 0} payment message{paymentRequestCount === 1 ? "" : "s"}.
         </div>
       ) : null}
 
       {hasLegacyBackfillNotice ? (
         <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
-          Backfilled payment charges for {backfilledCount} published fixture{backfilledCount === 1 ? "" : "s"}. Queued {Number.isFinite(paymentRequestCount) ? paymentRequestCount : 0} payment message{paymentRequestCount === 1 ? "" : "s"}.
+          Backfilled payment charges for {backfilledCount} published fixture{backfilledCount === 1 ? "" : "s"}.
+          Queued {Number.isFinite(paymentRequestCount) ? paymentRequestCount : 0} payment message{paymentRequestCount === 1 ? "" : "s"}.
         </div>
       ) : null}
 
       {hasRefereeBackfillNotice ? (
         <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm text-sky-100">
-          Linked {refereeBackfilledCount} fixture{refereeBackfilledCount === 1 ? "" : "s"} to referee night{refereeBackfilledCount === 1 ? "" : "s"}. Filled {Number.isFinite(refereeAssignedCount) ? refereeAssignedCount : 0} blank referee assignment{refereeAssignedCount === 1 ? "" : "s"}. Queued {Number.isFinite(refereeEmailCount) ? refereeEmailCount : 0} referee email{refereeEmailCount === 1 ? "" : "s"}.
+          Linked {refereeBackfilledCount} fixture{refereeBackfilledCount === 1 ? "" : "s"} to referee night{refereeBackfilledCount === 1 ? "" : "s"}.
+          Filled {Number.isFinite(refereeAssignedCount) ? refereeAssignedCount : 0} blank referee assignment{refereeAssignedCount === 1 ? "" : "s"}.
+          Queued {Number.isFinite(refereeEmailCount) ? refereeEmailCount : 0} referee email{refereeEmailCount === 1 ? "" : "s"}.
         </div>
       ) : null}
 
@@ -149,78 +167,138 @@ export default async function ImprovedFixtureGeneratorPage({
         </div>
       ) : null}
 
-      <AdminCard className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.06] p-6 md:p-8">
-        <form action={backfillStandardFixtureFeesAction} className="space-y-5">
+      <GenerateNextWeekFixturesPanel leagues={leagueOptions} />
+
+      <AdminCard className="rounded-3xl border border-emerald-400/15 bg-white/[0.03] p-6 md:p-8">
+        <form action={generateDraftFixturesWithDivisionsAction} className="space-y-8">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200/80">Standard team fees</p>
-            <h2 className="mt-2 text-2xl font-semibold text-white">Backfill fixture fees</h2>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300/80">
+              New league / full rebuild
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">Generate a full schedule</h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
-              Applies each team’s standard match fee to upcoming fixtures. Draft fixtures get the fee attached ready for later. Published fixtures with no active payment charge get payment charges created from each team’s own fee.
+              Creates every round in a round-robin schedule for the selected league or division, starting
+              from the date and week number below. This is <strong className="text-white">not</strong> the normal
+              one-week generator. All fixtures are created as drafts for review before publishing.
             </p>
           </div>
 
-          <div>
-            <label className={labelClass}>Current season</label>
-            <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
-              {leagues.map((league) => (
-                <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
-              ))}
-            </select>
-          </div>
-
-          <label className="flex cursor-pointer items-start gap-4 rounded-2xl border border-white/10 bg-black/25 p-4">
-            <input type="checkbox" name="sendPaymentRequests" defaultChecked className="mt-1" />
-            <span>
-              <span className="block text-sm font-semibold text-white">Queue payment request emails/SMS for newly created charges</span>
-              <span className="mt-1 block text-sm leading-6 text-white/55">
-                Only published fixtures can have payment requests queued. Draft fixtures will just have the standard fee stored.
-              </span>
-            </span>
-          </label>
-
-          <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl border border-amber-400/30 bg-amber-500/15 px-6 text-sm font-semibold text-amber-50 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-40">
-            Backfill fees from team settings
-          </button>
-        </form>
-      </AdminCard>
-
-      <AdminCard className="rounded-3xl border border-sky-400/25 bg-sky-500/[0.06] p-6 md:p-8">
-        <form action={backfillRefereeAssignmentsAction} className="space-y-5">
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200/80">Existing fixtures</p>
-            <h2 className="mt-2 text-2xl font-semibold text-white">Backfill referee assignments</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
-              Use this when fixtures already exist but referee nights/emails need setting up. It fills blank referee assignments from the pitch referees below, creates referee nights, and queues referee emails only. Team fixture emails are not resent.
-            </p>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_220px]">
+          <div className="grid gap-6 md:grid-cols-2">
             <div>
-              <label className={labelClass}>Current season</label>
+              <label className={labelClass}>League / current season</label>
               <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
                 {leagues.map((league) => (
-                  <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
+                  <option key={league.id} value={league.id}>
+                    {leagueLabel(league)}
+                  </option>
                 ))}
               </select>
             </div>
+
             <div>
-              <label className={labelClass}>Referee night fee</label>
-              <div className="relative">
-                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm font-semibold text-white/45">£</span>
-                <input type="number" name="refereeFeePounds" min="0" step="0.01" defaultValue="45.00" className={`${inputClass} pl-8`} />
-              </div>
+              <label className={labelClass}>Division to schedule</label>
+              <select name="divisionId" className={inputClass} disabled={noCurrentLeagues}>
+                <option value="">Whole league / league has no divisions</option>
+                {divisionOptions.map((division) => (
+                  <option key={division.id} value={division.id}>
+                    {divisionLabel(division)}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                If the league has divisions, choose the exact division. Leave blank only for a league that does not use divisions.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Date of the first fixture night</label>
+              <input type="date" name="startDate" required className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                Week 1 of the generated schedule starts on this date.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>First kick-off</label>
+              <input type="time" name="startTime" defaultValue="19:00" required className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">Example: 19:00 = first games start at 7pm.</p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Latest kick-off on the night</label>
+              <input type="time" name="lastGameStartTime" defaultValue="20:20" required className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                With 40-minute slots, 19:00 to 20:20 gives kick-offs at 19:00, 19:40 and 20:20.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Venue</label>
+              <select name="venueId" className={inputClass}>
+                <option value="">No venue selected</option>
+                {venues.map((venue) => (
+                  <option key={venue.id} value={venue.id}>{venue.name}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className={labelClass}>Number of pitches in use</label>
+              <input type="number" name="pitches" min={1} defaultValue={2} className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                Example: 2 means two matches can kick off at the same time.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Minutes between kick-offs</label>
+              <input type="number" name="slotMinutes" min={10} defaultValue={40} className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                Usually 40 minutes for SIXFL match slots.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Days between fixture nights</label>
+              <input type="number" name="weekGapDays" min={1} defaultValue={7} className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                Leave at 7 for a normal weekly league.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>First week number to create</label>
+              <input type="number" name="startRound" min={1} defaultValue={1} className={inputClass} />
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                Use 1 for a new season. Change this only when continuing from a later week.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Initial fixture status</label>
+              <select name="status" defaultValue={FixtureStatus.SCHEDULED} className={inputClass}>
+                <option value={FixtureStatus.SCHEDULED}>Scheduled</option>
+                <option value={FixtureStatus.POSTPONED}>Postponed</option>
+                <option value={FixtureStatus.CANCELLED}>Cancelled</option>
+              </select>
+              <p className="mt-2 text-xs leading-5 text-white/45">
+                Normally leave this as Scheduled. The fixtures are still unpublished drafts until you publish them.
+              </p>
             </div>
           </div>
 
-          <div className="rounded-2xl border border-white/10 bg-black/25 p-4">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Pitch referees</p>
-            <p className="mt-2 text-sm leading-6 text-white/55">Existing referee assignments are kept. Blank assignments are filled using the fixture pitch number.</p>
-            <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="rounded-3xl border border-white/10 bg-black/25 p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300/80">Referees</p>
+            <h3 className="mt-2 text-xl font-semibold text-white">Optional: assign a referee to each pitch</h3>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
+              If you already know the referee rota, choose the referee for each pitch. Leave a pitch unassigned if you will fill it later.
+            </p>
+            <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
               {Array.from({ length: 6 }, (_, index) => (
                 <div key={index + 1}>
-                  <label className={labelClass}>Pitch {index + 1} referee</label>
+                  <label className={labelClass}>Pitch {index + 1}</label>
                   <select name={`refereeIdByPitch${index + 1}`} className={inputClass}>
-                    <option value="">Leave blank</option>
+                    <option value="">No referee yet</option>
                     {referees.map((referee) => (
                       <option key={referee.id} value={referee.id}>{refereeLabel(referee)}</option>
                     ))}
@@ -230,124 +308,192 @@ export default async function ImprovedFixtureGeneratorPage({
             </div>
           </div>
 
-          <label className="flex cursor-pointer items-start gap-4 rounded-2xl border border-white/10 bg-black/25 p-4">
-            <input type="checkbox" name="sendRefereeEmails" defaultChecked className="mt-1" />
-            <span>
-              <span className="block text-sm font-semibold text-white">Queue referee assignment emails</span>
-              <span className="mt-1 block text-sm leading-6 text-white/55">Sends referee-only assignment emails for newly linked referee nights. It will not send team fixture amendment emails.</span>
-            </span>
-          </label>
-
-          <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl border border-sky-400/30 bg-sky-500/15 px-6 text-sm font-semibold text-sky-50 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-40">
-            Backfill referee assignments
-          </button>
-        </form>
-      </AdminCard>
-
-      <AdminCard className="rounded-3xl border border-rose-400/25 bg-rose-500/[0.06] p-6 md:p-8">
-        <form action={deleteUnpublishedFixturesAction} className="space-y-5">
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-rose-200/80">Safe draft cleanup</p>
-            <h2 className="mt-2 text-2xl font-semibold text-white">Delete unpublished fixtures only</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
-              Removes fixtures that are still draft/unpublished for the selected current season. Published/live fixtures are not deleted.
-            </p>
-          </div>
-
           <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <label className={labelClass}>Current season</label>
-              <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
-                {leagues.map((league) => (
-                  <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className={labelClass}>Division</label>
-              <select name="divisionId" className={inputClass} disabled={noCurrentLeagues}>
-                <option value="">Whole league / all divisions</option>
-                {divisionOptions.map((division) => (
-                  <option key={division.id} value={division.id}>{divisionLabel(division)}</option>
-                ))}
-              </select>
-              <p className="mt-2 text-xs leading-5 text-white/45">
-                Choose a division to remove only that division’s drafts, or leave blank to remove all unpublished fixtures in the season.
-              </p>
-            </div>
-          </div>
+            <label className="flex min-h-[120px] cursor-pointer items-start gap-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+              <input type="checkbox" name="doubleRoundRobin" className="mt-1" />
+              <span>
+                <span className="block text-sm font-semibold text-white">Play every opponent twice</span>
+                <span className="mt-1 block text-sm leading-6 text-white/50">
+                  Creates a second set of rounds with the home/away order reversed. Leave unticked if each pairing should happen once.
+                </span>
+              </span>
+            </label>
 
-          <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl border border-rose-300/30 bg-rose-500/15 px-6 text-sm font-semibold text-rose-50 transition hover:bg-rose-500/25 disabled:cursor-not-allowed disabled:opacity-40">
-            Delete unpublished fixtures
-          </button>
-        </form>
-      </AdminCard>
-
-      <AdminCard className="rounded-3xl border border-emerald-400/15 bg-white/[0.03] p-6 md:p-8">
-        <form action={generateDraftFixturesWithDivisionsAction} className="space-y-8">
-          <div className="grid gap-6 md:grid-cols-2">
-            <div>
-              <label className={labelClass}>Current season</label>
-              <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
-                {leagues.map((league) => (
-                  <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className={labelClass}>Division</label>
-              <select name="divisionId" className={inputClass} disabled={noCurrentLeagues}>
-                <option value="">Whole league / no division</option>
-                {divisionOptions.map((division) => (
-                  <option key={division.id} value={division.id}>{divisionLabel(division)}</option>
-                ))}
-              </select>
-              <p className="mt-2 text-xs leading-5 text-white/45">
-                For Harrogate, choose Premiership or Championship. Leave blank only for leagues without divisions.
-              </p>
-            </div>
-            <div><label className={labelClass}>Start date</label><input type="date" name="startDate" required className={inputClass} /></div>
-            <div><label className={labelClass}>Start time</label><input type="time" name="startTime" defaultValue="19:00" required className={inputClass} /><p className="mt-2 text-xs leading-5 text-white/45">First kick-off time. 19:00 means 7pm UK time.</p></div>
-            <div><label className={labelClass}>Last game start time</label><input type="time" name="lastGameStartTime" defaultValue="20:20" required className={inputClass} /><p className="mt-2 text-xs leading-5 text-white/45">Example: 19:00 start, 20:20 last game, 40 min slots = 19:00, 19:40 and 20:20.</p></div>
-            <div><label className={labelClass}>Venue</label><select name="venueId" className={inputClass}><option value="">No venue</option>{venues.map((venue) => <option key={venue.id} value={venue.id}>{venue.name}</option>)}</select></div>
-            <div><label className={labelClass}>Fixture status</label><select name="status" defaultValue={FixtureStatus.SCHEDULED} className={inputClass}><option value={FixtureStatus.SCHEDULED}>Scheduled</option><option value={FixtureStatus.POSTPONED}>Postponed</option><option value={FixtureStatus.CANCELLED}>Cancelled</option></select></div>
-            <div><label className={labelClass}>Pitches</label><input type="number" name="pitches" min={1} defaultValue={2} className={inputClass} /></div>
-            <div><label className={labelClass}>Slot minutes</label><input type="number" name="slotMinutes" min={10} defaultValue={40} className={inputClass} /></div>
-            <div><label className={labelClass}>Week gap days</label><input type="number" name="weekGapDays" min={1} defaultValue={7} className={inputClass} /></div>
-            <div><label className={labelClass}>Start week</label><input type="number" name="startRound" min={1} defaultValue={1} className={inputClass} /></div>
+            <label className="flex min-h-[120px] cursor-pointer items-start gap-4 rounded-2xl border border-red-400/20 bg-red-500/10 p-4">
+              <input type="checkbox" name="clearExisting" className="mt-1" />
+              <span>
+                <span className="block text-sm font-semibold text-red-100">Delete existing drafts before creating this schedule</span>
+                <span className="mt-1 block text-sm leading-6 text-red-100/65">
+                  Deletes unpublished fixtures for this league/division first. Published fixtures are never deleted. Use this only when intentionally rebuilding the draft schedule.
+                </span>
+              </span>
+            </label>
           </div>
 
           <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200/80">Payment safety rule</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">No payment messages for draft fixtures</h2>
-            <p className="mt-2 max-w-2xl text-sm leading-6 text-amber-50/70">Generated draft fixtures will now store the teams’ standard fixture fee. Payment charges and payment request messages are only created after fixtures are published or after you use the backfill fees button.</p>
-          </div>
-
-          <div className="rounded-3xl border border-white/10 bg-black/25 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300/80">Pitch referees</p>
-            <h2 className="mt-2 text-xl font-semibold text-white">Assign one referee per pitch</h2>
-            <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">Pitch 1 uses the Pitch 1 referee, Pitch 2 uses the Pitch 2 referee, and so on.</p>
-            <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {Array.from({ length: 6 }, (_, index) => (
-                <div key={index + 1}>
-                  <label className={labelClass}>Pitch {index + 1} referee</label>
-                  <select name={`refereeIdByPitch${index + 1}`} className={inputClass}><option value="">Unassigned</option>{referees.map((referee) => <option key={referee.id} value={referee.id}>{refereeLabel(referee)}</option>)}</select>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="flex min-h-[112px] cursor-pointer items-start gap-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4"><input type="checkbox" name="doubleRoundRobin" className="mt-1" /><span><span className="block text-sm font-semibold text-white">Double round robin</span><span className="mt-1 block text-sm leading-6 text-white/50">Every team plays each opponent twice.</span></span></label>
-            <label className="flex min-h-[112px] cursor-pointer items-start gap-4 rounded-2xl border border-red-400/20 bg-red-500/10 p-4"><input type="checkbox" name="clearExisting" className="mt-1" /><span><span className="block text-sm font-semibold text-red-100">Clear unpublished fixtures first</span><span className="mt-1 block text-sm leading-6 text-red-100/65">Deletes draft/unpublished fixtures only for the selected league/division. Published fixtures are kept.</span></span></label>
+            <h3 className="text-lg font-semibold text-white">What happens after you click generate?</h3>
+            <p className="mt-2 text-sm leading-6 text-amber-50/70">
+              Fixtures are saved as unpublished drafts with the teams’ standard match fee attached. No team payment requests are sent until fixtures are published.
+            </p>
           </div>
 
           <div className="flex flex-col gap-3 border-t border-white/10 pt-6 sm:flex-row sm:items-center">
-            <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl bg-emerald-400 px-6 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-40">Generate draft fixtures</button>
-            <p className="text-sm leading-6 text-white/45">The generator uses each team’s standard match fee from the team settings.</p>
+            <button
+              type="submit"
+              disabled={noCurrentLeagues}
+              className="inline-flex h-12 items-center justify-center rounded-2xl bg-emerald-400 px-6 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Generate full draft schedule
+            </button>
+            <p className="text-sm leading-6 text-white/45">Review every generated fixture before publishing.</p>
           </div>
         </form>
       </AdminCard>
+
+      <section className="space-y-4 border-t border-white/10 pt-8">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/35">Maintenance tools</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Fix existing fixtures</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">
+            These tools do not generate a normal fixture week. Use them only when existing fixtures are missing fees/referee setup, or when you need to remove unpublished drafts.
+          </p>
+        </div>
+
+        <AdminCard className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.06] p-6 md:p-8">
+          <form action={backfillStandardFixtureFeesAction} className="space-y-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200/80">Repair tool</p>
+              <h3 className="mt-2 text-xl font-semibold text-white">Add missing team fees to existing fixtures</h3>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
+                Use this only if fixtures already exist but their standard match fees/payment charges are missing. Drafts get the fee stored; published fixtures can also receive missing payment charges.
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>League / current season to repair</label>
+              <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
+                {leagues.map((league) => (
+                  <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
+                ))}
+              </select>
+            </div>
+
+            <label className="flex cursor-pointer items-start gap-4 rounded-2xl border border-white/10 bg-black/25 p-4">
+              <input type="checkbox" name="sendPaymentRequests" defaultChecked className="mt-1" />
+              <span>
+                <span className="block text-sm font-semibold text-white">Send payment requests for any newly created published charges</span>
+                <span className="mt-1 block text-sm leading-6 text-white/55">
+                  This only affects published fixtures. Draft fixtures will not send messages.
+                </span>
+              </span>
+            </label>
+
+            <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl border border-amber-400/30 bg-amber-500/15 px-6 text-sm font-semibold text-amber-50 transition hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-40">
+              Repair missing fixture fees
+            </button>
+          </form>
+        </AdminCard>
+
+        <AdminCard className="rounded-3xl border border-sky-400/25 bg-sky-500/[0.06] p-6 md:p-8">
+          <form action={backfillRefereeAssignmentsAction} className="space-y-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200/80">Repair tool</p>
+              <h3 className="mt-2 text-xl font-semibold text-white">Add missing referees to existing fixtures</h3>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
+                Use this when fixtures are already created but referee assignments/referee nights are incomplete. Existing referee assignments are kept; only blanks are filled.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_220px]">
+              <div>
+                <label className={labelClass}>League / current season to repair</label>
+                <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
+                  {leagues.map((league) => (
+                    <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Referee payment for the night</label>
+                <div className="relative">
+                  <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm font-semibold text-white/45">£</span>
+                  <input type="number" name="refereeFeePounds" min="0" step="0.01" defaultValue="45.00" className={`${inputClass} pl-8`} />
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-black/25 p-4">
+              <p className="text-sm leading-6 text-white/55">Choose which referee should fill blank assignments on each pitch.</p>
+              <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {Array.from({ length: 6 }, (_, index) => (
+                  <div key={index + 1}>
+                    <label className={labelClass}>Pitch {index + 1}</label>
+                    <select name={`refereeIdByPitch${index + 1}`} className={inputClass}>
+                      <option value="">Do not fill this pitch</option>
+                      {referees.map((referee) => (
+                        <option key={referee.id} value={referee.id}>{refereeLabel(referee)}</option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <label className="flex cursor-pointer items-start gap-4 rounded-2xl border border-white/10 bg-black/25 p-4">
+              <input type="checkbox" name="sendRefereeEmails" defaultChecked className="mt-1" />
+              <span>
+                <span className="block text-sm font-semibold text-white">Email referees about newly repaired assignments</span>
+                <span className="mt-1 block text-sm leading-6 text-white/55">
+                  Referee assignment emails only. Team fixture emails are not resent.
+                </span>
+              </span>
+            </label>
+
+            <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl border border-sky-400/30 bg-sky-500/15 px-6 text-sm font-semibold text-sky-50 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-40">
+              Repair missing referee assignments
+            </button>
+          </form>
+        </AdminCard>
+
+        <AdminCard className="rounded-3xl border border-rose-400/25 bg-rose-500/[0.06] p-6 md:p-8">
+          <form action={deleteUnpublishedFixturesAction} className="space-y-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-rose-200/80">Cleanup tool</p>
+              <h3 className="mt-2 text-xl font-semibold text-white">Delete draft fixtures</h3>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
+                Permanently removes unpublished draft fixtures for the selected league/division. Published/live fixtures are never deleted by this tool.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className={labelClass}>League / current season</label>
+                <select name="leagueId" required disabled={noCurrentLeagues} className={inputClass}>
+                  {leagues.map((league) => (
+                    <option key={league.id} value={league.id}>{leagueLabel(league)}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Which drafts to delete</label>
+                <select name="divisionId" className={inputClass} disabled={noCurrentLeagues}>
+                  <option value="">All unpublished fixtures in this league</option>
+                  {divisionOptions.map((division) => (
+                    <option key={division.id} value={division.id}>{divisionLabel(division)}</option>
+                  ))}
+                </select>
+                <p className="mt-2 text-xs leading-5 text-white/45">
+                  Choose a division to delete only its drafts, or leave blank for all drafts in the selected league.
+                </p>
+              </div>
+            </div>
+
+            <button type="submit" disabled={noCurrentLeagues} className="inline-flex h-12 items-center justify-center rounded-2xl border border-rose-300/30 bg-rose-500/15 px-6 text-sm font-semibold text-rose-50 transition hover:bg-rose-500/25 disabled:cursor-not-allowed disabled:opacity-40">
+              Delete draft fixtures
+            </button>
+          </form>
+        </AdminCard>
+      </section>
     </div>
   );
 }

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -18,7 +18,6 @@ import EmailTemplateListControlsBridge from "@/components/admin/email-templates/
 import PlayerPoolTemplateCtaBridge from "@/components/admin/email-templates/PlayerPoolTemplateCtaBridge";
 import FixtureCardResultLinksBridge from "@/components/admin/fixtures/FixtureCardResultLinksBridge";
 import FixtureSeasonWordingBridge from "@/components/admin/fixtures/FixtureSeasonWordingBridge";
-import GenerateNextWeekFixturesBridge from "@/components/admin/fixtures/GenerateNextWeekFixturesBridge";
 import FixtureChangeNotificationSubmitBridge from "@/components/admin/fixtures/FixtureChangeNotificationSubmitBridge";
 import AdminLeadEditButtonBridge from "@/components/admin/leads/AdminLeadEditButtonBridge";
 import AdminDivisionSelectBridge from "@/components/admin/leagues/AdminDivisionSelectBridge";
@@ -91,7 +90,6 @@ export default async function AdminLayout({
       <EmailBrandOptionBridge />
       <PlayerPoolTemplateCtaBridge />
       <PlayerPoolNudgeBridge />
-      <GenerateNextWeekFixturesBridge />
       <AdminSidebarDesktopColumnsBridge />
       <RemoveUnusedSettingsNavBridge />
       <AdminLeagueSeasonsBridge />

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -174,10 +174,10 @@ const navigationGroups = [
         description: "Availability",
       },
       {
-        name: "Bulk generator",
+        name: "Generate fixtures",
         href: "/admin/fixtures/generate",
         icon: CalendarDaysIcon,
-        description: "Drafts",
+        description: "Create schedule",
       },
       {
         name: "Drop team",

--- a/src/components/admin/fixtures/GenerateNextWeekFixturesPanel.tsx
+++ b/src/components/admin/fixtures/GenerateNextWeekFixturesPanel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+
+type LeagueOption = {
+  id: string;
+  label: string;
+};
+
+type GenerateFixturesResponse = {
+  created?: number;
+  round?: number;
+  error?: string;
+  requestId?: string;
+};
+
+export default function GenerateNextWeekFixturesPanel({
+  leagues,
+}: {
+  leagues: LeagueOption[];
+}) {
+  const [leagueId, setLeagueId] = useState(leagues[0]?.id ?? "");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function generate() {
+    if (!leagueId || busy) return;
+
+    setBusy(true);
+    setMessage("Checking previous fixtures and choosing the next set of opponents…");
+    setError(null);
+
+    try {
+      const response = await fetch("/api/admin/fixtures/generate-next-week", {
+        method: "POST",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ leagueId }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | GenerateFixturesResponse
+        | null;
+
+      if (!response.ok) {
+        const reference = payload?.requestId ? ` Reference: ${payload.requestId}.` : "";
+        throw new Error(`${payload?.error ?? "Could not generate the next week."}${reference}`);
+      }
+
+      if (payload?.created === undefined) {
+        throw new Error("The fixture generator returned an incomplete response.");
+      }
+
+      setMessage(
+        `Created ${payload.created} draft fixture${payload.created === 1 ? "" : "s"}${
+          payload.round ? ` for week ${payload.round}` : ""
+        }. They are ready to review on the Fixtures page.`,
+      );
+    } catch (caught) {
+      setMessage(null);
+      setError(caught instanceof Error ? caught.message : "Could not generate the next week.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-emerald-400/25 bg-emerald-500/[0.07] p-6 md:p-8">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-200/80">
+        Most common job
+      </p>
+      <h2 className="mt-2 text-2xl font-semibold text-white">Generate one week of fixtures</h2>
+      <p className="mt-2 max-w-3xl text-sm leading-6 text-white/65">
+        Creates only the next matchweek for the selected league. SIXFL looks at previous fixtures,
+        avoids recent repeat pairings where possible and balances how many games teams have played.
+        The new fixtures are drafts only — nothing is published or sent to teams.
+      </p>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div>
+          <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+            League to create next week for
+          </label>
+          <select
+            value={leagueId}
+            onChange={(event) => setLeagueId(event.target.value)}
+            disabled={leagues.length === 0 || busy}
+            className="h-14 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/20 disabled:opacity-40"
+          >
+            {leagues.map((league) => (
+              <option key={league.id} value={league.id}>
+                {league.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void generate()}
+          disabled={!leagueId || busy}
+          className="inline-flex h-14 items-center justify-center rounded-2xl bg-emerald-400 px-6 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {busy ? "Generating…" : "Generate next week"}
+        </button>
+      </div>
+
+      <p className="mt-3 text-xs leading-5 text-white/45">
+        Uses the latest existing fixture date, venue and pitch count as the starting point. Review the new drafts before publishing them.
+      </p>
+
+      {message ? (
+        <div className="mt-4 rounded-2xl border border-emerald-400/20 bg-black/20 px-4 py-3 text-sm text-emerald-100">
+          {message}
+        </div>
+      ) : null}
+      {error ? (
+        <div className="mt-4 rounded-2xl border border-red-400/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+          {error}
+        </div>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
Renames the admin navigation item to Generate fixtures, moves the existing one-week fixture generator into the Generate fixtures page as the primary workflow, clearly separates it from the full round-robin schedule generator, relabels technical fields in plain English, and groups fee/referee/draft cleanup tools under a maintenance section. Removes the old DOM-injected next-week generator from the general Fixtures page.