### PR TITLE
Repair Northallerton historical team credit

### DIFF
--- a/prisma/migrations/20260813161000_repair_northallerton_standard_credit_boundary/migration.sql
+++ b/prisma/migrations/20260813161000_repair_northallerton_standard_credit_boundary/migration.sql
@@ -1,0 +1,51 @@
+-- Northallerton Nomads was converted from MANAGED to STANDARD before
+-- standardCreditStartedAt was introduced. Without a boundary, historical
+-- managed-squad overpayments can be reconstructed as standard-team credit.
+--
+-- There is no historic team-mode audit table, so repair only the known affected
+-- current STANDARD row. updatedAt is the safest persisted proxy for the mode
+-- change available on that row and deliberately errs on the side of not carrying
+-- managed-period money into the standard-team ledger.
+WITH target_team AS (
+  SELECT "id", "updatedAt"
+  FROM "Team"
+  WHERE LOWER("name") = 'northallerton nomads'
+    AND "teamMode"::text = 'STANDARD'
+  ORDER BY "updatedAt" DESC
+  LIMIT 1
+)
+UPDATE "Team" team
+SET "standardCreditStartedAt" = COALESCE(team."standardCreditStartedAt", target_team."updatedAt")
+FROM target_team
+WHERE team."id" = target_team."id";
+
+-- Remove ledger rows whose underlying fixture/payment belongs to the managed
+-- period. This uses the source fixture/charge date rather than ledger createdAt,
+-- because a historical surplus may have been recalculated and inserted later.
+DELETE FROM "TeamCreditLedgerEntry" credit
+WHERE credit."teamId" = (
+  SELECT "id"
+  FROM "Team"
+  WHERE LOWER("name") = 'northallerton nomads'
+    AND "teamMode"::text = 'STANDARD'
+  ORDER BY "updatedAt" DESC
+  LIMIT 1
+)
+AND EXISTS (
+  SELECT 1
+  FROM "Team" team
+  LEFT JOIN "PaymentCharge" charge ON charge."id" = credit."chargeId"
+  LEFT JOIN "Fixture" source_fixture
+    ON source_fixture."id" = COALESCE(
+      credit."sourceFixtureId",
+      credit."fixtureId",
+      charge."fixtureId"
+    )
+  WHERE team."id" = credit."teamId"
+    AND team."standardCreditStartedAt" IS NOT NULL
+    AND COALESCE(
+      source_fixture."kickoffAt",
+      charge."dueDate",
+      credit."createdAt"
+    ) < team."standardCreditStartedAt"
+);


### PR DESCRIPTION
## What changed
- repairs the current **Northallerton Nomads** STANDARD team row when it has no `standardCreditStartedAt` boundary
- uses the row's persisted `updatedAt` as the conservative historic boundary because the database has no team-mode history table
- removes team-credit ledger rows whose underlying source fixture/payment predates that boundary
- judges the repair by source fixture/payment date rather than ledger `createdAt`, so an old managed-era surplus cannot survive merely because it was recalculated later

## Why
Northallerton Nomads was MANAGED before becoming STANDARD. The managed-to-standard boundary feature was added after that conversion, so its boundary could remain null and old managed-period surplus could be treated as standard-team credit.

## Scope and safety
This repair is deliberately targeted to the latest current STANDARD row named Northallerton Nomads. It does not guess conversion dates for other teams. Existing runtime credit sync already excludes fixture surplus before a non-null boundary, so once this repair runs the legacy £18 should not be recreated.