### PR TITLE
Add reusable system-wide Announcements to Communications

### DIFF
--- a/prisma/migrations/20260808232000_goal_of_week_launch_email_template/migration.sql
+++ b/prisma/migrations/20260808232000_goal_of_week_launch_email_template/migration.sql
@@ -1,0 +1,46 @@
+-- ========================================
+-- Migration: editable Goal of the Week launch email template
+-- ========================================
+
+INSERT INTO "EmailTemplate" (
+  "id",
+  "key",
+  "name",
+  "description",
+  "audience",
+  "interestType",
+  "subject",
+  "body",
+  "ctaLabel",
+  "ctaUrlKey",
+  "isActive",
+  "createdAt",
+  "updatedAt"
+) VALUES (
+  'goal-of-week-player-vote-launch',
+  'goal-of-week-player-vote-launch',
+  'Goal of the Week — player voting launch',
+  'System-wide announcement introducing player nominations and the weekly Goal of the Week vote. Edit this in Admin → Templates, then send it from Communications → Announcements.',
+  'PLAYER',
+  'PLAYER',
+  'Goal of the Week is now yours to decide ⚽',
+  $body$Hi {{firstName}},
+
+SIXFL Goal of the Week is changing — the players now choose it.
+
+After a recorded SIXFL TV match, players and captains can nominate the goals they think deserve to be in the running. If more than one person picks the same goal, those nominations are combined.
+
+The six most-nominated goals go into the following week's ballot. Every verified SIXFL player and captain gets one vote, and you can change your choice until voting closes.
+
+You will now see a Goal of the Week card on your SIXFL dashboard whenever there is something to nominate or a vote is open.
+
+{{cta}}
+
+So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.$body$,
+  'Open my SIXFL dashboard',
+  'dashboardUrl',
+  true,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+)
+ON CONFLICT ("key") DO NOTHING;

--- a/prisma/migrations/20260808232000_goal_of_week_launch_email_template/migration.sql
+++ b/prisma/migrations/20260808232000_goal_of_week_launch_email_template/migration.sql
@@ -38,7 +38,7 @@ You will now see a Goal of the Week card on your SIXFL dashboard whenever there 
 
 So if somebody scores an absolute worldie, don't just talk about it — nominate it. And when the shortlist opens, you decide the winner.$body$,
   'Open my SIXFL dashboard',
-  'dashboardUrl',
+  'captainDashboardUrl',
   true,
   CURRENT_TIMESTAMP,
   CURRENT_TIMESTAMP

--- a/prisma/migrations/20260809000500_guard_announcement_dispatch_duplicates/migration.sql
+++ b/prisma/migrations/20260809000500_guard_announcement_dispatch_duplicates/migration.sql
@@ -1,0 +1,9 @@
+-- Prevent concurrent/repeated submissions from queueing the same saved
+-- announcement revision more than once for the same notification recipient.
+-- Failed/skipped/cancelled attempts remain retryable because they are outside
+-- the partial unique index.
+
+CREATE UNIQUE INDEX IF NOT EXISTS "NotificationDispatch_announcement_recipient_once"
+ON "NotificationDispatch" ("recipientId", "sourceType", "sourceId")
+WHERE "sourceType" = 'ANNOUNCEMENT'
+  AND "status" IN ('QUEUED', 'PROCESSING', 'SENT');

--- a/scripts/apply-player-team-switcher.cjs
+++ b/scripts/apply-player-team-switcher.cjs
@@ -223,7 +223,7 @@ if (
   !source.includes("const playerMemberships = (") ||
   !source.includes("Switch team") ||
   !source.includes("previewMembershipId=${teamMembership.id}") ||
-  source.includes("where: { teamId: teamid },\n        select")
+  source.includes(oldMembershipSelect)
 ) {
   throw new Error("Player multi-team switcher was not applied correctly.");
 }

--- a/scripts/apply-player-team-switcher.cjs
+++ b/scripts/apply-player-team-switcher.cjs
@@ -221,9 +221,9 @@ fs.writeFileSync(absolutePath, source, "utf8");
 
 if (
   !source.includes("const playerMemberships = (") ||
-  !source.includes("playerMemberships.map((teamMembership) => {") ||
+  !source.includes("Switch team") ||
   !source.includes("previewMembershipId=${teamMembership.id}") ||
-  source.includes(oldMembershipSelect)
+  source.includes("where: { teamId: teamid },\n        select")
 ) {
   throw new Error("Player multi-team switcher was not applied correctly.");
 }

