### PR TITLE
Fix captain payment prebuild compatibility

### DIFF
--- a/.github/workflows/prebuild-compatibility.yml
+++ b/.github/workflows/prebuild-compatibility.yml
@@ -1,0 +1,24 @@
+name: Prebuild compatibility
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - "src/app/captain/team/[teamid]/player-payments/**"
+      - "package.json"
+      - ".github/workflows/prebuild-compatibility.yml"
+
+jobs:
+  prebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Run build-time compatibility patches
+        run: npm run prebuild

--- a/scripts/apply-modern-captain-player-payment-page.cjs
+++ b/scripts/apply-modern-captain-player-payment-page.cjs
@@ -62,31 +62,24 @@ replaceOnce(
     '  if (error === "no_team_charge") {',
     '    return "The fixture does not have an active team charge. SIXFL needs to review the fixture before player links can be created.";',
     "  }",
+    '  if (error === "charge_covered") {',
+    '    return "This fixture charge is already fully covered, so no new player links can be created.";',
+    "  }",
+    '  if (error === "allocation_exceeds_fee") {',
+    '    return "The selected player shares exceed the amount available to collect for this fixture. Reduce the amounts before saving.";',
+    "  }",
     "  return null;",
   ].join("\n"),
   "modern collection error messages",
 );
 
