### PR TITLE
Prevent managed captain login redirect loops

### DIFF
--- a/src/app/(public)/dashboard/page.tsx
+++ b/src/app/(public)/dashboard/page.tsx
@@ -5,7 +5,7 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { TeamRole, UserRole } from "@prisma/client";
+import { TeamMode, TeamRole, UserRole } from "@prisma/client";
 
 import { authOptions } from "@/auth";
 import { prisma } from "@/lib/prisma";
@@ -13,7 +13,15 @@ import { prisma } from "@/lib/prisma";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-function getTeamRedirectPath(input: { teamId: string; role: TeamRole }) {
+function getTeamRedirectPath(input: {
+  teamId: string;
+  role: TeamRole;
+  teamMode: TeamMode;
+}) {
+  if (input.teamMode === TeamMode.MANAGED) {
+    return `/player/team/${input.teamId}`;
+  }
+
   if (input.role === TeamRole.CAPTAIN || input.role === TeamRole.MANAGER) {
     return `/captain/team/${input.teamId}`;
   }
@@ -39,6 +47,7 @@ function TeamChoiceCard({
     team: {
       id: string;
       name: string;
+      teamMode: TeamMode;
       league: {
         name: string;
         season: string | null;
@@ -51,6 +60,7 @@ function TeamChoiceCard({
       href={getTeamRedirectPath({
         teamId: membership.teamId,
         role: membership.role,
+        teamMode: membership.team.teamMode,
       })}
       className="rounded-2xl border border-white/10 bg-white/[0.04] p-5 transition hover:border-emerald-400/30 hover:bg-emerald-500/10"
     >
@@ -99,6 +109,7 @@ export default async function DashboardPage() {
             select: {
               id: true,
               name: true,
+              teamMode: true,
               league: {
                 select: {
                   name: true,
@@ -181,6 +192,7 @@ export default async function DashboardPage() {
       getTeamRedirectPath({
         teamId: primaryMembership.teamId,
         role: primaryMembership.role,
+        teamMode: primaryMembership.team.teamMode,
       }),
     );
   }

--- a/src/lib/requireCaptain.ts
+++ b/src/lib/requireCaptain.ts
@@ -103,7 +103,7 @@ export async function requireCaptain(
   const isAdmin = Boolean(rawIsAdmin && !isCaptainOnlyPreview);
   const isCaptain = Boolean(!isManagedTeam && (membership || isCaptainOnlyPreview));
 
-  if ((!rawIsAdmin && !membership) || (isManagedTeam && !rawIsAdmin)) {
+  if (!rawIsAdmin && !membership) {
     if (process.env.NODE_ENV !== "production") {
       return {
         session,
@@ -116,6 +116,21 @@ export async function requireCaptain(
     }
 
     redirect("/dashboard");
+  }
+
+  if (isManagedTeam && !rawIsAdmin) {
+    if (process.env.NODE_ENV !== "production") {
+      return {
+        session,
+        user,
+        membership,
+        isAdmin: false,
+        isCaptain: false,
+        accessMode: "captain",
+      };
+    }
+
+    redirect(`/player/team/${teamId}`);
   }
 
   return {


### PR DESCRIPTION
Fixes the managed-team captain login loop without granting managed-team admin controls.

Root cause:
- `/dashboard` sent every CAPTAIN/MANAGER membership to `/captain/team/[teamid]`
- `requireCaptain()` rejects non-admin access when that team is `MANAGED` and sent the same user back to `/dashboard`
- this creates Dashboard -> Captain -> Dashboard until the browser reports too many redirects

Fix:
- dashboard routing now checks `teamMode`
- managed-team captains/managers go to their normal player/team area instead of the captain management area
- direct/stale captain URLs for managed teams also fall back to `/player/team/[teamid]` rather than `/dashboard`, so they cannot create a loop
- standard-team CAPTAIN/MANAGER routing is unchanged and still goes to the captain dashboard

This is intentionally conservative: it fixes login immediately while preserving the restriction that SIXFL manages managed teams.