### PR TITLE
Fix referee night score saving

### DIFF
--- a/src/app/(public)/referee/actions.ts
+++ b/src/app/(public)/referee/actions.ts
@@ -11,6 +11,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/lib/prisma";
 import { requireReferee } from "@/lib/admin";
 import {
+  getRefereeNightFixtureIds,
   parseMoneyToPence,
   recalculateRefereeNightCashup,
 } from "@/lib/referee-nights";
@@ -117,9 +118,6 @@ async function assertNightAccess(input: {
   const rows = await prisma.$queryRaw<Array<{ id: string; refereeId: string }>>(Prisma.sql`
     SELECT rn.id, rn."refereeId"
     FROM "RefereeNight" rn
-    ${input.fixtureId
-      ? Prisma.sql`JOIN "RefereeNightFixture" rnf ON rnf."refereeNightId" = rn.id AND rnf."fixtureId" = ${input.fixtureId}`
-      : Prisma.empty}
     WHERE rn.id = ${input.refereeNightId}
     LIMIT 1
   `);
@@ -129,6 +127,13 @@ async function assertNightAccess(input: {
 
   if (input.user.role !== UserRole.ADMIN && night.refereeId !== input.user.id) {
     throw new Error("You are not allowed to access this referee night.");
+  }
+
+  if (input.fixtureId) {
+    const visibleFixtureIds = await getRefereeNightFixtureIds(input.refereeNightId);
+    if (!visibleFixtureIds.includes(input.fixtureId)) {
+      throw new Error("Fixture is not part of this referee night.");
+    }
   }
 
   return night;


### PR DESCRIPTION
Fixes the referee-night form failure when a fixture is visible on the referee sheet through its live referee/date/league/venue assignment but does not have a direct RefereeNightFixture link.

Root cause:
- the referee sheet uses `getRefereeNightFixtureIds()`, which deliberately includes both explicit RefereeNightFixture links and fixtures matched by referee/date/league/venue
- the server action's `assertNightAccess()` only accepted explicit RefereeNightFixture rows
- therefore a score form could be shown to the referee but saving it threw a server-side exception before the result transaction ran

Fix:
- make `assertNightAccess()` use `getRefereeNightFixtureIds()` as the same source of truth as the page
- this also fixes the same mismatch for referee-night cash and disciplinary note actions
- no changes to result calculation, standings, match fees or referee-night visibility rules