### PR TITLE
Store AI predictions for every generated fixture

### DIFF
--- a/src/app/(admin)/admin/ai-predictor/page.tsx
+++ b/src/app/(admin)/admin/ai-predictor/page.tsx
@@ -24,8 +24,18 @@ type PredictionAuditRow = {
   predictedAwayScore: number | null;
   actualHomeScore: number;
   actualAwayScore: number;
-  source: string;
-  generatedAt: Date;
+  source: string | null;
+  generatedAt: Date | null;
+};
+
+type UpcomingCoverageRow = {
+  fixtureId: string;
+  kickoffAt: Date;
+  leagueName: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  predictedHomeScore: number | null;
+  predictedAwayScore: number | null;
 };
 
 type Outcome = "HOME" | "DRAW" | "AWAY";
@@ -42,7 +52,10 @@ type EvaluatedPrediction = PredictionAuditRow & {
 
 type WeeklyStats = {
   weekKey: string;
-  total: number;
+  totalFixtures: number;
+  measured: number;
+  recovered: number;
+  missing: number;
   correct: number;
   wrong: number;
   exact: number;
@@ -82,9 +95,9 @@ function weekLabel(weekKey: string) {
   return dateFormatter.format(new Date(`${weekKey}T12:00:00.000Z`));
 }
 
-function percentage(correct: number, total: number) {
+function percentage(value: number, total: number) {
   if (total === 0) return "—";
-  return `${Math.round((correct / total) * 100)}%`;
+  return `${Math.round((value / total) * 100)}%`;
 }
 
 function averageGoalError(goalError: number, total: number) {
@@ -100,7 +113,21 @@ function accuracyClasses(correct: number, total: number) {
   return "text-red-300";
 }
 
-function callBadge(row: EvaluatedPrediction) {
+function coverageClasses(stored: number, total: number) {
+  if (total === 0) return "text-white/55";
+  if (stored === total) return "text-emerald-300";
+  if (stored / total >= 0.9) return "text-amber-300";
+  return "text-red-300";
+}
+
+function callBadge(row: EvaluatedPrediction | null) {
+  if (!row) {
+    return {
+      label: "Missing prediction",
+      className: "border-red-400/25 bg-red-500/10 text-red-100",
+    };
+  }
+
   if (row.recovered) {
     return {
       label: "Recovered · excluded",
@@ -119,37 +146,79 @@ function callBadge(row: EvaluatedPrediction) {
       };
 }
 
+function hasStoredScore(row: {
+  predictedHomeScore: number | null;
+  predictedAwayScore: number | null;
+}) {
+  return row.predictedHomeScore !== null && row.predictedAwayScore !== null;
+}
+
+function emptyWeek(weekKey: string): WeeklyStats {
+  return {
+    weekKey,
+    totalFixtures: 0,
+    measured: 0,
+    recovered: 0,
+    missing: 0,
+    correct: 0,
+    wrong: 0,
+    exact: 0,
+    goalError: 0,
+  };
+}
+
 export default async function AiPredictorAccuracyPage() {
   await requireAdmin();
 
-  const rows = await prisma.$queryRaw<PredictionAuditRow[]>(Prisma.sql`
-    SELECT
-      prediction."fixtureId" AS "fixtureId",
-      fixture."kickoffAt" AS "kickoffAt",
-      league."name" AS "leagueName",
-      home_team."name" AS "homeTeamName",
-      away_team."name" AS "awayTeamName",
-      prediction."predictedHomeScore" AS "predictedHomeScore",
-      prediction."predictedAwayScore" AS "predictedAwayScore",
-      result."homeScore" AS "actualHomeScore",
-      result."awayScore" AS "actualAwayScore",
-      prediction."source" AS "source",
-      prediction."generatedAt" AS "generatedAt"
-    FROM "FixtureAiPrediction" prediction
-    JOIN "Fixture" fixture ON fixture."id" = prediction."fixtureId"
-    JOIN "MatchResult" result ON result."fixtureId" = fixture."id"
-    JOIN "League" league ON league."id" = fixture."leagueId"
-    JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
-    JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
-    WHERE fixture."status" = 'COMPLETED'
-      AND COALESCE(home_team."isFixturePlaceholder", false) = false
-      AND COALESCE(away_team."isFixturePlaceholder", false) = false
-    ORDER BY fixture."kickoffAt" DESC
-  `);
+  const [rows, upcomingRows] = await Promise.all([
+    prisma.$queryRaw<PredictionAuditRow[]>(Prisma.sql`
+      SELECT
+        fixture."id" AS "fixtureId",
+        fixture."kickoffAt" AS "kickoffAt",
+        league."name" AS "leagueName",
+        home_team."name" AS "homeTeamName",
+        away_team."name" AS "awayTeamName",
+        prediction."predictedHomeScore" AS "predictedHomeScore",
+        prediction."predictedAwayScore" AS "predictedAwayScore",
+        result."homeScore" AS "actualHomeScore",
+        result."awayScore" AS "actualAwayScore",
+        prediction."source" AS "source",
+        prediction."generatedAt" AS "generatedAt"
+      FROM "Fixture" fixture
+      JOIN "MatchResult" result ON result."fixtureId" = fixture."id"
+      JOIN "League" league ON league."id" = fixture."leagueId"
+      JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+      JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+      LEFT JOIN "FixtureAiPrediction" prediction ON prediction."fixtureId" = fixture."id"
+      WHERE fixture."status" = 'COMPLETED'
+        AND COALESCE(home_team."isFixturePlaceholder", false) = false
+        AND COALESCE(away_team."isFixturePlaceholder", false) = false
+      ORDER BY fixture."kickoffAt" DESC
+    `),
+    prisma.$queryRaw<UpcomingCoverageRow[]>(Prisma.sql`
+      SELECT
+        fixture."id" AS "fixtureId",
+        fixture."kickoffAt" AS "kickoffAt",
+        league."name" AS "leagueName",
+        home_team."name" AS "homeTeamName",
+        away_team."name" AS "awayTeamName",
+        prediction."predictedHomeScore" AS "predictedHomeScore",
+        prediction."predictedAwayScore" AS "predictedAwayScore"
+      FROM "Fixture" fixture
+      JOIN "League" league ON league."id" = fixture."leagueId"
+      JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+      JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+      LEFT JOIN "FixtureAiPrediction" prediction ON prediction."fixtureId" = fixture."id"
+      WHERE fixture."status" = 'SCHEDULED'
+        AND COALESCE(home_team."isFixturePlaceholder", false) = false
+        AND COALESCE(away_team."isFixturePlaceholder", false) = false
+      ORDER BY fixture."kickoffAt" ASC
+    `),
+  ]);
 
   const scoredRows = rows.filter(
     (row): row is PredictionAuditRow & { predictedHomeScore: number; predictedAwayScore: number } =>
-      row.predictedHomeScore !== null && row.predictedAwayScore !== null,
+      hasStoredScore(row),
   );
 
   const evaluated: EvaluatedPrediction[] = scoredRows.map((row) => {
@@ -172,31 +241,35 @@ export default async function AiPredictorAccuracyPage() {
     };
   });
 
-  // Recovered rows are useful for restoring missing historical fixture displays, but
-  // they were reconstructed later using the current predictor logic. Keep them visible
-  // for context without allowing them to inflate or depress the live accuracy measure.
   const measured = evaluated.filter((row) => !row.recovered);
-  const recoveredCount = evaluated.length - measured.length;
-  const unmeasurableCount = rows.length - scoredRows.length;
-
+  const evaluatedByFixtureId = new Map(evaluated.map((row) => [row.fixtureId, row]));
   const weeklyMap = new Map<string, WeeklyStats>();
 
-  for (const row of measured) {
-    const current = weeklyMap.get(row.weekKey) ?? {
-      weekKey: row.weekKey,
-      total: 0,
-      correct: 0,
-      wrong: 0,
-      exact: 0,
-      goalError: 0,
-    };
+  for (const row of rows) {
+    const weekKey = mondayKey(row.kickoffAt);
+    const week = weeklyMap.get(weekKey) ?? emptyWeek(weekKey);
+    week.totalFixtures += 1;
+    weeklyMap.set(weekKey, week);
+  }
 
-    current.total += 1;
-    current.correct += row.resultCorrect ? 1 : 0;
-    current.wrong += row.resultCorrect ? 0 : 1;
-    current.exact += row.exactScore ? 1 : 0;
-    current.goalError += row.goalError;
-    weeklyMap.set(row.weekKey, current);
+  for (const row of evaluated) {
+    const week = weeklyMap.get(row.weekKey) ?? emptyWeek(row.weekKey);
+
+    if (row.recovered) {
+      week.recovered += 1;
+    } else {
+      week.measured += 1;
+      week.correct += row.resultCorrect ? 1 : 0;
+      week.wrong += row.resultCorrect ? 0 : 1;
+      week.exact += row.exactScore ? 1 : 0;
+      week.goalError += row.goalError;
+    }
+
+    weeklyMap.set(row.weekKey, week);
+  }
+
+  for (const week of weeklyMap.values()) {
+    week.missing = Math.max(week.totalFixtures - week.measured - week.recovered, 0);
   }
 
   const weekly = Array.from(weeklyMap.values()).sort((a, b) => b.weekKey.localeCompare(a.weekKey));
@@ -205,6 +278,15 @@ export default async function AiPredictorAccuracyPage() {
   const totalWrong = measured.length - totalCorrect;
   const totalExact = measured.filter((row) => row.exactScore).length;
   const totalGoalError = measured.reduce((sum, row) => sum + row.goalError, 0);
+  const recoveredCount = evaluated.filter((row) => row.recovered).length;
+  const missingCompletedCount = rows.length - scoredRows.length;
+
+  const nextWeekKey = upcomingRows[0] ? mondayKey(upcomingRows[0].kickoffAt) : null;
+  const nextWeekRows = nextWeekKey
+    ? upcomingRows.filter((row) => mondayKey(row.kickoffAt) === nextWeekKey)
+    : [];
+  const nextWeekStored = nextWeekRows.filter(hasStoredScore);
+  const nextWeekMissing = nextWeekRows.filter((row) => !hasStoredScore(row));
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
@@ -214,24 +296,44 @@ export default async function AiPredictorAccuracyPage() {
             AI predictor monitoring
           </p>
           <h1 className="mt-2 text-3xl font-black tracking-tight text-white sm:text-4xl">
-            Predictor accuracy
+            Predictor accuracy & coverage
           </h1>
           <p className="mt-3 max-w-4xl text-sm leading-6 text-white/60">
-            Tracks completed fixtures with a genuine stored pre-match predictor score. Result accuracy means the predictor correctly called a home win, draw or away win. Exact-score accuracy is shown separately because it is a much stricter test.
+            Coverage shows whether every real fixture has a permanently stored pre-match prediction. Accuracy only scores genuine predictions that were stored before the result; recovered historical rows remain visible but are excluded.
           </p>
         </div>
         {recoveredCount > 0 ? (
           <div className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-100">
-            {recoveredCount} recovered historical row{recoveredCount === 1 ? "" : "s"} excluded
+            {recoveredCount} recovered historical row{recoveredCount === 1 ? "" : "s"} excluded from accuracy
           </div>
         ) : null}
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <div className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/65">Latest week accuracy</p>
-          <p className={`mt-3 text-4xl font-black ${latestWeek ? accuracyClasses(latestWeek.correct, latestWeek.total) : "text-white/55"}`}>
-            {latestWeek ? percentage(latestWeek.correct, latestWeek.total) : "—"}
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/65">Next fixture week coverage</p>
+          <p className={`mt-3 text-4xl font-black ${coverageClasses(nextWeekStored.length, nextWeekRows.length)}`}>
+            {nextWeekRows.length ? `${nextWeekStored.length}/${nextWeekRows.length}` : "—"}
+          </p>
+          <p className="mt-2 text-xs text-white/45">
+            {nextWeekKey ? `Week commencing ${weekLabel(nextWeekKey)} · ${percentage(nextWeekStored.length, nextWeekRows.length)} stored` : "No scheduled fixtures"}
+          </p>
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Latest played week coverage</p>
+          <p className={`mt-3 text-4xl font-black ${latestWeek ? coverageClasses(latestWeek.measured, latestWeek.totalFixtures) : "text-white/55"}`}>
+            {latestWeek ? `${latestWeek.measured}/${latestWeek.totalFixtures}` : "—"}
+          </p>
+          <p className="mt-2 text-xs text-white/45">
+            {latestWeek ? `${latestWeek.recovered} recovered · ${latestWeek.missing} missing` : "No completed fixtures yet"}
+          </p>
+        </div>
+
+        <div className="rounded-3xl border border-sky-400/20 bg-sky-500/10 p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-100/65">Latest result accuracy</p>
+          <p className={`mt-3 text-4xl font-black ${latestWeek ? accuracyClasses(latestWeek.correct, latestWeek.measured) : "text-white/55"}`}>
+            {latestWeek ? percentage(latestWeek.correct, latestWeek.measured) : "—"}
           </p>
           <p className="mt-2 text-xs text-white/45">
             {latestWeek ? `Week commencing ${weekLabel(latestWeek.weekKey)}` : "No completed live predictions yet"}
@@ -246,14 +348,14 @@ export default async function AiPredictorAccuracyPage() {
             <span className="text-3xl font-black text-red-300">{latestWeek?.wrong ?? 0}</span>
             <span className="pb-1 text-xs text-white/40">wrong</span>
           </div>
-          <p className="mt-2 text-xs text-white/45">{latestWeek?.total ?? 0} measured fixture{latestWeek?.total === 1 ? "" : "s"}</p>
+          <p className="mt-2 text-xs text-white/45">{latestWeek?.measured ?? 0} genuine prediction{latestWeek?.measured === 1 ? "" : "s"} measured</p>
         </div>
 
         <div className="rounded-3xl border border-sky-400/20 bg-sky-500/10 p-5">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-100/65">Latest exact scores</p>
           <p className="mt-3 text-4xl font-black text-sky-200">{latestWeek?.exact ?? 0}</p>
           <p className="mt-2 text-xs text-white/45">
-            {latestWeek ? `${percentage(latestWeek.exact, latestWeek.total)} of that week's fixtures` : "No completed live predictions yet"}
+            {latestWeek ? `${percentage(latestWeek.exact, latestWeek.measured)} of measured predictions` : "No completed live predictions yet"}
           </p>
         </div>
 
@@ -266,13 +368,34 @@ export default async function AiPredictorAccuracyPage() {
         </div>
       </div>
 
+      {nextWeekMissing.length > 0 ? (
+        <section className="rounded-3xl border border-red-400/25 bg-red-500/[0.08] p-6">
+          <h2 className="text-xl font-semibold text-red-100">Missing upcoming predictions</h2>
+          <p className="mt-1 text-sm text-red-100/65">
+            {nextWeekMissing.length} fixture{nextWeekMissing.length === 1 ? " is" : "s are"} missing a stored score in the next fixture week. These should be investigated before match night.
+          </p>
+          <div className="mt-4 grid gap-2 md:grid-cols-2">
+            {nextWeekMissing.map((row) => (
+              <div key={row.fixtureId} className="rounded-2xl border border-red-400/15 bg-black/20 px-4 py-3">
+                <div className="font-semibold text-white">{row.homeTeamName} v {row.awayTeamName}</div>
+                <div className="mt-1 text-xs text-white/45">{row.leagueName} · {dateTimeFormatter.format(row.kickoffAt)}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : nextWeekRows.length > 0 ? (
+        <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 px-4 py-3 text-sm font-semibold text-emerald-100">
+          All {nextWeekRows.length} fixtures in the next fixture week have a stored AI prediction.
+        </div>
+      ) : null}
+
       <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-white">Accuracy by week</h2>
-            <p className="mt-1 text-sm text-white/55">See whether genuine pre-match predictions are improving or becoming less reliable week by week.</p>
+            <h2 className="text-xl font-semibold text-white">Accuracy & coverage by week</h2>
+            <p className="mt-1 text-sm text-white/55">Total fixtures are shown alongside genuine measured predictions so incomplete coverage cannot look like a complete week.</p>
           </div>
-          <div className="text-xs text-white/40">{measured.length} live completed prediction{measured.length === 1 ? "" : "s"} measured</div>
+          <div className="text-xs text-white/40">{rows.length} completed real fixture{rows.length === 1 ? "" : "s"} checked</div>
         </div>
 
         <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
@@ -280,11 +403,14 @@ export default async function AiPredictorAccuracyPage() {
             <thead className="bg-white/[0.04] text-[11px] uppercase tracking-[0.16em] text-white/40">
               <tr>
                 <th className="px-4 py-3">Week commencing</th>
-                <th className="px-4 py-3">Fixtures</th>
+                <th className="px-4 py-3">Total fixtures</th>
+                <th className="px-4 py-3">Measured</th>
+                <th className="px-4 py-3">Recovered</th>
+                <th className="px-4 py-3">Missing</th>
                 <th className="px-4 py-3">Correct</th>
                 <th className="px-4 py-3">Wrong</th>
-                <th className="px-4 py-3">Result accuracy</th>
-                <th className="px-4 py-3">Exact scores</th>
+                <th className="px-4 py-3">Accuracy</th>
+                <th className="px-4 py-3">Exact</th>
                 <th className="px-4 py-3">Avg goals out</th>
               </tr>
             </thead>
@@ -292,16 +418,19 @@ export default async function AiPredictorAccuracyPage() {
               {weekly.map((week) => (
                 <tr key={week.weekKey} className="hover:bg-white/[0.025]">
                   <td className="px-4 py-3 font-semibold text-white">{weekLabel(week.weekKey)}</td>
-                  <td className="px-4 py-3 text-white/65">{week.total}</td>
+                  <td className="px-4 py-3 font-semibold text-white">{week.totalFixtures}</td>
+                  <td className={`px-4 py-3 font-semibold ${coverageClasses(week.measured, week.totalFixtures)}`}>{week.measured}</td>
+                  <td className="px-4 py-3 text-amber-200">{week.recovered}</td>
+                  <td className={week.missing ? "px-4 py-3 font-semibold text-red-300" : "px-4 py-3 text-white/45"}>{week.missing}</td>
                   <td className="px-4 py-3 font-semibold text-emerald-300">{week.correct}</td>
                   <td className="px-4 py-3 font-semibold text-red-300">{week.wrong}</td>
-                  <td className={`px-4 py-3 font-black ${accuracyClasses(week.correct, week.total)}`}>{percentage(week.correct, week.total)}</td>
-                  <td className="px-4 py-3 text-sky-200">{week.exact} ({percentage(week.exact, week.total)})</td>
-                  <td className="px-4 py-3 text-white/65">{averageGoalError(week.goalError, week.total)}</td>
+                  <td className={`px-4 py-3 font-black ${accuracyClasses(week.correct, week.measured)}`}>{percentage(week.correct, week.measured)}</td>
+                  <td className="px-4 py-3 text-sky-200">{week.exact} ({percentage(week.exact, week.measured)})</td>
+                  <td className="px-4 py-3 text-white/65">{averageGoalError(week.goalError, week.measured)}</td>
                 </tr>
               ))}
               {weekly.length === 0 ? (
-                <tr><td className="px-4 py-8 text-white/55" colSpan={7}>No completed genuine predictor scores are available yet.</td></tr>
+                <tr><td className="px-4 py-8 text-white/55" colSpan={10}>No completed fixtures are available yet.</td></tr>
               ) : null}
             </tbody>
           </table>
@@ -312,9 +441,9 @@ export default async function AiPredictorAccuracyPage() {
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h2 className="text-xl font-semibold text-white">Recent predictor checks</h2>
-            <p className="mt-1 text-sm text-white/55">Predicted score versus the result currently recorded. Recovered historical rows are visible but never counted in the accuracy percentages.</p>
+            <p className="mt-1 text-sm text-white/55">Every completed real fixture appears here, including fixtures where no genuine stored prediction exists.</p>
           </div>
-          <div className="text-xs text-white/40">Latest {Math.min(evaluated.length, 100)} shown</div>
+          <div className="text-xs text-white/40">Latest {Math.min(rows.length, 100)} shown</div>
         </div>
 
         <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
@@ -330,13 +459,14 @@ export default async function AiPredictorAccuracyPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-white/10">
-              {evaluated.slice(0, 100).map((row) => {
-                const badge = callBadge(row);
+              {rows.slice(0, 100).map((row) => {
+                const evaluatedRow = evaluatedByFixtureId.get(row.fixtureId) ?? null;
+                const badge = callBadge(evaluatedRow);
                 return (
                   <tr key={row.fixtureId} className="hover:bg-white/[0.025]">
                     <td className="px-4 py-3">
                       <div className="font-semibold text-white">{row.homeTeamName} v {row.awayTeamName}</div>
-                      {row.exactScore ? (
+                      {evaluatedRow?.exactScore ? (
                         <span className="mt-1 inline-flex rounded-full border border-sky-400/25 bg-sky-500/10 px-2 py-0.5 text-[10px] font-semibold text-sky-100">Exact score</span>
                       ) : null}
                     </td>
@@ -344,17 +474,19 @@ export default async function AiPredictorAccuracyPage() {
                       <div>{row.leagueName}</div>
                       <div className="mt-0.5 text-xs text-white/35">{dateTimeFormatter.format(row.kickoffAt)}</div>
                     </td>
-                    <td className="px-4 py-3 font-black text-white">{row.predictedHomeScore}–{row.predictedAwayScore}</td>
+                    <td className="px-4 py-3 font-black text-white">
+                      {hasStoredScore(row) ? `${row.predictedHomeScore}–${row.predictedAwayScore}` : "—"}
+                    </td>
                     <td className="px-4 py-3 font-black text-white">{row.actualHomeScore}–{row.actualAwayScore}</td>
                     <td className="px-4 py-3">
                       <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${badge.className}`}>{badge.label}</span>
                     </td>
-                    <td className="px-4 py-3 text-white/65">{row.goalError}</td>
+                    <td className="px-4 py-3 text-white/65">{evaluatedRow ? evaluatedRow.goalError : "—"}</td>
                   </tr>
                 );
               })}
-              {evaluated.length === 0 ? (
-                <tr><td className="px-4 py-8 text-white/55" colSpan={6}>No predictor results are ready to audit yet.</td></tr>
+              {rows.length === 0 ? (
+                <tr><td className="px-4 py-8 text-white/55" colSpan={6}>No completed fixtures are ready to audit yet.</td></tr>
               ) : null}
             </tbody>
           </table>
@@ -362,7 +494,7 @@ export default async function AiPredictorAccuracyPage() {
       </section>
 
       <div className="rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-xs leading-5 text-white/45">
-        Result accuracy is the main headline measure. “Avg goals out” is the average total difference between the predicted home/away scores and the actual home/away scores. Recovered historical rows use today’s predictor logic with only data that existed before kick-off, so they are shown for context but excluded from the live accuracy percentage. {unmeasurableCount > 0 ? `${unmeasurableCount} older completed prediction${unmeasurableCount === 1 ? " has" : "s have"} no stored score and ${unmeasurableCount === 1 ? "is" : "are"} also excluded.` : "All non-recovered completed prediction rows currently have a stored score."} Overall average goals out: {averageGoalError(totalGoalError, measured.length)}.
+        Result accuracy is based only on genuine stored pre-match predictions. Recovered rows are excluded because they were reconstructed later. Missing means the completed fixture has no stored predicted score at all. {missingCompletedCount > 0 ? `${missingCompletedCount} completed fixture${missingCompletedCount === 1 ? " is" : "s are"} currently missing a stored score.` : "Every completed fixture currently has a stored score or a clearly marked recovered row."} Overall average goals out: {averageGoalError(totalGoalError, measured.length)}.
       </div>
     </div>
   );

--- a/src/app/api/admin/fixtures/generate-next-week/route.ts
+++ b/src/app/api/admin/fixtures/generate-next-week/route.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 import { FixtureStatus, Prisma } from "@prisma/client";
 
+import { refreshStoredAiPreviewsForLeague } from "@/lib/fixtures/storedAiPredictions";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
@@ -311,7 +312,34 @@ export async function POST(request: Request) {
       }),
     });
 
+    const createdFixtures = await prisma.fixture.findMany({
+      where: {
+        leagueId,
+        round,
+        status: FixtureStatus.SCHEDULED,
+      },
+      select: { id: true },
+    });
+    const createdFixtureIds = createdFixtures.map((fixture) => fixture.id);
+
+    let predictorStored = true;
+    try {
+      await refreshStoredAiPreviewsForLeague(leagueId, {
+        fixtureIds: createdFixtureIds,
+      });
+    } catch (error) {
+      predictorStored = false;
+      console.error("Generated fixtures but failed to store their AI predictions", {
+        requestId,
+        leagueId,
+        round,
+        fixtureIds: createdFixtureIds,
+        error,
+      });
+    }
+
     revalidatePath("/admin/fixtures");
+    revalidatePath("/admin/ai-predictor");
     revalidatePath(`/admin/leagues/${leagueId}/fixtures`);
     revalidatePath(`/admin/leagues/${leagueId}`);
 
@@ -323,6 +351,8 @@ export async function POST(request: Request) {
     return NextResponse.json({
       ok: true,
       created: pairs.length,
+      predictorStored,
+      predictorFixtureCount: createdFixtureIds.length,
       round,
       requestId,
     });


### PR DESCRIPTION
## What changed
- after **Generate next week** creates a new round, it now finds those newly-created fixture IDs and calls the existing stored AI prediction service for that round
- revalidates the AI predictor admin page after generation
- returns predictor storage status/count in the generator response for diagnostics
- upgrades `/admin/ai-predictor` to compare prediction coverage against **all real fixtures**, not only fixtures that already have prediction rows
- shows next fixture-week coverage as `stored / total` and lists any upcoming fixtures missing a stored prediction
- shows completed weekly totals alongside measured, recovered and missing predictions so incomplete coverage cannot be mistaken for a complete week
- keeps recovered historical rows excluded from genuine accuracy percentages

## Root cause
The bulk next-week generator used `createMany()` and then only revalidated pages. It did not invoke the stored-prediction service. Public pages could still calculate/display fallback predictor output, which masked the missing database row until accuracy was audited later.

## Safety
Prediction generation is scoped to the newly-created round only. If the prediction service fails after fixtures were successfully created, fixture creation is not retried or rolled back; the failure is logged and the admin coverage page will visibly flag the missing predictions rather than hiding the gap.