### PR TITLE
Tidy squad payment helper spacing

### DIFF
--- a/src/components/captain/CaptainSupportPanel.tsx
+++ b/src/components/captain/CaptainSupportPanel.tsx
@@ -229,19 +229,19 @@ export default function CaptainSupportPanel({ teamId }: { teamId: string }) {
       </div>
 
       {isSquadPayments(pathname) ? (
-        <div className="mt-5 rounded-2xl border border-emerald-300/25 bg-emerald-500/10 p-4 sm:p-5">
+        <div className="mt-5 max-w-5xl rounded-2xl border border-emerald-300/25 bg-emerald-500/10 p-5 sm:p-6">
           <p className="text-sm font-semibold text-emerald-50">Set up squad payments in 5 steps</p>
-          <ol className="mt-3 grid gap-2 text-sm leading-6 text-emerald-50/80 md:grid-cols-5">
-            <li><strong className="text-white">1.</strong> Choose the fixture.</li>
-            <li><strong className="text-white">2.</strong> Enter the normal amount per player.</li>
-            <li><strong className="text-white">3.</strong> Tick the players contributing.</li>
-            <li><strong className="text-white">4.</strong> Choose how each player is paying.</li>
-            <li><strong className="text-white">5.</strong> Save player collection.</li>
+          <ol className="mt-4 grid gap-x-5 gap-y-3 text-sm leading-5 text-emerald-50/80 sm:grid-cols-2 lg:grid-cols-5">
+            <li className="flex gap-2"><strong className="shrink-0 text-white">1.</strong><span>Choose the fixture.</span></li>
+            <li className="flex gap-2"><strong className="shrink-0 text-white">2.</strong><span>Enter the normal amount per player.</span></li>
+            <li className="flex gap-2"><strong className="shrink-0 text-white">3.</strong><span>Tick the players contributing.</span></li>
+            <li className="flex gap-2"><strong className="shrink-0 text-white">4.</strong><span>Choose how each player is paying.</span></li>
+            <li className="flex gap-2"><strong className="shrink-0 text-white">5.</strong><span>Save player collection.</span></li>
           </ol>
-          <div className="mt-4 rounded-xl border border-amber-300/25 bg-amber-400/10 p-3 text-sm font-semibold leading-6 text-amber-50">
+          <div className="mt-5 rounded-xl border border-amber-300/25 bg-amber-400/10 px-4 py-3.5 text-sm font-semibold leading-6 text-amber-50">
             Important: make sure every player has an email address saved in your Squad before setting up payments. If an email address is missing, SIXFL cannot email that player's payment link.
           </div>
-          <div className="mt-4 flex flex-wrap gap-3">
+          <div className="mt-5 flex flex-wrap items-center gap-2.5">
             <Link href={`/captain/team/${teamId}/help#squad-payments`} className="inline-flex items-center justify-center rounded-full border border-emerald-300/30 bg-emerald-400/15 px-4 py-2.5 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-400/20">
               Show full squad payment guide
             </Link>


### PR DESCRIPTION
Small visual tidy-up to the new squad payment helper.

Changes only the helper layout/spacing:
- constrains the helper width so it does not stretch awkwardly across large screens
- gives the five steps clearer spacing and alignment
- improves wrapping on smaller screens
- adds breathing room around the email warning
- tightens the spacing between the two help buttons

No wording, payment logic or behaviour is changed.