### PR TITLE
Give team badges more space inside the review box

### DIFF
--- a/src/components/captain/TeamBadgeReviewPanel.tsx
+++ b/src/components/captain/TeamBadgeReviewPanel.tsx
@@ -186,7 +186,7 @@ export default function TeamBadgeReviewPanel({
                 src={logoUrl ?? ""}
                 alt={`${teamName} team badge`}
                 onError={() => setImageFailed(true)}
-                className="max-h-full max-w-full object-contain object-center"
+                className="max-h-[88%] max-w-[88%] object-contain object-center"
               />
             ) : (
               <div className="text-center">


### PR DESCRIPTION
## What changed
- reduces the displayed badge to 88% of the available review-box area
- keeps `object-contain` and centred positioning
- adds visible breathing room around wide badges so the sides do not look clipped

## Scope
UI-only change in the captain kit badge review panel. No badge data, kit-order logic, or other team displays are changed.