### PR TITLE
Fix player switcher prebuild failure

### DIFF
--- a/scripts/apply-critical-player-dashboard-features.cjs
+++ b/scripts/apply-critical-player-dashboard-features.cjs
@@ -1,10 +1,12 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-// These two features have previously disappeared when their standalone patch
-// scripts dropped out of the prebuild chain. Keep them grouped as one critical
-// player-dashboard contract so a normal build restores and verifies both.
-require("./apply-player-team-switcher.cjs");
+// The player team switcher is applied earlier in the normal prebuild chain via
+// apply-player-pool-edit-details -> apply-player-merge-controls. Do not rerun
+// that source patch here: its layout pass deliberately changes presentation
+// copy, so a second patch pass can misread the polished version as missing.
+// Keep the temporary-player label patch here, then verify both features from
+// their structural contracts rather than fragile headings.
 require("./apply-temporary-player-team-label-clarity.cjs");
 
 const root = process.cwd();
@@ -19,7 +21,11 @@ const routeScoped = read("src/components/RouteScopedBridges.tsx");
 
 const checks = [
   {
-    ok: playerPage.includes("Switch team") && playerPage.includes("playerMemberships.length > 1"),
+    ok:
+      playerPage.includes("const playerMemberships = (") &&
+      playerPage.includes("playerMemberships.length > 1") &&
+      playerPage.includes("teamMembership.team.id === teamid") &&
+      playerPage.includes("previewMembershipId=${teamMembership.id}"),
     message: "Player multi-team switcher is missing from the player team dashboard.",
   },
   {

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -6,7 +6,6 @@ require("./apply-captain-dom-observer-performance-guard.cjs");
 require("./apply-player-payments-freeze-fix.cjs");
 require("./apply-matchday-fee-waiver-reasons.cjs");
 require("./apply-captain-team-switcher-access-guard.cjs");
-require("./apply-player-team-switcher.cjs");
 require("./prepare-standard-pay-per-kit-flow.cjs");
 require("./apply-standard-pay-per-kit-flow.cjs");
 require("./apply-kit-design-deselect-lock.cjs");


### PR DESCRIPTION
## Cause

The player multi-team switcher was already being applied earlier in the prebuild chain. Its layout pass then changed the visible heading from `Switch team` to `Choose a team`. The later central-standings check reran the original switcher patch and used the old heading as a success marker, so it incorrectly threw `Player multi-team switcher was not applied correctly.`

## Fix

- stop rerunning the player-switcher source patch inside the later verification stage
- keep the critical dashboard safeguard, but verify the actual switcher structure instead of fragile display wording
- continue checking that multiple memberships, the current-team comparison and preview switching URL are present
- leave player data, routing and UI behaviour unchanged

## Safety

- no database or Prisma changes
- no player records or memberships changed
- no DOM bridge added
- the switcher is still applied once through the existing prebuild chain and is then verified separately

This directly addresses the Vercel build error at `scripts/apply-player-team-switcher.cjs:228`.