### PR TITLE
Promote Goal of the Week on player and captain dashboards

### DIFF
--- a/prisma/migrations/20260808232000_goal_of_week_launch_email_template/migration.sql
+++ b/prisma/migrations/20260808232000_goal_of_week_launch_email_template/migration.sql
@@ -1,0 +1,46 @@
+-- ========================================
+-- Migration: editable Goal of the Week launch email template
+-- ========================================
+
+INSERT INTO "EmailTemplate" (
+  "id",
+  "key",
+  "name",
+  "description",
+  "audience",
+  "interestType",
+  "subject",
+  "body",
+  "ctaLabel",
+  "ctaUrlKey",
+  "isActive",
+  "createdAt",
+  "updatedAt"
+) VALUES (
+  'goal-of-week-player-vote-launch',
+  'goal-of-week-player-vote-launch',
+  'Goal of the Week — player voting launch',
+  'Launch email to current SIXFL players and captains explaining Goal of the Week nominations and the weekly player vote. Edit this template before sending from SIXFL TV admin.',
+  'PLAYER',
+  'PLAYER',
+  'Goal of the Week is now yours to decide ⚽',
+  $body$Hi {{firstName}},
+
+SIXFL Goal of the Week is changing — the players now choose it.
+
+After a recorded SIXFL TV match, players and captains can nominate the goals they think deserve to be in the running. If more than one person picks the same goal, those nominations are combined.
+
+The six most-nominated goals go into the following week's ballot. Every verified SIXFL player and captain gets one vote, and you can change your choice until voting closes.
+
+You will now see a Goal of the Week card on your SIXFL dashboard whenever there is something to nominate or a vote is open.
+
+{{cta}}
+
+So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.$body$,
+  'Open my SIXFL dashboard',
+  'captainDashboardUrl',
+  true,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+)
+ON CONFLICT ("key") DO NOTHING;

