### PR TITLE
Standardise kick-off wording in fixture emails

### DIFF
--- a/prisma/migrations/20260808000500_standardise_fixture_email_kick_off/migration.sql
+++ b/prisma/migrations/20260808000500_standardise_fixture_email_kick_off/migration.sql
@@ -1,0 +1,30 @@
+-- Standardise UK football wording in existing fixture-related email templates.
+-- Keep template variable names such as {{kickoffLabel}} unchanged.
+
+UPDATE "NotificationTemplate"
+SET "body" = REPLACE("body", 'New kickoff:', 'New kick-off:')
+WHERE "key" = 'fixture-change-email';
+
+UPDATE "NotificationTemplate"
+SET "body" = REPLACE("body", 'before kickoff.', 'before kick-off.')
+WHERE "key" = 'fixture-publish-digest-email';
+
+UPDATE "NotificationTemplate"
+SET "body" = REPLACE(
+  REPLACE("body", 'Kickoff: {{kickoffLabel}}', 'Kick-off: {{kickoffLabel}}'),
+  'ready for kickoff.',
+  'ready for kick-off.'
+)
+WHERE "key" = 'fixture-reminder-email';
+
+UPDATE "NotificationTemplate"
+SET "body" = REPLACE(
+  REPLACE("body", 'Kickoff: {{kickoffLabel}}', 'Kick-off: {{kickoffLabel}}'),
+  'after kickoff.',
+  'after kick-off.'
+)
+WHERE "key" = 'match-fee-due-email';
+
+UPDATE "NotificationTemplate"
+SET "body" = REPLACE("body", 'Kickoff: {{kickoffLabel}}', 'Kick-off: {{kickoffLabel}}')
+WHERE "key" = 'match-fee-reminder-email';

--- a/prisma/seed-notifications.ts
+++ b/prisma/seed-notifications.ts
@@ -169,7 +169,7 @@ SIXFL`,
 Please note this fixture has changed.
 
 - Match: {{homeTeam}} vs {{awayTeam}}
-- New kickoff: {{kickoffTime}}
+- New kick-off: {{kickoffTime}}
 - Venue: {{venueName}}
 
 {{cta}}`,
@@ -201,7 +201,7 @@ Your fixtures for {{leagueDisplayName}} are now live.
 
 {{fixturesList}}
 
-You will also receive automatic reminders before kickoff.
+You will also receive automatic reminders before kick-off.
 
 {{cta}}`,
     ctaLabel: "View fixtures",
@@ -211,7 +211,7 @@ You will also receive automatic reminders before kickoff.
   await upsertTemplate({
     key: "fixture-reminder-email",
     name: "Fixture reminder email",
-    description: "Automated reminder email before kickoff.",
+    description: "Automated reminder email before kick-off.",
     kind: NotificationTemplateKind.TRANSACTIONAL,
     channel: NotificationChannel.EMAIL,
     audience: NotificationAudience.TEAM,
@@ -219,9 +219,9 @@ You will also receive automatic reminders before kickoff.
     body: `Hi {{firstName}}
 
 Reminder: {{fixtureName}}
-Kickoff: {{kickoffLabel}}
+Kick-off: {{kickoffLabel}}
 
-Please make sure your team is ready for kickoff.
+Please make sure your team is ready for kick-off.
 
 {{cta}}`,
     ctaLabel: "View fixtures",
@@ -263,10 +263,10 @@ Please make sure your team is ready for kickoff.
 A match fee has been raised for your SIXFL fixture.
 
 Fixture: {{fixtureName}}
-Kickoff: {{kickoffLabel}}
+Kick-off: {{kickoffLabel}}
 Amount due: {{amount}}
 
-Payment is normally settled after the match. If the charge is still unpaid, SIXFL will automatically send reminder emails 24 hours and 72 hours after kickoff.
+Payment is normally settled after the match. If the charge is still unpaid, SIXFL will automatically send reminder emails 24 hours and 72 hours after kick-off.
 
 Use the secure payment link below to review the charge and pay online.
 
@@ -299,7 +299,7 @@ Use the secure payment link below to review the charge and pay online.
 {{reminderIntro}}
 
 Fixture: {{fixtureName}}
-Kickoff: {{kickoffLabel}}
+Kick-off: {{kickoffLabel}}
 
 Please use the secure payment link below to review the charge and pay the outstanding balance.
 

--- a/src/lib/fixtures/confirmation-emails.ts
+++ b/src/lib/fixtures/confirmation-emails.ts
@@ -56,20 +56,20 @@ function getEmailCopy(input: {
   if (input.mode === "auto24h") {
     return {
       subject: `Urgent: confirm ${fixtureLabel}`,
-      body: `Your fixture is now within 24 hours and still needs confirming.\n\nFixture: ${fixtureLabel}\nKickoff: ${kickoffLabel}\n\nPlease confirm now or raise an issue using the button below.`,
+      body: `Your fixture is now within 24 hours and still needs confirming.\n\nFixture: ${fixtureLabel}\nKick-off: ${kickoffLabel}\n\nPlease confirm now or raise an issue using the button below.`,
     };
   }
 
   if (input.mode === "auto72h") {
     return {
       subject: `Reminder: confirm ${fixtureLabel}`,
-      body: `We are still waiting for confirmation of your upcoming fixture.\n\nFixture: ${fixtureLabel}\nKickoff: ${kickoffLabel}\n\nPlease confirm the fixture or raise an issue using the button below.`,
+      body: `We are still waiting for confirmation of your upcoming fixture.\n\nFixture: ${fixtureLabel}\nKick-off: ${kickoffLabel}\n\nPlease confirm the fixture or raise an issue using the button below.`,
     };
   }
 
   return {
     subject: `Please confirm ${fixtureLabel}`,
-    body: `A new SIXFL fixture is live and needs your confirmation.\n\nFixture: ${fixtureLabel}\nKickoff: ${kickoffLabel}\n\nPlease confirm the fixture or raise an issue using the button below.`,
+    body: `A new SIXFL fixture is live and needs your confirmation.\n\nFixture: ${fixtureLabel}\nKick-off: ${kickoffLabel}\n\nPlease confirm the fixture or raise an issue using the button below.`,
   };
 }
 


### PR DESCRIPTION
Changes fixture-related email copy to use UK football wording consistently: “Kick-off” as a noun label and “kick-off” in noun phrases. Updates hard-coded fixture confirmation emails, seed templates, and adds a migration to update existing production NotificationTemplate bodies without altering template variable names such as {{kickoffLabel}}. SMS wording is left unchanged unless it is part of an email template description.