### PR TITLE
Add historical AI predictor backtest

### DIFF
--- a/src/app/(admin)/admin/ai-predictor/backtest/page.tsx
+++ b/src/app/(admin)/admin/ai-predictor/backtest/page.tsx
@@ -1,0 +1,250 @@
+import Link from "next/link";
+import { Prisma } from "@prisma/client";
+
+import {
+  runPredictorBacktest,
+  type PredictorBacktestRow,
+} from "@/lib/fixtures/predictorBacktest";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "AI Predictor Back-test | SIXFL Admin",
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-GB", {
+  timeZone: "Europe/London",
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function percentage(value: number | null) {
+  if (value === null || !Number.isFinite(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function points(value: number) {
+  const rounded = Math.round(value * 1000) / 10;
+  return `${rounded > 0 ? "+" : ""}${rounded.toFixed(1)} pts`;
+}
+
+function accuracyClass(value: number, baseline: number) {
+  if (value >= Math.max(0.6, baseline + 0.08)) return "text-emerald-300";
+  if (value >= baseline + 0.02) return "text-amber-300";
+  return "text-red-300";
+}
+
+function brier(value: number | null) {
+  if (value === null) return "—";
+  return value.toFixed(3);
+}
+
+function goalError(value: number | null) {
+  if (value === null) return "—";
+  return value.toFixed(1);
+}
+
+export default async function PredictorBacktestPage() {
+  await requireAdmin();
+
+  const rows = await prisma.$queryRaw<PredictorBacktestRow[]>(Prisma.sql`
+    SELECT
+      fixture."id" AS "fixtureId",
+      fixture."leagueId" AS "leagueId",
+      league."name" AS "leagueName",
+      fixture."kickoffAt" AS "kickoffAt",
+      result."enteredAt" AS "resultEnteredAt",
+      home_team."id" AS "homeTeamId",
+      home_team."name" AS "homeTeamName",
+      away_team."id" AS "awayTeamId",
+      away_team."name" AS "awayTeamName",
+      result."homeScore" AS "actualHomeScore",
+      result."awayScore" AS "actualAwayScore"
+    FROM "Fixture" fixture
+    JOIN "MatchResult" result ON result."fixtureId" = fixture."id"
+    JOIN "League" league ON league."id" = fixture."leagueId"
+    JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+    JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+    WHERE fixture."status" = 'COMPLETED'
+      AND COALESCE(home_team."isFixturePlaceholder", false) = false
+      AND COALESCE(away_team."isFixturePlaceholder", false) = false
+    ORDER BY fixture."kickoffAt" ASC, fixture."id" ASC
+  `);
+
+  const backtest = runPredictorBacktest(rows);
+  const current = backtest.methods.find((method) => method.key === "sixfl") ?? null;
+  const candidate = backtest.methods.find((method) => method.key === "elo-goals") ?? null;
+  const candidateImprovement =
+    current && candidate ? candidate.accuracy - current.accuracy : null;
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-violet-300/80">
+            AI predictor laboratory
+          </p>
+          <h1 className="mt-2 text-3xl font-black tracking-tight text-white sm:text-4xl">
+            Historical predictor back-test
+          </h1>
+          <p className="mt-3 max-w-4xl text-sm leading-6 text-white/60">
+            Replays completed SIXFL fixtures in chronological order. For every match, the models can only see results whose kick-off and result-entry time were both before that match kicked off. The match being predicted and all future results are excluded.
+          </p>
+        </div>
+        <Link
+          href="/admin/ai-predictor"
+          className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/75 transition hover:border-white/20 hover:bg-white/[0.07] hover:text-white"
+        >
+          ← Live predictor monitoring
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-3xl border border-violet-400/20 bg-violet-500/10 p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-violet-100/65">Fixtures replayed</p>
+          <p className="mt-3 text-4xl font-black text-violet-200">{backtest.eligibleFixtures}</p>
+          <p className="mt-2 text-xs text-white/45">
+            {backtest.totalCompletedFixtures} completed · {backtest.skippedTooEarly} too early to call
+          </p>
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Draw rate</p>
+          <p className="mt-3 text-4xl font-black text-white">{percentage(backtest.drawRate)}</p>
+          <p className="mt-2 text-xs text-white/45">{backtest.draws} draws in the shared test sample</p>
+        </div>
+
+        <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/65">Blind two-team guess</p>
+          <p className="mt-3 text-4xl font-black text-amber-200">{percentage(backtest.twoTeamCoinExpectedAccuracy)}</p>
+          <p className="mt-2 text-xs text-white/45">Expected accuracy from a 50/50 team choice, with draws always missed</p>
+        </div>
+
+        <div className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/65">Best historical method</p>
+          <p className="mt-3 text-2xl font-black text-emerald-200">{backtest.bestMethodLabel ?? "—"}</p>
+          <p className="mt-2 text-sm font-semibold text-white/75">{percentage(backtest.bestAccuracy)}</p>
+        </div>
+      </div>
+
+      {current && candidate ? (
+        <section className="rounded-3xl border border-sky-400/20 bg-sky-500/[0.07] p-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-100/60">Candidate check</p>
+              <h2 className="mt-2 text-xl font-semibold text-white">Does Elo + goals beat the live model?</h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">
+                Current SIXFL: {percentage(current.accuracy)} · Elo + goals: {percentage(candidate.accuracy)}. This is a historical test only; it does not rewrite any stored prediction or live result.
+              </p>
+            </div>
+            <div className={`text-4xl font-black ${candidateImprovement !== null && candidateImprovement > 0 ? "text-emerald-300" : "text-red-300"}`}>
+              {candidateImprovement === null ? "—" : points(candidateImprovement)}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Model comparison</h2>
+          <p className="mt-1 max-w-4xl text-sm leading-6 text-white/55">
+            Accuracy is the home/draw/away call. Exact score and goals-out are shown only for models that predict a score. Brier score measures probability quality — lower is better — so an overconfident wrong prediction is penalised more heavily.
+          </p>
+        </div>
+
+        <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-white/[0.04] text-[11px] uppercase tracking-[0.16em] text-white/40">
+              <tr>
+                <th className="px-4 py-3">Method</th>
+                <th className="px-4 py-3">Calls</th>
+                <th className="px-4 py-3">Correct</th>
+                <th className="px-4 py-3">Accuracy</th>
+                <th className="px-4 py-3">Vs blind guess</th>
+                <th className="px-4 py-3">Exact</th>
+                <th className="px-4 py-3">Avg goals out</th>
+                <th className="px-4 py-3">Brier</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/10">
+              {backtest.methods.map((method) => (
+                <tr key={method.key} className="hover:bg-white/[0.025]">
+                  <td className="max-w-md px-4 py-4">
+                    <div className="font-semibold text-white">{method.label}</div>
+                    <div className="mt-1 text-xs leading-5 text-white/40">{method.description}</div>
+                  </td>
+                  <td className="px-4 py-4 text-white/65">{method.calls}</td>
+                  <td className="px-4 py-4 font-semibold text-white">{method.correct}</td>
+                  <td className={`px-4 py-4 text-lg font-black ${accuracyClass(method.accuracy, backtest.twoTeamCoinExpectedAccuracy)}`}>
+                    {percentage(method.accuracy)}
+                  </td>
+                  <td className={`px-4 py-4 font-semibold ${method.accuracy > backtest.twoTeamCoinExpectedAccuracy ? "text-emerald-300" : "text-red-300"}`}>
+                    {points(method.accuracy - backtest.twoTeamCoinExpectedAccuracy)}
+                  </td>
+                  <td className="px-4 py-4 text-sky-200">
+                    {method.exact === null ? "—" : `${method.exact} (${percentage(method.exactAccuracy)})`}
+                  </td>
+                  <td className="px-4 py-4 text-white/65">{goalError(method.averageGoalError)}</td>
+                  <td className="px-4 py-4 text-white/65">{brier(method.brierScore)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Recent replay examples</h2>
+            <p className="mt-1 text-sm text-white/55">Useful for spotting what each method is doing differently on real SIXFL fixtures.</p>
+          </div>
+          <div className="text-xs text-white/40">Latest {backtest.examples.length} eligible historical fixtures</div>
+        </div>
+
+        <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-white/[0.04] text-[11px] uppercase tracking-[0.16em] text-white/40">
+              <tr>
+                <th className="px-4 py-3">Fixture</th>
+                <th className="px-4 py-3">Actual</th>
+                <th className="px-4 py-3">Current SIXFL</th>
+                <th className="px-4 py-3">Elo + goals</th>
+                <th className="px-4 py-3">PPG</th>
+                <th className="px-4 py-3">Elo</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/10">
+              {backtest.examples.map((row) => (
+                <tr key={row.fixtureId} className="hover:bg-white/[0.025]">
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-white">{row.fixture}</div>
+                    <div className="mt-1 text-xs text-white/40">{row.leagueName} · {dateTimeFormatter.format(row.kickoffAt)}</div>
+                  </td>
+                  <td className="px-4 py-3 text-lg font-black text-white">{row.actual}</td>
+                  <td className="px-4 py-3 font-semibold text-sky-200">{row.sixfl}</td>
+                  <td className="px-4 py-3 font-semibold text-emerald-200">{row.eloGoals}</td>
+                  <td className="px-4 py-3 text-white/65">{row.ppg}</td>
+                  <td className="px-4 py-3 text-white/65">{row.elo}</td>
+                </tr>
+              ))}
+              {backtest.examples.length === 0 ? (
+                <tr><td className="px-4 py-8 text-white/55" colSpan={6}>There is not enough historical data to run a fair replay yet.</td></tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div className="rounded-2xl border border-amber-400/15 bg-amber-500/[0.06] px-4 py-3 text-xs leading-5 text-amber-50/65">
+        Back-testing is evidence, not proof. Once we choose a better model, future stored pre-match predictions remain the final test because they cannot benefit from retrospective tuning. No historical prediction rows are changed by this page.
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -294,6 +294,12 @@ const navigationGroups = [
         description: "Weekly accuracy",
       },
       {
+        name: "Predictor backtest",
+        href: "/admin/ai-predictor/backtest",
+        icon: TrophyIcon,
+        description: "Historical test",
+      },
+      {
         name: "Identity audit",
         href: "/admin/users/identity-audit",
         icon: ExclamationTriangleIcon,

--- a/src/lib/fixtures/predictorBacktest.ts
+++ b/src/lib/fixtures/predictorBacktest.ts
@@ -1,0 +1,680 @@
+import { calculateFixtureWinChance, type WinChanceFixture } from "@/lib/fixtures/winChance";
+
+export type PredictorBacktestRow = {
+  fixtureId: string;
+  leagueId: string;
+  leagueName: string;
+  kickoffAt: Date;
+  resultEnteredAt: Date;
+  homeTeamId: string;
+  homeTeamName: string;
+  awayTeamId: string;
+  awayTeamName: string;
+  actualHomeScore: number;
+  actualAwayScore: number;
+};
+
+type Outcome = "HOME" | "DRAW" | "AWAY";
+
+type Probabilities = {
+  home: number;
+  draw: number;
+  away: number;
+};
+
+type TeamStats = {
+  played: number;
+  points: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  recentGoalsFor: number[];
+  recentGoalsAgainst: number[];
+};
+
+type ModelPrediction = {
+  outcome: Outcome;
+  probabilities?: Probabilities;
+  score?: { home: number; away: number };
+};
+
+type MutableMethod = {
+  key: string;
+  label: string;
+  description: string;
+  calls: number;
+  correct: number;
+  exact: number;
+  scoredCalls: number;
+  totalGoalError: number;
+  brierTotal: number;
+  brierCalls: number;
+};
+
+export type PredictorBacktestMethod = {
+  key: string;
+  label: string;
+  description: string;
+  calls: number;
+  correct: number;
+  accuracy: number;
+  exact: number | null;
+  exactAccuracy: number | null;
+  averageGoalError: number | null;
+  brierScore: number | null;
+};
+
+export type PredictorBacktestExample = {
+  fixtureId: string;
+  leagueName: string;
+  kickoffAt: Date;
+  fixture: string;
+  actual: string;
+  sixfl: string;
+  eloGoals: string;
+  ppg: Outcome;
+  elo: Outcome;
+};
+
+export type PredictorBacktestResult = {
+  totalCompletedFixtures: number;
+  eligibleFixtures: number;
+  skippedTooEarly: number;
+  draws: number;
+  drawRate: number;
+  twoTeamCoinExpectedAccuracy: number;
+  methods: PredictorBacktestMethod[];
+  bestMethodKey: string | null;
+  bestMethodLabel: string | null;
+  bestAccuracy: number | null;
+  examples: PredictorBacktestExample[];
+};
+
+const MAX_SCORE = 12;
+const ELO_K = 30;
+const ELO_DRAW_THRESHOLD = 34;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normaliseTeamName(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function canonicalTeamId(input: {
+  leagueId: string;
+  teamId: string;
+  teamName: string;
+}) {
+  const name = normaliseTeamName(input.teamName);
+  return `${input.leagueId}:${name || input.teamId}`;
+}
+
+function outcome(home: number, away: number): Outcome {
+  if (home > away) return "HOME";
+  if (away > home) return "AWAY";
+  return "DRAW";
+}
+
+function percentageProbability(value: number) {
+  return clamp(value / 100, 0, 1);
+}
+
+function brierScore(probabilities: Probabilities, actual: Outcome) {
+  const expected = {
+    HOME: { home: 1, draw: 0, away: 0 },
+    DRAW: { home: 0, draw: 1, away: 0 },
+    AWAY: { home: 0, draw: 0, away: 1 },
+  }[actual];
+
+  return (
+    (Math.pow(probabilities.home - expected.home, 2) +
+      Math.pow(probabilities.draw - expected.draw, 2) +
+      Math.pow(probabilities.away - expected.away, 2)) /
+    3
+  );
+}
+
+function logFactorial(value: number) {
+  let total = 0;
+  for (let index = 2; index <= value; index += 1) total += Math.log(index);
+  return total;
+}
+
+function poissonProbability(score: number, expectedGoals: number) {
+  const lambda = Math.max(expectedGoals, 0.01);
+  return Math.exp(score * Math.log(lambda) - lambda - logFactorial(score));
+}
+
+function poissonOutcomeProbabilities(homeExpected: number, awayExpected: number) {
+  let home = 0;
+  let draw = 0;
+  let away = 0;
+  let total = 0;
+
+  for (let homeScore = 0; homeScore <= MAX_SCORE; homeScore += 1) {
+    const homeProbability = poissonProbability(homeScore, homeExpected);
+    for (let awayScore = 0; awayScore <= MAX_SCORE; awayScore += 1) {
+      const probability = homeProbability * poissonProbability(awayScore, awayExpected);
+      total += probability;
+      if (homeScore > awayScore) home += probability;
+      else if (awayScore > homeScore) away += probability;
+      else draw += probability;
+    }
+  }
+
+  if (total <= 0) return { home: 1 / 3, draw: 1 / 3, away: 1 / 3 };
+  return { home: home / total, draw: draw / total, away: away / total };
+}
+
+function predictedOutcome(probabilities: Probabilities): Outcome {
+  if (probabilities.draw >= probabilities.home && probabilities.draw >= probabilities.away) {
+    return "DRAW";
+  }
+  return probabilities.home >= probabilities.away ? "HOME" : "AWAY";
+}
+
+function mostLikelyScoreForOutcome(input: {
+  homeExpected: number;
+  awayExpected: number;
+  predictedOutcome: Outcome;
+}) {
+  let best: { home: number; away: number; probability: number } | null = null;
+
+  for (let home = 0; home <= MAX_SCORE; home += 1) {
+    for (let away = 0; away <= MAX_SCORE; away += 1) {
+      if (outcome(home, away) !== input.predictedOutcome) continue;
+      const probability =
+        poissonProbability(home, input.homeExpected) *
+        poissonProbability(away, input.awayExpected);
+      if (!best || probability > best.probability) {
+        best = { home, away, probability };
+      }
+    }
+  }
+
+  return best ?? { home: 0, away: 0 };
+}
+
+function emptyTeamStats(): TeamStats {
+  return {
+    played: 0,
+    points: 0,
+    goalsFor: 0,
+    goalsAgainst: 0,
+    recentGoalsFor: [],
+    recentGoalsAgainst: [],
+  };
+}
+
+function buildStats(history: WinChanceFixture[]) {
+  const stats = new Map<string, TeamStats>();
+
+  const get = (id: string) => {
+    const existing = stats.get(id);
+    if (existing) return existing;
+    const created = emptyTeamStats();
+    stats.set(id, created);
+    return created;
+  };
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.kickoffAt ?? 0).getTime() - new Date(b.kickoffAt ?? 0).getTime(),
+  );
+
+  for (const fixture of sorted) {
+    if (!fixture.result) continue;
+    const home = get(fixture.homeTeam.id);
+    const away = get(fixture.awayTeam.id);
+
+    home.played += 1;
+    away.played += 1;
+    home.goalsFor += fixture.result.homeScore;
+    home.goalsAgainst += fixture.result.awayScore;
+    away.goalsFor += fixture.result.awayScore;
+    away.goalsAgainst += fixture.result.homeScore;
+    home.recentGoalsFor.push(fixture.result.homeScore);
+    home.recentGoalsAgainst.push(fixture.result.awayScore);
+    away.recentGoalsFor.push(fixture.result.awayScore);
+    away.recentGoalsAgainst.push(fixture.result.homeScore);
+
+    if (fixture.result.homeScore > fixture.result.awayScore) home.points += 3;
+    else if (fixture.result.awayScore > fixture.result.homeScore) away.points += 3;
+    else {
+      home.points += 1;
+      away.points += 1;
+    }
+  }
+
+  return stats;
+}
+
+function leagueAverages(stats: Map<string, TeamStats>) {
+  let games = 0;
+  let points = 0;
+  let goals = 0;
+
+  for (const team of stats.values()) {
+    games += team.played;
+    points += team.points;
+    goals += team.goalsFor;
+  }
+
+  return {
+    pointsPerGame: games > 0 ? points / games : 1.5,
+    goalsPerTeamGame: games > 0 ? goals / games : 3.5,
+  };
+}
+
+function weightedRecent(values: number[], fallback: number) {
+  const recent = values.slice(-5);
+  if (recent.length === 0) return fallback;
+  let total = 0;
+  let weightTotal = 0;
+  recent.forEach((value, index) => {
+    const weight = index + 1;
+    total += value * weight;
+    weightTotal += weight;
+  });
+  return total / weightTotal;
+}
+
+function smoothedRate(total: number, played: number, leagueAverage: number, priorGames = 1) {
+  return (total + leagueAverage * priorGames) / (played + priorGames);
+}
+
+function buildEloRatings(history: WinChanceFixture[]) {
+  const ratings = new Map<string, number>();
+  const get = (id: string) => ratings.get(id) ?? 1500;
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.kickoffAt ?? 0).getTime() - new Date(b.kickoffAt ?? 0).getTime(),
+  );
+
+  for (const fixture of sorted) {
+    if (!fixture.result) continue;
+    const homeRating = get(fixture.homeTeam.id);
+    const awayRating = get(fixture.awayTeam.id);
+    const expectedHome = 1 / (1 + Math.pow(10, (awayRating - homeRating) / 400));
+    const actualHome =
+      fixture.result.homeScore > fixture.result.awayScore
+        ? 1
+        : fixture.result.homeScore < fixture.result.awayScore
+          ? 0
+          : 0.5;
+    const margin = Math.abs(fixture.result.homeScore - fixture.result.awayScore);
+    const marginMultiplier = 1 + Math.log1p(margin) * 0.22;
+    const change = ELO_K * marginMultiplier * (actualHome - expectedHome);
+    ratings.set(fixture.homeTeam.id, homeRating + change);
+    ratings.set(fixture.awayTeam.id, awayRating - change);
+  }
+
+  return ratings;
+}
+
+function eloProbabilities(homeRating: number, awayRating: number): Probabilities {
+  const difference = homeRating - awayRating;
+  const noDrawHome = 1 / (1 + Math.pow(10, -difference / 400));
+  const draw = clamp(0.27 - Math.abs(difference) / 950, 0.11, 0.27);
+  const remaining = 1 - draw;
+  return {
+    home: remaining * noDrawHome,
+    draw,
+    away: remaining * (1 - noDrawHome),
+  };
+}
+
+function ppgPrediction(input: {
+  homeStats: TeamStats | undefined;
+  awayStats: TeamStats | undefined;
+  leaguePpg: number;
+}): ModelPrediction {
+  const homePpg = input.homeStats?.played
+    ? input.homeStats.points / input.homeStats.played
+    : input.leaguePpg;
+  const awayPpg = input.awayStats?.played
+    ? input.awayStats.points / input.awayStats.played
+    : input.leaguePpg;
+  const difference = homePpg - awayPpg;
+
+  return {
+    outcome: difference > 0.14 ? "HOME" : difference < -0.14 ? "AWAY" : "DRAW",
+  };
+}
+
+function eloPrediction(homeRating: number, awayRating: number): ModelPrediction {
+  const difference = homeRating - awayRating;
+  const probabilities = eloProbabilities(homeRating, awayRating);
+  return {
+    outcome:
+      Math.abs(difference) < ELO_DRAW_THRESHOLD
+        ? "DRAW"
+        : difference > 0
+          ? "HOME"
+          : "AWAY",
+    probabilities,
+  };
+}
+
+function eloGoalsPrediction(input: {
+  homeTeamId: string;
+  awayTeamId: string;
+  stats: Map<string, TeamStats>;
+  ratings: Map<string, number>;
+}): ModelPrediction {
+  const home = input.stats.get(input.homeTeamId);
+  const away = input.stats.get(input.awayTeamId);
+  const averages = leagueAverages(input.stats);
+  const leagueGoals = clamp(averages.goalsPerTeamGame, 1, 8.5);
+
+  const homeSeasonAttack = smoothedRate(home?.goalsFor ?? 0, home?.played ?? 0, leagueGoals, 1);
+  const awaySeasonAttack = smoothedRate(away?.goalsFor ?? 0, away?.played ?? 0, leagueGoals, 1);
+  const homeSeasonConcede = smoothedRate(home?.goalsAgainst ?? 0, home?.played ?? 0, leagueGoals, 1);
+  const awaySeasonConcede = smoothedRate(away?.goalsAgainst ?? 0, away?.played ?? 0, leagueGoals, 1);
+
+  const homeRecentAttack = weightedRecent(home?.recentGoalsFor ?? [], homeSeasonAttack);
+  const awayRecentAttack = weightedRecent(away?.recentGoalsFor ?? [], awaySeasonAttack);
+  const homeRecentConcede = weightedRecent(home?.recentGoalsAgainst ?? [], homeSeasonConcede);
+  const awayRecentConcede = weightedRecent(away?.recentGoalsAgainst ?? [], awaySeasonConcede);
+
+  const homeAttack = homeSeasonAttack * 0.68 + homeRecentAttack * 0.32;
+  const awayAttack = awaySeasonAttack * 0.68 + awayRecentAttack * 0.32;
+  const homeConcede = homeSeasonConcede * 0.68 + homeRecentConcede * 0.32;
+  const awayConcede = awaySeasonConcede * 0.68 + awayRecentConcede * 0.32;
+
+  const homeRating = input.ratings.get(input.homeTeamId) ?? 1500;
+  const awayRating = input.ratings.get(input.awayTeamId) ?? 1500;
+  const eloDifference = clamp(homeRating - awayRating, -350, 350);
+  const eloHomeMultiplier = Math.exp(eloDifference / 1150);
+  const eloAwayMultiplier = Math.exp(-eloDifference / 1150);
+
+  const homeExpected = clamp(
+    leagueGoals *
+      Math.pow(clamp(homeAttack / leagueGoals, 0.3, 3), 0.62) *
+      Math.pow(clamp(awayConcede / leagueGoals, 0.3, 3), 0.38) *
+      eloHomeMultiplier,
+    0.35,
+    10.5,
+  );
+  const awayExpected = clamp(
+    leagueGoals *
+      Math.pow(clamp(awayAttack / leagueGoals, 0.3, 3), 0.62) *
+      Math.pow(clamp(homeConcede / leagueGoals, 0.3, 3), 0.38) *
+      eloAwayMultiplier,
+    0.35,
+    10.5,
+  );
+
+  const probabilities = poissonOutcomeProbabilities(homeExpected, awayExpected);
+  const predicted = predictedOutcome(probabilities);
+  const score = mostLikelyScoreForOutcome({
+    homeExpected,
+    awayExpected,
+    predictedOutcome: predicted,
+  });
+
+  return { outcome: predicted, probabilities, score };
+}
+
+function initialiseMethods(): MutableMethod[] {
+  return [
+    {
+      key: "sixfl",
+      label: "Current SIXFL model",
+      description: "The live hand-weighted strength model with the current goal model, replayed using only pre-kick-off history.",
+      calls: 0,
+      correct: 0,
+      exact: 0,
+      scoredCalls: 0,
+      totalGoalError: 0,
+      brierTotal: 0,
+      brierCalls: 0,
+    },
+    {
+      key: "elo-goals",
+      label: "Elo + goals candidate",
+      description: "A candidate model combining opponent-adjusted Elo strength with team scoring, conceding and recent goal rates.",
+      calls: 0,
+      correct: 0,
+      exact: 0,
+      scoredCalls: 0,
+      totalGoalError: 0,
+      brierTotal: 0,
+      brierCalls: 0,
+    },
+    {
+      key: "ppg",
+      label: "Better PPG baseline",
+      description: "A deliberately simple baseline that calls the team with the better points-per-game record, with a narrow draw band.",
+      calls: 0,
+      correct: 0,
+      exact: 0,
+      scoredCalls: 0,
+      totalGoalError: 0,
+      brierTotal: 0,
+      brierCalls: 0,
+    },
+    {
+      key: "elo",
+      label: "Elo-only baseline",
+      description: "A neutral-pitch Elo baseline updated after every available historical result, with a small draw band.",
+      calls: 0,
+      correct: 0,
+      exact: 0,
+      scoredCalls: 0,
+      totalGoalError: 0,
+      brierTotal: 0,
+      brierCalls: 0,
+    },
+  ];
+}
+
+function recordPrediction(input: {
+  method: MutableMethod;
+  prediction: ModelPrediction;
+  actualOutcome: Outcome;
+  actualHome: number;
+  actualAway: number;
+}) {
+  input.method.calls += 1;
+  if (input.prediction.outcome === input.actualOutcome) input.method.correct += 1;
+
+  if (input.prediction.score) {
+    input.method.scoredCalls += 1;
+    if (
+      input.prediction.score.home === input.actualHome &&
+      input.prediction.score.away === input.actualAway
+    ) {
+      input.method.exact += 1;
+    }
+    input.method.totalGoalError +=
+      Math.abs(input.prediction.score.home - input.actualHome) +
+      Math.abs(input.prediction.score.away - input.actualAway);
+  }
+
+  if (input.prediction.probabilities) {
+    input.method.brierCalls += 1;
+    input.method.brierTotal += brierScore(input.prediction.probabilities, input.actualOutcome);
+  }
+}
+
+function toSummary(method: MutableMethod): PredictorBacktestMethod {
+  return {
+    key: method.key,
+    label: method.label,
+    description: method.description,
+    calls: method.calls,
+    correct: method.correct,
+    accuracy: method.calls > 0 ? method.correct / method.calls : 0,
+    exact: method.scoredCalls > 0 ? method.exact : null,
+    exactAccuracy: method.scoredCalls > 0 ? method.exact / method.scoredCalls : null,
+    averageGoalError:
+      method.scoredCalls > 0 ? method.totalGoalError / method.scoredCalls : null,
+    brierScore: method.brierCalls > 0 ? method.brierTotal / method.brierCalls : null,
+  };
+}
+
+function scoreLabel(prediction: ModelPrediction) {
+  return prediction.score
+    ? `${prediction.score.home}–${prediction.score.away}`
+    : prediction.outcome;
+}
+
+export function runPredictorBacktest(rows: PredictorBacktestRow[]): PredictorBacktestResult {
+  const sorted = [...rows].sort(
+    (a, b) => a.kickoffAt.getTime() - b.kickoffAt.getTime() || a.fixtureId.localeCompare(b.fixtureId),
+  );
+  const methods = initialiseMethods();
+  const methodsByKey = new Map(methods.map((method) => [method.key, method]));
+  const examples: PredictorBacktestExample[] = [];
+  let eligibleFixtures = 0;
+  let skippedTooEarly = 0;
+  let draws = 0;
+
+  for (const target of sorted) {
+    const targetTime = target.kickoffAt.getTime();
+    const leagueRows = sorted.filter(
+      (row) =>
+        row.leagueId === target.leagueId &&
+        row.fixtureId !== target.fixtureId &&
+        row.kickoffAt.getTime() < targetTime &&
+        row.resultEnteredAt.getTime() < targetTime,
+    );
+
+    const history: WinChanceFixture[] = leagueRows.map((row) => ({
+      kickoffAt: row.kickoffAt,
+      status: "COMPLETED",
+      homeTeam: {
+        id: canonicalTeamId({
+          leagueId: row.leagueId,
+          teamId: row.homeTeamId,
+          teamName: row.homeTeamName,
+        }),
+      },
+      awayTeam: {
+        id: canonicalTeamId({
+          leagueId: row.leagueId,
+          teamId: row.awayTeamId,
+          teamName: row.awayTeamName,
+        }),
+      },
+      result: { homeScore: row.actualHomeScore, awayScore: row.actualAwayScore },
+    }));
+
+    const homeTeamId = canonicalTeamId({
+      leagueId: target.leagueId,
+      teamId: target.homeTeamId,
+      teamName: target.homeTeamName,
+    });
+    const awayTeamId = canonicalTeamId({
+      leagueId: target.leagueId,
+      teamId: target.awayTeamId,
+      teamName: target.awayTeamName,
+    });
+
+    const current = calculateFixtureWinChance({ homeTeamId, awayTeamId, fixtures: history });
+    if (current.predictedResult.label === "Too early") {
+      skippedTooEarly += 1;
+      continue;
+    }
+
+    eligibleFixtures += 1;
+    const actual = outcome(target.actualHomeScore, target.actualAwayScore);
+    if (actual === "DRAW") draws += 1;
+
+    const stats = buildStats(history);
+    const averages = leagueAverages(stats);
+    const ratings = buildEloRatings(history);
+
+    const sixflPrediction: ModelPrediction = {
+      outcome: predictedOutcome({
+        home: percentageProbability(current.home),
+        draw: percentageProbability(current.draw),
+        away: percentageProbability(current.away),
+      }),
+      probabilities: {
+        home: percentageProbability(current.home),
+        draw: percentageProbability(current.draw),
+        away: percentageProbability(current.away),
+      },
+      score: {
+        home: current.predictedResult.homeScore,
+        away: current.predictedResult.awayScore,
+      },
+    };
+
+    const candidate = eloGoalsPrediction({ homeTeamId, awayTeamId, stats, ratings });
+    const ppg = ppgPrediction({
+      homeStats: stats.get(homeTeamId),
+      awayStats: stats.get(awayTeamId),
+      leaguePpg: averages.pointsPerGame,
+    });
+    const elo = eloPrediction(ratings.get(homeTeamId) ?? 1500, ratings.get(awayTeamId) ?? 1500);
+
+    recordPrediction({
+      method: methodsByKey.get("sixfl")!,
+      prediction: sixflPrediction,
+      actualOutcome: actual,
+      actualHome: target.actualHomeScore,
+      actualAway: target.actualAwayScore,
+    });
+    recordPrediction({
+      method: methodsByKey.get("elo-goals")!,
+      prediction: candidate,
+      actualOutcome: actual,
+      actualHome: target.actualHomeScore,
+      actualAway: target.actualAwayScore,
+    });
+    recordPrediction({
+      method: methodsByKey.get("ppg")!,
+      prediction: ppg,
+      actualOutcome: actual,
+      actualHome: target.actualHomeScore,
+      actualAway: target.actualAwayScore,
+    });
+    recordPrediction({
+      method: methodsByKey.get("elo")!,
+      prediction: elo,
+      actualOutcome: actual,
+      actualHome: target.actualHomeScore,
+      actualAway: target.actualAwayScore,
+    });
+
+    examples.push({
+      fixtureId: target.fixtureId,
+      leagueName: target.leagueName,
+      kickoffAt: target.kickoffAt,
+      fixture: `${target.homeTeamName} v ${target.awayTeamName}`,
+      actual: `${target.actualHomeScore}–${target.actualAwayScore}`,
+      sixfl: scoreLabel(sixflPrediction),
+      eloGoals: scoreLabel(candidate),
+      ppg: ppg.outcome,
+      elo: elo.outcome,
+    });
+  }
+
+  const summaries = methods.map(toSummary);
+  const best = summaries
+    .filter((method) => method.calls > 0)
+    .sort((a, b) => b.accuracy - a.accuracy || (a.brierScore ?? 99) - (b.brierScore ?? 99))[0] ?? null;
+  const nonDrawRate = eligibleFixtures > 0 ? (eligibleFixtures - draws) / eligibleFixtures : 0;
+
+  return {
+    totalCompletedFixtures: sorted.length,
+    eligibleFixtures,
+    skippedTooEarly,
+    draws,
+    drawRate: eligibleFixtures > 0 ? draws / eligibleFixtures : 0,
+    twoTeamCoinExpectedAccuracy: nonDrawRate * 0.5,
+    methods: summaries,
+    bestMethodKey: best?.key ?? null,
+    bestMethodLabel: best?.label ?? null,
+    bestAccuracy: best?.accuracy ?? null,
+    examples: examples.slice(-20).reverse(),
+  };
+}


### PR DESCRIPTION
Adds a proper historical replay laboratory for the SIXFL AI Predictor.

What it does:
- adds Admin → Back end functions → Predictor backtest
- replays every completed real fixture chronologically
- for each target match, only uses earlier fixtures whose result was entered before the target kick-off
- excludes the target result and all future data
- compares the current SIXFL model against an Elo + goals candidate, a simple points-per-game baseline and an Elo-only baseline
- calculates the expected accuracy of a blind 50/50 choice between the two listed teams after accounting for draws
- compares result accuracy on a shared eligible sample
- reports exact-score accuracy and average score error for score-predicting models
- reports Brier score for probabilistic models so overconfident wrong calls are visible
- shows recent replay examples for debugging

The backtest is read-only. It does not alter fixtures, results, stored predictions, standings or the live predictor model.