+// Keep this compatibility patch deliberately granular. Other payment safeguards now
+// add their own totals (for example zero-fee settled shares) to this same section.
+// Replacing one large historical block made the build brittle whenever a native
+// safeguard was added. Patch only the fields this script owns and preserve the rest.
 replaceOnce(
+  '  const selectedTeamFeePence =\n    selectedEntry?.amountPence ?? selectedFixture?.matchFeePence ?? 4000;',
   [
-    "  const playerAllocationPence = selectedFees.reduce(",
-    "    (sum, fee) => sum + fee.amountPence,",
-    "    0,",
-    "  );",
-    "  const hasPlayerCollection = selectedFees.length > 0;",
-    "  const selectedTeamFeePence =",
-    "    selectedEntry?.amountPence ?? selectedFixture?.matchFeePence ?? 4000;",
-    "  const directPaidPence = selectedEntry?.directPaidPence ?? 0;",
-    "  const collectedPence = selectedEntry?.playerPaidPence ?? 0;",
-    "  const playerOutstandingPence = selectedEntry?.playerOpenPence ?? 0;",
-    "  const stillToCoverPence = selectedEntry?.outstandingPence ?? 0;",
-  ].join("\n"),
-  [
-    "  const playerAllocationPence = selectedFees.reduce(",
-    "    (sum, fee) => sum + fee.amountPence,",
-    "    0,",
-    "  );",
-    "  const hasPlayerCollection = selectedFees.length > 0;",
     "  const selectedFixtureTeamFeePence = selectedFixture",
     "    ? relatedTeamIds.includes(selectedFixture.homeTeamId)",
     "      ? selectedFixture.homeMatchFeePence ?? selectedFixture.matchFeePence",
@@ -98,22 +91,42 @@ replaceOnce(
     "    selectedEntry?.amountPence ??",
     "    selectedFixtureTeamFeePence ??",
     "    (selectedFixture ? 4000 : 0);",
-    "  const directPaidPence = selectedEntry?.directPaidPence ?? 0;",
+  ].join("\n"),
+  "modern team-specific fixture fee",
+);
+
+replaceOnce(
+  '  const collectedPence = selectedEntry?.playerPaidPence ?? 0;',
+  [
     "  const playerPaidWithoutLedgerPence = selectedFees",
     '    .filter((fee) => fee.status === "PAID")',
     "    .reduce((sum, fee) => sum + fee.amountPence, 0);",
+    "  const collectedPence =",
+    "    selectedEntry?.playerPaidPence ?? playerPaidWithoutLedgerPence;",
+  ].join("\n"),
+  "modern paid-player fallback total",
+);
+
+replaceOnce(
+  '  const playerOutstandingPence = selectedEntry?.playerOpenPence ?? 0;',
+  [
     "  const playerOpenWithoutLedgerPence = selectedFees",
     '    .filter((fee) => fee.status === "OPEN")',
     "    .reduce((sum, fee) => sum + fee.amountPence, 0);",
-    "  const collectedPence =",
-    "    selectedEntry?.playerPaidPence ?? playerPaidWithoutLedgerPence;",
     "  const playerOutstandingPence =",
     "    selectedEntry?.playerOpenPence ?? playerOpenWithoutLedgerPence;",
+  ].join("\n"),
+  "modern open-player fallback total",
+);
+
+replaceOnce(
+  '  const stillToCoverPence = selectedEntry?.outstandingPence ?? 0;',
+  [
     "  const stillToCoverPence =",
     "    selectedEntry?.outstandingPence ??",
-    "    Math.max(selectedTeamFeePence - collectedPence, 0);",
+    "    Math.max(selectedTeamFeePence - captainSettledPence, 0);",
   ].join("\n"),
-  "modern team-specific fixture fee totals",
+  "modern no-ledger remaining balance",
 );
 
 replaceOnce(
@@ -170,6 +183,8 @@ replaceOnce(
 
 if (
   !source.includes("selectedFixtureTeamFeePence") ||
+  !source.includes("playerPaidWithoutLedgerPence") ||
+  !source.includes("playerOpenWithoutLedgerPence") ||
   !source.includes("Close unpaid links") ||
   !source.includes("team credit pot")
 ) {

--- a/scripts/apply-modern-payment-script-compatibility.cjs
+++ b/scripts/apply-modern-payment-script-compatibility.cjs
@@ -191,6 +191,23 @@ if (fs.existsSync(feeCapAbsolutePath)) {
     '  \'  const captainSettledPence = collectedPence + captainSettledBoostPence;\\n  const playerOpenWithoutLedgerPence = selectedFees\\n    .filter((fee) => fee.status === "OPEN")\\n    .reduce((sum, fee) => sum + fee.amountPence, 0);\\n  const playerOutstandingPence =\\n    (selectedEntry?.playerOpenPence ?? playerOpenWithoutLedgerPence) +\\n    captainOpenBoostPence;\',',
     "player match-fee cap modern open fallback output",
   );
+
+  // The fixture-card wording was renamed from "paid" to "settled" before the
+  // cap feature was added. Keep the current variable name in both the expected
+  // and generated fixture-card snippets so later JSX continues to reference it.
+  patchFile(
+    feeCapScriptPath,
+    '              const captainPlayerPaidPence = entry.playerPaidPence + zeroFeeSettledPence;\\n              const hasCollection = captainPlayerPaidPence > 0 || entry.playerOpenPence > 0;',
+    '              const captainPlayerSettledPence = entry.playerPaidPence + zeroFeeSettledPence;\\n              const hasCollection = captainPlayerSettledPence > 0 || entry.playerOpenPence > 0;',
+    "player match-fee cap settled fixture input",
+  );
+
+  patchFile(
+    feeCapScriptPath,
+    '              const captainPlayerPaidPence = entry.playerPaidPence + settledBoostPence;\\n              const captainPlayerOpenPence = entry.playerOpenPence + openBoostPence;\\n              const hasCollection = captainPlayerPaidPence > 0 || captainPlayerOpenPence > 0;',
+    '              const captainPlayerSettledPence = entry.playerPaidPence + settledBoostPence;\\n              const captainPlayerOpenPence = entry.playerOpenPence + openBoostPence;\\n              const hasCollection = captainPlayerSettledPence > 0 || captainPlayerOpenPence > 0;',
+    "player match-fee cap settled fixture output",
+  );
 }
 
 console.log(

--- a/scripts/apply-modern-payment-script-compatibility.cjs
+++ b/scripts/apply-modern-payment-script-compatibility.cjs
@@ -210,6 +210,20 @@ if (fs.existsSync(feeCapAbsolutePath)) {
   );
 }
 
+// The predictor monitor filters rows to those with stored scores before creating
+// EvaluatedPrediction objects. Reflect that invariant in the type so downstream
+// scoreline calculations are correctly narrowed after source preparation.
+const predictorPagePath = "src/app/(admin)/admin/ai-predictor/page.tsx";
+const predictorAbsolutePath = path.join(root, predictorPagePath);
+if (fs.existsSync(predictorAbsolutePath)) {
+  patchFile(
+    predictorPagePath,
+    "type EvaluatedPrediction = PredictionAuditRow & {\n  weekKey: string;",
+    "type EvaluatedPrediction = PredictionAuditRow & {\n  predictedHomeScore: number;\n  predictedAwayScore: number;\n  weekKey: string;",
+    "AI predictor evaluated score type narrowing",
+  );
+}
+
 console.log(
   "Made legacy squad-payment build patches compatible with the modern captain page.",
 );

--- a/scripts/apply-modern-payment-script-compatibility.cjs
+++ b/scripts/apply-modern-payment-script-compatibility.cjs
@@ -79,13 +79,12 @@ patchFile(
   "modern team-credit page compatibility",
 );
 
-// A later player-fee-cap patch was added after this compatibility layer. Its
-// generated TypeScript policy was wrapped in a JavaScript template literal but
-// also contained an unescaped nested template literal, so Node could not parse
-// the build script at all. Repair the generated line before that script runs.
+// A later player-fee-cap patch was added after this compatibility layer. It must
+// compose with the admin-only player-fee safeguard which runs earlier in prebuild.
 const feeCapScriptPath = "scripts/apply-player-match-fee-cap.cjs";
 const feeCapAbsolutePath = path.join(root, feeCapScriptPath);
 if (fs.existsSync(feeCapAbsolutePath)) {
+  // Repair an unescaped nested template literal in the generated policy text.
   patchFile(
     feeCapScriptPath,
     [
@@ -101,9 +100,7 @@ if (fs.existsSync(feeCapAbsolutePath)) {
     "player match-fee cap generated note syntax",
   );
 
-  // The admin-only override patch runs earlier in prebuild and has already
-  // wrapped the existing fee field by the time the cap patch executes. Teach
-  // the cap patch to accept either the original field or that admin-only form.
+  // The player edit field is already admin-only by this point in the patch chain.
   patchFile(
     feeCapScriptPath,
     'editPage = replaceRequired(editPage, oldFeeBlock, newFeeBlock, "admin fee settings block");',
@@ -135,6 +132,47 @@ if (fs.existsSync(feeCapAbsolutePath)) {
       ");",
     ].join("\n"),
     "player match-fee cap admin field compatibility",
+  );
+
+  // Server-side validation is already restricted to admins, so make that the
+  // cap patch's expected starting point rather than the older unrestricted form.
+  patchFile(
+    feeCapScriptPath,
+    '  \'  if (Number.isNaN(playerMatchFeeOverride)) {\\n    redirect(getErrorRedirect(teamid, "Player fee override must be a valid amount or left blank.", access.isAdmin));\\n  }\',',
+    '  \'  if (access.isAdmin && Number.isNaN(playerMatchFeeOverride)) {\\n    redirect(getErrorRedirect(teamid, "Player fee override must be a valid amount or left blank.", access.isAdmin));\\n  }\',',
+    "player match-fee cap admin validation compatibility",
+  );
+
+  // The admin-only safeguard has also expanded the existing-profile query.
+  patchFile(
+    feeCapScriptPath,
+    '  \'  const existingProfiles = await prisma.$queryRaw<\\n    Array<{ sourceProspectId: string | null }>\\n  >`\\n    SELECT "sourceProspectId"\\n    FROM "TeamMemberProfile"\',',
+    '  \'  const existingProfiles = await prisma.$queryRaw<\\n    Array<{\\n      sourceProspectId: string | null;\\n      playerMatchFeePenceOverride: number | null;\\n    }>\\n  >`\\n    SELECT "sourceProspectId", "playerMatchFeePenceOverride"\\n    FROM "TeamMemberProfile"\',',
+    "player match-fee cap existing profile query compatibility",
+  );
+
+  // Preserve the earlier override-audit calculation while adding the cap state.
+  patchFile(
+    feeCapScriptPath,
+    '  \'  const sourceProspectId = existingProfiles[0]?.sourceProspectId ?? null;\\n\\n  await prisma.$transaction(async (tx) => {\',',
+    '  \'  const sourceProspectId = existingProfiles[0]?.sourceProspectId ?? null;\\n  const existingPlayerMatchFeeOverride =\\n    existingProfiles[0]?.playerMatchFeePenceOverride ?? null;\\n  const nextPlayerMatchFeeOverride = access.isAdmin\\n    ? playerMatchFeeOverride\\n    : existingPlayerMatchFeeOverride;\\n  const playerMatchFeeOverrideChanged =\\n    access.isAdmin &&\\n    existingPlayerMatchFeeOverride !== nextPlayerMatchFeeOverride;\\n\\n  await prisma.$transaction(async (tx) => {\',',
+    "player match-fee cap protected settings compatibility",
+  );
+
+  patchFile(
+    feeCapScriptPath,
+    '  const nextPlayerMatchFeeCap = access.isAdmin\\n    ? playerMatchFeeCap\\n    : existingPlayerMatchFeeCap;\\n\\n  await prisma.$transaction(async (tx) => {',
+    '  const nextPlayerMatchFeeCap = access.isAdmin\\n    ? playerMatchFeeCap\\n    : existingPlayerMatchFeeCap;\\n  const playerMatchFeeOverrideChanged =\\n    access.isAdmin &&\\n    existingPlayerMatchFeeOverride !== nextPlayerMatchFeeOverride;\\n\\n  await prisma.$transaction(async (tx) => {',
+    "player match-fee cap audit preservation",
+  );
+
+  // The earlier safeguard already renamed this persisted value to the protected
+  // next-value variable; the cap patch should extend it rather than look for the old one.
+  patchFile(
+    feeCapScriptPath,
+    '  \'        ${phone},\\n        ${playerMatchFeeOverride},\\n        ${preferredPositions},\',',
+    '  \'        ${phone},\\n        ${nextPlayerMatchFeeOverride},\\n        ${preferredPositions},\',',
+    "player match-fee cap protected insert compatibility",
   );
 }
 

--- a/scripts/apply-modern-payment-script-compatibility.cjs
+++ b/scripts/apply-modern-payment-script-compatibility.cjs
@@ -174,6 +174,23 @@ if (fs.existsSync(feeCapAbsolutePath)) {
     '  \'        ${phone},\\n        ${nextPlayerMatchFeeOverride},\\n        ${preferredPositions},\',',
     "player match-fee cap protected insert compatibility",
   );
+
+  // The modern squad-payment page has a no-ledger OPEN fallback between the
+  // settled and outstanding totals. Preserve it when the cap patch adds the
+  // captain-facing nominal boost for capped players.
+  patchFile(
+    feeCapScriptPath,
+    '  \'  const captainSettledPence = collectedPence + zeroFeeSettledPence;\\n  const playerOutstandingPence = selectedEntry?.playerOpenPence ?? 0;\',',
+    '  \'  const captainSettledPence = collectedPence + zeroFeeSettledPence;\\n  const playerOpenWithoutLedgerPence = selectedFees\\n    .filter((fee) => fee.status === "OPEN")\\n    .reduce((sum, fee) => sum + fee.amountPence, 0);\\n  const playerOutstandingPence =\\n    selectedEntry?.playerOpenPence ?? playerOpenWithoutLedgerPence;\',',
+    "player match-fee cap modern open fallback input",
+  );
+
+  patchFile(
+    feeCapScriptPath,
+    '  \'  const captainSettledPence = collectedPence + captainSettledBoostPence;\\n  const playerOutstandingPence =\\n    (selectedEntry?.playerOpenPence ?? 0) + captainOpenBoostPence;\',',
+    '  \'  const captainSettledPence = collectedPence + captainSettledBoostPence;\\n  const playerOpenWithoutLedgerPence = selectedFees\\n    .filter((fee) => fee.status === "OPEN")\\n    .reduce((sum, fee) => sum + fee.amountPence, 0);\\n  const playerOutstandingPence =\\n    (selectedEntry?.playerOpenPence ?? playerOpenWithoutLedgerPence) +\\n    captainOpenBoostPence;\',',
+    "player match-fee cap modern open fallback output",
+  );
 }
 
 console.log(

--- a/scripts/apply-modern-payment-script-compatibility.cjs
+++ b/scripts/apply-modern-payment-script-compatibility.cjs
@@ -79,6 +79,29 @@ patchFile(
   "modern team-credit page compatibility",
 );
 
+// A later player-fee-cap patch was added after this compatibility layer. Its
+// generated TypeScript policy was wrapped in a JavaScript template literal but
+// also contained an unescaped nested template literal, so Node could not parse
+// the build script at all. Repair the generated line before that script runs.
+const feeCapScriptPath = "scripts/apply-player-match-fee-cap.cjs";
+const feeCapAbsolutePath = path.join(root, feeCapScriptPath);
+if (fs.existsSync(feeCapAbsolutePath)) {
+  patchFile(
+    feeCapScriptPath,
+    [
+      "    const capNote = cappedPlayer\\n",
+      '      ? `${PLAYER_FEE_CAP_NOTE}: captain share ${formatMoney(enteredAmountPence)}; player charged ${formatMoney(payableAmountPence)}.`\\n',
+      "      : null;\\n",
+    ].join(""),
+    [
+      "    const capNote = cappedPlayer\\n",
+      '      ? PLAYER_FEE_CAP_NOTE + ": captain share " + formatMoney(enteredAmountPence) + "; player charged " + formatMoney(payableAmountPence) + "."\\n',
+      "      : null;\\n",
+    ].join(""),
+    "player match-fee cap generated note syntax",
+  );
+}
+
 console.log(
   "Made legacy squad-payment build patches compatible with the modern captain page.",
 );

--- a/scripts/apply-modern-payment-script-compatibility.cjs
+++ b/scripts/apply-modern-payment-script-compatibility.cjs
@@ -100,6 +100,42 @@ if (fs.existsSync(feeCapAbsolutePath)) {
     ].join(""),
     "player match-fee cap generated note syntax",
   );
+
+  // The admin-only override patch runs earlier in prebuild and has already
+  // wrapped the existing fee field by the time the cap patch executes. Teach
+  // the cap patch to accept either the original field or that admin-only form.
+  patchFile(
+    feeCapScriptPath,
+    'editPage = replaceRequired(editPage, oldFeeBlock, newFeeBlock, "admin fee settings block");',
+    [
+      "const priorAdminFeeBlock = [",
+      '  "          {access.isAdmin ? (",',
+      '  "            <div>",',
+      '  "              <p className=\\\"text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45\\\">",',
+      '  "                Match fee setting · Admin only",',
+      '  "              </p>",',
+      '  "              <div className=\\\"mt-4 grid gap-4 md:grid-cols-2\\\">",',
+      '  "                <Field",',
+      '  "                  label=\\\"Player fee override\\\"",',
+      '  "                  name=\\\"playerMatchFeeOverride\\\"",',
+      '  "                  type=\\\"number\\\"",',
+      '  "                  defaultValue={formatFeeOverride(profile?.playerMatchFeePenceOverride)}",',
+      '  "                  placeholder=\\\"Leave blank to use the team default\\\"",',
+      '  "                  help=\\\"Admin-only setting. Use 0 for a free player. Every change is recorded in the audit log.\\\"",',
+      '  "                />",',
+      '  "              </div>",',
+      '  "            </div>",',
+      '  "          ) : null}",',
+      '].join("\\n");',
+      "editPage = replaceRequired(",
+      "  editPage,",
+      "  editPage.includes(oldFeeBlock) ? oldFeeBlock : priorAdminFeeBlock,",
+      "  newFeeBlock,",
+      '  "admin fee settings block",',
+      ");",
+    ].join("\n"),
+    "player match-fee cap admin field compatibility",
+  );
 }
 
 console.log(

--- a/scripts/apply-native-captain-collected-summary.cjs
+++ b/scripts/apply-native-captain-collected-summary.cjs
@@ -12,18 +12,6 @@ const actionsPath = path.join(
 
 let source = fs.readFileSync(pagePath, "utf8");
 
-function replaceBetweenRequired(startMarker, endMarker, replacement, label) {
-  if (source.includes(replacement)) return;
-
-  const start = source.indexOf(startMarker);
-  const end = start >= 0 ? source.indexOf(endMarker, start) : -1;
-  if (start < 0 || end < 0) {
-    throw new Error(`Expected ${label} source was not found in squad payments.`);
-  }
-
-  source = source.slice(0, start) + replacement + source.slice(end);
-}
-
 function insertBeforeRequired(marker, block, appliedMarker, label) {
   if (source.includes(appliedMarker)) return;
 
@@ -43,9 +31,15 @@ function replaceTextRequired(before, after, appliedMarker, label) {
   source = source.replace(before, after);
 }
 
-replaceBetweenRequired(
-  "function isCaptainCollected(note?: string | null) {",
-  "\n\nfunction statusLabel",
+// Only replace the captain-collected helper itself. The modern payment page now
+// has additional helpers (including zero-fee settled-player handling) immediately
+// after it, so the old broad start/end replacement could delete unrelated logic.
+replaceTextRequired(
+  [
+    "function isCaptainCollected(note?: string | null) {",
+    '  return Boolean(note?.includes("captain/organiser marked"));',
+    "}",
+  ].join("\n"),
   [
     "function isCaptainCollected(note?: string | null) {",
     '  const normalised = note?.toLowerCase() ?? "";',
@@ -55,6 +49,7 @@ replaceBetweenRequired(
     "  );",
     "}",
   ].join("\n"),
+  'normalised.includes("paid captain directly: captain collected")',
   "captain-collected note recognition",
 );
 
@@ -74,13 +69,9 @@ insertBeforeRequired(
   "captain-collected totals",
 );
 
-replaceTextRequired(
-  "Players have paid ${formatMoney(collectedPence)} and ${formatMoney(playerOutstandingPence)}",
-  "Players have paid ${formatMoney(collectedPence)} through SIXFL and ${formatMoney(playerOutstandingPence)}",
-  "Players have paid ${formatMoney(collectedPence)} through SIXFL",
-  "native summary paid-through-SIXFL wording",
-);
-
+// The current server page no longer uses the old sentence beginning
+// "Players have paid ...". Keep the separate captain-collected panel as the
+// authoritative distinction instead of coupling this patch to summary prose.
 const summaryParagraph =
   '        <p className="mt-3 max-w-4xl text-sm leading-6 text-white/70">{summaryText}</p>';
 replaceTextRequired(
@@ -105,10 +96,10 @@ replaceTextRequired(
 
 if (
   !source.includes('normalised.includes("paid captain directly: captain collected")') ||
+  !source.includes("function isZeroFeeCaptainSettled(") ||
   !source.includes("captainCollectedPence") ||
   !source.includes("Paid directly to captain:") ||
-  !source.includes("captain passes on to SIXFL") ||
-  !source.includes("Players have paid ${formatMoney(collectedPence)} through SIXFL")
+  !source.includes("captain passes on to SIXFL")
 ) {
   throw new Error("Native captain-collected payment summary was not applied correctly.");
 }

--- a/scripts/apply-unknown-player-payment-details.cjs
+++ b/scripts/apply-unknown-player-payment-details.cjs
@@ -67,29 +67,32 @@ function UnlinkedPlayerPaymentExplanation({
   source = source.replace(helperAnchor, `${helpers}${helperAnchor}`);
 }
 
-replaceRequired(
-  '                  <div className="font-semibold text-white">{playerName(fee)}</div>',
-  `                  <div className="font-semibold text-white">
+const playerLabelBefore =
+  '                  <div className="font-semibold text-white">{playerName(fee)}</div>';
+const playerLabelAfter = `                  <div className="font-semibold text-white">
                     {!fee.teamMember && !fee.prospect && isTemporaryPlayerPassFee(fee.note)
                       ? "Temporary player"
                       : playerName(fee)}
-                  </div>`,
+                  </div>`;
+
+replaceRequired(
+  playerLabelBefore,
+  playerLabelAfter,
   "temporary player display label",
 );
 
+// Add the explanation beside the player identity rather than matching the full
+// amount/team detail row. Earlier build patches are allowed to evolve that detail
+// copy, so using it as an anchor made deployments fail even though the actual
+// unlinked-player responsibility had not changed.
 if (!source.includes("<UnlinkedPlayerPaymentExplanation fee={fee} />")) {
-  const detailAnchor = `                  <div className="mt-1 text-xs text-white/45">
-                    {formatMoney(fee.amountPence)} ·{" "}
-                    {fee.teamId === teamid ? "Current team" : "Historical team row"}
-                  </div>`;
-
-  if (!source.includes(detailAnchor)) {
-    throw new Error(`Expected player payment detail row was not found in ${pagePath}`);
+  if (!source.includes(playerLabelAfter)) {
+    throw new Error(`Expected temporary player label was not found in ${pagePath}`);
   }
 
   source = source.replace(
-    detailAnchor,
-    `${detailAnchor}
+    playerLabelAfter,
+    `${playerLabelAfter}
                   {!fee.teamMember && !fee.prospect ? (
                     <UnlinkedPlayerPaymentExplanation fee={fee} />
                   ) : null}`,


### PR DESCRIPTION
Fixes the deployment failure in `scripts/apply-modern-captain-player-payment-page.cjs`.

The modern squad-payment page now contains native zero-fee settled-player totals, so the compatibility script's old large-block replacement no longer matched and aborted `npm run build`.

Changes:
- replaces the fragile large totals-block rewrite with small idempotent replacements
- preserves zero-fee settled-share calculations
- keeps team-specific fixture fee fallbacks
- keeps paid/open player fallbacks when no ledger row exists
- keeps close-unpaid-links controls and team-credit copy
- adds the charge-covered and allocation-exceeds-fee error messages used by the safety guard

No payment data or business rules are changed by this PR; it makes the build-time compatibility layer match the current native page instead of expecting an older source shape.