### PR TITLE
Restore homepage SIXFL TV branding and video links

### DIFF
--- a/src/app/api/public/sixfl-tv/latest/route.ts
+++ b/src/app/api/public/sixfl-tv/latest/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type TvFixtureRow = {
+  id: string;
+  kickoffAt: Date;
+  sixflTvUrl: string | null;
+  homeTeamName: string;
+  awayTeamName: string;
+};
+
+type LatestTvItem = {
+  id: string;
+  fixtureId: string;
+  matchup: string;
+  kickoffAt: string;
+  kind: "Highlights" | "Full match" | "Clip";
+  href: string;
+};
+
+function normaliseHttpUrl(value: string) {
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function parseVideoLinks(value: string | null) {
+  if (!value) return [] as string[];
+
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,]+/)
+        .map((part) => normaliseHttpUrl(part))
+        .filter((part): part is string => Boolean(part)),
+    ),
+  );
+}
+
+export async function GET() {
+  try {
+    const fixtures = await prisma.$queryRaw<TvFixtureRow[]>(Prisma.sql`
+      SELECT
+        f."id",
+        f."kickoffAt",
+        f."sixflTvUrl",
+        home."name" AS "homeTeamName",
+        away."name" AS "awayTeamName"
+      FROM "Fixture" f
+      JOIN "Team" home ON home."id" = f."homeTeamId"
+      JOIN "Team" away ON away."id" = f."awayTeamId"
+      WHERE f."sixflTvUrl" IS NOT NULL
+        AND BTRIM(f."sixflTvUrl") <> ''
+      ORDER BY f."kickoffAt" DESC, f."updatedAt" DESC
+      LIMIT 8
+    `);
+
+    const items: LatestTvItem[] = [];
+
+    for (const fixture of fixtures) {
+      const links = parseVideoLinks(fixture.sixflTvUrl);
+      links.forEach((href, index) => {
+        if (items.length >= 6) return;
+        items.push({
+          id: `${fixture.id}:${index}`,
+          fixtureId: fixture.id,
+          matchup: `${fixture.homeTeamName} vs ${fixture.awayTeamName}`,
+          kickoffAt: fixture.kickoffAt.toISOString(),
+          kind: index === 0 ? "Highlights" : index === 1 ? "Full match" : "Clip",
+          href,
+        });
+      });
+      if (items.length >= 6) break;
+    }
+
+    return NextResponse.json({ items });
+  } catch (error) {
+    console.error("Could not load homepage SIXFL TV links", error);
+    return NextResponse.json({ items: [] });
+  }
+}

