### PR TITLE
Fix AI predictor upcoming fixture coverage

### DIFF
--- a/src/app/(admin)/admin/ai-predictor/page.tsx
+++ b/src/app/(admin)/admin/ai-predictor/page.tsx
@@ -223,6 +223,7 @@ export default async function AiPredictorAccuracyPage() {
       JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
       LEFT JOIN "FixtureAiPrediction" prediction ON prediction."fixtureId" = fixture."id"
       WHERE fixture."status" = 'SCHEDULED'
+        AND fixture."kickoffAt" >= CURRENT_TIMESTAMP
         AND COALESCE(home_team."isFixturePlaceholder", false) = false
         AND COALESCE(away_team."isFixturePlaceholder", false) = false
       ORDER BY fixture."kickoffAt" ASC


### PR DESCRIPTION
The AI Predictor monitoring page was treating every fixture still marked SCHEDULED as upcoming, even if its kickoff date was already in the past. This caused stale 30 June fixtures to appear as the next fixture week in August.

Fix:
- require scheduled fixtures to also have `kickoffAt >= CURRENT_TIMESTAMP`
- leave historical fixture statuses untouched for separate data audit

This changes only the monitoring query; it does not modify predictions, results or fixture records.