--- a/scripts/apply-player-team-switcher.cjs
+++ b/scripts/apply-player-team-switcher.cjs
@@ -221,7 +221,7 @@ fs.writeFileSync(absolutePath, source, "utf8");
 
 if (
   !source.includes("const playerMemberships = (") ||
-  !source.includes("Switch team") ||
+  !source.includes("playerMemberships.map((teamMembership) => {") ||
   !source.includes("previewMembershipId=${teamMembership.id}") ||
   source.includes(oldMembershipSelect)
 ) {

--- a/src/app/(admin)/admin/messaging/announcements/actions.ts
+++ b/src/app/(admin)/admin/messaging/announcements/actions.ts
@@ -8,6 +8,7 @@ import {
   findOrCreateAnnouncementRecipient,
   getAnnouncementAlreadyQueuedEmails,
   getAnnouncementFirstName,
+  getAnnouncementSourceId,
   getAnnouncementTemplateCompatibility,
   getSystemAnnouncementAudience,
   resolveAnnouncementCta,
@@ -92,9 +93,17 @@ export async function sendSystemAnnouncementAction(formData: FormData) {
     );
   }
 
+  const announcementSourceId = getAnnouncementSourceId({
+    id: template.id,
+    subject: template.subject,
+    body: template.body,
+    ctaLabel: template.ctaLabel,
+    ctaUrlKey: template.ctaUrlKey,
+  });
+
   const [audience, alreadyQueuedEmails] = await Promise.all([
     getSystemAnnouncementAudience(),
-    getAnnouncementAlreadyQueuedEmails(template.id),
+    getAnnouncementAlreadyQueuedEmails(announcementSourceId),
   ]);
 
   const publicSite = getPublicSiteUrl();
@@ -130,7 +139,7 @@ export async function sendSystemAnnouncementAction(formData: FormData) {
         body: template.body,
         isTransactional: true,
         sourceType: ANNOUNCEMENT_SOURCE_TYPE,
-        sourceId: template.id,
+        sourceId: announcementSourceId,
         variables: {
           firstName: getAnnouncementFirstName(person.displayName),
           name: displayName,
@@ -142,6 +151,7 @@ export async function sendSystemAnnouncementAction(formData: FormData) {
         },
         emailCta,
         metadata: {
+          announcementSourceId,
           announcementTemplateId: template.id,
           announcementTemplateKey: template.key,
           announcementTemplateName: template.name,
@@ -159,6 +169,7 @@ export async function sendSystemAnnouncementAction(formData: FormData) {
       failed += 1;
       console.error("System announcement queue failed", {
         templateId: template.id,
+        announcementSourceId,
         email: person.email,
         error,
       });

--- a/src/app/(admin)/admin/messaging/announcements/actions.ts
+++ b/src/app/(admin)/admin/messaging/announcements/actions.ts
@@ -1,0 +1,411 @@
+"use server";
+
+import { createHash } from "crypto";
+import {
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+  Prisma,
+} from "@prisma/client";
+import { redirect } from "next/navigation";
+
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { extractNotificationTokens } from "@/lib/notifications/renderer";
+import { processNotificationQueue } from "@/lib/notifications/processor";
+import { queueDirectNotification } from "@/lib/notifications/service";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { getPublicSiteUrl } from "@/lib/stripe/client";
+
+const ANNOUNCEMENT_SOURCE_TYPE = "ANNOUNCEMENT";
+
+const SUPPORTED_ANNOUNCEMENT_TOKENS = new Set([
+  "firstName",
+  "name",
+  "fullName",
+  "link",
+  "captainDashboardUrl",
+  "signInUrl",
+  "signupUrl",
+  "cta",
+]);
+
+export type SystemAnnouncementAudienceRow = {
+  email: string;
+  displayName: string | null;
+};
+
+type ExistingRecipientRow = {
+  id: string;
+  sourceType: string;
+  isSuppressed: boolean;
+};
+
+function cleanEmail(value: string | null | undefined) {
+  const email = value?.trim().toLowerCase() || "";
+  return email.includes("@") ? email : "";
+}
+
+function firstName(value: string | null) {
+  return value?.trim().split(/\s+/)[0]?.trim() || "there";
+}
+
+function appendParams(path: string, values: Record<string, string | number | null | undefined>) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value === null || value === undefined || String(value).trim() === "") continue;
+    params.set(key, String(value));
+  }
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+function getRecipientPriority(sourceType: string) {
+  switch (sourceType) {
+    case "USER":
+      return 0;
+    case "PLAYER":
+      return 1;
+    case "TEAM":
+      return 2;
+    case "REFEREE":
+      return 3;
+    case "LEAD":
+      return 4;
+    default:
+      return 5;
+  }
+}
+
+export async function getSystemAnnouncementAudience() {
+  const rows = await prisma.$queryRaw<SystemAnnouncementAudienceRow[]>(Prisma.sql`
+    WITH raw_emails AS (
+      SELECT
+        LOWER(TRIM(users."email")) AS "email",
+        NULLIF(TRIM(users."name"), '') AS "displayName"
+      FROM "User" users
+      WHERE users."email" IS NOT NULL
+        AND TRIM(users."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(team."contactEmail")) AS "email",
+        COALESCE(NULLIF(TRIM(team."contactName"), ''), NULLIF(TRIM(team."name"), '')) AS "displayName"
+      FROM "Team" team
+      WHERE team."contactEmail" IS NOT NULL
+        AND TRIM(team."contactEmail") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(prospect."email")) AS "email",
+        NULLIF(TRIM(CONCAT_WS(' ', prospect."firstName", prospect."lastName")), '') AS "displayName"
+      FROM "TeamPlayerProspect" prospect
+      WHERE prospect."email" IS NOT NULL
+        AND TRIM(prospect."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(lead."email")) AS "email",
+        COALESCE(NULLIF(TRIM(lead."contactName"), ''), NULLIF(TRIM(lead."teamName"), '')) AS "displayName"
+      FROM "InterestLead" lead
+      WHERE lead."email" IS NOT NULL
+        AND TRIM(lead."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(recipient."email")) AS "email",
+        NULLIF(TRIM(recipient."displayName"), '') AS "displayName"
+      FROM "NotificationRecipient" recipient
+      WHERE recipient."email" IS NOT NULL
+        AND TRIM(recipient."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(pool."emailNormalized")) AS "email",
+        NULL::TEXT AS "displayName"
+      FROM "PlayerPoolProfile" pool
+      WHERE pool."emailNormalized" IS NOT NULL
+        AND TRIM(pool."emailNormalized") <> ''
+    )
+    SELECT
+      raw_emails."email",
+      MAX(raw_emails."displayName") AS "displayName"
+    FROM raw_emails
+    WHERE raw_emails."email" LIKE '%@%'
+    GROUP BY raw_emails."email"
+    ORDER BY raw_emails."email" ASC
+  `);
+
+  return rows
+    .map((row) => ({
+      email: cleanEmail(row.email),
+      displayName: row.displayName?.trim() || null,
+    }))
+    .filter((row) => Boolean(row.email));
+}
+
+export async function getAnnouncementAlreadyQueuedEmails(templateId: string) {
+  if (!templateId) return new Set<string>();
+
+  const rows = await prisma.$queryRaw<Array<{ email: string }>>(Prisma.sql`
+    SELECT DISTINCT
+      LOWER(TRIM(COALESCE(recipient."emailNormalized", recipient."email"))) AS "email"
+    FROM "NotificationDispatch" dispatch
+    INNER JOIN "NotificationRecipient" recipient
+      ON recipient."id" = dispatch."recipientId"
+    WHERE dispatch."sourceType" = ${ANNOUNCEMENT_SOURCE_TYPE}
+      AND dispatch."sourceId" = ${templateId}
+      AND dispatch."status" IN ('QUEUED', 'PROCESSING', 'SENT')
+      AND COALESCE(recipient."emailNormalized", recipient."email") IS NOT NULL
+  `);
+
+  return new Set(rows.map((row) => cleanEmail(row.email)).filter(Boolean));
+}
+
+export async function getAnnouncementTemplateCompatibility(input: {
+  subject: string;
+  body: string;
+  ctaLabel: string | null;
+  ctaUrlKey: string | null;
+}) {
+  const tokens = new Set([
+    ...extractNotificationTokens(input.subject),
+    ...extractNotificationTokens(input.body),
+  ]);
+  const unsupportedTokens = Array.from(tokens).filter(
+    (token) => !SUPPORTED_ANNOUNCEMENT_TOKENS.has(token),
+  );
+
+  const unsupportedCta =
+    input.ctaLabel && input.ctaUrlKey &&
+    !["captainDashboardUrl", "signupUrl"].includes(input.ctaUrlKey)
+      ? input.ctaUrlKey
+      : null;
+
+  return {
+    unsupportedTokens,
+    unsupportedCta,
+    compatible: unsupportedTokens.length === 0 && !unsupportedCta,
+  };
+}
+
+async function findOrCreateAnnouncementRecipient(person: SystemAnnouncementAudienceRow) {
+  const matches = await prisma.$queryRaw<ExistingRecipientRow[]>(Prisma.sql`
+    SELECT
+      recipient."id",
+      recipient."sourceType"::TEXT AS "sourceType",
+      recipient."isSuppressed"
+    FROM "NotificationRecipient" recipient
+    WHERE LOWER(TRIM(COALESCE(recipient."emailNormalized", recipient."email"))) = ${person.email}
+    ORDER BY recipient."createdAt" ASC
+  `);
+
+  if (matches.length > 0) {
+    const suppressed = matches.find((recipient) => recipient.isSuppressed);
+    if (suppressed) return suppressed.id;
+
+    return [...matches].sort(
+      (a, b) => getRecipientPriority(a.sourceType) - getRecipientPriority(b.sourceType),
+    )[0]!.id;
+  }
+
+  const sourceId = `announcement-email-${createHash("sha256")
+    .update(person.email)
+    .digest("hex")}`;
+
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.GENERAL,
+    sourceId,
+    audience: NotificationAudience.GENERAL,
+    displayName: person.displayName,
+    email: person.email,
+    transactionalEmailOptIn: true,
+    transactionalSmsOptIn: true,
+    marketingEmailOptIn: false,
+    marketingSmsOptIn: false,
+    metadata: {
+      createdForSystemAnnouncements: true,
+    },
+  });
+
+  return recipient.id;
+}
+
+function resolveAnnouncementCta(input: {
+  label: string | null;
+  urlKey: string | null;
+  dashboardUrl: string;
+  signupUrl: string;
+}) {
+  const label = input.label?.trim() || "";
+  const key = input.urlKey?.trim() || "";
+  if (!label || !key) return undefined;
+
+  if (key === "captainDashboardUrl") {
+    return { label, url: input.dashboardUrl };
+  }
+  if (key === "signupUrl") {
+    return { label, url: input.signupUrl };
+  }
+
+  return undefined;
+}
+
+export async function sendSystemAnnouncementAction(formData: FormData) {
+  const admin = await requireAdmin();
+  const templateId = String(formData.get("templateId") ?? "").trim();
+  const confirmed = String(formData.get("confirm") ?? "").trim() === "yes";
+  const basePath = "/admin/messaging/announcements";
+
+  if (!templateId) {
+    redirect(appendParams(basePath, { error: "Choose an email template first." }));
+  }
+
+  if (!confirmed) {
+    redirect(
+      appendParams(basePath, {
+        template: templateId,
+        error: "Confirm that you have reviewed the announcement before queueing it.",
+      }),
+    );
+  }
+
+  const template = await prisma.emailTemplate.findUnique({
+    where: { id: templateId },
+  });
+
+  if (!template || !template.isActive) {
+    redirect(
+      appendParams(basePath, {
+        template: templateId,
+        error: "That email template is missing or inactive.",
+      }),
+    );
+  }
+
+  const compatibility = await getAnnouncementTemplateCompatibility({
+    subject: template.subject,
+    body: template.body,
+    ctaLabel: template.ctaLabel,
+    ctaUrlKey: template.ctaUrlKey,
+  });
+
+  if (!compatibility.compatible) {
+    const problems = [
+      compatibility.unsupportedTokens.length
+        ? `Unsupported announcement placeholders: ${compatibility.unsupportedTokens
+            .map((token) => `{{${token}}}`)
+            .join(", ")}.`
+        : null,
+      compatibility.unsupportedCta
+        ? `CTA destination ${compatibility.unsupportedCta} is recipient-specific and cannot be used for a system-wide announcement.`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    redirect(
+      appendParams(basePath, {
+        template: template.id,
+        error: problems,
+      }),
+    );
+  }
+
+  const [audience, alreadyQueuedEmails] = await Promise.all([
+    getSystemAnnouncementAudience(),
+    getAnnouncementAlreadyQueuedEmails(template.id),
+  ]);
+
+  const publicSite = getPublicSiteUrl();
+  const dashboardUrl = `${publicSite}/dashboard`;
+  const signupUrl = `${publicSite}/register-interest`;
+  const emailCta = resolveAnnouncementCta({
+    label: template.ctaLabel,
+    urlKey: template.ctaUrlKey,
+    dashboardUrl,
+    signupUrl,
+  });
+
+  let queued = 0;
+  let skipped = 0;
+  let already = 0;
+  let failed = 0;
+
+  for (const person of audience) {
+    if (alreadyQueuedEmails.has(person.email)) {
+      already += 1;
+      continue;
+    }
+
+    try {
+      const recipientId = await findOrCreateAnnouncementRecipient(person);
+      const displayName = person.displayName?.trim() || "there";
+
+      const dispatch = await queueDirectNotification({
+        recipientId,
+        channel: NotificationChannel.EMAIL,
+        audience: NotificationAudience.GENERAL,
+        subject: template.subject,
+        body: template.body,
+        isTransactional: true,
+        sourceType: ANNOUNCEMENT_SOURCE_TYPE,
+        sourceId: template.id,
+        variables: {
+          firstName: firstName(person.displayName),
+          name: displayName,
+          fullName: displayName,
+          link: dashboardUrl,
+          captainDashboardUrl: dashboardUrl,
+          signInUrl: dashboardUrl,
+          signupUrl,
+        },
+        emailCta,
+        metadata: {
+          announcementTemplateId: template.id,
+          announcementTemplateKey: template.key,
+          announcementTemplateName: template.name,
+          emailNormalized: person.email,
+        },
+        createdByUserId: admin.user?.id ?? null,
+      });
+
+      if (dispatch.status === "SKIPPED" || dispatch.status === "CANCELLED") {
+        skipped += 1;
+      } else {
+        queued += 1;
+      }
+    } catch (error) {
+      failed += 1;
+      console.error("System announcement queue failed", {
+        templateId: template.id,
+        email: person.email,
+        error,
+      });
+    }
+  }
+
+  if (queued > 0) {
+    try {
+      await processNotificationQueue(Math.max(queued + 20, 50));
+    } catch (error) {
+      console.error("System announcement immediate queue processing failed", error);
+    }
+  }
+
+  redirect(
+    appendParams(basePath, {
+      template: template.id,
+      sent: 1,
+      queued,
+      skipped,
+      already,
+      failed,
+    }),
+  );
+}

--- a/src/app/(admin)/admin/messaging/announcements/actions.ts
+++ b/src/app/(admin)/admin/messaging/announcements/actions.ts
@@ -1,56 +1,27 @@
 "use server";
 
-import { createHash } from "crypto";
-import {
-  NotificationAudience,
-  NotificationChannel,
-  NotificationRecipientSourceType,
-  Prisma,
-} from "@prisma/client";
+import { NotificationAudience, NotificationChannel } from "@prisma/client";
 import { redirect } from "next/navigation";
 
-import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
-import { extractNotificationTokens } from "@/lib/notifications/renderer";
+import {
+  ANNOUNCEMENT_SOURCE_TYPE,
+  findOrCreateAnnouncementRecipient,
+  getAnnouncementAlreadyQueuedEmails,
+  getAnnouncementFirstName,
+  getAnnouncementTemplateCompatibility,
+  getSystemAnnouncementAudience,
+  resolveAnnouncementCta,
+} from "@/lib/communications/system-announcements";
 import { processNotificationQueue } from "@/lib/notifications/processor";
 import { queueDirectNotification } from "@/lib/notifications/service";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { getPublicSiteUrl } from "@/lib/stripe/client";
 
-const ANNOUNCEMENT_SOURCE_TYPE = "ANNOUNCEMENT";
-
-const SUPPORTED_ANNOUNCEMENT_TOKENS = new Set([
-  "firstName",
-  "name",
-  "fullName",
-  "link",
-  "captainDashboardUrl",
-  "signInUrl",
-  "signupUrl",
-  "cta",
-]);
-
-export type SystemAnnouncementAudienceRow = {
-  email: string;
-  displayName: string | null;
-};
-
-type ExistingRecipientRow = {
-  id: string;
-  sourceType: string;
-  isSuppressed: boolean;
-};
-
-function cleanEmail(value: string | null | undefined) {
-  const email = value?.trim().toLowerCase() || "";
-  return email.includes("@") ? email : "";
-}
-
-function firstName(value: string | null) {
-  return value?.trim().split(/\s+/)[0]?.trim() || "there";
-}
-
-function appendParams(path: string, values: Record<string, string | number | null | undefined>) {
+function appendParams(
+  path: string,
+  values: Record<string, string | number | null | undefined>,
+) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(values)) {
     if (value === null || value === undefined || String(value).trim() === "") continue;
@@ -58,202 +29,6 @@ function appendParams(path: string, values: Record<string, string | number | nul
   }
   const query = params.toString();
   return query ? `${path}?${query}` : path;
-}
-
-function getRecipientPriority(sourceType: string) {
-  switch (sourceType) {
-    case "USER":
-      return 0;
-    case "PLAYER":
-      return 1;
-    case "TEAM":
-      return 2;
-    case "REFEREE":
-      return 3;
-    case "LEAD":
-      return 4;
-    default:
-      return 5;
-  }
-}
-
-export async function getSystemAnnouncementAudience() {
-  const rows = await prisma.$queryRaw<SystemAnnouncementAudienceRow[]>(Prisma.sql`
-    WITH raw_emails AS (
-      SELECT
-        LOWER(TRIM(users."email")) AS "email",
-        NULLIF(TRIM(users."name"), '') AS "displayName"
-      FROM "User" users
-      WHERE users."email" IS NOT NULL
-        AND TRIM(users."email") <> ''
-
-      UNION ALL
-
-      SELECT
-        LOWER(TRIM(team."contactEmail")) AS "email",
-        COALESCE(NULLIF(TRIM(team."contactName"), ''), NULLIF(TRIM(team."name"), '')) AS "displayName"
-      FROM "Team" team
-      WHERE team."contactEmail" IS NOT NULL
-        AND TRIM(team."contactEmail") <> ''
-
-      UNION ALL
-
-      SELECT
-        LOWER(TRIM(prospect."email")) AS "email",
-        NULLIF(TRIM(CONCAT_WS(' ', prospect."firstName", prospect."lastName")), '') AS "displayName"
-      FROM "TeamPlayerProspect" prospect
-      WHERE prospect."email" IS NOT NULL
-        AND TRIM(prospect."email") <> ''
-
-      UNION ALL
-
-      SELECT
-        LOWER(TRIM(lead."email")) AS "email",
-        COALESCE(NULLIF(TRIM(lead."contactName"), ''), NULLIF(TRIM(lead."teamName"), '')) AS "displayName"
-      FROM "InterestLead" lead
-      WHERE lead."email" IS NOT NULL
-        AND TRIM(lead."email") <> ''
-
-      UNION ALL
-
-      SELECT
-        LOWER(TRIM(recipient."email")) AS "email",
-        NULLIF(TRIM(recipient."displayName"), '') AS "displayName"
-      FROM "NotificationRecipient" recipient
-      WHERE recipient."email" IS NOT NULL
-        AND TRIM(recipient."email") <> ''
-
-      UNION ALL
-
-      SELECT
-        LOWER(TRIM(pool."emailNormalized")) AS "email",
-        NULL::TEXT AS "displayName"
-      FROM "PlayerPoolProfile" pool
-      WHERE pool."emailNormalized" IS NOT NULL
-        AND TRIM(pool."emailNormalized") <> ''
-    )
-    SELECT
-      raw_emails."email",
-      MAX(raw_emails."displayName") AS "displayName"
-    FROM raw_emails
-    WHERE raw_emails."email" LIKE '%@%'
-    GROUP BY raw_emails."email"
-    ORDER BY raw_emails."email" ASC
-  `);
-
-  return rows
-    .map((row) => ({
-      email: cleanEmail(row.email),
-      displayName: row.displayName?.trim() || null,
-    }))
-    .filter((row) => Boolean(row.email));
-}
-
-export async function getAnnouncementAlreadyQueuedEmails(templateId: string) {
-  if (!templateId) return new Set<string>();
-
-  const rows = await prisma.$queryRaw<Array<{ email: string }>>(Prisma.sql`
-    SELECT DISTINCT
-      LOWER(TRIM(COALESCE(recipient."emailNormalized", recipient."email"))) AS "email"
-    FROM "NotificationDispatch" dispatch
-    INNER JOIN "NotificationRecipient" recipient
-      ON recipient."id" = dispatch."recipientId"
-    WHERE dispatch."sourceType" = ${ANNOUNCEMENT_SOURCE_TYPE}
-      AND dispatch."sourceId" = ${templateId}
-      AND dispatch."status" IN ('QUEUED', 'PROCESSING', 'SENT')
-      AND COALESCE(recipient."emailNormalized", recipient."email") IS NOT NULL
-  `);
-
-  return new Set(rows.map((row) => cleanEmail(row.email)).filter(Boolean));
-}
-
-export async function getAnnouncementTemplateCompatibility(input: {
-  subject: string;
-  body: string;
-  ctaLabel: string | null;
-  ctaUrlKey: string | null;
-}) {
-  const tokens = new Set([
-    ...extractNotificationTokens(input.subject),
-    ...extractNotificationTokens(input.body),
-  ]);
-  const unsupportedTokens = Array.from(tokens).filter(
-    (token) => !SUPPORTED_ANNOUNCEMENT_TOKENS.has(token),
-  );
-
-  const unsupportedCta =
-    input.ctaLabel && input.ctaUrlKey &&
-    !["captainDashboardUrl", "signupUrl"].includes(input.ctaUrlKey)
-      ? input.ctaUrlKey
-      : null;
-
-  return {
-    unsupportedTokens,
-    unsupportedCta,
-    compatible: unsupportedTokens.length === 0 && !unsupportedCta,
-  };
-}
-
-async function findOrCreateAnnouncementRecipient(person: SystemAnnouncementAudienceRow) {
-  const matches = await prisma.$queryRaw<ExistingRecipientRow[]>(Prisma.sql`
-    SELECT
-      recipient."id",
-      recipient."sourceType"::TEXT AS "sourceType",
-      recipient."isSuppressed"
-    FROM "NotificationRecipient" recipient
-    WHERE LOWER(TRIM(COALESCE(recipient."emailNormalized", recipient."email"))) = ${person.email}
-    ORDER BY recipient."createdAt" ASC
-  `);
-
-  if (matches.length > 0) {
-    const suppressed = matches.find((recipient) => recipient.isSuppressed);
-    if (suppressed) return suppressed.id;
-
-    return [...matches].sort(
-      (a, b) => getRecipientPriority(a.sourceType) - getRecipientPriority(b.sourceType),
-    )[0]!.id;
-  }
-
-  const sourceId = `announcement-email-${createHash("sha256")
-    .update(person.email)
-    .digest("hex")}`;
-
-  const recipient = await upsertNotificationRecipient({
-    sourceType: NotificationRecipientSourceType.GENERAL,
-    sourceId,
-    audience: NotificationAudience.GENERAL,
-    displayName: person.displayName,
-    email: person.email,
-    transactionalEmailOptIn: true,
-    transactionalSmsOptIn: true,
-    marketingEmailOptIn: false,
-    marketingSmsOptIn: false,
-    metadata: {
-      createdForSystemAnnouncements: true,
-    },
-  });
-
-  return recipient.id;
-}
-
-function resolveAnnouncementCta(input: {
-  label: string | null;
-  urlKey: string | null;
-  dashboardUrl: string;
-  signupUrl: string;
-}) {
-  const label = input.label?.trim() || "";
-  const key = input.urlKey?.trim() || "";
-  if (!label || !key) return undefined;
-
-  if (key === "captainDashboardUrl") {
-    return { label, url: input.dashboardUrl };
-  }
-  if (key === "signupUrl") {
-    return { label, url: input.signupUrl };
-  }
-
-  return undefined;
 }
 
 export async function sendSystemAnnouncementAction(formData: FormData) {
@@ -288,7 +63,7 @@ export async function sendSystemAnnouncementAction(formData: FormData) {
     );
   }
 
-  const compatibility = await getAnnouncementTemplateCompatibility({
+  const compatibility = getAnnouncementTemplateCompatibility({
     subject: template.subject,
     body: template.body,
     ctaLabel: template.ctaLabel,
@@ -357,7 +132,7 @@ export async function sendSystemAnnouncementAction(formData: FormData) {
         sourceType: ANNOUNCEMENT_SOURCE_TYPE,
         sourceId: template.id,
         variables: {
-          firstName: firstName(person.displayName),
+          firstName: getAnnouncementFirstName(person.displayName),
           name: displayName,
           fullName: displayName,
           link: dashboardUrl,

--- a/src/app/(admin)/admin/messaging/announcements/page.tsx
+++ b/src/app/(admin)/admin/messaging/announcements/page.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 
-import { prisma } from "@/lib/prisma";
-import { requireAdmin } from "@/lib/requireAdmin";
 import {
   getAnnouncementAlreadyQueuedEmails,
   getAnnouncementTemplateCompatibility,
   getSystemAnnouncementAudience,
-  sendSystemAnnouncementAction,
-} from "./actions";
+} from "@/lib/communications/system-announcements";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { sendSystemAnnouncementAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -81,7 +81,7 @@ export default async function AnnouncementsPage({
     ? await getAnnouncementAlreadyQueuedEmails(selectedTemplate.id)
     : new Set<string>();
   const compatibility = selectedTemplate
-    ? await getAnnouncementTemplateCompatibility({
+    ? getAnnouncementTemplateCompatibility({
         subject: selectedTemplate.subject,
         body: selectedTemplate.body,
         ctaLabel: selectedTemplate.ctaLabel,
@@ -98,24 +98,6 @@ export default async function AnnouncementsPage({
   return (
     <div className="w-full px-4 pb-10 pt-6 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl space-y-6">
-        <nav className="flex flex-wrap gap-2 rounded-2xl border border-white/10 bg-black/20 p-2">
-          <Link
-            href="/admin/messaging"
-            className="rounded-xl px-4 py-2 text-sm font-semibold text-white/60 transition hover:bg-white/[0.06] hover:text-white"
-          >
-            Inbox & communications
-          </Link>
-          <span className="rounded-xl bg-emerald-500/15 px-4 py-2 text-sm font-semibold text-emerald-100">
-            Announcements
-          </span>
-          <Link
-            href="/admin/templates"
-            className="rounded-xl px-4 py-2 text-sm font-semibold text-white/60 transition hover:bg-white/[0.06] hover:text-white"
-          >
-            Templates
-          </Link>
-        </nav>
-
         <section className="rounded-3xl border border-emerald-400/20 bg-[radial-gradient(circle_at_top_right,rgba(16,185,129,0.16),transparent_36%),rgba(255,255,255,0.04)] p-6 lg:p-8">
           <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-200/70">
             System-wide email

--- a/src/app/(admin)/admin/messaging/announcements/page.tsx
+++ b/src/app/(admin)/admin/messaging/announcements/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import {
   getAnnouncementAlreadyQueuedEmails,
+  getAnnouncementSourceId,
   getAnnouncementTemplateCompatibility,
   getSystemAnnouncementAudience,
 } from "@/lib/communications/system-announcements";
@@ -76,9 +77,19 @@ export default async function AnnouncementsPage({
         template.id === requestedTemplate || template.key === requestedTemplate,
     ) ?? templates[0] ?? null;
 
+  const announcementSourceId = selectedTemplate
+    ? getAnnouncementSourceId({
+        id: selectedTemplate.id,
+        subject: selectedTemplate.subject,
+        body: selectedTemplate.body,
+        ctaLabel: selectedTemplate.ctaLabel,
+        ctaUrlKey: selectedTemplate.ctaUrlKey,
+      })
+    : null;
+
   const audience = await getSystemAnnouncementAudience();
-  const alreadyQueuedEmails = selectedTemplate
-    ? await getAnnouncementAlreadyQueuedEmails(selectedTemplate.id)
+  const alreadyQueuedEmails = announcementSourceId
+    ? await getAnnouncementAlreadyQueuedEmails(announcementSourceId)
     : new Set<string>();
   const compatibility = selectedTemplate
     ? getAnnouncementTemplateCompatibility({
@@ -106,7 +117,7 @@ export default async function AnnouncementsPage({
             Announcements
           </h1>
           <p className="mt-3 max-w-4xl text-sm leading-6 text-white/65 sm:text-base">
-            Send one existing SIXFL email template to every unique email address saved in the system. The audience is deduplicated by normalised email address, so the same address receives this announcement only once even if it appears as a user, player, team contact, lead or notification contact.
+            Send one existing SIXFL email template to every unique email address saved in the system. The audience is deduplicated by normalised email address, so the same address receives each saved announcement only once even if it appears as a user, player, team contact, lead or notification contact.
           </p>
 
           <div className="mt-6 grid gap-4 sm:grid-cols-3">
@@ -121,7 +132,7 @@ export default async function AnnouncementsPage({
                 Already queued / sent
               </div>
               <div className="mt-2 text-3xl font-black text-white">{alreadyCount}</div>
-              <div className="mt-1 text-xs text-white/40">For the selected template</div>
+              <div className="mt-1 text-xs text-white/40">For this saved announcement revision</div>
             </div>
             <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4">
               <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-100/60">
@@ -250,7 +261,7 @@ export default async function AnnouncementsPage({
             </p>
             <h2 className="mt-2 text-2xl font-black text-white">Send this announcement</h2>
             <p className="mt-2 max-w-4xl text-sm leading-6 text-amber-50/70">
-              This uses the normal SIXFL notification queue, branded email renderer, preferences, suppression handling and delivery processing. Re-running the same announcement only considers email addresses that have not already been queued or sent for this template.
+              This uses the normal SIXFL notification queue, branded email renderer, preferences, suppression handling and delivery processing. Re-running this unchanged announcement cannot send a second copy to an address that was already queued or sent. If you later edit the template into a genuinely new announcement, that new saved revision can be sent once in its own right.
             </p>
 
             <form action={sendSystemAnnouncementAction} className="mt-5 space-y-4">
@@ -264,7 +275,7 @@ export default async function AnnouncementsPage({
                   className="mt-1 h-4 w-4 rounded border-white/20"
                 />
                 <span>
-                  I have reviewed the selected template and understand that this will queue it to every remaining unique saved email address.
+                  I have reviewed the selected template and understand that this saved announcement revision will be queued to every remaining unique saved email address.
                 </span>
               </label>
 

--- a/src/app/(admin)/admin/messaging/announcements/page.tsx
+++ b/src/app/(admin)/admin/messaging/announcements/page.tsx
@@ -1,0 +1,304 @@
+import Link from "next/link";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import {
+  getAnnouncementAlreadyQueuedEmails,
+  getAnnouncementTemplateCompatibility,
+  getSystemAnnouncementAudience,
+  sendSystemAnnouncementAction,
+} from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Announcements | SIXFL Admin",
+};
+
+type SearchParams = {
+  template?: string;
+  sent?: string;
+  queued?: string;
+  skipped?: string;
+  already?: string;
+  failed?: string;
+  error?: string;
+};
+
+function previewBody(body: string, ctaLabel: string | null) {
+  return body
+    .replaceAll("{{firstName}}", "[first name]")
+    .replaceAll("{{name}}", "[name]")
+    .replaceAll("{{fullName}}", "[full name]")
+    .replaceAll("{{captainDashboardUrl}}", "https://www.sixfl.co.uk/dashboard")
+    .replaceAll("{{signInUrl}}", "https://www.sixfl.co.uk/dashboard")
+    .replaceAll("{{signupUrl}}", "https://www.sixfl.co.uk/register-interest")
+    .replaceAll("{{link}}", "https://www.sixfl.co.uk/dashboard")
+    .replaceAll("{{cta}}", ctaLabel ? `[Button: ${ctaLabel}]` : "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function resultNumber(value?: string) {
+  const parsed = Number(value ?? "0");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export default async function AnnouncementsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  await requireAdmin();
+
+  const sp = (await searchParams) ?? {};
+  const templates = await prisma.emailTemplate.findMany({
+    where: { isActive: true },
+    orderBy: [{ name: "asc" }],
+    select: {
+      id: true,
+      key: true,
+      name: true,
+      description: true,
+      subject: true,
+      body: true,
+      ctaLabel: true,
+      ctaUrlKey: true,
+      audience: true,
+    },
+  });
+
+  const requestedTemplate = sp.template?.trim() || "";
+  const selectedTemplate =
+    templates.find(
+      (template) =>
+        template.id === requestedTemplate || template.key === requestedTemplate,
+    ) ?? templates[0] ?? null;
+
+  const audience = await getSystemAnnouncementAudience();
+  const alreadyQueuedEmails = selectedTemplate
+    ? await getAnnouncementAlreadyQueuedEmails(selectedTemplate.id)
+    : new Set<string>();
+  const compatibility = selectedTemplate
+    ? await getAnnouncementTemplateCompatibility({
+        subject: selectedTemplate.subject,
+        body: selectedTemplate.body,
+        ctaLabel: selectedTemplate.ctaLabel,
+        ctaUrlKey: selectedTemplate.ctaUrlKey,
+      })
+    : null;
+
+  const alreadyCount = audience.filter((person) =>
+    alreadyQueuedEmails.has(person.email),
+  ).length;
+  const remainingCount = Math.max(0, audience.length - alreadyCount);
+  const hasResult = sp.sent === "1";
+
+  return (
+    <div className="w-full px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <nav className="flex flex-wrap gap-2 rounded-2xl border border-white/10 bg-black/20 p-2">
+          <Link
+            href="/admin/messaging"
+            className="rounded-xl px-4 py-2 text-sm font-semibold text-white/60 transition hover:bg-white/[0.06] hover:text-white"
+          >
+            Inbox & communications
+          </Link>
+          <span className="rounded-xl bg-emerald-500/15 px-4 py-2 text-sm font-semibold text-emerald-100">
+            Announcements
+          </span>
+          <Link
+            href="/admin/templates"
+            className="rounded-xl px-4 py-2 text-sm font-semibold text-white/60 transition hover:bg-white/[0.06] hover:text-white"
+          >
+            Templates
+          </Link>
+        </nav>
+
+        <section className="rounded-3xl border border-emerald-400/20 bg-[radial-gradient(circle_at_top_right,rgba(16,185,129,0.16),transparent_36%),rgba(255,255,255,0.04)] p-6 lg:p-8">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-200/70">
+            System-wide email
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Announcements
+          </h1>
+          <p className="mt-3 max-w-4xl text-sm leading-6 text-white/65 sm:text-base">
+            Send one existing SIXFL email template to every unique email address saved in the system. The audience is deduplicated by normalised email address, so the same address receives this announcement only once even if it appears as a user, player, team contact, lead or notification contact.
+          </p>
+
+          <div className="mt-6 grid gap-4 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-white/40">
+                Unique emails in system
+              </div>
+              <div className="mt-2 text-3xl font-black text-white">{audience.length}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-white/40">
+                Already queued / sent
+              </div>
+              <div className="mt-2 text-3xl font-black text-white">{alreadyCount}</div>
+              <div className="mt-1 text-xs text-white/40">For the selected template</div>
+            </div>
+            <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-100/60">
+                Remaining
+              </div>
+              <div className="mt-2 text-3xl font-black text-emerald-50">{remainingCount}</div>
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/50">
+            Sources include saved user accounts, team contact emails, player/prospect emails, leads, PlayerPool and existing notification recipients. SIXFL's existing suppression and email-preference rules still apply, so suppressed or disabled recipients are recorded as skipped rather than bypassed.
+          </div>
+        </section>
+
+        {sp.error ? (
+          <section className="rounded-2xl border border-red-400/25 bg-red-500/10 p-4 text-sm text-red-100">
+            {sp.error}
+          </section>
+        ) : null}
+
+        {hasResult ? (
+          <section className="rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-4 text-sm text-emerald-50">
+            <strong>Announcement processed.</strong>{" "}
+            Queued: {resultNumber(sp.queued)} · Skipped by normal email rules: {resultNumber(sp.skipped)} · Already queued/sent: {resultNumber(sp.already)} · Failed: {resultNumber(sp.failed)}.
+          </section>
+        ) : null}
+
+        <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 lg:p-8">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+                1 · Choose existing template
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">
+                Use the email system you already have
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-white/55">
+                Announcements does not have its own email editor. Create or amend the message in Admin → Templates, then select it here.
+              </p>
+            </div>
+            <Link
+              href="/admin/templates/new"
+              className="inline-flex h-11 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white/80 transition hover:bg-white/[0.08]"
+            >
+              Create email template
+            </Link>
+          </div>
+
+          {templates.length > 0 ? (
+            <form method="get" action="/admin/messaging/announcements" className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <select
+                name="template"
+                defaultValue={selectedTemplate?.id ?? ""}
+                className="min-h-11 min-w-0 flex-1 rounded-2xl border border-white/10 bg-[#0d1428] px-4 text-sm text-white"
+              >
+                {templates.map((template) => (
+                  <option key={template.id} value={template.id}>
+                    {template.name} · {template.audience}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="submit"
+                className="rounded-2xl border border-emerald-400/25 bg-emerald-500/10 px-5 py-3 text-sm font-semibold text-emerald-100"
+              >
+                Load template
+              </button>
+            </form>
+          ) : (
+            <div className="mt-5 rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">
+              There are no active email templates yet.
+            </div>
+          )}
+        </section>
+
+        {selectedTemplate ? (
+          <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 lg:p-8">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-fuchsia-200/65">
+                  2 · Review
+                </p>
+                <h2 className="mt-2 text-2xl font-black text-white">{selectedTemplate.name}</h2>
+                {selectedTemplate.description ? (
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-white/50">
+                    {selectedTemplate.description}
+                  </p>
+                ) : null}
+              </div>
+              <Link
+                href={`/admin/templates/${selectedTemplate.id}`}
+                className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-fuchsia-300/25 bg-fuchsia-500/10 px-4 text-sm font-semibold text-fuchsia-100"
+              >
+                Edit this email template
+              </Link>
+            </div>
+
+            {compatibility && !compatibility.compatible ? (
+              <div className="mt-5 rounded-2xl border border-amber-400/25 bg-amber-500/10 p-4 text-sm leading-6 text-amber-100">
+                This template uses recipient-specific features that cannot safely be sent to every email address.
+                {compatibility.unsupportedTokens.length > 0
+                  ? ` Unsupported placeholders: ${compatibility.unsupportedTokens.map((token) => `{{${token}}}`).join(", ")}.`
+                  : ""}
+                {compatibility.unsupportedCta
+                  ? ` The ${compatibility.unsupportedCta} button destination is also recipient-specific.`
+                  : ""}
+              </div>
+            ) : null}
+
+            <div className="mt-5 overflow-hidden rounded-2xl border border-white/10 bg-black/25">
+              <div className="border-b border-white/10 px-5 py-4">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-white/35">Subject</div>
+                <div className="mt-1 font-semibold text-white">{selectedTemplate.subject}</div>
+              </div>
+              <pre className="whitespace-pre-wrap px-5 py-5 font-sans text-sm leading-6 text-white/70">
+                {previewBody(selectedTemplate.body, selectedTemplate.ctaLabel)}
+              </pre>
+            </div>
+          </section>
+        ) : null}
+
+        {selectedTemplate ? (
+          <section className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.08] p-6 lg:p-8">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/65">
+              3 · Queue once
+            </p>
+            <h2 className="mt-2 text-2xl font-black text-white">Send this announcement</h2>
+            <p className="mt-2 max-w-4xl text-sm leading-6 text-amber-50/70">
+              This uses the normal SIXFL notification queue, branded email renderer, preferences, suppression handling and delivery processing. Re-running the same announcement only considers email addresses that have not already been queued or sent for this template.
+            </p>
+
+            <form action={sendSystemAnnouncementAction} className="mt-5 space-y-4">
+              <input type="hidden" name="templateId" value={selectedTemplate.id} />
+              <label className="flex max-w-3xl items-start gap-3 rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-white/70">
+                <input
+                  type="checkbox"
+                  name="confirm"
+                  value="yes"
+                  required
+                  className="mt-1 h-4 w-4 rounded border-white/20"
+                />
+                <span>
+                  I have reviewed the selected template and understand that this will queue it to every remaining unique saved email address.
+                </span>
+              </label>
+
+              <button
+                type="submit"
+                disabled={!compatibility?.compatible || remainingCount === 0}
+                className="inline-flex min-h-12 items-center justify-center rounded-2xl bg-emerald-400 px-6 py-3 text-sm font-black text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-45"
+              >
+                {remainingCount > 0
+                  ? `Queue announcement to ${remainingCount} email${remainingCount === 1 ? "" : "s"}`
+                  : "Everyone has already received this announcement"}
+              </button>
+            </form>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/messaging/layout.tsx
+++ b/src/app/(admin)/admin/messaging/layout.tsx
@@ -5,6 +5,7 @@
 import Link from "next/link";
 import { NotificationDispatchStatus } from "@prisma/client";
 
+import CommunicationsTabs from "@/components/admin/communications/CommunicationsTabs";
 import AdminMessagingNoticeBridge from "@/components/admin/messages/AdminMessagingNoticeBridge";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
@@ -35,6 +36,7 @@ export default async function AdminMessagingLayout({
   return (
     <div className="space-y-4">
       <AdminMessagingNoticeBridge />
+      <CommunicationsTabs />
 
       {queuedSmsCount > 0 ? (
         <div className="mx-4 mt-4 rounded-2xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-amber-50 sm:mx-6 lg:mx-8">

--- a/src/app/player/team/[teamid]/layout.tsx
+++ b/src/app/player/team/[teamid]/layout.tsx
@@ -3,6 +3,7 @@
 // ========================================
 
 import { Suspense, type ReactNode } from "react";
+import GoalOfWeekDashboardPromo from "@/components/goal-of-week/GoalOfWeekDashboardPromo";
 import PlayerDashboardOnly from "@/components/player/PlayerDashboardOnly";
 import PlayerLeagueMediaPanel from "@/components/player/PlayerLeagueMediaPanel";
 import PlayerMessageBox from "@/components/player/PlayerMessageBox";
@@ -28,6 +29,14 @@ export default async function PlayerTeamLayout({
       <Suspense>
         <PlayerPreviewLinkPersistence teamId={teamid} />
       </Suspense>
+      <PlayerDashboardOnly teamId={teamid}>
+        <div className="mx-auto w-full max-w-6xl px-4 pt-6">
+          <GoalOfWeekDashboardPromo
+            teamId={teamid}
+            href={`/player/team/${teamid}/tv`}
+          />
+        </div>
+      </PlayerDashboardOnly>
       {children}
       <PlayerDashboardOnly teamId={teamid}>
         <div className="space-y-8 pb-8">

--- a/src/components/admin/communications/CommunicationsTabs.tsx
+++ b/src/components/admin/communications/CommunicationsTabs.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { href: "/admin/messaging", label: "Inbox & communications", exact: true },
+  { href: "/admin/messaging/announcements", label: "Announcements", exact: false },
+] as const;
+
+export default function CommunicationsTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Communications sections"
+      className="mx-4 mt-4 flex flex-wrap gap-2 rounded-2xl border border-white/10 bg-black/20 p-2 sm:mx-6 lg:mx-8"
+    >
+      {tabs.map((tab) => {
+        const active = tab.exact
+          ? pathname === tab.href || pathname === `${tab.href}/`
+          : pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={active ? "page" : undefined}
+            className={[
+              "rounded-xl px-4 py-2 text-sm font-semibold transition",
+              active
+                ? "bg-emerald-500/15 text-emerald-100"
+                : "text-white/60 hover:bg-white/[0.06] hover:text-white",
+            ].join(" ")}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+
+      <Link
+        href="/admin/templates"
+        className="rounded-xl px-4 py-2 text-sm font-semibold text-white/60 transition hover:bg-white/[0.06] hover:text-white"
+      >
+        Templates
+      </Link>
+    </nav>
+  );
+}

--- a/src/components/captain/CaptainSupportPanel.tsx
+++ b/src/components/captain/CaptainSupportPanel.tsx
@@ -9,6 +9,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import { sendCaptainSupportRequestAction } from "@/app/captain/team/[teamid]/support/actions";
+import GoalOfWeekDashboardPromo from "@/components/goal-of-week/GoalOfWeekDashboardPromo";
 
 type HelpContext = {
   topic: string;
@@ -138,6 +139,13 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
   if (isOverview(pathname, teamId)) {
     return (
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="md:col-span-2 xl:col-span-4">
+          <GoalOfWeekDashboardPromo
+            teamId={teamId}
+            href={`/captain/team/${teamId}/tv`}
+          />
+        </div>
+
         <Link
           href={`/captain/team/${teamId}/weeks-unavailable`}
           className="md:col-span-2 xl:col-span-4 rounded-3xl border border-amber-400/25 bg-amber-500/[0.08] p-5 transition hover:border-amber-300/35 hover:bg-amber-500/[0.12] sm:p-6"

--- a/src/components/goal-of-week/GoalOfWeekDashboardPromo.tsx
+++ b/src/components/goal-of-week/GoalOfWeekDashboardPromo.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type GoalCandidate = {
+  id: string;
+};
+
+type GoalPayload = {
+  nomination: {
+    closesAt: string;
+    fixtures: Array<{ id: string }>;
+  };
+  voting: {
+    closesAt: string;
+    open: boolean;
+    selectedCandidateId: string | null;
+    candidates: GoalCandidate[];
+  };
+  latestWinner: {
+    scorerName: string | null;
+    teamName: string;
+  } | null;
+};
+
+function formatDeadline(value: string) {
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      weekday: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "Europe/London",
+    }).format(new Date(value));
+  } catch {
+    return null;
+  }
+}
+
+export default function GoalOfWeekDashboardPromo({
+  teamId,
+  href,
+}: {
+  teamId: string;
+  href: string;
+}) {
+  const [payload, setPayload] = useState<GoalPayload | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const response = await fetch(
+          `/api/goal-of-week/community?teamId=${encodeURIComponent(teamId)}`,
+          { cache: "no-store" },
+        );
+        const result = (await response.json().catch(() => null)) as
+          | GoalPayload
+          | { error?: string }
+          | null;
+
+        if (!cancelled && response.ok && result && "nomination" in result) {
+          setPayload(result);
+        }
+      } catch {
+        // Keep the generic Goal of the Week promotion visible even if the
+        // live ballot endpoint is temporarily unavailable.
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId]);
+
+  const content = useMemo(() => {
+    const ballotCount = payload?.voting.candidates.length ?? 0;
+    const nominationsAvailable = (payload?.nomination.fixtures.length ?? 0) > 0;
+    const votingOpen = Boolean(payload?.voting.open && ballotCount > 0);
+
+    if (votingOpen) {
+      const deadline = payload ? formatDeadline(payload.voting.closesAt) : null;
+      return {
+        eyebrow: "GOAL OF THE WEEK · VOTING OPEN",
+        title: "Six goals. One vote. Pick this week’s winner.",
+        body: payload?.voting.selectedCandidateId
+          ? `Your vote is saved${deadline ? ` — you can change it until ${deadline}` : ""}.`
+          : `${ballotCount} nominated goal${ballotCount === 1 ? " is" : "s are"} on the player ballot${deadline ? ` until ${deadline}` : ""}.`,
+        cta: payload?.voting.selectedCandidateId ? "View or change my vote" : "Vote now",
+        secondary: nominationsAvailable ? "You can also nominate goals from this week’s SIXFL TV matches." : null,
+      };
+    }
+
+    if (nominationsAvailable) {
+      const deadline = payload ? formatDeadline(payload.nomination.closesAt) : null;
+      return {
+        eyebrow: "GOAL OF THE WEEK · NOMINATIONS OPEN",
+        title: "Seen a worldie? Put it forward.",
+        body: `Nominate a goal from your completed SIXFL TV match${deadline ? ` before ${deadline}` : ""}. The six most-nominated goals make the player vote.`,
+        cta: "Nominate a goal",
+        secondary: null,
+      };
+    }
+
+    if (payload?.latestWinner) {
+      const winnerName = payload.latestWinner.scorerName || payload.latestWinner.teamName;
+      return {
+        eyebrow: "SIXFL GOAL OF THE WEEK",
+        title: "Goal of the Week is chosen by SIXFL players.",
+        body: `${winnerName} is the latest player-voted winner. Open SIXFL TV to watch, nominate and vote when the next ballot is ready.`,
+        cta: "Open Goal of the Week",
+        secondary: null,
+      };
+    }
+
+    return {
+      eyebrow: "SIXFL GOAL OF THE WEEK",
+      title: "You choose the best goal.",
+      body: "SIXFL players can nominate goals from recorded matches, then vote on the six-goal weekly shortlist.",
+      cta: "See Goal of the Week",
+      secondary: null,
+    };
+  }, [payload]);
+
+  if (!loaded) {
+    return (
+      <section className="rounded-3xl border border-fuchsia-400/20 bg-fuchsia-500/[0.06] p-5 sm:p-6" aria-label="Loading Goal of the Week">
+        <div className="h-3 w-44 animate-pulse rounded-full bg-fuchsia-200/15" />
+        <div className="mt-4 h-7 w-3/4 animate-pulse rounded-xl bg-white/10" />
+        <div className="mt-3 h-4 w-full max-w-2xl animate-pulse rounded-xl bg-white/[0.06]" />
+      </section>
+    );
+  }
+
+  return (
+    <section className="overflow-hidden rounded-3xl border border-fuchsia-300/30 bg-[radial-gradient(circle_at_top_right,rgba(217,70,239,0.22),transparent_38%),linear-gradient(135deg,rgba(88,28,135,0.34),rgba(0,0,0,0.35))] p-5 shadow-[0_20px_70px_rgba(88,28,135,0.2)] sm:p-6" data-testid="goal-of-week-dashboard-promo">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-black uppercase tracking-[0.2em] text-fuchsia-100/75">
+            {content.eyebrow}
+          </p>
+          <h2 className="mt-2 text-2xl font-black tracking-tight text-white sm:text-3xl">
+            {content.title}
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-fuchsia-50/75 sm:text-base">
+            {content.body}
+          </p>
+          {content.secondary ? (
+            <p className="mt-2 text-sm text-fuchsia-100/55">{content.secondary}</p>
+          ) : null}
+        </div>
+
+        <Link
+          href={href}
+          className="inline-flex min-h-12 shrink-0 items-center justify-center rounded-2xl bg-fuchsia-300 px-5 py-3 text-sm font-black text-black shadow-lg shadow-fuchsia-500/20 transition hover:-translate-y-0.5 hover:bg-fuchsia-200"
+        >
+          {content.cta} →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/communications/system-announcements.ts
+++ b/src/lib/communications/system-announcements.ts
@@ -1,0 +1,242 @@
+import { createHash } from "crypto";
+import {
+  NotificationAudience,
+  NotificationRecipientSourceType,
+  Prisma,
+} from "@prisma/client";
+
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { extractNotificationTokens } from "@/lib/notifications/renderer";
+import { prisma } from "@/lib/prisma";
+
+export const ANNOUNCEMENT_SOURCE_TYPE = "ANNOUNCEMENT";
+
+const SUPPORTED_ANNOUNCEMENT_TOKENS = new Set([
+  "firstName",
+  "name",
+  "fullName",
+  "link",
+  "captainDashboardUrl",
+  "signInUrl",
+  "signupUrl",
+  "cta",
+]);
+
+export type SystemAnnouncementAudienceRow = {
+  email: string;
+  displayName: string | null;
+};
+
+type ExistingRecipientRow = {
+  id: string;
+  sourceType: string;
+  isSuppressed: boolean;
+};
+
+function cleanEmail(value: string | null | undefined) {
+  const email = value?.trim().toLowerCase() || "";
+  return email.includes("@") ? email : "";
+}
+
+export function getAnnouncementFirstName(value: string | null) {
+  return value?.trim().split(/\s+/)[0]?.trim() || "there";
+}
+
+function getRecipientPriority(sourceType: string) {
+  switch (sourceType) {
+    case "USER":
+      return 0;
+    case "PLAYER":
+      return 1;
+    case "TEAM":
+      return 2;
+    case "REFEREE":
+      return 3;
+    case "LEAD":
+      return 4;
+    default:
+      return 5;
+  }
+}
+
+export async function getSystemAnnouncementAudience() {
+  const rows = await prisma.$queryRaw<SystemAnnouncementAudienceRow[]>(Prisma.sql`
+    WITH raw_emails AS (
+      SELECT
+        LOWER(TRIM(users."email")) AS "email",
+        NULLIF(TRIM(users."name"), '') AS "displayName"
+      FROM "User" users
+      WHERE users."email" IS NOT NULL
+        AND TRIM(users."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(team."contactEmail")) AS "email",
+        COALESCE(NULLIF(TRIM(team."contactName"), ''), NULLIF(TRIM(team."name"), '')) AS "displayName"
+      FROM "Team" team
+      WHERE team."contactEmail" IS NOT NULL
+        AND TRIM(team."contactEmail") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(prospect."email")) AS "email",
+        NULLIF(TRIM(CONCAT_WS(' ', prospect."firstName", prospect."lastName")), '') AS "displayName"
+      FROM "TeamPlayerProspect" prospect
+      WHERE prospect."email" IS NOT NULL
+        AND TRIM(prospect."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(lead."email")) AS "email",
+        COALESCE(NULLIF(TRIM(lead."contactName"), ''), NULLIF(TRIM(lead."teamName"), '')) AS "displayName"
+      FROM "InterestLead" lead
+      WHERE lead."email" IS NOT NULL
+        AND TRIM(lead."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(recipient."email")) AS "email",
+        NULLIF(TRIM(recipient."displayName"), '') AS "displayName"
+      FROM "NotificationRecipient" recipient
+      WHERE recipient."email" IS NOT NULL
+        AND TRIM(recipient."email") <> ''
+
+      UNION ALL
+
+      SELECT
+        LOWER(TRIM(pool."emailNormalized")) AS "email",
+        NULL::TEXT AS "displayName"
+      FROM "PlayerPoolProfile" pool
+      WHERE pool."emailNormalized" IS NOT NULL
+        AND TRIM(pool."emailNormalized") <> ''
+    )
+    SELECT
+      raw_emails."email",
+      MAX(raw_emails."displayName") AS "displayName"
+    FROM raw_emails
+    WHERE raw_emails."email" LIKE '%@%'
+    GROUP BY raw_emails."email"
+    ORDER BY raw_emails."email" ASC
+  `);
+
+  return rows
+    .map((row) => ({
+      email: cleanEmail(row.email),
+      displayName: row.displayName?.trim() || null,
+    }))
+    .filter((row) => Boolean(row.email));
+}
+
+export async function getAnnouncementAlreadyQueuedEmails(templateId: string) {
+  if (!templateId) return new Set<string>();
+
+  const rows = await prisma.$queryRaw<Array<{ email: string }>>(Prisma.sql`
+    SELECT DISTINCT
+      LOWER(TRIM(COALESCE(recipient."emailNormalized", recipient."email"))) AS "email"
+    FROM "NotificationDispatch" dispatch
+    INNER JOIN "NotificationRecipient" recipient
+      ON recipient."id" = dispatch."recipientId"
+    WHERE dispatch."sourceType" = ${ANNOUNCEMENT_SOURCE_TYPE}
+      AND dispatch."sourceId" = ${templateId}
+      AND dispatch."status" IN ('QUEUED', 'PROCESSING', 'SENT')
+      AND COALESCE(recipient."emailNormalized", recipient."email") IS NOT NULL
+  `);
+
+  return new Set(rows.map((row) => cleanEmail(row.email)).filter(Boolean));
+}
+
+export function getAnnouncementTemplateCompatibility(input: {
+  subject: string;
+  body: string;
+  ctaLabel: string | null;
+  ctaUrlKey: string | null;
+}) {
+  const tokens = new Set([
+    ...extractNotificationTokens(input.subject),
+    ...extractNotificationTokens(input.body),
+  ]);
+  const unsupportedTokens = Array.from(tokens).filter(
+    (token) => !SUPPORTED_ANNOUNCEMENT_TOKENS.has(token),
+  );
+
+  const unsupportedCta =
+    input.ctaLabel &&
+    input.ctaUrlKey &&
+    !["captainDashboardUrl", "signupUrl"].includes(input.ctaUrlKey)
+      ? input.ctaUrlKey
+      : null;
+
+  return {
+    unsupportedTokens,
+    unsupportedCta,
+    compatible: unsupportedTokens.length === 0 && !unsupportedCta,
+  };
+}
+
+export async function findOrCreateAnnouncementRecipient(
+  person: SystemAnnouncementAudienceRow,
+) {
+  const matches = await prisma.$queryRaw<ExistingRecipientRow[]>(Prisma.sql`
+    SELECT
+      recipient."id",
+      recipient."sourceType"::TEXT AS "sourceType",
+      recipient."isSuppressed"
+    FROM "NotificationRecipient" recipient
+    WHERE LOWER(TRIM(COALESCE(recipient."emailNormalized", recipient."email"))) = ${person.email}
+    ORDER BY recipient."createdAt" ASC
+  `);
+
+  if (matches.length > 0) {
+    const suppressed = matches.find((recipient) => recipient.isSuppressed);
+    if (suppressed) return suppressed.id;
+
+    return [...matches].sort(
+      (a, b) => getRecipientPriority(a.sourceType) - getRecipientPriority(b.sourceType),
+    )[0]!.id;
+  }
+
+  const sourceId = `announcement-email-${createHash("sha256")
+    .update(person.email)
+    .digest("hex")}`;
+
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.GENERAL,
+    sourceId,
+    audience: NotificationAudience.GENERAL,
+    displayName: person.displayName,
+    email: person.email,
+    transactionalEmailOptIn: true,
+    transactionalSmsOptIn: true,
+    marketingEmailOptIn: false,
+    marketingSmsOptIn: false,
+    metadata: {
+      createdForSystemAnnouncements: true,
+    },
+  });
+
+  return recipient.id;
+}
+
+export function resolveAnnouncementCta(input: {
+  label: string | null;
+  urlKey: string | null;
+  dashboardUrl: string;
+  signupUrl: string;
+}) {
+  const label = input.label?.trim() || "";
+  const key = input.urlKey?.trim() || "";
+  if (!label || !key) return undefined;
+
+  if (key === "captainDashboardUrl") {
+    return { label, url: input.dashboardUrl };
+  }
+  if (key === "signupUrl") {
+    return { label, url: input.signupUrl };
+  }
+
+  return undefined;
+}

--- a/src/lib/communications/system-announcements.ts
+++ b/src/lib/communications/system-announcements.ts
@@ -42,6 +42,35 @@ export function getAnnouncementFirstName(value: string | null) {
   return value?.trim().split(/\s+/)[0]?.trim() || "there";
 }
 
+/**
+ * An announcement is one saved revision of an existing email template, not the
+ * template forever. Re-submitting the same unchanged revision cannot duplicate
+ * it; editing the subject/body/CTA produces a new fingerprint and therefore a
+ * genuinely new announcement that can be sent again.
+ */
+export function getAnnouncementSourceId(input: {
+  id: string;
+  subject: string;
+  body: string;
+  ctaLabel: string | null;
+  ctaUrlKey: string | null;
+}) {
+  const fingerprint = createHash("sha256")
+    .update(
+      JSON.stringify({
+        id: input.id,
+        subject: input.subject,
+        body: input.body,
+        ctaLabel: input.ctaLabel ?? null,
+        ctaUrlKey: input.ctaUrlKey ?? null,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 32);
+
+  return `${input.id}:${fingerprint}`;
+}
+
 function getRecipientPriority(sourceType: string) {
   switch (sourceType) {
     case "USER":
@@ -131,8 +160,10 @@ export async function getSystemAnnouncementAudience() {
     .filter((row) => Boolean(row.email));
 }
 
-export async function getAnnouncementAlreadyQueuedEmails(templateId: string) {
-  if (!templateId) return new Set<string>();
+export async function getAnnouncementAlreadyQueuedEmails(
+  announcementSourceId: string,
+) {
+  if (!announcementSourceId) return new Set<string>();
 
   const rows = await prisma.$queryRaw<Array<{ email: string }>>(Prisma.sql`
     SELECT DISTINCT
@@ -141,7 +172,7 @@ export async function getAnnouncementAlreadyQueuedEmails(templateId: string) {
     INNER JOIN "NotificationRecipient" recipient
       ON recipient."id" = dispatch."recipientId"
     WHERE dispatch."sourceType" = ${ANNOUNCEMENT_SOURCE_TYPE}
-      AND dispatch."sourceId" = ${templateId}
+      AND dispatch."sourceId" = ${announcementSourceId}
       AND dispatch."status" IN ('QUEUED', 'PROCESSING', 'SENT')
       AND COALESCE(recipient."emailNormalized", recipient."email") IS NOT NULL
   `);


### PR DESCRIPTION
## What changed

### Reusable Announcements tab
- adds **Communications → Announcements** as a normal tab inside the existing messaging area
- does not create a second email system or separate editor
- selects from the existing Admin email templates and links straight to the existing template editor
- uses the existing SIXFL notification queue, branded email renderer, preferences, suppression handling and queue processor

### One email address = one copy
- builds one deduplicated system-wide audience from saved User, Team contact, TeamPlayerProspect, InterestLead, PlayerPool and NotificationRecipient emails
- deduplicates by normalised email address, not by database row/source
- identifies an announcement by the selected template **plus its currently saved subject/body/CTA revision**
- re-submitting the same unchanged announcement cannot queue a second copy to an address already QUEUED / PROCESSING / SENT
- editing the template into a genuinely new announcement creates a new revision identity, so the template remains reusable
- new email addresses added after an announcement can still receive that unchanged announcement on a later run
- adds a database-level partial unique index so two tabs/rapid submissions cannot queue the same announcement revision twice for the same notification recipient
- failed/skipped/cancelled deliveries remain retryable
- suppressed/disabled recipients continue through the existing notification rules and are reported as skipped

### Template safety
- announcement page previews the currently saved template before sending
- recipient-specific placeholders / CTA destinations that cannot work system-wide block the send rather than producing broken emails
- requires an explicit review checkbox before queueing
- shows total unique system emails, already queued/sent and remaining recipient count

### Goal of the Week
- keeps the dashboard promotion from the earlier Goal of the Week PR
- seeds `Goal of the Week — player voting launch` as a normal editable email template
- the Goal of the Week email is now sent through the generic Announcements tab, not a special Goal-of-the-Week mailer

## Why
Announcements should be an audience/deduplication feature on top of the communications system SIXFL already has, rather than another email implementation.

## Safety
- no announcement is sent by deployment
- no existing email template or recipient is overwritten
- sending is admin-only and requires an explicit form submission
- no new DOM bridge or source-patching system is added
- the same saved announcement revision is idempotent at both application and database level
- current `main` already contains the central player-switcher prebuild fix; this PR does not carry a competing copy of that repair