--- a/src/components/home/GoalOfWeekHomepageFeature.tsx
+++ b/src/components/home/GoalOfWeekHomepageFeature.tsx
@@ -40,12 +40,21 @@ function ChannelFallback({ channelUrl }: { channelUrl: string }) {
       className="group flex min-h-[330px] w-full flex-col items-center justify-center rounded-3xl border border-white/10 bg-black/70 p-6 transition hover:-translate-y-0.5 hover:border-violet-300/35 hover:bg-black/80 sm:min-h-[390px] sm:p-8"
       aria-label="Open the SIXFL TV YouTube channel"
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src="/logos/you-tube.png"
-        alt="YouTube"
-        className="h-auto w-full max-w-[340px] object-contain sm:max-w-[400px]"
-      />
+      <div className="flex w-full max-w-[360px] items-center justify-center gap-4 rounded-3xl border border-red-400/20 bg-red-500/[0.08] px-6 py-7 shadow-[0_18px_55px_rgba(239,68,68,0.12)]">
+        <div className="flex h-16 w-24 shrink-0 items-center justify-center rounded-2xl bg-red-600 shadow-[0_12px_34px_rgba(220,38,38,0.3)]">
+          <svg
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            className="h-9 w-9 fill-white"
+          >
+            <path d="M8 5.5v13l10-6.5-10-6.5Z" />
+          </svg>
+        </div>
+        <div className="text-left">
+          <div className="text-2xl font-black tracking-tight text-white sm:text-3xl">YouTube</div>
+          <div className="mt-1 text-[11px] font-bold uppercase tracking-[0.18em] text-white/45">SIXFL TV</div>
+        </div>
+      </div>
       <div className="mt-8 flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.2em] text-white/55 transition group-hover:text-white/75">
         <span>Watch on YouTube</span>
         <span aria-hidden="true">↗</span>

--- a/src/components/home/HomepageAiPredictorCopyBridge.tsx
+++ b/src/components/home/HomepageAiPredictorCopyBridge.tsx
@@ -7,6 +7,8 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 
+import predictorLogo from "../../../public/logos/sixfl-ai-predictor.png";
+
 const COPY_REPLACEMENTS = new Map([
   ["Sample prediction", "Match prediction"],
   [
@@ -36,7 +38,7 @@ function addPredictorLogo(predictorSection: HTMLElement) {
     "relative -mt-2 h-32 w-full max-w-xl overflow-hidden rounded-2xl border border-emerald-400/20 bg-black/70 shadow-[0_18px_55px_rgba(0,0,0,0.35)] sm:h-40";
 
   const logo = document.createElement("img");
-  logo.src = "/logos/sixfl-ai-predictor.png";
+  logo.src = predictorLogo.src;
   logo.alt = "SIXFL AI Predictor";
   logo.className = "h-full w-full object-cover object-[center_58%]";
   logo.loading = "eager";

--- a/src/components/home/HomepageSixflTvLatestLinks.tsx
+++ b/src/components/home/HomepageSixflTvLatestLinks.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type LatestTvItem = {
+  id: string;
+  fixtureId: string;
+  matchup: string;
+  kickoffAt: string;
+  kind: "Highlights" | "Full match" | "Clip";
+  href: string;
+};
+
+type LatestTvResponse = {
+  items?: LatestTvItem[];
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    timeZone: "Europe/London",
+  }).format(new Date(value));
+}
+
+export default function HomepageSixflTvLatestLinks() {
+  const [items, setItems] = useState<LatestTvItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch("/api/public/sixfl-tv/latest", {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload: LatestTvResponse | null) => {
+        setItems(payload?.items ?? []);
+      })
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        console.error("Could not load latest SIXFL TV links", error);
+      })
+      .finally(() => setLoaded(true));
+
+    return () => controller.abort();
+  }, []);
+
+  if (!loaded || items.length === 0) return null;
+
+  return (
+    <div className="mt-7 border-t border-white/10 pt-6">
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <div className="text-[10px] font-black uppercase tracking-[0.22em] text-fuchsia-200/70">
+            Latest on SIXFL TV
+          </div>
+          <div className="mt-1 text-sm text-white/50">
+            Highlights and recorded matches already uploaded.
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2">
+        {items.map((item) => (
+          <a
+            key={item.id}
+            href={item.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group rounded-2xl border border-white/10 bg-black/30 p-3.5 transition hover:border-fuchsia-300/30 hover:bg-white/[0.06]"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="rounded-full border border-fuchsia-300/20 bg-fuchsia-400/10 px-2.5 py-1 text-[9px] font-black uppercase tracking-[0.15em] text-fuchsia-100">
+                {item.kind}
+              </span>
+              <span className="text-[10px] font-semibold text-white/35">
+                {formatDate(item.kickoffAt)} ↗
+              </span>
+            </div>
+            <div className="mt-2 line-clamp-2 text-sm font-bold leading-5 text-white/80 transition group-hover:text-white">
+              {item.matchup}
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/SixflTvHomepageSection.tsx
+++ b/src/components/home/SixflTvHomepageSection.tsx
@@ -2,6 +2,12 @@
 // File: src/components/home/SixflTvHomepageSection.tsx
 // ========================================
 
+import Image from "next/image";
+
+import GoalOfWeekHomepageFeature from "@/components/home/GoalOfWeekHomepageFeature";
+import HomepageSixflTvLatestLinks from "@/components/home/HomepageSixflTvLatestLinks";
+import sixflTvLogo from "../../../public/Sixfl-tv.png";
+
 const SIXFL_TV_CHANNEL_URL =
   "https://youtube.com/@sixfl?si=it2uNcdU3fHIf094";
 
@@ -15,25 +21,8 @@ export default function SixflTvHomepageSection() {
           <div className="absolute right-[7.4rem] top-1/2 h-16 w-16 -translate-y-1/2 rounded-full bg-white/10" />
         </div>
 
-        <div className="relative grid gap-8 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] lg:items-center">
-          <a
-            href={SIXFL_TV_CHANNEL_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group flex min-h-[330px] w-full flex-col items-center justify-center rounded-3xl border border-white/10 bg-black/70 p-6 transition hover:-translate-y-0.5 hover:border-violet-300/35 hover:bg-black/80 sm:min-h-[390px] sm:p-8"
-            aria-label="Open the SIXFL TV YouTube channel"
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="/logos/you-tube.png"
-              alt="YouTube"
-              className="h-auto w-full max-w-[340px] object-contain sm:max-w-[400px]"
-            />
-            <div className="mt-8 flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.2em] text-white/55 transition group-hover:text-white/75">
-              <span>Watch on YouTube</span>
-              <span aria-hidden="true">↗</span>
-            </div>
-          </a>
+        <div className="relative grid gap-8 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] lg:items-start">
+          <GoalOfWeekHomepageFeature channelUrl={SIXFL_TV_CHANNEL_URL} />
 
           <div>
             <a
@@ -43,11 +32,11 @@ export default function SixflTvHomepageSection() {
               className="inline-flex transition hover:scale-[1.02] hover:opacity-90"
               aria-label="Open SIXFL TV on YouTube"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src="/Sixfl-tv.png"
+              <Image
+                src={sixflTvLogo}
                 alt="SIXFL TV"
                 className="h-auto w-full max-w-[330px] object-contain drop-shadow-[0_14px_34px_rgba(0,0,0,0.45)] sm:max-w-[400px]"
+                sizes="(max-width: 640px) 330px, 400px"
               />
             </a>
 
@@ -58,14 +47,15 @@ export default function SixflTvHomepageSection() {
               id="sixfl-tv-heading"
               className="mt-5 text-3xl font-black tracking-tight text-white sm:text-4xl"
             >
-              Watch SIXFL matches, highlights and goals.
+              Watch the Goal of the Week and every SIXFL highlight.
             </h2>
             <p className="mt-4 max-w-2xl text-sm leading-7 text-white/68 sm:text-base">
-              Selected SIXFL fixtures are recorded and uploaded to SIXFL TV, giving teams and players the chance to watch matches back, relive the best goals and share matchday highlights.
+              See the latest Goal of the Week, then open uploaded highlights, full matches and matchday moments from across SIXFL.
             </p>
 
             <div className="mt-6 flex flex-wrap gap-2">
               {[
+                "Goal of the Week",
                 "Recorded matches",
                 "Highlights and goals",
                 "Matchday moments",
@@ -88,6 +78,8 @@ export default function SixflTvHomepageSection() {
               WATCH SIXFL TV
               <span aria-hidden="true">↗</span>
             </a>
+
+            <HomepageSixflTvLatestLinks />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Fixes the homepage regression

The live homepage was showing broken SIXFL TV / YouTube / AI Predictor branding and had lost the individual SIXFL TV highlight/full-match links.

### What changed
- makes Goal of the Week a normal part of `SixflTvHomepageSection` instead of relying on the build patch to insert it
- replaces the broken YouTube PNG fallback with a self-contained YouTube/SIXFL TV mark, so it cannot render as a broken image
- bundles the official SIXFL TV logo through Next rather than relying on a handwritten `/Sixfl-tv.png` runtime URL
- bundles the AI Predictor logo through Next rather than assigning `/logos/sixfl-ai-predictor.png` directly at runtime
- adds `/api/public/sixfl-tv/latest`, using the existing raw SIXFL TV fixture fields
- restores up to six recent homepage links labelled Highlights, Full match or Clip
- validates public video URLs before returning them

### Why the links disappeared
The current homepage TV component only contained the generic channel CTA. The Goal of the Week build patch replaced the left card but did not provide the old/latest highlights list, so the individual media links were no longer represented in the component at all.

### Safety
- no fixture/result/player data is changed
- no SIXFL TV URLs are rewritten
- this only reads existing `sixflTvUrl` values
- no new DOM bridge is added
- existing homepage placement bridge is left untouched in this urgent regression fix; it can be removed separately when the homepage structure is migrated natively