--- a/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/actions.ts
+++ b/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/actions.ts
@@ -1,0 +1,171 @@
+"use server";
+
+import {
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+} from "@prisma/client";
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { queueDirectNotification } from "@/lib/notifications/service";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { getPublicSiteUrl } from "@/lib/stripe/client";
+
+const CAMPAIGN_KEY = "goal-of-week-player-vote-launch-2026-08";
+
+export type GoalOfWeekAnnouncementRecipient = {
+  userId: string;
+  email: string;
+  name: string | null;
+};
+
+export async function getGoalOfWeekAnnouncementRecipients() {
+  const rows = await prisma.$queryRaw<GoalOfWeekAnnouncementRecipient[]>`
+    SELECT DISTINCT
+      users."id" AS "userId",
+      users."email" AS "email",
+      users."name" AS "name"
+    FROM "User" users
+    WHERE users."email" IS NOT NULL
+      AND TRIM(users."email") <> ''
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM "TeamMember" membership
+          INNER JOIN "LeagueSeasonTeam" season_team
+            ON season_team."teamId" = membership."teamId"
+           AND season_team."isActive" = TRUE
+          WHERE membership."userId" = users."id"
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM "Team" team
+          INNER JOIN "LeagueSeasonTeam" season_team
+            ON season_team."teamId" = team."id"
+           AND season_team."isActive" = TRUE
+          WHERE team."captainUserId" = users."id"
+        )
+      )
+    ORDER BY users."email" ASC
+  `;
+
+  return rows.map((row) => ({
+    ...row,
+    email: row.email.trim().toLowerCase(),
+  }));
+}
+
+function firstName(value: string | null) {
+  return value?.trim().split(/\s+/)[0]?.trim() || "there";
+}
+
+export async function sendGoalOfWeekLaunchAnnouncementAction() {
+  const admin = await requireAdmin();
+  const recipients = await getGoalOfWeekAnnouncementRecipients();
+  const dashboardUrl = `${getPublicSiteUrl()}/dashboard`;
+
+  let queued = 0;
+  let skipped = 0;
+  let alreadyQueued = 0;
+  let failed = 0;
+
+  for (const person of recipients) {
+    try {
+      const existingRecipient = await prisma.notificationRecipient.findFirst({
+        where: {
+          sourceType: NotificationRecipientSourceType.USER,
+          sourceId: person.userId,
+        },
+        include: { preferences: true },
+      });
+
+      const recipient = await upsertNotificationRecipient({
+        sourceType: NotificationRecipientSourceType.USER,
+        sourceId: person.userId,
+        audience: NotificationAudience.USER,
+        displayName: person.name,
+        email: person.email,
+        marketingEmailOptIn: existingRecipient?.marketingEmailOptIn ?? false,
+        marketingSmsOptIn: existingRecipient?.marketingSmsOptIn ?? false,
+        transactionalEmailOptIn: existingRecipient?.transactionalEmailOptIn ?? true,
+        transactionalSmsOptIn: existingRecipient?.transactionalSmsOptIn ?? true,
+        metadata: {
+          ...(existingRecipient?.metadata && typeof existingRecipient.metadata === "object" && !Array.isArray(existingRecipient.metadata)
+            ? existingRecipient.metadata
+            : {}),
+          goalOfWeekLaunchAudience: true,
+        },
+      });
+
+      const duplicate = await prisma.notificationDispatch.findFirst({
+        where: {
+          recipientId: recipient.id,
+          sourceType: "GOAL_OF_WEEK",
+          sourceId: CAMPAIGN_KEY,
+        },
+        select: { id: true },
+      });
+
+      if (duplicate) {
+        alreadyQueued += 1;
+        continue;
+      }
+
+      const dispatch = await queueDirectNotification({
+        recipientId: recipient.id,
+        channel: NotificationChannel.EMAIL,
+        audience: NotificationAudience.USER,
+        subject: "Goal of the Week is now yours to decide ⚽",
+        body: [
+          "Hi {{firstName}},",
+          "",
+          "SIXFL Goal of the Week is changing — the players now choose it.",
+          "",
+          "After a recorded SIXFL TV match, players and captains can nominate the goals they think deserve to be in the running. If more than one person picks the same goal, those nominations are combined.",
+          "",
+          "The six most-nominated goals go into the following week's ballot. Every verified SIXFL player and captain gets one vote, and you can change your choice until voting closes.",
+          "",
+          "You will now see a Goal of the Week card on your SIXFL dashboard whenever there is something to nominate or a vote is open.",
+          "",
+          "{{cta}}",
+          "",
+          "So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.",
+        ].join("\n"),
+        variables: {
+          firstName: firstName(person.name),
+        },
+        emailCta: {
+          label: "Open my SIXFL dashboard",
+          url: dashboardUrl,
+        },
+        isTransactional: true,
+        sourceType: "GOAL_OF_WEEK",
+        sourceId: CAMPAIGN_KEY,
+        metadata: {
+          purpose: "Goal of the Week player-vote launch",
+          campaignKey: CAMPAIGN_KEY,
+          userId: person.userId,
+        },
+        createdByUserId: admin.user?.id ?? null,
+      });
+
+      if (dispatch.status === "SKIPPED" || dispatch.status === "CANCELLED") {
+        skipped += 1;
+      } else {
+        queued += 1;
+      }
+    } catch (error) {
+      console.error("Goal of the Week launch announcement failed", {
+        userId: person.userId,
+        error,
+      });
+      failed += 1;
+    }
+  }
+
+  redirect(
+    `/admin/sixfl-tv/goal-of-week/announcement?sent=1&queued=${queued}&skipped=${skipped}&already=${alreadyQueued}&failed=${failed}`,
+  );
+}

--- a/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/actions.ts
+++ b/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/actions.ts
@@ -14,12 +14,31 @@ import { requireAdmin } from "@/lib/requireAdmin";
 import { getPublicSiteUrl } from "@/lib/stripe/client";
 
 const CAMPAIGN_KEY = "goal-of-week-player-vote-launch-2026-08";
+export const GOAL_OF_WEEK_LAUNCH_TEMPLATE_KEY = "goal-of-week-player-vote-launch";
 
 export type GoalOfWeekAnnouncementRecipient = {
   userId: string;
   email: string;
   name: string | null;
 };
