### PR TITLE
Clarify Stripe subscription setup states

### DIFF
--- a/src/app/(admin)/admin/payments/subscriptions/page.tsx
+++ b/src/app/(admin)/admin/payments/subscriptions/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
 import { listTeamSubscriptionSnapshots } from "@/lib/payments/team-subscriptions";
+import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 export const dynamic = "force-dynamic";
@@ -36,8 +37,16 @@ function formatDateTime(value: Date | null) {
   });
 }
 
-function formatStatus(status: string | null) {
-  if (!status) return "Not set up";
+function formatStatus(input: {
+  subscriptionStatus: string | null;
+  setupStarted: boolean;
+  hasStripeCustomer: boolean;
+}) {
+  if (!input.subscriptionStatus) {
+    if (input.setupStarted) return "Setup started — not completed";
+    if (input.hasStripeCustomer) return "Stripe customer only";
+    return "Not started";
+  }
 
   const labels: Record<string, string> = {
     active: "Active",
@@ -50,11 +59,14 @@ function formatStatus(status: string | null) {
     paused: "Paused",
   };
 
-  return labels[status] ?? status.replaceAll("_", " ");
+  return labels[input.subscriptionStatus] ?? input.subscriptionStatus.replaceAll("_", " ");
 }
 
-function getStatusTone(status: string | null) {
-  switch (status) {
+function getStatusTone(input: {
+  subscriptionStatus: string | null;
+  setupStarted: boolean;
+}) {
+  switch (input.subscriptionStatus) {
     case "active":
     case "trialing":
       return "border-emerald-400/25 bg-emerald-500/10 text-emerald-100";
@@ -66,7 +78,9 @@ function getStatusTone(status: string | null) {
     case "incomplete_expired":
       return "border-red-400/25 bg-red-500/10 text-red-100";
     default:
-      return "border-white/10 bg-white/[0.05] text-white/60";
+      return input.setupStarted
+        ? "border-amber-400/25 bg-amber-500/10 text-amber-100"
+        : "border-white/10 bg-white/[0.05] text-white/60";
   }
 }
 
@@ -79,12 +93,28 @@ function maskStripeId(value: string | null) {
 export default async function AdminPaymentSubscriptionsPage() {
   await requireAdmin();
 
-  const subscriptions = await listTeamSubscriptionSnapshots();
+  const [subscriptions, setupRows] = await Promise.all([
+    listTeamSubscriptionSnapshots(),
+    prisma.$queryRaw<
+      Array<{ id: string; autoPaySetupCheckoutSessionId: string | null }>
+    >`
+      SELECT "id", "autoPaySetupCheckoutSessionId"
+      FROM "Team"
+      WHERE "autoPaySetupCheckoutSessionId" IS NOT NULL
+    `,
+  ]);
+
+  const setupSessionByTeamId = new Map(
+    setupRows.map((row) => [row.id, row.autoPaySetupCheckoutSessionId]),
+  );
+
   const activeCount = subscriptions.filter((item) =>
     ["active", "trialing"].includes(item.subscriptionStatus ?? ""),
   ).length;
-  const attentionCount = subscriptions.filter((item) =>
-    ["past_due", "unpaid", "incomplete"].includes(item.subscriptionStatus ?? ""),
+  const setupStartedCount = subscriptions.filter(
+    (item) =>
+      !item.subscriptionStatus &&
+      Boolean(setupSessionByTeamId.get(item.id)),
   ).length;
   const failedCount = subscriptions.filter(
     (item) => item.subscriptionLastPaymentFailedAt,
@@ -101,7 +131,7 @@ export default async function AdminPaymentSubscriptionsPage() {
             Recurring subscriptions
           </h1>
           <p className="max-w-3xl text-sm leading-6 text-white/60">
-            Simple Stripe subscription tracking for teams. Successful Stripe renewal invoices are recorded as payment transactions.
+            Stripe-linked teams, including completed subscriptions and teams that have only started setup. Successful Stripe renewal invoices are recorded as payment transactions.
           </p>
         </div>
 
@@ -116,12 +146,12 @@ export default async function AdminPaymentSubscriptionsPage() {
       <section className="grid gap-4 md:grid-cols-4">
         <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/45">
-            Subscriptions
+            Stripe-linked teams
           </div>
           <div className="mt-3 text-3xl font-semibold text-white">
             {subscriptions.length}
           </div>
-          <p className="mt-2 text-sm text-white/50">Teams with Stripe subscription data.</p>
+          <p className="mt-2 text-sm text-white/50">Customer, setup or subscription data exists.</p>
         </div>
 
         <div className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5">
@@ -131,17 +161,17 @@ export default async function AdminPaymentSubscriptionsPage() {
           <div className="mt-3 text-3xl font-semibold text-white">
             {activeCount}
           </div>
-          <p className="mt-2 text-sm text-emerald-100/75">Active or trialling.</p>
+          <p className="mt-2 text-sm text-emerald-100/75">Active or trialling subscriptions.</p>
         </div>
 
         <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-100/70">
-            Needs attention
+            Setup not completed
           </div>
           <div className="mt-3 text-3xl font-semibold text-white">
-            {attentionCount}
+            {setupStartedCount}
           </div>
-          <p className="mt-2 text-sm text-amber-100/75">Past due, unpaid, or incomplete.</p>
+          <p className="mt-2 text-sm text-amber-100/75">Stripe setup was started but no subscription is recorded.</p>
         </div>
 
         <div className="rounded-3xl border border-red-400/20 bg-red-500/10 p-5">
@@ -158,9 +188,9 @@ export default async function AdminPaymentSubscriptionsPage() {
       <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-white">Team subscriptions</h2>
+            <h2 className="text-xl font-semibold text-white">Team Stripe status</h2>
             <p className="mt-1 text-sm text-white/55">
-              Stripe remains the source of truth. This screen shows what SIXFL has recorded from webhooks.
+              A Stripe customer record alone is not an active subscription. “Setup started” means SIXFL recorded a Stripe setup checkout session, but no subscription has been completed.
             </p>
           </div>
         </div>
@@ -168,85 +198,114 @@ export default async function AdminPaymentSubscriptionsPage() {
         <div className="mt-5 space-y-3">
           {subscriptions.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-8 text-sm text-white/55">
-              No recurring subscriptions have been recorded yet.
+              No Stripe-linked teams have been recorded yet.
             </div>
           ) : null}
 
-          {subscriptions.map((item) => (
-            <div key={item.id} className="rounded-2xl border border-white/10 bg-[#0d1428] p-4">
-              <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Link
-                      href={`/admin/teams/${item.id}`}
-                      className="text-base font-semibold text-white transition hover:text-emerald-200"
-                    >
-                      {item.name}
-                    </Link>
-                    <span
-                      className={[
-                        "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]",
-                        getStatusTone(item.subscriptionStatus),
+          {subscriptions.map((item) => {
+            const setupSessionId = setupSessionByTeamId.get(item.id) ?? null;
+            const setupStarted = Boolean(setupSessionId);
+            const hasSubscription = Boolean(item.subscriptionStatus || item.stripeSubscriptionId);
+            const statusLabel = formatStatus({
+              subscriptionStatus: item.subscriptionStatus,
+              setupStarted,
+              hasStripeCustomer: Boolean(item.stripeCustomerId),
+            });
+
+            return (
+              <div key={item.id} className="rounded-2xl border border-white/10 bg-[#0d1428] p-4">
+                <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Link
+                        href={`/admin/teams/${item.id}`}
+                        className="text-base font-semibold text-white transition hover:text-emerald-200"
+                      >
+                        {item.name}
+                      </Link>
+                      <span
+                        className={[
+                          "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]",
+                          getStatusTone({
+                            subscriptionStatus: item.subscriptionStatus,
+                            setupStarted,
+                          }),
+                        ].join(" ")}
+                      >
+                        {statusLabel}
+                      </span>
+                    </div>
+
+                    <div className="mt-1 text-sm text-white/55">
+                      {item.leagueName
+                        ? `${item.leagueName}${item.leagueSeason ? ` · ${item.leagueSeason}` : ""}`
+                        : "No league assigned"}
+                    </div>
+
+                    {!hasSubscription ? (
+                      <div className={[
+                        "mt-3 rounded-xl border px-3 py-2 text-xs leading-5",
+                        setupStarted
+                          ? "border-amber-400/20 bg-amber-500/10 text-amber-100/80"
+                          : "border-white/10 bg-white/[0.03] text-white/50",
                       ].join(" ")}
-                    >
-                      {formatStatus(item.subscriptionStatus)}
-                    </span>
+                      >
+                        {setupStarted
+                          ? "The captain reached the Stripe setup flow, but SIXFL has not recorded a completed subscription."
+                          : "A Stripe customer exists, but there is no recorded autopay setup session or subscription."}
+                      </div>
+                    ) : null}
+
+                    <div className="mt-3 grid gap-2 text-xs text-white/45 sm:grid-cols-2 lg:grid-cols-4">
+                      <div>Customer: {maskStripeId(item.stripeCustomerId)}</div>
+                      <div>Setup session: {maskStripeId(setupSessionId)}</div>
+                      <div>Subscription: {maskStripeId(item.stripeSubscriptionId)}</div>
+                      <div>Price: {maskStripeId(item.subscriptionPriceId)}</div>
+                    </div>
                   </div>
 
-                  <div className="mt-1 text-sm text-white/55">
-                    {item.leagueName
-                      ? `${item.leagueName}${item.leagueSeason ? ` · ${item.leagueSeason}` : ""}`
-                      : "No league assigned"}
-                  </div>
-
-                  <div className="mt-3 grid gap-2 text-xs text-white/45 sm:grid-cols-2 lg:grid-cols-3">
-                    <div>Customer: {maskStripeId(item.stripeCustomerId)}</div>
-                    <div>Subscription: {maskStripeId(item.stripeSubscriptionId)}</div>
-                    <div>Price: {maskStripeId(item.subscriptionPriceId)}</div>
-                  </div>
-                </div>
-
-                <div className="grid gap-3 text-sm text-white/60 sm:grid-cols-2 xl:min-w-[520px] xl:grid-cols-4 xl:text-right">
-                  <div>
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
-                      Next renewal
+                  <div className="grid gap-3 text-sm text-white/60 sm:grid-cols-2 xl:min-w-[520px] xl:grid-cols-4 xl:text-right">
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                        Next renewal
+                      </div>
+                      <div className="mt-1 text-white/80">
+                        {formatDate(item.subscriptionCurrentPeriodEnd)}
+                      </div>
                     </div>
-                    <div className="mt-1 text-white/80">
-                      {formatDate(item.subscriptionCurrentPeriodEnd)}
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                        Last paid
+                      </div>
+                      <div className="mt-1 text-white/80">
+                        {formatDateTime(item.subscriptionLastPaymentAt)}
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
-                      Last paid
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                        Last failed
+                      </div>
+                      <div className={[
+                        "mt-1",
+                        item.subscriptionLastPaymentFailedAt ? "text-red-200" : "text-white/80",
+                      ].join(" ")}
+                      >
+                        {formatDateTime(item.subscriptionLastPaymentFailedAt)}
+                      </div>
                     </div>
-                    <div className="mt-1 text-white/80">
-                      {formatDateTime(item.subscriptionLastPaymentAt)}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
-                      Last failed
-                    </div>
-                    <div className={[
-                      "mt-1",
-                      item.subscriptionLastPaymentFailedAt ? "text-red-200" : "text-white/80",
-                    ].join(" ")}
-                    >
-                      {formatDateTime(item.subscriptionLastPaymentFailedAt)}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
-                      Cancelled
-                    </div>
-                    <div className="mt-1 text-white/80">
-                      {formatDateTime(item.subscriptionCancelledAt)}
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                        Cancelled
+                      </div>
+                      <div className="mt-1 text-white/80">
+                        {formatDateTime(item.subscriptionCancelledAt)}
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
     </div>


### PR DESCRIPTION
Makes the admin subscriptions page distinguish active subscriptions from genuine setup attempts and Stripe-customer-only records. Uses the existing autoPaySetupCheckoutSessionId to label teams as “Setup started — not completed”, shows Stripe customer-only records separately, updates the page summary counts, and adds a short explanation so a cus_ ID is not mistaken for a subscription.