### PR TITLE
Recover missing historical AI predictions safely

### DIFF
--- a/src/lib/fixtures/recoverHistoricalAiPredictions.ts
+++ b/src/lib/fixtures/recoverHistoricalAiPredictions.ts
@@ -1,0 +1,175 @@
+import { createHash } from "crypto";
+import { Prisma } from "@prisma/client";
+
+import { getFallbackFixtureAiPreview } from "@/lib/fixtures/aiPredictor";
+import { buildNameAwareWinChanceFixtures } from "@/lib/fixtures/winChanceHistory";
+import { calculateFixtureWinChance } from "@/lib/fixtures/winChance";
+import { prisma } from "@/lib/prisma";
+import { getFixturePlaceholderTeamIds } from "@/lib/teams/fixture-placeholders";
+
+type RecoveryFixture = {
+  id: string;
+  leagueId: string;
+  kickoffAt: Date;
+  status: string;
+  homeTeam: { id: string; name: string };
+  awayTeam: { id: string; name: string };
+};
+
+function recoveryHash(input: {
+  fixture: RecoveryFixture;
+  predictedResult: string;
+  home: number;
+  draw: number;
+  away: number;
+  confidence: string;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        recoveryVersion: 1,
+        fixtureId: input.fixture.id,
+        homeTeamId: input.fixture.homeTeam.id,
+        homeTeamName: input.fixture.homeTeam.name,
+        awayTeamId: input.fixture.awayTeam.id,
+        awayTeamName: input.fixture.awayTeam.name,
+        predictedResult: input.predictedResult,
+        home: input.home,
+        draw: input.draw,
+        away: input.away,
+        confidence: input.confidence,
+      }),
+    )
+    .digest("hex");
+}
+
+async function ensurePredictionScoreColumns() {
+  await prisma.$executeRawUnsafe(
+    'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "predictedHomeScore" INTEGER',
+  );
+  await prisma.$executeRawUnsafe(
+    'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "predictedAwayScore" INTEGER',
+  );
+}
+
+export async function recoverMissingHistoricalAiPredictions(fixtureIds: string[]) {
+  const ids = Array.from(new Set(fixtureIds.filter(Boolean)));
+  if (ids.length === 0) return 0;
+
+  await ensurePredictionScoreColumns();
+
+  const existingRows = await prisma.$queryRaw<Array<{ fixtureId: string }>>`
+    SELECT "fixtureId"
+    FROM "FixtureAiPrediction"
+    WHERE "fixtureId" IN (${Prisma.join(ids)})
+  `;
+  const existingIds = new Set(existingRows.map((row) => row.fixtureId));
+  const missingIds = ids.filter((id) => !existingIds.has(id));
+  if (missingIds.length === 0) return 0;
+
+  const candidates = await prisma.fixture.findMany({
+    where: {
+      id: { in: missingIds },
+      publishedAt: { not: null },
+      result: { isNot: null },
+    },
+    select: {
+      id: true,
+      leagueId: true,
+      kickoffAt: true,
+      status: true,
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+    },
+  });
+
+  let recovered = 0;
+
+  for (const fixture of candidates) {
+    const placeholderTeamIds = await getFixturePlaceholderTeamIds([
+      fixture.homeTeam.id,
+      fixture.awayTeam.id,
+    ]);
+    if (placeholderTeamIds.size > 0) continue;
+
+    // Only use results that were actually entered before this fixture kicked off.
+    // That prevents this fixture's result, future results, or late backfills from
+    // leaking into the recovered pre-match prediction.
+    const historyFixtures = await prisma.fixture.findMany({
+      where: {
+        leagueId: fixture.leagueId,
+        publishedAt: { not: null },
+        kickoffAt: { lt: fixture.kickoffAt },
+        result: {
+          is: {
+            enteredAt: { lt: fixture.kickoffAt },
+          },
+        },
+      },
+      orderBy: [{ kickoffAt: "asc" }],
+      select: {
+        kickoffAt: true,
+        status: true,
+        homeTeam: { select: { id: true, name: true } },
+        awayTeam: { select: { id: true, name: true } },
+        result: { select: { homeScore: true, awayScore: true } },
+      },
+    });
+
+    const predictionHistory = buildNameAwareWinChanceFixtures({
+      historyFixtures,
+      targetFixtures: [fixture],
+    });
+    const winChance = calculateFixtureWinChance({
+      homeTeamId: fixture.homeTeam.id,
+      awayTeamId: fixture.awayTeam.id,
+      fixtures: predictionHistory,
+    });
+    const preview = getFallbackFixtureAiPreview(
+      {
+        homeTeamName: fixture.homeTeam.name,
+        awayTeamName: fixture.awayTeam.name,
+        winChance,
+      },
+      "Recovered from results that were recorded before kick-off because the original stored prediction row was missing.",
+    );
+    const inputHash = recoveryHash({
+      fixture,
+      predictedResult: winChance.predictedResult.label,
+      home: winChance.home,
+      draw: winChance.draw,
+      away: winChance.away,
+      confidence: winChance.confidence,
+    });
+
+    const inserted = await prisma.$executeRaw`
+      INSERT INTO "FixtureAiPrediction" (
+        "fixtureId",
+        "headline",
+        "summary",
+        "source",
+        "inputHash",
+        "generatedAt",
+        "updatedAt",
+        "predictedHomeScore",
+        "predictedAwayScore"
+      )
+      VALUES (
+        ${fixture.id},
+        ${preview.headline},
+        ${preview.summary},
+        'recovered',
+        ${inputHash},
+        NOW(),
+        NOW(),
+        ${winChance.predictedResult.homeScore},
+        ${winChance.predictedResult.awayScore}
+      )
+      ON CONFLICT ("fixtureId") DO NOTHING
+    `;
+
+    if (inserted > 0) recovered += 1;
+  }
+
+  return recovered;
+}

