### PR TITLE
Move player stats and results into League & media

### DIFF
--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -330,7 +330,6 @@ export default async function CaptainTeamLayout({
       items: [
         { href: `/captain/team/${teamid}`, label: "Overview" },
         { href: squadHref, label: "Squad" },
-        { href: `/captain/team/${teamid}/player-stats`, label: "Player stats" },
         ...(access.isAdmin
           ? [{ href: `/captain/team/${teamid}/prospects`, label: "Prospects" }]
           : []),
@@ -349,7 +348,6 @@ export default async function CaptainTeamLayout({
           href: `/captain/team/${teamid}/weeks-unavailable`,
           label: "Weeks unavailable",
         },
-        { href: `/captain/team/${teamid}/results-history`, label: "Results" },
         { href: `/captain/team/${teamid}/results`, label: "Match reports" },
       ],
     },
@@ -360,6 +358,8 @@ export default async function CaptainTeamLayout({
           href: `/captain/team/${teamid}#captain-league-table`,
           label: "Table",
         },
+        { href: `/captain/team/${teamid}/results-history`, label: "Results" },
+        { href: `/captain/team/${teamid}/player-stats`, label: "Player stats" },
         {
           href: `/captain/team/${teamid}/tv`,
           label: "SIXFL TV",


### PR DESCRIPTION
## What changed

- moves **Player stats** out of **Team & players**
- moves **Results** out of **Matchday**
- places both links in **League & media** alongside **Table** and **SIXFL TV**
- leaves **Match reports** in Matchday because that is where captains complete match information

## New League & media order

Table → Results → Player stats → SIXFL TV

## Safety

- navigation order only
- no routes, permissions, tables, results data or player statistics logic changed
- no DOM bridge or build-time patch added