### PR TITLE
Make SIXFL fixtures venue-neutral

### DIFF
--- a/src/app/(admin)/admin/fixtures/generate/division-actions.ts
+++ b/src/app/(admin)/admin/fixtures/generate/division-actions.ts
@@ -18,7 +18,8 @@ import { voidFixtureMatchFeeChargesOrThrow } from "@/lib/payments/fixture-match-
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
-type Pair = { homeId: string; awayId: string };
+type Pair = { team1Id: string; team2Id: string };
+type CountRow = { count: number | bigint };
 
 type TeamSchedulingRule = {
   id: string;
@@ -97,24 +98,24 @@ function getSessionCapacity(input: {
   return { startDateTime, slotCount, gamesPerSession: slotCount * input.pitches };
 }
 
-function isKickoffAllowed(kickoffAt: Date, homeTeam: TeamSchedulingRule, awayTeam: TeamSchedulingRule) {
+function isKickoffAllowed(kickoffAt: Date, team1: TeamSchedulingRule, team2: TeamSchedulingRule) {
   const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);
-  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);
-  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);
+  const team1Latest = parseTimeToMinutes(team1.latestKickoffTime);
+  const team2Latest = parseTimeToMinutes(team2.latestKickoffTime);
 
-  if (homeLatest !== null && kickoffMinutes > homeLatest) {
-    return { allowed: false, reason: `${homeTeam.name} cannot kick off later than ${homeTeam.latestKickoffTime}.` };
+  if (team1Latest !== null && kickoffMinutes > team1Latest) {
+    return { allowed: false, reason: `${team1.name} cannot kick off later than ${team1.latestKickoffTime}.` };
   }
-  if (awayLatest !== null && kickoffMinutes > awayLatest) {
-    return { allowed: false, reason: `${awayTeam.name} cannot kick off later than ${awayTeam.latestKickoffTime}.` };
+  if (team2Latest !== null && kickoffMinutes > team2Latest) {
+    return { allowed: false, reason: `${team2.name} cannot kick off later than ${team2.latestKickoffTime}.` };
   }
   return { allowed: true, reason: null };
 }
 
-function getStandardFixtureFee(homeTeam: TeamSchedulingRule, awayTeam: TeamSchedulingRule) {
-  const homeFee = homeTeam.standardMatchFeePence ?? 0;
-  const awayFee = awayTeam.standardMatchFeePence ?? 0;
-  const highestFee = Math.max(homeFee, awayFee);
+function getStandardFixtureFee(team1: TeamSchedulingRule, team2: TeamSchedulingRule) {
+  const team1Fee = team1.standardMatchFeePence ?? 0;
+  const team2Fee = team2.standardMatchFeePence ?? 0;
+  const highestFee = Math.max(team1Fee, team2Fee);
   return highestFee > 0 ? highestFee : null;
 }
 
@@ -133,8 +134,7 @@ function generateRounds(teamIds: string[]): Pair[][] {
       const a = arr[i];
       const b = arr[n - 1 - i];
       if (!a || !b) continue;
-      const isEvenRound = round % 2 === 0;
-      pairs.push({ homeId: isEvenRound ? a : b, awayId: isEvenRound ? b : a });
+      pairs.push({ team1Id: a, team2Id: b });
     }
     rounds.push(pairs);
     const fixed = arr[0];
@@ -146,23 +146,25 @@ function generateRounds(teamIds: string[]): Pair[][] {
   return rounds;
 }
 
-function mirrorRounds(rounds: Pair[][]): Pair[][] {
-  return rounds.map((pairs) => pairs.map((pair) => ({ homeId: pair.awayId, awayId: pair.homeId })));
+function repeatRounds(rounds: Pair[][]): Pair[][] {
+  return rounds.map((pairs) =>
+    pairs.map((pair) => ({ team1Id: pair.team1Id, team2Id: pair.team2Id })),
+  );
 }
 
 function sortPairsByRestriction(pairs: Pair[], teamMap: Map<string, TeamSchedulingRule>) {
   return [...pairs].sort((a, b) => {
-    const aHome = teamMap.get(a.homeId);
-    const aAway = teamMap.get(a.awayId);
-    const bHome = teamMap.get(b.homeId);
-    const bAway = teamMap.get(b.awayId);
+    const aTeam1 = teamMap.get(a.team1Id);
+    const aTeam2 = teamMap.get(a.team2Id);
+    const bTeam1 = teamMap.get(b.team1Id);
+    const bTeam2 = teamMap.get(b.team2Id);
     const aLimit = Math.min(
-      parseTimeToMinutes(aHome?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
-      parseTimeToMinutes(aAway?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
+      parseTimeToMinutes(aTeam1?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
+      parseTimeToMinutes(aTeam2?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
     );
     const bLimit = Math.min(
-      parseTimeToMinutes(bHome?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
-      parseTimeToMinutes(bAway?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
+      parseTimeToMinutes(bTeam1?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
+      parseTimeToMinutes(bTeam2?.latestKickoffTime ?? null) ?? Number.MAX_SAFE_INTEGER,
     );
     return aLimit - bLimit;
   });
@@ -274,7 +276,7 @@ async function getGenerationTeams(input: { leagueId: string; divisionId: string 
       WHERE lst."leagueId" = ${input.leagueId}
         AND lst."divisionId" = ${input.divisionId}
         AND lst."isActive" = true
-        AND t."leagueId" = ${input.leagueId}
+        AND COALESCE(t."isFixturePlaceholder", false) = false
       ORDER BY t."name" ASC
     `);
   }
@@ -285,7 +287,7 @@ async function getGenerationTeams(input: { leagueId: string; divisionId: string 
     JOIN "Team" t ON t."id" = lst."teamId"
     WHERE lst."leagueId" = ${input.leagueId}
       AND lst."isActive" = true
-      AND t."leagueId" = ${input.leagueId}
+      AND COALESCE(t."isFixturePlaceholder", false) = false
     ORDER BY t."name" ASC
   `);
 }
@@ -346,7 +348,7 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
     pitches,
   });
 
-  const [league, divisionRows, teams, venue, selectedReferees] = await Promise.all([
+  const [league, divisionRows, teams, venue, selectedReferees, activeDivisionRows] = await Promise.all([
     prisma.league.findUnique({ where: { id: leagueId }, select: { id: true, name: true, season: true, slug: true } }),
     divisionId
       ? prisma.$queryRaw<Array<{ id: string; name: string }>>(Prisma.sql`
@@ -354,6 +356,7 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
           FROM "LeagueDivision"
           WHERE "id" = ${divisionId}
             AND "leagueId" = ${leagueId}
+            AND "isActive" = true
           LIMIT 1
         `)
       : Promise.resolve([]),
@@ -363,10 +366,19 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
       where: { id: { in: selectedRefereeIds }, role: "REFEREE" },
       select: { id: true },
     }),
+    prisma.$queryRaw<CountRow[]>(Prisma.sql`
+      SELECT COUNT(*)::int AS "count"
+      FROM "LeagueDivision"
+      WHERE "leagueId" = ${leagueId}
+        AND "isActive" = true
+    `),
   ]);
 
   if (!league) throw new Error("League not found.");
-  if (divisionId && !divisionRows[0]) throw new Error("Selected division was not found for this league.");
+  if (divisionId && !divisionRows[0]) throw new Error("Selected active division was not found for this league.");
+  if (!divisionId && Number(activeDivisionRows[0]?.count ?? 0) > 0) {
+    throw new Error("This league uses active divisions. Choose the exact division to schedule so teams from different divisions cannot be mixed.");
+  }
   if (teams.length < 2) {
     throw new Error(divisionId ? "This division needs at least 2 active teams assigned before generating fixtures. Check the teams are still attached to this season." : "This league needs at least 2 active teams assigned before generating fixtures. Check the teams are still attached to this season.");
   }
@@ -377,14 +389,14 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
   if (invalidRefereeIds.length > 0) throw new Error("One or more selected pitch referees could not be found.");
 
   let rounds = generateRounds(teams.map((team) => team.id));
-  if (doubleRoundRobin) rounds = [...rounds, ...mirrorRounds(rounds)];
+  if (doubleRoundRobin) rounds = [...rounds, ...repeatRounds(rounds)];
 
   const teamMap = new Map<string, TeamSchedulingRule>(teams.map((team) => [team.id, team]));
   const fixturesToCreate: Array<{
     leagueId: string;
     divisionId: string | null;
-    homeTeamId: string;
-    awayTeamId: string;
+    team1Id: string;
+    team2Id: string;
     venueId: string | null;
     refereeId: string | null;
     kickoffAt: Date;
@@ -409,20 +421,20 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
         if (slotIndex >= slotCount) throw new Error("Fixture generation tried to use more slots than the session allows.");
 
         const kickoffAt = addMinutes(sessionBase, slotIndex * slotMinutes);
-        const homeTeam = teamMap.get(pair.homeId);
-        const awayTeam = teamMap.get(pair.awayId);
-        if (!homeTeam || !awayTeam) throw new Error("Fixture generation failed because a team was missing.");
+        const team1 = teamMap.get(pair.team1Id);
+        const team2 = teamMap.get(pair.team2Id);
+        if (!team1 || !team2) throw new Error("Fixture generation failed because a team was missing.");
 
-        const allowed = isKickoffAllowed(kickoffAt, homeTeam, awayTeam);
+        const allowed = isKickoffAllowed(kickoffAt, team1, team2);
         if (!allowed.allowed) {
-          throw new Error(`Unable to generate fixtures. Week ${roundNumber} would place ${homeTeam.name} vs ${awayTeam.name} at ${formatTimeInLondon(kickoffAt)}, but ${allowed.reason}`);
+          throw new Error(`Unable to generate fixtures. Week ${roundNumber} would place ${team1.name} vs ${team2.name} at ${formatTimeInLondon(kickoffAt)}, but ${allowed.reason}`);
         }
 
         fixturesToCreate.push({
           leagueId,
           divisionId,
-          homeTeamId: pair.homeId,
-          awayTeamId: pair.awayId,
+          team1Id: pair.team1Id,
+          team2Id: pair.team2Id,
           venueId,
           refereeId: refereeIdsByPitch[pitchNumber - 1] ?? null,
           kickoffAt,
@@ -430,7 +442,7 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
           position: chunkStart + nightlyIndex + 1,
           pitch: `Pitch ${pitchNumber}`,
           status,
-          matchFeePence: getStandardFixtureFee(homeTeam, awayTeam),
+          matchFeePence: getStandardFixtureFee(team1, team2),
         });
       });
 
@@ -449,8 +461,9 @@ export async function generateDraftFixturesWithDivisionsAction(formData: FormDat
       const created = await tx.fixture.create({
         data: {
           leagueId: fixtureData.leagueId,
-          homeTeamId: fixtureData.homeTeamId,
-          awayTeamId: fixtureData.awayTeamId,
+          // Legacy database column names are technical team slots only.
+          homeTeamId: fixtureData.team1Id,
+          awayTeamId: fixtureData.team2Id,
           venueId: fixtureData.venueId,
           refereeId: fixtureData.refereeId,
           kickoffAt: fixtureData.kickoffAt,

--- a/src/app/(admin)/admin/fixtures/generate/page.tsx
+++ b/src/app/(admin)/admin/fixtures/generate/page.tsx
@@ -314,7 +314,7 @@ export default async function FixtureGeneratorPage({
               <span>
                 <span className="block text-sm font-semibold text-white">Play every opponent twice</span>
                 <span className="mt-1 block text-sm leading-6 text-white/50">
-                  Creates a second set of rounds with the home/away order reversed. Leave unticked if each pairing should happen once.
+                  Creates a second set of meetings so every pairing happens twice. SIXFL has no home/away significance. Leave unticked if each pairing should happen once.
                 </span>
               </span>
             </label>

--- a/src/app/api/admin/fixtures/generate-next-week/route.ts
+++ b/src/app/api/admin/fixtures/generate-next-week/route.ts
@@ -16,8 +16,8 @@ type TeamSeed = {
 };
 
 type Pair = {
-  homeTeamId: string;
-  awayTeamId: string;
+  team1Id: string;
+  team2Id: string;
 };
 
 type FixtureSeed = {
@@ -26,6 +26,8 @@ type FixtureSeed = {
   kickoffAt: Date;
   round: number | null;
 };
+
+type CountRow = { count: number | bigint };
 
 function addDays(value: Date, days: number) {
   const next = new Date(value);
@@ -56,8 +58,6 @@ function chooseFixtures(input: {
 }) {
   const pairCounts = new Map<string, number>();
   const pairLatestRound = new Map<string, number>();
-  const homeCounts = new Map<string, number>();
-  const awayCounts = new Map<string, number>();
   const playedCounts = new Map<string, number>();
   const maxRound = Math.max(
     0,
@@ -72,14 +72,6 @@ function chooseFixtures(input: {
     pairLatestRound.set(
       key,
       Math.max(pairLatestRound.get(key) ?? 0, fixture.round ?? 0),
-    );
-    homeCounts.set(
-      fixture.homeTeamId,
-      (homeCounts.get(fixture.homeTeamId) ?? 0) + 1,
-    );
-    awayCounts.set(
-      fixture.awayTeamId,
-      (awayCounts.get(fixture.awayTeamId) ?? 0) + 1,
     );
     playedCounts.set(
       fixture.homeTeamId,
@@ -154,17 +146,9 @@ function chooseFixtures(input: {
     const opponent = remaining.splice(bestOpponentIndex, 1)[0];
     if (!opponent) break;
 
-    const firstBalance =
-      (homeCounts.get(first.id) ?? 0) - (awayCounts.get(first.id) ?? 0);
-    const opponentBalance =
-      (homeCounts.get(opponent.id) ?? 0) -
-      (awayCounts.get(opponent.id) ?? 0);
-
-    if (firstBalance <= opponentBalance) {
-      pairs.push({ homeTeamId: first.id, awayTeamId: opponent.id });
-    } else {
-      pairs.push({ homeTeamId: opponent.id, awayTeamId: first.id });
-    }
+    // SIXFL fixtures are venue-neutral. These are two technical storage slots,
+    // not sporting home/away roles.
+    pairs.push({ team1Id: first.id, team2Id: opponent.id });
   }
 
   return pairs;
@@ -217,16 +201,20 @@ export async function POST(request: Request) {
       );
     }
 
-    const [league, teams, existingFixtures] = await Promise.all([
+    const [league, teams, existingFixtures, activeDivisionRows] = await Promise.all([
       prisma.league.findUnique({
         where: { id: leagueId },
         select: { id: true, slug: true },
       }),
-      prisma.team.findMany({
-        where: { leagueId },
-        orderBy: { name: "asc" },
-        select: { id: true, name: true },
-      }),
+      prisma.$queryRaw<TeamSeed[]>(Prisma.sql`
+        SELECT t."id", t."name"
+        FROM "LeagueSeasonTeam" lst
+        JOIN "Team" t ON t."id" = lst."teamId"
+        WHERE lst."leagueId" = ${leagueId}
+          AND lst."isActive" = true
+          AND COALESCE(t."isFixturePlaceholder", false) = false
+        ORDER BY t."name" ASC
+      `),
       prisma.fixture.findMany({
         where: { leagueId },
         orderBy: [{ kickoffAt: "asc" }, { position: "asc" }],
@@ -239,6 +227,12 @@ export async function POST(request: Request) {
           pitch: true,
         },
       }),
+      prisma.$queryRaw<CountRow[]>(Prisma.sql`
+        SELECT COUNT(*)::int AS "count"
+        FROM "LeagueDivision"
+        WHERE "leagueId" = ${leagueId}
+          AND "isActive" = true
+      `),
     ]);
 
     if (!league) {
@@ -248,11 +242,22 @@ export async function POST(request: Request) {
       );
     }
 
+    if (Number(activeDivisionRows[0]?.count ?? 0) > 0) {
+      return NextResponse.json(
+        {
+          error:
+            "This league currently has active divisions. The one-week generator is temporarily blocked here so it cannot mix divisions; use the division schedule tool until the Divisions v2 weekly generator is enabled.",
+          requestId,
+        },
+        { status: 409 },
+      );
+    }
+
     if (teams.length < 2) {
       return NextResponse.json(
         {
           error:
-            "This league needs at least two linked teams before fixtures can be generated.",
+            "This league needs at least two active season teams before fixtures can be generated.",
           requestId,
         },
         { status: 400 },
@@ -299,8 +304,9 @@ export async function POST(request: Request) {
 
         return {
           leagueId,
-          homeTeamId: pair.homeTeamId,
-          awayTeamId: pair.awayTeamId,
+          // Legacy database column names are storage slots only.
+          homeTeamId: pair.team1Id,
+          awayTeamId: pair.team2Id,
           venueId,
           kickoffAt: addMinutes(kickoffBase, batch * slotMinutes),
           round,

--- a/src/app/api/admin/fixtures/matchup-grid/route.ts
+++ b/src/app/api/admin/fixtures/matchup-grid/route.ts
@@ -13,9 +13,7 @@ import { requireAdmin } from "@/lib/requireAdmin";
 type MatchupCell = {
   opponentId: string;
   opponentName: string;
-  homeCount: number;
-  awayCount: number;
-  totalCount: number;
+  meetingCount: number;
   latestKickoffAt: string | null;
 };
 
@@ -40,13 +38,8 @@ const COUNTABLE_FIXTURE_STATUSES = [
 ] as const;
 
 function getCellLabel(cell: MatchupCell) {
-  if (cell.totalCount === 0) return "—";
-
-  const parts: string[] = [];
-  if (cell.homeCount > 0) parts.push(`H${cell.homeCount}`);
-  if (cell.awayCount > 0) parts.push(`A${cell.awayCount}`);
-
-  return parts.join(" · ");
+  if (cell.meetingCount === 0) return "—";
+  return `${cell.meetingCount} fixture${cell.meetingCount === 1 ? "" : "s"}`;
 }
 
 function parseVisibility(value: string | null): FixtureVisibilityFilter {
@@ -162,8 +155,8 @@ export async function GET(request: Request) {
       fixtures: [],
       summary: {
         scheduledPairs: 0,
-        oneWayPairs: 0,
-        completedPairs: 0,
+        singleMeetingPairs: 0,
+        twoMeetingPairs: 0,
         missingPairs: 0,
       },
     });
@@ -235,9 +228,7 @@ export async function GET(request: Request) {
     const cell: MatchupCell = {
       opponentId,
       opponentName,
-      homeCount: 0,
-      awayCount: 0,
-      totalCount: 0,
+      meetingCount: 0,
       latestKickoffAt: null,
     };
 
@@ -250,15 +241,15 @@ export async function GET(request: Request) {
     if (!fixture.homeTeamId || !fixture.awayTeamId) continue;
     if (!teamIds.has(fixture.homeTeamId) || !teamIds.has(fixture.awayTeamId)) continue;
 
-    const homeCell = getCell(fixture.homeTeamId, fixture.awayTeamId);
-    homeCell.homeCount += 1;
-    homeCell.totalCount += 1;
-    homeCell.latestKickoffAt = fixture.kickoffAt.toISOString();
+    // homeTeamId/awayTeamId are storage slots only. Each fixture increments the
+    // meeting count for both teams equally; direction has no sporting meaning.
+    const firstCell = getCell(fixture.homeTeamId, fixture.awayTeamId);
+    firstCell.meetingCount += 1;
+    firstCell.latestKickoffAt = fixture.kickoffAt.toISOString();
 
-    const awayCell = getCell(fixture.awayTeamId, fixture.homeTeamId);
-    awayCell.awayCount += 1;
-    awayCell.totalCount += 1;
-    awayCell.latestKickoffAt = fixture.kickoffAt.toISOString();
+    const secondCell = getCell(fixture.awayTeamId, fixture.homeTeamId);
+    secondCell.meetingCount += 1;
+    secondCell.latestKickoffAt = fixture.kickoffAt.toISOString();
   }
 
   const cells = teams.map((team) => ({
@@ -269,9 +260,7 @@ export async function GET(request: Request) {
         return {
           opponentId: opponent.id,
           opponentName: opponent.name,
-          homeCount: 0,
-          awayCount: 0,
-          totalCount: 0,
+          meetingCount: 0,
           latestKickoffAt: null,
           label: "—",
           isSelf: true,
@@ -289,24 +278,20 @@ export async function GET(request: Request) {
   }));
 
   let missingPairs = 0;
-  let oneWayPairs = 0;
-  let completedPairs = 0;
+  let singleMeetingPairs = 0;
+  let twoMeetingPairs = 0;
   let scheduledPairs = 0;
 
   for (let row = 0; row < teams.length; row += 1) {
     for (let col = row + 1; col < teams.length; col += 1) {
       const a = teams[row];
       const b = teams[col];
-      const aCell = getCell(a.id, b.id);
-      const bCell = getCell(b.id, a.id);
-      const total = aCell.totalCount + bCell.totalCount;
-      const hasBothDirections =
-        aCell.homeCount > 0 && aCell.awayCount > 0 && bCell.homeCount > 0 && bCell.awayCount > 0;
+      const meetingCount = getCell(a.id, b.id).meetingCount;
 
-      if (total === 0) missingPairs += 1;
-      else if (hasBothDirections) completedPairs += 1;
-      else oneWayPairs += 1;
-      if (total > 0) scheduledPairs += 1;
+      if (meetingCount === 0) missingPairs += 1;
+      else if (meetingCount === 1) singleMeetingPairs += 1;
+      else twoMeetingPairs += 1;
+      if (meetingCount > 0) scheduledPairs += 1;
     }
   }
 
@@ -396,8 +381,8 @@ export async function GET(request: Request) {
     }),
     summary: {
       scheduledPairs,
-      oneWayPairs,
-      completedPairs,
+      singleMeetingPairs,
+      twoMeetingPairs,
       missingPairs,
     },
   });

--- a/src/components/admin/fixtures/FixtureMatchupGrid.tsx
+++ b/src/components/admin/fixtures/FixtureMatchupGrid.tsx
@@ -21,9 +21,7 @@ type ConfirmationStatus = "PENDING" | "CONFIRMED" | "ISSUE_RAISED" | "OVERDUE" |
 type GridCell = {
   opponentId: string;
   opponentName: string;
-  homeCount: number;
-  awayCount: number;
-  totalCount: number;
+  meetingCount: number;
   latestKickoffAt: string | null;
   label: string;
   isSelf: boolean;
@@ -81,8 +79,8 @@ type MatchupGridData = {
   fixtures: GridFixture[];
   summary: {
     scheduledPairs: number;
-    oneWayPairs: number;
-    completedPairs: number;
+    singleMeetingPairs: number;
+    twoMeetingPairs: number;
     missingPairs: number;
   };
 };
@@ -147,17 +145,17 @@ function buildFixtureEditHref(input: {
 
 function getCellTone(cell: GridCell) {
   if (cell.isSelf) return "border-white/5 bg-white/[0.02] text-white/15";
-  if (cell.totalCount === 0) return "border-red-400/15 bg-red-500/[0.06] text-red-100/70";
-  if (cell.homeCount > 0 && cell.awayCount > 0) return "border-emerald-400/20 bg-emerald-500/10 text-emerald-100";
+  if (cell.meetingCount === 0) return "border-red-400/15 bg-red-500/[0.06] text-red-100/70";
+  if (cell.meetingCount >= 2) return "border-emerald-400/20 bg-emerald-500/10 text-emerald-100";
   return "border-amber-400/20 bg-amber-500/10 text-amber-100";
 }
 
 function getCellHelper(cell: GridCell) {
   if (cell.isSelf) return "";
-  if (cell.totalCount === 0) return "Not scheduled";
-  if (cell.homeCount > 0 && cell.awayCount > 0) return "Both ways";
-  if (cell.homeCount > 0) return "Only as team 1";
-  return "Only as team 2";
+  if (cell.meetingCount === 0) return "Not scheduled";
+  if (cell.meetingCount === 1) return "1 of 2 meetings";
+  if (cell.meetingCount === 2) return "Pair has met twice";
+  return `${cell.meetingCount} meetings scheduled`;
 }
 
 function formatFixtureDate(value: string) {
@@ -465,12 +463,12 @@ export default function FixtureMatchupGrid({
             <div className="mt-2 text-sm font-semibold text-white">{selectedLeague?.name ?? data?.selectedLeagueLabel ?? "—"}</div>
             <div className="mt-1 text-xs text-sky-200/70">{selectedDivision?.name ?? data?.selectedDivisionLabel ?? "All divisions"} · {visibilityLabel(selectedVisibility)} · {statusLabel(selectedStatus)}</div>
           </div>
-          <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4"><div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-100/60">Both ways</div><div className="mt-2 text-2xl font-semibold text-white">{data?.summary.completedPairs ?? 0}</div></div>
-          <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4"><div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-100/60">One way only</div><div className="mt-2 text-2xl font-semibold text-white">{data?.summary.oneWayPairs ?? 0}</div></div>
-          <div className="rounded-2xl border border-red-400/20 bg-red-500/10 p-4"><div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-red-100/60">Missing</div><div className="mt-2 text-2xl font-semibold text-white">{data?.summary.missingPairs ?? 0}</div></div>
+          <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4"><div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-100/60">Met twice or more</div><div className="mt-2 text-2xl font-semibold text-white">{data?.summary.twoMeetingPairs ?? 0}</div></div>
+          <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4"><div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-100/60">Met once</div><div className="mt-2 text-2xl font-semibold text-white">{data?.summary.singleMeetingPairs ?? 0}</div></div>
+          <div className="rounded-2xl border border-red-400/20 bg-red-500/10 p-4"><div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-red-100/60">Not yet met</div><div className="mt-2 text-2xl font-semibold text-white">{data?.summary.missingPairs ?? 0}</div></div>
         </div>
 
-        {selectedStatus !== "active" ? <div className="mt-4 rounded-2xl border border-amber-400/20 bg-amber-500/10 px-4 py-3 text-sm leading-6 text-amber-50/80">Postponed and cancelled fixtures are shown in the fixture cards below, but they do not count as completed matchup coverage in the grid.</div> : null}
+        {selectedStatus !== "active" ? <div className="mt-4 rounded-2xl border border-amber-400/20 bg-amber-500/10 px-4 py-3 text-sm leading-6 text-amber-50/80">Postponed and cancelled fixtures are shown in the fixture cards below, but they do not count as matchup coverage in the grid.</div> : null}
         {isLoading ? <div className="mt-6 rounded-2xl border border-white/10 bg-black/20 p-6 text-sm text-white/55">Loading matchup grid...</div> : null}
         {!isLoading && (!data || data.teams.length === 0) ? <div className="mt-6 rounded-2xl border border-white/10 bg-black/20 p-6 text-sm text-white/55">No teams found for this league/division/filter yet.</div> : null}
 
@@ -492,7 +490,7 @@ export default function FixtureMatchupGrid({
                         <td key={cell.opponentId} className="border-r border-white/10 p-2 align-top">
                           <div className={`min-h-[72px] rounded-2xl border px-3 py-2 ${getCellTone(cell)}`}>
                             <div className="text-sm font-semibold">{cell.label}</div>
-                            {!cell.isSelf ? <><div className="mt-1 text-[11px] opacity-75">{getCellHelper(cell)}</div>{cell.totalCount > 1 ? <div className="mt-1 text-[11px] opacity-70">{cell.totalCount} fixtures</div> : null}</> : null}
+                            {!cell.isSelf ? <div className="mt-1 text-[11px] opacity-75">{getCellHelper(cell)}</div> : null}
                           </div>
                         </td>
                       ))}
@@ -503,8 +501,8 @@ export default function FixtureMatchupGrid({
             </div>
 
             <div className="mt-5 flex flex-wrap gap-2 text-xs text-white/55">
-              <span className="rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-emerald-100">H + A = both directions covered</span>
-              <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-amber-100">Only H or only A = reverse fixture missing</span>
+              <span className="rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-emerald-100">2+ fixtures = pair has met at least twice</span>
+              <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-amber-100">1 fixture = pair has met once</span>
               <span className="rounded-full border border-red-400/20 bg-red-500/10 px-3 py-1 text-red-100">— = teams have not met</span>
             </div>
 
@@ -550,8 +548,8 @@ export default function FixtureMatchupGrid({
                               <div className="mt-4 grid gap-2 text-sm text-white/65 sm:grid-cols-2">
                                 <div className="rounded-2xl border border-white/10 bg-white/[0.035] px-3 py-2"><div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-white/35">Kickoff</div><div className="mt-1 font-medium text-white/80">{formatFixtureDate(fixture.kickoffAt)}</div></div>
                                 <div className="rounded-2xl border border-white/10 bg-white/[0.035] px-3 py-2"><div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-white/35">Venue</div><div className="mt-1 font-medium text-white/80">{fixture.venueName || "No venue"}</div></div>
-                                <FeePanel label="Team 1 fee" teamName={fixture.homeTeamName} amountPence={fixture.homeMatchFeePence} paidPence={fixture.homePaidPence} outstandingPence={fixture.homeOutstandingPence} hasPaymentCharge={fixture.homeHasPaymentCharge} paymentStatus={fixture.homePaymentStatus} tone="emerald" />
-                                <FeePanel label="Team 2 fee" teamName={fixture.awayTeamName} amountPence={fixture.awayMatchFeePence} paidPence={fixture.awayPaidPence} outstandingPence={fixture.awayOutstandingPence} hasPaymentCharge={fixture.awayHasPaymentCharge} paymentStatus={fixture.awayPaymentStatus} tone="sky" />
+                                <FeePanel label="Team fee" teamName={fixture.homeTeamName} amountPence={fixture.homeMatchFeePence} paidPence={fixture.homePaidPence} outstandingPence={fixture.homeOutstandingPence} hasPaymentCharge={fixture.homeHasPaymentCharge} paymentStatus={fixture.homePaymentStatus} tone="emerald" />
+                                <FeePanel label="Team fee" teamName={fixture.awayTeamName} amountPence={fixture.awayMatchFeePence} paidPence={fixture.awayPaidPence} outstandingPence={fixture.awayOutstandingPence} hasPaymentCharge={fixture.awayHasPaymentCharge} paymentStatus={fixture.awayPaymentStatus} tone="sky" />
                               </div>
 
                               {showCaptainConfirmations ? (


### PR DESCRIPTION
Part 1 of #195.

## What changed
- removes home/away direction from the admin matchup grid
- replaces `H1 · A1`, `Both ways` and `reverse fixture missing` with neutral meeting counts
- treats two meetings between a pair as complete regardless of which legacy database slot each team occupied
- changes summary cards to `Met twice or more`, `Met once`, and `Not yet met`
- removes home/away balancing from the normal one-week fixture generator
- rewrites the full-schedule generator around neutral `team1/team2` pairings; playing each opponent twice now means a second meeting, not a reverse fixture
- removes the visible full-schedule wording about reversed home/away order
- keeps `homeTeamId` / `awayTeamId` only as technical database storage slots
- makes both generators take eligible teams from active `LeagueSeasonTeam` membership rather than requiring legacy `Team.leagueId`
- excludes fixture-placeholder/TBC teams from generation
- prevents the full-schedule generator from mixing active divisions when no division is selected
- temporarily blocks the one-week generator if active divisions exist, rather than risk cross-division pairing before the Divisions v2 weekly generator is completed

## Why
SIXFL teams play at the same venue on allocated pitches, so home/away has no sporting meaning. The previous matrix incorrectly treated a pairing as complete only when each team had appeared once in each storage direction, and the generators were still assigning meaning to those directions.

## Safety
- no schema changes
- no existing fixtures or results are rewritten
- stored home/away columns remain unchanged for backwards compatibility
- result score mapping remains untouched
- division schedule generation now requires an explicit active division when active divisions exist

## Next under #195
- make the normal one-week generator properly division-aware using canonical `LeagueSeasonTeam` pools
- remove legacy membership reads/writes and read-time repairs
- migrate remaining captain/public/results wording where home/away leaks through
- add league integrity checks