### PR TITLE
Hide current and past week-off notices from fixture planning

### DIFF
--- a/src/app/(admin)/admin/team-unavailability/page.tsx
+++ b/src/app/(admin)/admin/team-unavailability/page.tsx
@@ -50,7 +50,8 @@ function statusCopy(status: "CLEAR" | "DRAFT_CONFLICT" | "PUBLISHED_CONFLICT") {
 export default async function AdminTeamUnavailabilityPage() {
   await requireAdmin();
 
-  const from = getCurrentWeekStart();
+  // This planning list starts next Monday so completed/current weeks disappear.
+  const from = addWeeks(getCurrentWeekStart(), 1);
   const to = addWeeks(from, 20);
   const notices = await getTeamWeekUnavailabilityOverview({ from, to });
 

--- a/src/app/api/admin/team-week-unavailability/route.ts
+++ b/src/app/api/admin/team-week-unavailability/route.ts
@@ -17,7 +17,8 @@ export const revalidate = 0;
 export async function GET() {
   await requireAdmin();
 
-  const from = getCurrentWeekStart();
+  // Keep the API aligned with fixture planning: return complete future weeks only.
+  const from = addWeeks(getCurrentWeekStart(), 1);
   const to = addWeeks(from, 20);
   const notices = await getTeamWeekUnavailabilityOverview({ from, to });
 

--- a/src/components/admin/fixtures/AdminFixtureUnavailabilitySummary.tsx
+++ b/src/components/admin/fixtures/AdminFixtureUnavailabilitySummary.tsx
@@ -28,7 +28,8 @@ function statusCopy(status: "CLEAR" | "DRAFT_CONFLICT" | "PUBLISHED_CONFLICT") {
 }
 
 export default async function AdminFixtureUnavailabilitySummary() {
-  const from = getCurrentWeekStart();
+  // Fixture planning is for complete upcoming weeks, so start from next Monday.
+  const from = addWeeks(getCurrentWeekStart(), 1);
   const to = addWeeks(from, 20);
   const notices = await getTeamWeekUnavailabilityOverview({ from, to });
   const draftConflicts = notices.filter(


### PR DESCRIPTION
## What changed

- starts the fixture-generator unavailability summary from next Monday
- applies the same future-only window to the full admin unavailability page
- keeps the admin unavailability API aligned with those views

## Result

The completed/current Monday-to-Sunday week no longer remains in the planning list. For example, once the week of 3–9 August is underway, the list begins with Monday 10 August.

Stored records are retained for history; they are simply excluded from future fixture-planning views.

## Safety

- three small query-window changes only
- no database deletion or migration
- no form or captain submission logic changed
- no DOM bridge or build-time patch added