### PR TITLE
Show temporary-player names and require a team-set fee

### DIFF
--- a/scripts/apply-zero-team-fixture-fee-selection.cjs
+++ b/scripts/apply-zero-team-fixture-fee-selection.cjs
@@ -290,18 +290,30 @@ patchFile(pagePath, [
   },
   {
     label: "zero-fee expected total",
-    before: '  const expectedTotal = activeFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE;',
-    after: '  const expectedTotal = ignorePlayerFees ? 0 : activeFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE;',
+    before: [
+      '  const expectedTotal =',
+      '    standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE +',
+      '    temporaryPlayerTotal;',
+    ].join("\n"),
+    after: [
+      '  const expectedTotal = ignorePlayerFees',
+      '    ? 0',
+      '    : standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE +',
+      '      temporaryPlayerTotal;',
+    ].join("\n"),
   },
   {
     label: "zero-fee mismatch suppression",
     before: [
       '  const hasAmountMismatch =',
-      '    activeFees.length > 0 && totals.total !== expectedTotal;',
+      '    standardActiveFees.length > 0 &&',
+      '    standardFeeTotal !== standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE;',
     ].join("\n"),
     after: [
       '  const hasAmountMismatch =',
-      '    !ignorePlayerFees && activeFees.length > 0 && totals.total !== expectedTotal;',
+      '    !ignorePlayerFees &&',
+      '    standardActiveFees.length > 0 &&',
+      '    standardFeeTotal !== standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE;',
     ].join("\n"),
   },
   {

--- a/src/app/api/captain/team/[teamid]/temporary-player-requests/route.ts
+++ b/src/app/api/captain/team/[teamid]/temporary-player-requests/route.ts
@@ -10,6 +10,17 @@ import {
 } from "@/lib/temporary-player-requests";
 import { TemporaryPlayerPassError } from "@/lib/temporary-player-passes";
 
+function parseAmountPence(value: unknown) {
+  const cleaned = String(value ?? "")
+    .replace(/[£,\s]/g, "")
+    .trim();
+  if (!cleaned) return null;
+
+  const amount = Number(cleaned);
+  if (!Number.isFinite(amount) || amount < 0 || amount > 100) return null;
+  return Math.round(amount * 100);
+}
+
 async function fixtureBelongsToTeam(fixtureId: string, teamId: string) {
   const fixture = await prisma.fixture.findFirst({
     where: {
@@ -25,7 +36,8 @@ async function fixtureBelongsToTeam(fixtureId: string, teamId: string) {
 
 function errorResponse(error: unknown) {
   if (error instanceof TemporaryPlayerPassError) {
-    return NextResponse.json({ error: error.message }, { status: 409 });
+    const status = error.code === "INVALID_AMOUNT" ? 400 : 409;
+    return NextResponse.json({ error: error.message, code: error.code }, { status });
   }
 
   console.error("Temporary-player request action failed.", error);
@@ -70,6 +82,7 @@ export async function POST(
         fixtureId?: unknown;
         requestId?: unknown;
         decision?: unknown;
+        amount?: unknown;
       }
     | null;
 
@@ -90,17 +103,32 @@ export async function POST(
 
   try {
     if (decision === "accept") {
+      const amountPence = parseAmountPence(body?.amount);
+      if (amountPence === null) {
+        return NextResponse.json(
+          {
+            error:
+              "Enter the temporary player's match fee before accepting. Use £0 if no fee is due.",
+          },
+          { status: 400 },
+        );
+      }
+
       const player = await acceptTemporaryPlayerRequest({
         requestId,
         teamId: teamid,
         fixtureId,
+        amountPence,
         acceptedByUserId: access.user?.id ?? null,
       });
 
       return NextResponse.json({
         ok: true,
         decision: "accepted",
-        player: { displayName: player.displayName },
+        player: {
+          displayName: player.displayName,
+          amountPence: player.amountPence,
+        },
       });
     }
 

--- a/src/app/api/captain/team/[teamid]/temporary-player/route.ts
+++ b/src/app/api/captain/team/[teamid]/temporary-player/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 
 import { publishedFixtureWhere } from "@/lib/fixtures/publishing";
+import { cancelQueuedPlayerMatchFeeNotificationDispatches } from "@/lib/payments/cancel-player-match-fee-notifications";
+import { ensurePlayerMatchFeePaymentDetails } from "@/lib/payments/player-match-fees";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
 import {
@@ -12,9 +14,29 @@ type TemporaryPlayerRow = {
   id: string;
   firstName: string;
   surnameInitial: string;
+  email: string | null;
   status: string;
   amountPence: number;
 };
+
+type EditableTemporaryPlayerRow = TemporaryPlayerRow & {
+  userId: string;
+};
+
+function parseAmountPence(value: unknown) {
+  const cleaned = String(value ?? "")
+    .replace(/[£,\s]/g, "")
+    .trim();
+  if (!cleaned) return null;
+
+  const amount = Number(cleaned);
+  if (!Number.isFinite(amount) || amount < 0 || amount > 100) return null;
+  return Math.round(amount * 100);
+}
+
+function displayName(player: Pick<TemporaryPlayerRow, "firstName" | "surnameInitial">) {
+  return `${player.firstName}${player.surnameInitial ? ` ${player.surnameInitial}.` : ""}`;
+}
 
 async function fixtureBelongsToTeam(fixtureId: string, teamId: string) {
   const fixture = await prisma.fixture.findFirst({
@@ -32,14 +54,16 @@ async function fixtureBelongsToTeam(fixtureId: string, teamId: string) {
 function passErrorResponse(error: unknown) {
   if (error instanceof TemporaryPlayerPassError) {
     const status =
-      error.code === "PASS_USED" ||
-      error.code === "PASS_REVOKED" ||
-      error.code === "ALREADY_IN_SQUAD" ||
-      error.code === "ALREADY_ADDED"
-        ? 409
-        : error.code === "FIXTURE_NOT_FOUND"
-          ? 404
-          : 400;
+      error.code === "INVALID_AMOUNT"
+        ? 400
+        : error.code === "PASS_USED" ||
+            error.code === "PASS_REVOKED" ||
+            error.code === "ALREADY_IN_SQUAD" ||
+            error.code === "ALREADY_ADDED"
+          ? 409
+          : error.code === "FIXTURE_NOT_FOUND"
+            ? 404
+            : 400;
 
     return NextResponse.json({ error: error.message, code: error.code }, { status });
   }
@@ -72,6 +96,7 @@ export async function GET(
         THEN UPPER(LEFT((REGEXP_SPLIT_TO_ARRAY(TRIM(u."name"), '\\s+'))[2], 1))
         ELSE ''
       END AS "surnameInitial",
+      u."email",
       pmf."status"::text AS "status",
       pmf."amountPence"
     FROM "PlayerMatchFee" pmf
@@ -94,15 +119,26 @@ export async function POST(
   const access = await requireCaptain(teamid);
 
   const body = (await request.json().catch(() => null)) as
-    | { fixtureId?: unknown; passCode?: unknown }
+    | { fixtureId?: unknown; passCode?: unknown; amount?: unknown }
     | null;
 
   const fixtureId = String(body?.fixtureId ?? "").trim();
   const passCode = String(body?.passCode ?? "").trim();
+  const amountPence = parseAmountPence(body?.amount);
 
   if (!fixtureId || !passCode) {
     return NextResponse.json(
       { error: "Enter the one-time pass sent to you by the player." },
+      { status: 400 },
+    );
+  }
+
+  if (amountPence === null) {
+    return NextResponse.json(
+      {
+        error:
+          "Enter the temporary player's match fee before linking them. Use £0 if no fee is due.",
+      },
       { status: 400 },
     );
   }
@@ -116,6 +152,7 @@ export async function POST(
       code: passCode,
       fixtureId,
       teamId: teamid,
+      amountPence,
       acceptedByUserId: access.user?.id ?? null,
     });
 
@@ -124,9 +161,147 @@ export async function POST(
       player: {
         displayName: player.displayName,
         label: "Temporary player",
+        amountPence: player.amountPence,
       },
     });
   } catch (error) {
     return passErrorResponse(error);
   }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const body = (await request.json().catch(() => null)) as
+    | { fixtureId?: unknown; feeId?: unknown; amount?: unknown }
+    | null;
+
+  const fixtureId = String(body?.fixtureId ?? "").trim();
+  const feeId = String(body?.feeId ?? "").trim();
+  const amountPence = parseAmountPence(body?.amount);
+
+  if (!fixtureId || !feeId) {
+    return NextResponse.json(
+      { error: "Choose the temporary player and fixture first." },
+      { status: 400 },
+    );
+  }
+
+  if (amountPence === null) {
+    return NextResponse.json(
+      { error: "Enter a match fee between £0 and £100." },
+      { status: 400 },
+    );
+  }
+
+  if (!(await fixtureBelongsToTeam(fixtureId, teamid))) {
+    return NextResponse.json({ error: "Fixture not found" }, { status: 404 });
+  }
+
+  const rows = await prisma.$queryRaw<EditableTemporaryPlayerRow[]>`
+    SELECT
+      pmf."id",
+      pmf."temporaryUserId" AS "userId",
+      COALESCE(NULLIF(SPLIT_PART(TRIM(COALESCE(u."name", '')), ' ', 1), ''), 'Player') AS "firstName",
+      CASE
+        WHEN ARRAY_LENGTH(REGEXP_SPLIT_TO_ARRAY(TRIM(COALESCE(u."name", '')), '\\s+'), 1) > 1
+        THEN UPPER(LEFT((REGEXP_SPLIT_TO_ARRAY(TRIM(u."name"), '\\s+'))[2], 1))
+        ELSE ''
+      END AS "surnameInitial",
+      u."email",
+      pmf."status"::text AS "status",
+      pmf."amountPence"
+    FROM "PlayerMatchFee" pmf
+    JOIN "User" u ON u."id" = pmf."temporaryUserId"
+    WHERE pmf."id" = ${feeId}
+      AND pmf."teamId" = ${teamid}
+      AND pmf."fixtureId" = ${fixtureId}
+      AND pmf."temporaryUserId" IS NOT NULL
+    LIMIT 1
+  `;
+
+  const player = rows[0] ?? null;
+  if (!player) {
+    return NextResponse.json(
+      { error: "That temporary-player fee could not be found." },
+      { status: 404 },
+    );
+  }
+
+  if (player.status === "PAID" || player.status === "CANCELLED") {
+    return NextResponse.json(
+      {
+        error:
+          player.status === "PAID"
+            ? "A paid temporary-player fee is locked. SIXFL admin must reconcile it before changing the amount."
+            : "A cancelled temporary-player fee cannot be reopened here.",
+      },
+      { status: 409 },
+    );
+  }
+
+  await cancelQueuedPlayerMatchFeeNotificationDispatches(
+    [feeId],
+    "Temporary-player match fee changed by the team.",
+  );
+
+  const note =
+    amountPence === 0
+      ? "Temporary-player match fee updated by the team: no fee due."
+      : `Temporary-player match fee updated by the team to £${(
+          amountPence / 100
+        ).toFixed(2)}.`;
+
+  if (amountPence === 0) {
+    await prisma.$executeRaw`
+      UPDATE "PlayerMatchFee"
+      SET
+        "amountPence" = 0,
+        "status" = 'WAIVED'::"PlayerMatchFeeStatus",
+        "paidAt" = NULL,
+        "waivedAt" = NOW(),
+        "cancelledAt" = NULL,
+        "paymentUrl" = NULL,
+        "paymentToken" = NULL,
+        "note" = CASE
+          WHEN TRIM(COALESCE("note", '')) = '' THEN ${note}
+          ELSE "note" || E'\n' || ${note}
+        END,
+        "updatedAt" = NOW()
+      WHERE "id" = ${feeId}
+    `;
+  } else {
+    await prisma.$executeRaw`
+      UPDATE "PlayerMatchFee"
+      SET
+        "amountPence" = ${amountPence},
+        "status" = 'OPEN'::"PlayerMatchFeeStatus",
+        "paidAt" = NULL,
+        "waivedAt" = NULL,
+        "cancelledAt" = NULL,
+        "note" = CASE
+          WHEN TRIM(COALESCE("note", '')) = '' THEN ${note}
+          ELSE "note" || E'\n' || ${note}
+        END,
+        "updatedAt" = NOW()
+      WHERE "id" = ${feeId}
+    `;
+
+    await ensurePlayerMatchFeePaymentDetails(feeId);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    player: {
+      id: player.id,
+      displayName: displayName(player),
+      label: "Temporary player",
+      amountPence,
+      status: amountPence === 0 ? "WAIVED" : "OPEN",
+    },
+  });
 }

--- a/src/app/captain/team/[teamid]/match-fees/page.tsx
+++ b/src/app/captain/team/[teamid]/match-fees/page.tsx
@@ -4,7 +4,7 @@
 
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import type { PlayerMatchFeeStatus } from "@prisma/client";
+import { Prisma, type PlayerMatchFeeStatus } from "@prisma/client";
 
 import MatchdaySquadSelectionForm from "@/components/captain/MatchdaySquadSelectionForm";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
@@ -31,6 +31,12 @@ const DEFAULT_PLAYER_MATCH_FEE_PENCE = 600;
 type Props = {
   params: Promise<{ teamid: string }>;
   searchParams?: Promise<{ fixtureId?: string; saved?: string; error?: string }>;
+};
+
+type TemporaryPlayerIdentityRow = {
+  feeId: string;
+  firstName: string;
+  email: string | null;
 };
 
 function formatUkDateTime(value: Date) {
@@ -146,6 +152,10 @@ function getFriendlyFeeNote(note: string | null, fee: { status: PlayerMatchFeeSt
       fee.paidAt
         ? "Paid fee cancelled because the player was removed from the matchday squad. Payment retained for audit and player credit created."
         : "Unpaid fee cancelled because the player was removed from the matchday squad. No payment was taken and no credit is due.",
+    )
+    .replace(
+      /Temporary player joined using a player-created one-time pass\. Fee uses the configured default player match fee and can be reviewed by the captain\./gi,
+      "Temporary player linked using a player-created pass. The team can choose and update this player's match fee.",
     )
     .replace(/Voided:/gi, "Fixture fee cancelled:");
 }
@@ -374,6 +384,26 @@ export default async function CaptainManagedPlayerMatchFeesPage({
       ])
     : [[], []];
 
+  const temporaryPlayerRows = selectedFixture
+    ? await prisma.$queryRaw<TemporaryPlayerIdentityRow[]>(Prisma.sql`
+        SELECT
+          pmf."id" AS "feeId",
+          COALESCE(
+            NULLIF(SPLIT_PART(TRIM(COALESCE(player."name", '')), ' ', 1), ''),
+            'Player'
+          ) AS "firstName",
+          player."email"
+        FROM "PlayerMatchFee" pmf
+        INNER JOIN "User" player ON player."id" = pmf."temporaryUserId"
+        WHERE pmf."teamId" = ${teamid}
+          AND pmf."fixtureId" = ${selectedFixture.id}
+          AND pmf."temporaryUserId" IS NOT NULL
+      `)
+    : [];
+  const temporaryPlayerByFeeId = new Map(
+    temporaryPlayerRows.map((player) => [player.feeId, player]),
+  );
+
   const availabilityByMemberId = new Map(
     selectedFixtureAvailabilities.map((availability) => [
       availability.teamMemberId,
@@ -401,6 +431,18 @@ export default async function CaptainManagedPlayerMatchFeesPage({
   );
 
   const activeFees = fees.filter((fee) => fee.status !== "CANCELLED");
+  const standardActiveFees = activeFees.filter(
+    (fee) => !temporaryPlayerByFeeId.has(fee.id),
+  );
+  const temporaryPlayerTotal = activeFees.reduce(
+    (sum, fee) =>
+      sum + (temporaryPlayerByFeeId.has(fee.id) ? fee.amountPence : 0),
+    0,
+  );
+  const standardFeeTotal = standardActiveFees.reduce(
+    (sum, fee) => sum + fee.amountPence,
+    0,
+  );
   const feeByMemberId = new Map(
     activeFees
       .filter((fee) => Boolean(fee.teamMemberId))
@@ -442,7 +484,9 @@ export default async function CaptainManagedPlayerMatchFeesPage({
   const paidCount = activeFees.filter((fee) => fee.status === "PAID").length;
   const openCount = activeFees.filter((fee) => fee.status === "OPEN").length;
   const waivedCount = activeFees.filter((fee) => fee.status === "WAIVED").length;
-  const expectedTotal = activeFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE;
+  const expectedTotal =
+    standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE +
+    temporaryPlayerTotal;
   const selectedCount = activeFees.length;
   const targetSize = team.matchdayTargetSize ?? 0;
   const hasSelection = selectedCount > 0;
@@ -450,7 +494,8 @@ export default async function CaptainManagedPlayerMatchFeesPage({
     targetSize > 0 && selectedCount > 0 && selectedCount < targetSize;
   const isOverTarget = targetSize > 0 && selectedCount > targetSize;
   const hasAmountMismatch =
-    activeFees.length > 0 && totals.total !== expectedTotal;
+    standardActiveFees.length > 0 &&
+    standardFeeTotal !== standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE;
   const savedMessage = getSavedMessage(sp.saved, isAdmin);
   const errorMessage = getErrorMessage(sp.error);
 
@@ -465,7 +510,13 @@ export default async function CaptainManagedPlayerMatchFeesPage({
       ? `Captain selected ${selectedCount} players, above the target squad size of ${targetSize}. Check whether any backup or extra players should be charged.`
       : null,
     hasAmountMismatch
-      ? `Fee total does not match the £6 default. Expected ${formatMoney(expectedTotal)} for ${selectedCount} selected player${selectedCount === 1 ? "" : "s"}; current fee total is ${formatMoney(totals.total)}.`
+      ? `Linked squad-player fees do not match the £6 default. Expected ${formatMoney(
+          standardActiveFees.length * DEFAULT_PLAYER_MATCH_FEE_PENCE,
+        )} for ${standardActiveFees.length} linked player${
+          standardActiveFees.length === 1 ? "" : "s"
+        }; their current total is ${formatMoney(
+          standardFeeTotal,
+        )}. Temporary-player fees are excluded because the team sets them individually.`
       : null,
   ].filter(Boolean) as string[];
 
@@ -546,7 +597,10 @@ export default async function CaptainManagedPlayerMatchFeesPage({
               {
                 label: "Expected",
                 value: formatMoney(expectedTotal),
-                text: "Selected players × £6.00.",
+                text:
+                  temporaryPlayerRows.length > 0
+                    ? "Linked squad players × £6.00; temporary-player fees are set by the team."
+                    : "Selected players × £6.00.",
                 classes:
                   "border-emerald-400/20 bg-emerald-500/10 text-emerald-100/70",
               },
@@ -590,7 +644,7 @@ export default async function CaptainManagedPlayerMatchFeesPage({
             </section>
           ) : (
             <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5 text-sm text-emerald-100">
-              Selection and expected £6 player fee total look aligned for this fixture.
+              Selection and player fee totals look aligned for this fixture.
             </section>
           )}
 
@@ -934,8 +988,11 @@ export default async function CaptainManagedPlayerMatchFeesPage({
               </div>
             ) : null}
             {fees.map((fee) => {
-              const playerName = getPlayerName(fee);
-              const playerContact = getPlayerContact(fee);
+              const temporaryPlayer = temporaryPlayerByFeeId.get(fee.id) ?? null;
+              const playerName = temporaryPlayer?.firstName ?? getPlayerName(fee);
+              const playerContact = temporaryPlayer
+                ? temporaryPlayer.email || "Player account linked"
+                : getPlayerContact(fee);
               const statusButtons = [
                 "OPEN",
                 "WAIVED",
@@ -955,6 +1012,11 @@ export default async function CaptainManagedPlayerMatchFeesPage({
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
                       <div className="font-semibold text-white">{playerName}</div>
+                      {temporaryPlayer ? (
+                        <span className="rounded-full border border-violet-400/25 bg-violet-500/10 px-2.5 py-1 text-xs font-medium text-violet-100">
+                          Temporary player
+                        </span>
+                      ) : null}
                       <span
                         className={`rounded-full border px-2.5 py-1 text-xs font-medium ${getFeeStatusClasses(
                           fee.status,

--- a/src/components/captain/TemporaryPlayerPassLauncher.tsx
+++ b/src/components/captain/TemporaryPlayerPassLauncher.tsx
@@ -28,6 +28,15 @@ type PlayerPassPayload = {
   passes: PlayerPass[];
 };
 
+type LinkedTemporaryPlayer = {
+  id: string;
+  firstName: string;
+  surnameInitial: string;
+  email: string | null;
+  status: "OPEN" | "PAID" | "WAIVED" | "CANCELLED";
+  amountPence: number;
+};
+
 function formatDateTime(value: string) {
   return new Intl.DateTimeFormat("en-GB", {
     weekday: "short",
@@ -36,6 +45,13 @@ function formatDateTime(value: string) {
     hour: "2-digit",
     minute: "2-digit",
   }).format(new Date(value));
+}
+
+function formatMoney(amountPence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(amountPence / 100);
 }
 
 function passStatusLabel(status: PlayerPass["status"]) {
@@ -63,6 +79,19 @@ function passStatusClasses(status: PlayerPass["status"]) {
   }
 }
 
+function linkedPlayerStatusLabel(status: LinkedTemporaryPlayer["status"]) {
+  switch (status) {
+    case "PAID":
+      return "Paid";
+    case "WAIVED":
+      return "No fee";
+    case "CANCELLED":
+      return "Cancelled";
+    default:
+      return "Awaiting payment";
+  }
+}
+
 export default function TemporaryPlayerPassLauncher() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -73,6 +102,10 @@ export default function TemporaryPlayerPassLauncher() {
   const [message, setMessage] = useState("");
   const [playerData, setPlayerData] = useState<PlayerPassPayload | null>(null);
   const [selection, setSelection] = useState("");
+  const [linkedPlayers, setLinkedPlayers] = useState<LinkedTemporaryPlayer[]>([]);
+  const [linkedFeeAmounts, setLinkedFeeAmounts] = useState<Record<string, string>>(
+    {},
+  );
 
   useEffect(() => setMounted(true), []);
 
@@ -117,10 +150,52 @@ export default function TemporaryPlayerPassLauncher() {
     }
   }
 
+  async function loadLinkedTemporaryPlayers() {
+    if (!teamId || !fixtureId) {
+      setLinkedPlayers([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `/api/captain/team/${teamId}/temporary-player?fixtureId=${encodeURIComponent(fixtureId)}`,
+        { cache: "no-store" },
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string; players?: LinkedTemporaryPlayer[] }
+        | null;
+      if (!response.ok) {
+        throw new Error(payload?.error || "Temporary players could not be loaded.");
+      }
+
+      const players = payload?.players ?? [];
+      setLinkedPlayers(players);
+      setLinkedFeeAmounts(
+        Object.fromEntries(
+          players.map((player) => [
+            player.id,
+            (player.amountPence / 100).toFixed(2),
+          ]),
+        ),
+      );
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : "Temporary players could not be loaded.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
   async function openLauncher() {
     setMessage("");
     setOpen(true);
-    if (isPlayerArea) await loadPlayerPasses();
+    if (isPlayerArea) {
+      await loadPlayerPasses();
+    } else if (captainMatch) {
+      await loadLinkedTemporaryPlayers();
+    }
   }
 
   async function createPass() {
@@ -213,6 +288,14 @@ export default function TemporaryPlayerPassLauncher() {
 
     const form = new FormData(event.currentTarget);
     const passCode = String(form.get("passCode") ?? "").trim();
+    const amount = String(form.get("amount") ?? "").trim();
+    if (!amount) {
+      setMessage(
+        "Enter the temporary player's match fee before linking them. Use £0 if no fee is due.",
+      );
+      return;
+    }
+
     setBusy(true);
     setMessage("");
 
@@ -220,19 +303,69 @@ export default function TemporaryPlayerPassLauncher() {
       const response = await fetch(`/api/captain/team/${teamId}/temporary-player`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ fixtureId, passCode }),
+        body: JSON.stringify({ fixtureId, passCode, amount }),
       });
       const result = (await response.json().catch(() => null)) as
-        | { error?: string; player?: { displayName: string } }
+        | {
+            error?: string;
+            player?: { displayName: string; amountPence: number };
+          }
         | null;
       if (!response.ok || !result?.player) {
         throw new Error(result?.error || "The temporary player could not be added.");
       }
 
-      setMessage(`${result.player.displayName} has been linked to this fixture.`);
-      window.setTimeout(() => window.location.reload(), 700);
+      setMessage(
+        result.player.amountPence > 0
+          ? `${result.player.displayName} has been linked as a temporary player with a ${formatMoney(result.player.amountPence)} match fee.`
+          : `${result.player.displayName} has been linked as a temporary player with no match fee.`,
+      );
+      window.setTimeout(() => window.location.reload(), 900);
     } catch (error) {
       setMessage(error instanceof Error ? error.message : "The temporary player could not be added.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function updateLinkedTemporaryPlayerFee(player: LinkedTemporaryPlayer) {
+    const amount = linkedFeeAmounts[player.id]?.trim() ?? "";
+    if (!amount) {
+      setMessage("Enter the match fee to save. Use £0 if no fee is due.");
+      return;
+    }
+
+    setBusy(true);
+    setMessage("");
+    try {
+      const response = await fetch(`/api/captain/team/${teamId}/temporary-player`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fixtureId, feeId: player.id, amount }),
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | {
+            error?: string;
+            player?: { displayName: string; amountPence: number; status: string };
+          }
+        | null;
+      if (!response.ok || !payload?.player) {
+        throw new Error(payload?.error || "The temporary-player fee could not be updated.");
+      }
+
+      setMessage(
+        payload.player.amountPence > 0
+          ? `${payload.player.displayName}'s temporary-player fee is now ${formatMoney(payload.player.amountPence)}.`
+          : `${payload.player.displayName} now has no match fee for this fixture.`,
+      );
+      await loadLinkedTemporaryPlayers();
+      window.setTimeout(() => window.location.reload(), 900);
+    } catch (error) {
+      setMessage(
+        error instanceof Error
+          ? error.message
+          : "The temporary-player fee could not be updated.",
+      );
     } finally {
       setBusy(false);
     }
@@ -264,7 +397,7 @@ export default function TemporaryPlayerPassLauncher() {
                 </h2>
                 <p className="mt-2 text-sm leading-6 text-white/65">
                   {captainMatch
-                    ? "The player must create the pass from their own dashboard first. Enter the one-time code they sent you; it will only work for this team and fixture."
+                    ? "The player must create the pass from their own dashboard first. Enter the code and choose what this team wants them to pay for this fixture."
                     : "Choose the team and fixture you are offering to play in. You stay in control: the pass works once, expires automatically and can be cancelled before the captain accepts it."}
                 </p>
               </div>
@@ -274,22 +407,127 @@ export default function TemporaryPlayerPassLauncher() {
             </div>
 
             {captainMatch ? (
-              <form onSubmit={submitCaptainPass} className="mt-6 space-y-4">
-                <label className="block text-sm font-semibold text-white">
-                  One-time player pass
-                  <input
-                    name="passCode"
-                    required
-                    placeholder="TP-7K4P9A"
-                    autoComplete="off"
-                    className="mt-2 w-full rounded-xl border border-white/15 bg-black/25 px-4 py-3 font-mono uppercase text-white outline-none focus:border-emerald-400"
-                  />
-                </label>
-                {message ? <p className="rounded-xl bg-white/[0.06] px-4 py-3 text-sm text-white/80">{message}</p> : null}
-                <button disabled={busy} className="w-full rounded-xl bg-emerald-400 px-4 py-3 font-bold text-black hover:bg-emerald-300 disabled:opacity-50">
-                  {busy ? "Adding player…" : "Add to this fixture"}
-                </button>
-              </form>
+              <div className="mt-6 space-y-5">
+                <form onSubmit={submitCaptainPass} className="space-y-4">
+                  <label className="block text-sm font-semibold text-white">
+                    One-time player pass
+                    <input
+                      name="passCode"
+                      required
+                      placeholder="TP-7K4P9A"
+                      autoComplete="off"
+                      className="mt-2 w-full rounded-xl border border-white/15 bg-black/25 px-4 py-3 font-mono uppercase text-white outline-none focus:border-emerald-400"
+                    />
+                  </label>
+                  <label className="block text-sm font-semibold text-white">
+                    Match fee for this temporary player
+                    <div className="relative mt-2">
+                      <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-white/45">
+                        £
+                      </span>
+                      <input
+                        name="amount"
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="0.01"
+                        inputMode="decimal"
+                        required
+                        placeholder="Enter amount"
+                        className="w-full rounded-xl border border-white/15 bg-black/25 py-3 pl-7 pr-4 text-white outline-none placeholder:text-white/30 focus:border-emerald-400"
+                      />
+                    </div>
+                    <span className="mt-1 block text-xs font-normal text-white/45">
+                      The team chooses the amount. Enter 0 if no match fee is due.
+                    </span>
+                  </label>
+                  {message ? <p className="rounded-xl bg-white/[0.06] px-4 py-3 text-sm text-white/80">{message}</p> : null}
+                  <button disabled={busy} className="w-full rounded-xl bg-emerald-400 px-4 py-3 font-bold text-black hover:bg-emerald-300 disabled:opacity-50">
+                    {busy ? "Adding player…" : "Link temporary player and set fee"}
+                  </button>
+                </form>
+
+                {loading ? (
+                  <p className="rounded-xl bg-white/[0.06] px-4 py-3 text-sm text-white/70">
+                    Loading temporary players…
+                  </p>
+                ) : null}
+
+                {linkedPlayers.length > 0 ? (
+                  <section className="space-y-3 border-t border-white/10 pt-5">
+                    <div>
+                      <h3 className="font-semibold text-white">
+                        Temporary players linked to this fixture
+                      </h3>
+                      <p className="mt-1 text-xs leading-5 text-white/45">
+                        The team can revise an unpaid temporary-player fee here. Paid fees stay locked for safe reconciliation.
+                      </p>
+                    </div>
+                    {linkedPlayers.map((player) => {
+                      const playerName = `${player.firstName}${
+                        player.surnameInitial ? ` ${player.surnameInitial}.` : ""
+                      }`;
+                      const locked = player.status === "PAID" || player.status === "CANCELLED";
+
+                      return (
+                        <article
+                          key={player.id}
+                          className="rounded-2xl border border-violet-400/20 bg-violet-500/[0.07] p-4"
+                        >
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="font-semibold text-white">{playerName}</p>
+                            <span className="rounded-full border border-violet-400/25 bg-violet-500/10 px-2.5 py-1 text-[11px] font-semibold text-violet-100">
+                              Temporary player
+                            </span>
+                            <span className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-[11px] text-white/60">
+                              {linkedPlayerStatusLabel(player.status)}
+                            </span>
+                          </div>
+                          <p className="mt-1 text-xs text-white/45">
+                            {player.email || "Player account linked"}
+                          </p>
+                          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                            <div className="relative flex-1">
+                              <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-white/45">
+                                £
+                              </span>
+                              <input
+                                type="number"
+                                min="0"
+                                max="100"
+                                step="0.01"
+                                inputMode="decimal"
+                                disabled={locked || busy}
+                                value={linkedFeeAmounts[player.id] ?? ""}
+                                onChange={(event) =>
+                                  setLinkedFeeAmounts((current) => ({
+                                    ...current,
+                                    [player.id]: event.target.value,
+                                  }))
+                                }
+                                className="w-full rounded-xl border border-white/15 bg-black/25 py-2.5 pl-7 pr-3 text-white outline-none focus:border-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
+                              />
+                            </div>
+                            <button
+                              type="button"
+                              disabled={locked || busy}
+                              onClick={() => void updateLinkedTemporaryPlayerFee(player)}
+                              className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              Update fee
+                            </button>
+                          </div>
+                          {locked ? (
+                            <p className="mt-2 text-xs text-white/45">
+                              Current fee: {formatMoney(player.amountPence)}. This fee is locked because it is {player.status.toLowerCase()}.
+                            </p>
+                          ) : null}
+                        </article>
+                      );
+                    })}
+                  </section>
+                ) : null}
+              </div>
             ) : (
               <div className="mt-6 space-y-5">
                 {loading ? (

--- a/src/components/captain/TemporaryPlayerRequestsPanel.tsx
+++ b/src/components/captain/TemporaryPlayerRequestsPanel.tsx
@@ -18,11 +18,19 @@ function formatTime(value: string) {
   }).format(new Date(value));
 }
 
+function formatMoney(amountPence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(amountPence / 100);
+}
+
 export default function TemporaryPlayerRequestsPanel() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [mounted, setMounted] = useState(false);
   const [requests, setRequests] = useState<PendingRequest[]>([]);
+  const [feeAmounts, setFeeAmounts] = useState<Record<string, string>>({});
   const [busyId, setBusyId] = useState<string | null>(null);
   const [message, setMessage] = useState("");
 
@@ -52,7 +60,13 @@ export default function TemporaryPlayerRequestsPanel() {
           | { requests?: PendingRequest[] }
           | null;
         if (!cancelled && response.ok) {
-          setRequests(payload?.requests ?? []);
+          const nextRequests = payload?.requests ?? [];
+          setRequests(nextRequests);
+          setFeeAmounts((current) => {
+            const next: Record<string, string> = {};
+            for (const item of nextRequests) next[item.id] = current[item.id] ?? "";
+            return next;
+          });
         }
       } catch {
         // Keep the current panel state if a background refresh fails.
@@ -69,6 +83,14 @@ export default function TemporaryPlayerRequestsPanel() {
   }, [fixtureId, teamId]);
 
   async function decide(requestId: string, decision: "accept" | "decline") {
+    const amount = feeAmounts[requestId]?.trim() ?? "";
+    if (decision === "accept" && !amount) {
+      setMessage(
+        "Enter this temporary player's match fee before accepting. Use £0 if no fee is due.",
+      );
+      return;
+    }
+
     setBusyId(requestId);
     setMessage("");
 
@@ -78,13 +100,18 @@ export default function TemporaryPlayerRequestsPanel() {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ fixtureId, requestId, decision }),
+          body: JSON.stringify({
+            fixtureId,
+            requestId,
+            decision,
+            ...(decision === "accept" ? { amount } : {}),
+          }),
         },
       );
       const payload = (await response.json().catch(() => null)) as
         | {
             error?: string;
-            player?: { displayName?: string };
+            player?: { displayName?: string; amountPence?: number };
             decision?: string;
           }
         | null;
@@ -98,11 +125,19 @@ export default function TemporaryPlayerRequestsPanel() {
       setRequests((current) =>
         current.filter((request) => request.id !== requestId),
       );
+      setFeeAmounts((current) => {
+        const next = { ...current };
+        delete next[requestId];
+        return next;
+      });
 
       const playerName = payload?.player?.displayName ?? "The player";
       if (decision === "accept") {
+        const amountPence = payload?.player?.amountPence ?? 0;
         setMessage(
-          `${playerName} has been added to this fixture and their match fee is now open for review.`,
+          amountPence > 0
+            ? `${playerName} has been added as a temporary player. Their match fee is ${formatMoney(amountPence)}.`
+            : `${playerName} has been added as a temporary player with no match fee.`,
         );
         window.setTimeout(() => window.location.reload(), 900);
       } else {
@@ -149,11 +184,45 @@ export default function TemporaryPlayerRequestsPanel() {
                 key={request.id}
                 className="rounded-2xl border border-white/10 bg-white/[0.04] p-4"
               >
-                <p className="font-semibold text-white">{request.displayName}</p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-semibold text-white">{request.displayName}</p>
+                  <span className="rounded-full border border-violet-400/25 bg-violet-500/10 px-2.5 py-1 text-[11px] font-semibold text-violet-100">
+                    Temporary player
+                  </span>
+                </div>
                 <p className="mt-1 text-sm leading-6 text-white/65">
-                  Wants to play for your team in this fixture and pay their match fee.
-                  The request expires at {formatTime(request.expiresAt)}.
+                  Wants to play for your team in this fixture. Choose what they
+                  should pay before accepting. The request expires at {formatTime(request.expiresAt)}.
                 </p>
+
+                <label className="mt-4 block text-sm font-semibold text-white">
+                  Match fee for this temporary player
+                  <div className="relative mt-2">
+                    <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-white/45">
+                      £
+                    </span>
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.01"
+                      inputMode="decimal"
+                      value={feeAmounts[request.id] ?? ""}
+                      onChange={(event) =>
+                        setFeeAmounts((current) => ({
+                          ...current,
+                          [request.id]: event.target.value,
+                        }))
+                      }
+                      placeholder="Enter amount"
+                      className="w-full rounded-xl border border-white/15 bg-black/25 py-2.5 pl-7 pr-3 text-white outline-none placeholder:text-white/30 focus:border-emerald-400"
+                    />
+                  </div>
+                  <span className="mt-1 block text-xs font-normal text-white/45">
+                    Enter 0 if no match fee is due. Nothing is assumed automatically.
+                  </span>
+                </label>
+
                 <div className="mt-4 grid grid-cols-2 gap-2">
                   <button
                     type="button"
@@ -161,7 +230,7 @@ export default function TemporaryPlayerRequestsPanel() {
                     onClick={() => void decide(request.id, "accept")}
                     className="rounded-xl bg-emerald-400 px-4 py-2.5 text-sm font-bold text-black transition hover:bg-emerald-300 disabled:opacity-50"
                   >
-                    {busyId === request.id ? "Updating…" : "Accept"}
+                    {busyId === request.id ? "Updating…" : "Accept and set fee"}
                   </button>
                   <button
                     type="button"

--- a/src/lib/temporary-player-passes.ts
+++ b/src/lib/temporary-player-passes.ts
@@ -5,17 +5,7 @@ import { prisma } from "@/lib/prisma";
 
 const PASS_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const PASS_LIFETIME_MS = 24 * 60 * 60 * 1000;
-const DEFAULT_PLAYER_MATCH_FEE_PENCE = Number.parseInt(
-  process.env.DEFAULT_PLAYER_MATCH_FEE_PENCE ?? "600",
-  10,
-);
-
-function getDefaultPlayerMatchFeePence() {
-  return Number.isFinite(DEFAULT_PLAYER_MATCH_FEE_PENCE) &&
-    DEFAULT_PLAYER_MATCH_FEE_PENCE >= 0
-    ? DEFAULT_PLAYER_MATCH_FEE_PENCE
-    : 600;
-}
+const MAX_TEMPORARY_PLAYER_MATCH_FEE_PENCE = 10_000;
 
 export type TemporaryPlayerPassStatus =
   | "OPEN"
@@ -56,6 +46,7 @@ export class TemporaryPlayerPassError extends Error {
   constructor(
     public readonly code:
       | "INVALID_PASS"
+      | "INVALID_AMOUNT"
       | "PASS_EXPIRED"
       | "PASS_USED"
       | "PASS_REVOKED"
@@ -327,12 +318,23 @@ export async function redeemTemporaryPlayerPass(input: {
   code: string;
   fixtureId: string;
   teamId: string;
+  amountPence: number;
   acceptedByUserId: string | null;
 }) {
   await expireOldPasses();
   const code = normaliseTemporaryPlayerPassCode(input.code);
   if (!/^TP-[A-Z0-9]{6}$/.test(code)) {
     throw new TemporaryPlayerPassError("INVALID_PASS", "That temporary-player pass is not valid.");
+  }
+  if (
+    !Number.isInteger(input.amountPence) ||
+    input.amountPence < 0 ||
+    input.amountPence > MAX_TEMPORARY_PLAYER_MATCH_FEE_PENCE
+  ) {
+    throw new TemporaryPlayerPassError(
+      "INVALID_AMOUNT",
+      "Choose a temporary-player match fee between £0 and £100.",
+    );
   }
 
   return prisma.$transaction(async (tx) => {
@@ -413,15 +415,23 @@ export async function redeemTemporaryPlayerPass(input: {
     }
 
     const playerMatchFeeId = createId("tmp");
-    const amountPence = getDefaultPlayerMatchFeePence();
+    const amountPence = input.amountPence;
+    const feeStatus = amountPence === 0 ? "WAIVED" : "OPEN";
+    const waivedAt = amountPence === 0 ? new Date() : null;
+    const feeNote =
+      amountPence === 0
+        ? "Temporary player linked using a player-created one-time pass. The captain set this player as having no match fee when accepting the pass."
+        : `Temporary player linked using a player-created one-time pass. The captain set the match fee to £${(
+            amountPence / 100
+          ).toFixed(2)} when accepting the pass.`;
+
     await tx.$executeRaw`
       INSERT INTO "PlayerMatchFee" (
         "id", "fixtureId", "teamId", "temporaryUserId", "amountPence",
-        "status", "note", "createdAt", "updatedAt"
+        "status", "waivedAt", "note", "createdAt", "updatedAt"
       ) VALUES (
         ${playerMatchFeeId}, ${input.fixtureId}, ${input.teamId}, ${pass.userId}, ${amountPence},
-        'OPEN'::"PlayerMatchFeeStatus",
-        'Temporary player joined using a player-created one-time pass. Fee uses the configured default player match fee and can be reviewed by the captain.',
+        ${feeStatus}::"PlayerMatchFeeStatus", ${waivedAt}, ${feeNote},
         NOW(), NOW()
       )
     `;

--- a/src/lib/temporary-player-requests.ts
+++ b/src/lib/temporary-player-requests.ts
@@ -90,6 +90,7 @@ export async function acceptTemporaryPlayerRequest(input: {
   requestId: string;
   teamId: string;
   fixtureId: string;
+  amountPence: number;
   acceptedByUserId: string | null;
 }) {
   const request = await getOpenRequest(input);
@@ -104,6 +105,7 @@ export async function acceptTemporaryPlayerRequest(input: {
     code: request.code,
     fixtureId: input.fixtureId,
     teamId: input.teamId,
+    amountPence: input.amountPence,
     acceptedByUserId: input.acceptedByUserId,
   });
 }


### PR DESCRIPTION
## What was wrong

A player linked through the temporary-player pass was stored with `temporaryUserId`, but the Matchday Squad tracker only resolved ordinary squad members and prospects. That left a correctly linked player displayed as **Unknown player / No contact**.

The acceptance flow also created an automatic £6 fee before the team had chosen what the temporary player should pay.

## What changed

- resolves the linked temporary player's account and shows their **first name** and email in the admin fee tracker
- adds a clear **Temporary player** badge
- rewrites the old default-fee note into player-facing wording
- excludes team-set temporary-player fees from the normal £6 mismatch warning
- requires the captain/team to enter the temporary-player fee before accepting either an automatic request or a one-time pass
- allows **£0** where no fee is due; no amount is prefilled or assumed
- creates positive fees as Open and £0 fees as Waived
- lets captains revise an unpaid temporary-player fee from the temporary-player panel
- locks paid or cancelled fees so they cannot be changed unsafely
- cancels stale queued payment notifications when an unpaid temporary-player amount is changed

## Existing records

Existing temporary-player rows are identified by their stored `temporaryUserId`, so Louie's existing row will display his first name after deployment. Its current £6 value is not silently changed; the team can open **Add temporary player** and update the unpaid fee to the intended amount, including £0.

## Safety

- no player records or memberships are merged or recreated
- no database migration is required; the existing temporary-user link is used
- paid fees remain locked
- no DOM bridge was added
- existing £6 defaults for ordinary managed-squad players are unchanged