### PR TITLE
Add league table to captain navigation

### DIFF
--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -329,6 +329,10 @@ export default async function CaptainTeamLayout({
     },
     { href: `/captain/team/${teamid}/whatsapp`, label: "WhatsApp" },
     { href: `/captain/team/${teamid}/fixtures`, label: "Fixtures" },
+    {
+      href: `/captain/team/${teamid}#captain-league-table`,
+      label: "Table",
+    },
     { href: `/captain/team/${teamid}/results-history`, label: "Results" },
     { href: `/captain/team/${teamid}/results`, label: "Match reports" },
     {


### PR DESCRIPTION
## What changed

- adds a **Table** option to the captain team navigation
- places it beside **Fixtures** and **Results**
- links directly to the existing current league table on the captain overview page

## Result

Captains and admin viewers can open the league table from any captain-team page without first finding it on the overview.

## Safety

- reuses the existing native captain league-table component and anchor
- no database, standings calculation or payment changes
- no DOM bridge or build-time patch added