--- a/src/lib/fixtures/storedAiPredictions.ts
+++ b/src/lib/fixtures/storedAiPredictions.ts
@@ -11,6 +11,7 @@ import {
   hasOpenAiPredictorConfig,
   type FixtureAiPreview,
 } from "@/lib/fixtures/aiPredictor";
+import { recoverMissingHistoricalAiPredictions } from "@/lib/fixtures/recoverHistoricalAiPredictions";
 import { calculateFixtureWinChance, type FixtureWinChance, type WinChanceFixture } from "@/lib/fixtures/winChance";
 import { prisma } from "@/lib/prisma";
 import { getFixturePlaceholderTeamIds } from "@/lib/teams/fixture-placeholders";
@@ -138,6 +139,11 @@ export async function getStoredAiPreviewsByFixtureIds(fixtureIds: string[]) {
   if (ids.length === 0) return new Map<string, StoredFixtureAiPreview>();
 
   await ensurePredictionScoreColumns();
+
+  // Repair only genuinely missing completed-fixture rows. Recovery is calculated
+  // from results that had been entered before each fixture kicked off, so the
+  // fixture's own result and later information cannot influence the score.
+  await recoverMissingHistoricalAiPredictions(ids);
 
   const rows = await prisma.$queryRaw<StoredPredictionRow[]>`
     SELECT


### PR DESCRIPTION
Recovers completed-fixture AI score predictions when the original stored FixtureAiPrediction row is missing.

Recovery safeguards:
- never overwrites an existing stored prediction
- only considers published fixtures that already have a result
- only uses earlier league fixtures
- only uses results whose enteredAt timestamp was before the target fixture kicked off
- excludes the target fixture result, future results and late-entered historical results
- uses the same deterministic SIXFL scoreline calculation and name-aware team history used by the live predictor
- records recovered rows internally with source = recovered

The stored prediction loader now runs this repair before returning results, so a missing completed prediction can reappear automatically when the captain/results UI loads it.

This specifically addresses completed results showing no AI score because no pre-match prediction row was persisted. It does not alter any existing genuine predictions or match results.