### PR TITLE
CI-only: validate payment DOM retirement

### DIFF
--- a/src/components/captain/PaymentDomCiMarker.tsx
+++ b/src/components/captain/PaymentDomCiMarker.tsx
@@ -1,0 +1,1 @@
+export const paymentDomCiMarker = true;


### PR DESCRIPTION
Temporary validation PR. It contains only a docs marker on top of current main and is not intended to merge. Used to run the repository's PR checks against the current payment-DOM retirement state.