+
+export async function getGoalOfWeekLaunchTemplate() {
+  return prisma.emailTemplate.findUnique({
+    where: { key: GOAL_OF_WEEK_LAUNCH_TEMPLATE_KEY },
+    select: {
+      id: true,
+      key: true,
+      name: true,
+      description: true,
+      subject: true,
+      body: true,
+      ctaLabel: true,
+      ctaUrlKey: true,
+      isActive: true,
+      updatedAt: true,
+    },
+  });
+}
 
 export async function getGoalOfWeekAnnouncementRecipients() {
   const rows = await prisma.$queryRaw<GoalOfWeekAnnouncementRecipient[]>`
@@ -63,7 +82,19 @@ function firstName(value: string | null) {
 
 export async function sendGoalOfWeekLaunchAnnouncementAction() {
   const admin = await requireAdmin();
-  const recipients = await getGoalOfWeekAnnouncementRecipients();
+  const [recipients, template] = await Promise.all([
+    getGoalOfWeekAnnouncementRecipients(),
+    getGoalOfWeekLaunchTemplate(),
+  ]);
+
+  if (!template) {
+    redirect("/admin/sixfl-tv/goal-of-week/announcement?template=missing");
+  }
+
+  if (!template.isActive) {
+    redirect("/admin/sixfl-tv/goal-of-week/announcement?template=inactive");
+  }
+
   const dashboardUrl = `${getPublicSiteUrl()}/dashboard`;
 
   let queued = 0;
@@ -92,7 +123,9 @@ export async function sendGoalOfWeekLaunchAnnouncementAction() {
         transactionalEmailOptIn: existingRecipient?.transactionalEmailOptIn ?? true,
         transactionalSmsOptIn: existingRecipient?.transactionalSmsOptIn ?? true,
         metadata: {
-          ...(existingRecipient?.metadata && typeof existingRecipient.metadata === "object" && !Array.isArray(existingRecipient.metadata)
+          ...(existingRecipient?.metadata &&
+          typeof existingRecipient.metadata === "object" &&
+          !Array.isArray(existingRecipient.metadata)
             ? existingRecipient.metadata
             : {}),
           goalOfWeekLaunchAudience: true,
@@ -117,35 +150,26 @@ export async function sendGoalOfWeekLaunchAnnouncementAction() {
         recipientId: recipient.id,
         channel: NotificationChannel.EMAIL,
         audience: NotificationAudience.USER,
-        subject: "Goal of the Week is now yours to decide ⚽",
-        body: [
-          "Hi {{firstName}},",
-          "",
-          "SIXFL Goal of the Week is changing — the players now choose it.",
-          "",
-          "After a recorded SIXFL TV match, players and captains can nominate the goals they think deserve to be in the running. If more than one person picks the same goal, those nominations are combined.",
-          "",
-          "The six most-nominated goals go into the following week's ballot. Every verified SIXFL player and captain gets one vote, and you can change your choice until voting closes.",
-          "",
-          "You will now see a Goal of the Week card on your SIXFL dashboard whenever there is something to nominate or a vote is open.",
-          "",
-          "{{cta}}",
-          "",
-          "So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.",
-        ].join("\n"),
+        subject: template.subject,
+        body: template.body,
         variables: {
           firstName: firstName(person.name),
+          captainDashboardUrl: dashboardUrl,
         },
-        emailCta: {
-          label: "Open my SIXFL dashboard",
-          url: dashboardUrl,
-        },
+        emailCta: template.ctaLabel
+          ? {
+              label: template.ctaLabel,
+              url: dashboardUrl,
+            }
+          : undefined,
         isTransactional: true,
         sourceType: "GOAL_OF_WEEK",
         sourceId: CAMPAIGN_KEY,
         metadata: {
           purpose: "Goal of the Week player-vote launch",
           campaignKey: CAMPAIGN_KEY,
+          emailTemplateKey: template.key,
+          emailTemplateId: template.id,
           userId: person.userId,
         },
         createdByUserId: admin.user?.id ?? null,

--- a/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/page.tsx
+++ b/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/page.tsx
@@ -3,12 +3,24 @@ import Link from "next/link";
 import { requireAdmin } from "@/lib/requireAdmin";
 import {
   getGoalOfWeekAnnouncementRecipients,
+  getGoalOfWeekLaunchTemplate,
   sendGoalOfWeekLaunchAnnouncementAction,
 } from "./actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 export const metadata = { title: "Goal of the Week announcement | SIXFL Admin" };
+
+function previewTemplateBody(body: string, ctaLabel: string | null) {
+  return body
+    .replaceAll("{{firstName}}", "[first name]")
+    .replaceAll(
+      "{{cta}}",
+      ctaLabel ? `[BUTTON: ${ctaLabel}]` : "",
+    )
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 
 export default async function GoalOfWeekAnnouncementPage({
   searchParams,
@@ -19,12 +31,17 @@ export default async function GoalOfWeekAnnouncementPage({
     skipped?: string;
     already?: string;
     failed?: string;
+    template?: string;
   }>;
 }) {
   await requireAdmin();
-  const recipients = await getGoalOfWeekAnnouncementRecipients();
+  const [recipients, template] = await Promise.all([
+    getGoalOfWeekAnnouncementRecipients(),
+    getGoalOfWeekLaunchTemplate(),
+  ]);
   const sp = (await searchParams) ?? {};
   const hasResult = sp.sent === "1";
+  const canSend = Boolean(template?.isActive && recipients.length > 0);
 
   return (
     <div className="mx-auto max-w-5xl space-y-6">
@@ -78,48 +95,81 @@ export default async function GoalOfWeekAnnouncementPage({
         </section>
       ) : null}
 
+      {sp.template === "missing" || !template ? (
+        <section className="rounded-3xl border border-red-400/25 bg-red-500/10 p-5 text-red-100">
+          The Goal of the Week launch email template is missing. Wait for the database migration to deploy before sending.
+        </section>
+      ) : null}
+
+      {sp.template === "inactive" || (template && !template.isActive) ? (
+        <section className="rounded-3xl border border-amber-400/25 bg-amber-500/10 p-5 text-amber-100">
+          The Goal of the Week launch email template is inactive. Open the template, amend it if needed, and switch it back on before sending.
+        </section>
+      ) : null}
+
       <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 lg:p-8">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <p className="text-[11px] font-black uppercase tracking-[0.18em] text-fuchsia-200/70">Email preview</p>
-            <h2 className="mt-2 text-2xl font-black text-white">Goal of the Week is now yours to decide ⚽</h2>
+            <p className="text-[11px] font-black uppercase tracking-[0.18em] text-fuchsia-200/70">Editable email template</p>
+            <h2 className="mt-2 text-2xl font-black text-white">
+              {template?.subject ?? "Goal of the Week launch email"}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-white/50">
+              The preview below is read from the saved Admin template. Amend the subject, wording or button there and this page will use the new version automatically.
+            </p>
           </div>
-          <span className="rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
-            SIXFL service update
-          </span>
+
+          {template ? (
+            <Link
+              href={`/admin/templates/${template.id}`}
+              className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-2xl border border-fuchsia-300/30 bg-fuchsia-500/10 px-4 py-2.5 text-sm font-black text-fuchsia-100 transition hover:bg-fuchsia-500/15"
+            >
+              Edit email template
+            </Link>
+          ) : (
+            <Link
+              href="/admin/templates?type=campaign&channel=EMAIL"
+              className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-semibold text-white/70"
+            >
+              Open templates
+            </Link>
+          )}
         </div>
 
-        <div className="mt-6 space-y-4 rounded-2xl border border-white/10 bg-black/25 p-5 text-sm leading-6 text-white/70">
-          <p>Hi [first name],</p>
-          <p><strong className="text-white">SIXFL Goal of the Week is changing — the players now choose it.</strong></p>
-          <p>
-            After a recorded SIXFL TV match, players and captains can nominate the goals they think deserve to be in the running. If more than one person picks the same goal, those nominations are combined.
-          </p>
-          <p>
-            The six most-nominated goals go into the following week's ballot. Every verified SIXFL player and captain gets one vote, and you can change your choice until voting closes.
-          </p>
-          <p>
-            You will now see a Goal of the Week card on your SIXFL dashboard whenever there is something to nominate or a vote is open.
-          </p>
-          <div className="inline-flex rounded-xl bg-fuchsia-300 px-4 py-2.5 font-black text-black">
-            Open my SIXFL dashboard
-          </div>
-          <p>
-            So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.
-          </p>
-        </div>
+        {template ? (
+          <>
+            <div className="mt-5 flex flex-wrap gap-2 text-xs">
+              <span className={`rounded-full border px-3 py-1 ${template.isActive ? "border-emerald-400/20 bg-emerald-500/10 text-emerald-100" : "border-amber-400/20 bg-amber-500/10 text-amber-100"}`}>
+                {template.isActive ? "Active template" : "Inactive template"}
+              </span>
+              <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-white/50">
+                Template: {template.name}
+              </span>
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-white/10 bg-black/25 p-5 text-sm leading-6 text-white/70">
+              <div className="mb-4 border-b border-white/10 pb-4">
+                <span className="text-[10px] font-black uppercase tracking-[0.16em] text-white/35">Subject</span>
+                <div className="mt-1 font-semibold text-white">{template.subject}</div>
+              </div>
+              <div className="whitespace-pre-wrap">
+                {previewTemplateBody(template.body, template.ctaLabel)}
+              </div>
+            </div>
+          </>
+        ) : null}
       </section>
 
       <section className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.08] p-6">
         <h2 className="text-xl font-black text-white">Ready to send?</h2>
         <p className="mt-2 max-w-3xl text-sm leading-6 text-amber-50/70">
-          This is a league-service announcement to current players and captains. It is queued through SIXFL's normal notification system rather than sent directly from this browser.
+          Edit and save the template first. When you return here, check this preview again. The send action reads the latest saved template at the moment you press the button.
         </p>
 
         <form action={sendGoalOfWeekLaunchAnnouncementAction} className="mt-5">
           <button
             type="submit"
-            disabled={recipients.length === 0}
+            disabled={!canSend}
             className="inline-flex min-h-12 items-center justify-center rounded-2xl bg-fuchsia-300 px-6 py-3 text-sm font-black text-black transition hover:bg-fuchsia-200 disabled:cursor-not-allowed disabled:opacity-50"
           >
             Queue announcement to {recipients.length} people

--- a/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/page.tsx
+++ b/src/app/(admin)/admin/sixfl-tv/goal-of-week/announcement/page.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+
+import { requireAdmin } from "@/lib/requireAdmin";
+import {
+  getGoalOfWeekAnnouncementRecipients,
+  sendGoalOfWeekLaunchAnnouncementAction,
+} from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata = { title: "Goal of the Week announcement | SIXFL Admin" };
+
+export default async function GoalOfWeekAnnouncementPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{
+    sent?: string;
+    queued?: string;
+    skipped?: string;
+    already?: string;
+    failed?: string;
+  }>;
+}) {
+  await requireAdmin();
+  const recipients = await getGoalOfWeekAnnouncementRecipients();
+  const sp = (await searchParams) ?? {};
+  const hasResult = sp.sent === "1";
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Link
+          href="/admin/sixfl-tv/goal-of-week"
+          className="text-sm font-semibold text-fuchsia-200 hover:text-fuchsia-100"
+        >
+          ← Back to Goal of the Week
+        </Link>
+        <Link
+          href="/admin/sixfl-tv"
+          className="text-sm text-white/55 hover:text-white"
+        >
+          SIXFL TV admin
+        </Link>
+      </div>
+
+      <section className="rounded-3xl border border-fuchsia-400/25 bg-[radial-gradient(circle_at_top_right,rgba(217,70,239,0.18),transparent_38%),rgba(255,255,255,0.04)] p-6 lg:p-8">
+        <p className="text-[11px] font-black uppercase tracking-[0.2em] text-fuchsia-100/70">
+          Goal of the Week launch
+        </p>
+        <h1 className="mt-2 text-3xl font-black text-white">
+          Announce player nominations & voting
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">
+          This queues one SIXFL-branded email to each distinct active player or captain account with a saved email address. It is deduplicated, so pressing send again will not queue a second copy for somebody who already has this launch announcement.
+        </p>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+            <div className="text-[10px] font-black uppercase tracking-[0.16em] text-white/40">Recipients found</div>
+            <div className="mt-2 text-3xl font-black text-white">{recipients.length}</div>
+            <div className="mt-1 text-xs text-white/45">Active SIXFL players and captains</div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-4 sm:col-span-2">
+            <div className="text-[10px] font-black uppercase tracking-[0.16em] text-white/40">Audience rule</div>
+            <p className="mt-2 text-sm leading-6 text-white/65">
+              Only users attached to an active season team — as a player/team member or captain — are included. Prospects, old/inactive teams and people without an email address are not included.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {hasResult ? (
+        <section className="rounded-3xl border border-emerald-400/25 bg-emerald-500/10 p-5 text-emerald-50">
+          <h2 className="text-lg font-black">Announcement queued</h2>
+          <p className="mt-2 text-sm leading-6">
+            Queued: {sp.queued ?? "0"} · Skipped: {sp.skipped ?? "0"} · Already queued/sent: {sp.already ?? "0"} · Failed: {sp.failed ?? "0"}.
+          </p>
+        </section>
+      ) : null}
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 lg:p-8">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-[0.18em] text-fuchsia-200/70">Email preview</p>
+            <h2 className="mt-2 text-2xl font-black text-white">Goal of the Week is now yours to decide ⚽</h2>
+          </div>
+          <span className="rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
+            SIXFL service update
+          </span>
+        </div>
+
+        <div className="mt-6 space-y-4 rounded-2xl border border-white/10 bg-black/25 p-5 text-sm leading-6 text-white/70">
+          <p>Hi [first name],</p>
+          <p><strong className="text-white">SIXFL Goal of the Week is changing — the players now choose it.</strong></p>
+          <p>
+            After a recorded SIXFL TV match, players and captains can nominate the goals they think deserve to be in the running. If more than one person picks the same goal, those nominations are combined.
+          </p>
+          <p>
+            The six most-nominated goals go into the following week's ballot. Every verified SIXFL player and captain gets one vote, and you can change your choice until voting closes.
+          </p>
+          <p>
+            You will now see a Goal of the Week card on your SIXFL dashboard whenever there is something to nominate or a vote is open.
+          </p>
+          <div className="inline-flex rounded-xl bg-fuchsia-300 px-4 py-2.5 font-black text-black">
+            Open my SIXFL dashboard
+          </div>
+          <p>
+            So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.
+          </p>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.08] p-6">
+        <h2 className="text-xl font-black text-white">Ready to send?</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-amber-50/70">
+          This is a league-service announcement to current players and captains. It is queued through SIXFL's normal notification system rather than sent directly from this browser.
+        </p>
+
+        <form action={sendGoalOfWeekLaunchAnnouncementAction} className="mt-5">
+          <button
+            type="submit"
+            disabled={recipients.length === 0}
+            className="inline-flex min-h-12 items-center justify-center rounded-2xl bg-fuchsia-300 px-6 py-3 text-sm font-black text-black transition hover:bg-fuchsia-200 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Queue announcement to {recipients.length} people
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/app/player/team/[teamid]/layout.tsx
+++ b/src/app/player/team/[teamid]/layout.tsx
@@ -3,6 +3,7 @@
 // ========================================
 
 import { Suspense, type ReactNode } from "react";
+import GoalOfWeekDashboardPromo from "@/components/goal-of-week/GoalOfWeekDashboardPromo";
 import PlayerDashboardOnly from "@/components/player/PlayerDashboardOnly";
 import PlayerLeagueMediaPanel from "@/components/player/PlayerLeagueMediaPanel";
 import PlayerMessageBox from "@/components/player/PlayerMessageBox";
@@ -28,6 +29,14 @@ export default async function PlayerTeamLayout({
       <Suspense>
         <PlayerPreviewLinkPersistence teamId={teamid} />
       </Suspense>
+      <PlayerDashboardOnly teamId={teamid}>
+        <div className="mx-auto w-full max-w-6xl px-4 pt-6">
+          <GoalOfWeekDashboardPromo
+            teamId={teamid}
+            href={`/player/team/${teamid}/tv`}
+          />
+        </div>
+      </PlayerDashboardOnly>
       {children}
       <PlayerDashboardOnly teamId={teamid}>
         <div className="space-y-8 pb-8">

--- a/src/components/captain/CaptainSupportPanel.tsx
+++ b/src/components/captain/CaptainSupportPanel.tsx
@@ -9,6 +9,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import { sendCaptainSupportRequestAction } from "@/app/captain/team/[teamid]/support/actions";
+import GoalOfWeekDashboardPromo from "@/components/goal-of-week/GoalOfWeekDashboardPromo";
 
 type HelpContext = {
   topic: string;
@@ -138,6 +139,13 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
   if (isOverview(pathname, teamId)) {
     return (
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="md:col-span-2 xl:col-span-4">
+          <GoalOfWeekDashboardPromo
+            teamId={teamId}
+            href={`/captain/team/${teamId}/tv`}
+          />
+        </div>
+
         <Link
           href={`/captain/team/${teamId}/weeks-unavailable`}
           className="md:col-span-2 xl:col-span-4 rounded-3xl border border-amber-400/25 bg-amber-500/[0.08] p-5 transition hover:border-amber-300/35 hover:bg-amber-500/[0.12] sm:p-6"

--- a/src/components/goal-of-week/GoalOfWeekDashboardPromo.tsx
+++ b/src/components/goal-of-week/GoalOfWeekDashboardPromo.tsx
@@ -64,6 +64,9 @@ export default function GoalOfWeekDashboardPromo({
         if (!cancelled && response.ok && result && !("error" in result)) {
           setPayload(result);
         }
+      } catch {
+        // Keep the generic Goal of the Week promotion visible even if the
+        // live ballot endpoint is temporarily unavailable.
       } finally {
         if (!cancelled) setLoaded(true);
       }

--- a/src/components/goal-of-week/GoalOfWeekDashboardPromo.tsx
+++ b/src/components/goal-of-week/GoalOfWeekDashboardPromo.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type GoalCandidate = {
+  id: string;
+};
+
+type GoalPayload = {
+  nomination: {
+    closesAt: string;
+    fixtures: Array<{ id: string }>;
+  };
+  voting: {
+    closesAt: string;
+    open: boolean;
+    selectedCandidateId: string | null;
+    candidates: GoalCandidate[];
+  };
+  latestWinner: {
+    scorerName: string | null;
+    teamName: string;
+  } | null;
+};
+
+function formatDeadline(value: string) {
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      weekday: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "Europe/London",
+    }).format(new Date(value));
+  } catch {
+    return null;
+  }
+}
+
+export default function GoalOfWeekDashboardPromo({
+  teamId,
+  href,
+}: {
+  teamId: string;
+  href: string;
+}) {
+  const [payload, setPayload] = useState<GoalPayload | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const response = await fetch(
+          `/api/goal-of-week/community?teamId=${encodeURIComponent(teamId)}`,
+          { cache: "no-store" },
+        );
+        const result = (await response.json().catch(() => null)) as
+          | GoalPayload
+          | { error?: string }
+          | null;
+
+        if (!cancelled && response.ok && result && !("error" in result)) {
+          setPayload(result);
+        }
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId]);
+
+  const content = useMemo(() => {
+    const ballotCount = payload?.voting.candidates.length ?? 0;
+    const nominationsAvailable = (payload?.nomination.fixtures.length ?? 0) > 0;
+    const votingOpen = Boolean(payload?.voting.open && ballotCount > 0);
+
+    if (votingOpen) {
+      const deadline = payload ? formatDeadline(payload.voting.closesAt) : null;
+      return {
+        eyebrow: "GOAL OF THE WEEK · VOTING OPEN",
+        title: "Six goals. One vote. Pick this week’s winner.",
+        body: payload?.voting.selectedCandidateId
+          ? `Your vote is saved${deadline ? ` — you can change it until ${deadline}` : ""}.`
+          : `${ballotCount} nominated goal${ballotCount === 1 ? " is" : "s are"} on the player ballot${deadline ? ` until ${deadline}` : ""}.`,
+        cta: payload?.voting.selectedCandidateId ? "View or change my vote" : "Vote now",
+        secondary: nominationsAvailable ? "You can also nominate goals from this week’s SIXFL TV matches." : null,
+      };
+    }
+
+    if (nominationsAvailable) {
+      const deadline = payload ? formatDeadline(payload.nomination.closesAt) : null;
+      return {
+        eyebrow: "GOAL OF THE WEEK · NOMINATIONS OPEN",
+        title: "Seen a worldie? Put it forward.",
+        body: `Nominate a goal from your completed SIXFL TV match${deadline ? ` before ${deadline}` : ""}. The six most-nominated goals make the player vote.`,
+        cta: "Nominate a goal",
+        secondary: null,
+      };
+    }
+
+    if (payload?.latestWinner) {
+      const winnerName = payload.latestWinner.scorerName || payload.latestWinner.teamName;
+      return {
+        eyebrow: "SIXFL GOAL OF THE WEEK",
+        title: "Goal of the Week is chosen by SIXFL players.",
+        body: `${winnerName} is the latest player-voted winner. Open SIXFL TV to watch, nominate and vote when the next ballot is ready.`,
+        cta: "Open Goal of the Week",
+        secondary: null,
+      };
+    }
+
+    return {
+      eyebrow: "SIXFL GOAL OF THE WEEK",
+      title: "You choose the best goal.",
+      body: "SIXFL players can nominate goals from recorded matches, then vote on the six-goal weekly shortlist.",
+      cta: "See Goal of the Week",
+      secondary: null,
+    };
+  }, [payload]);
+
+  if (!loaded) {
+    return (
+      <section className="rounded-3xl border border-fuchsia-400/20 bg-fuchsia-500/[0.06] p-5 sm:p-6" aria-label="Loading Goal of the Week">
+        <div className="h-3 w-44 animate-pulse rounded-full bg-fuchsia-200/15" />
+        <div className="mt-4 h-7 w-3/4 animate-pulse rounded-xl bg-white/10" />
+        <div className="mt-3 h-4 w-full max-w-2xl animate-pulse rounded-xl bg-white/[0.06]" />
+      </section>
+    );
+  }
+
+  return (
+    <section className="overflow-hidden rounded-3xl border border-fuchsia-300/30 bg-[radial-gradient(circle_at_top_right,rgba(217,70,239,0.22),transparent_38%),linear-gradient(135deg,rgba(88,28,135,0.34),rgba(0,0,0,0.35))] p-5 shadow-[0_20px_70px_rgba(88,28,135,0.2)] sm:p-6" data-testid="goal-of-week-dashboard-promo">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-black uppercase tracking-[0.2em] text-fuchsia-100/75">
+            {content.eyebrow}
+          </p>
+          <h2 className="mt-2 text-2xl font-black tracking-tight text-white sm:text-3xl">
+            {content.title}
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-fuchsia-50/75 sm:text-base">
+            {content.body}
+          </p>
+          {content.secondary ? (
+            <p className="mt-2 text-sm text-fuchsia-100/55">{content.secondary}</p>
+          ) : null}
+        </div>
+
+        <Link
+          href={href}
+          className="inline-flex min-h-12 shrink-0 items-center justify-center rounded-2xl bg-fuchsia-300 px-5 py-3 text-sm font-black text-black shadow-lg shadow-fuchsia-500/20 transition hover:-translate-y-0.5 hover:bg-fuchsia-200"
+        >
+          {content.cta} →
+        </Link>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Superseded by #208.

The Goal of the Week dashboard promotion is retained there, but the one-off Goal-of-the-Week-specific sender has been replaced by a reusable **Communications → Announcements** feature that uses SIXFL's existing templates, notification queue, branded email renderer, preferences/suppression handling and delivery processing. System-wide announcements deduplicate by normalised email address and only queue each announcement once per address.