### PR TITLE
Release cancelled remittance checkouts

### DIFF
--- a/src/app/captain/team/[teamid]/payments/remit-collected/cancel/route.ts
+++ b/src/app/captain/team/[teamid]/payments/remit-collected/cancel/route.ts
@@ -15,7 +15,7 @@ function paymentsUrl(teamId: string, state: string) {
   return url;
 }
 
-async function cancelPendingCheckouts(teamId: string) {
+async function cancelLatestPendingCheckout(teamId: string) {
   await ensureCaptainCollectedRemittanceTable();
 
   const ledger = await getTeamPaymentLedger(teamId);
@@ -24,7 +24,7 @@ async function cancelPendingCheckouts(teamId: string) {
   const chargeIds = Array.from(
     new Set(ledger.entries.filter((entry) => Boolean(entry.fixtureId)).map((entry) => entry.chargeId)),
   );
-  if (chargeIds.length === 0 || ledger.relatedTeamIds.length === 0) return "cancelled";
+  if (chargeIds.length === 0 || ledger.relatedTeamIds.length === 0) return "released";
 
   const pendingRows = await prisma.$queryRaw<Array<{ checkoutSessionId: string }>>(Prisma.sql`
     SELECT remittance."checkoutSessionId"
@@ -34,50 +34,49 @@ async function cancelPendingCheckouts(teamId: string) {
     WHERE remittance."chargeId" IN (${Prisma.join(chargeIds)})
       AND remittance."teamId" IN (${Prisma.join(ledger.relatedTeamIds)})
       AND payment."id" IS NULL
+    ORDER BY remittance."createdAt" DESC
+    LIMIT 1
   `);
 
-  if (pendingRows.length === 0) return "cancelled";
+  const pending = pendingRows[0];
+  if (!pending) return "released";
 
-  const stripe = getStripeServerClient();
-  let released = 0;
+  try {
+    const stripe = getStripeServerClient();
+    const session = await stripe.checkout.sessions.retrieve(pending.checkoutSessionId);
 
-  for (const row of pendingRows) {
-    try {
-      const session = await stripe.checkout.sessions.retrieve(row.checkoutSessionId);
-
-      if (session.payment_status === "paid" || session.status === "complete") {
-        continue;
-      }
-
-      if (session.status === "open") {
-        await stripe.checkout.sessions.expire(row.checkoutSessionId);
-      }
-
-      await prisma.$executeRaw(Prisma.sql`
-        DELETE FROM "CaptainCollectedRemittanceCheckout"
-        WHERE "checkoutSessionId" = ${row.checkoutSessionId}
-          AND NOT EXISTS (
-            SELECT 1
-            FROM "PaymentTransaction" payment
-            WHERE payment."stripeCheckoutSessionId" = ${row.checkoutSessionId}
-          )
-      `);
-      released += 1;
-    } catch (error) {
-      console.error("Could not cancel captain collected remittance checkout", {
-        teamId,
-        checkoutSessionId: row.checkoutSessionId,
-        error,
-      });
+    if (session.payment_status === "paid" || session.status === "complete") {
+      return "processing";
     }
-  }
 
-  return released > 0 ? "cancelled" : "processing";
+    if (session.status === "open") {
+      await stripe.checkout.sessions.expire(pending.checkoutSessionId);
+    }
+
+    await prisma.$executeRaw(Prisma.sql`
+      DELETE FROM "CaptainCollectedRemittanceCheckout"
+      WHERE "checkoutSessionId" = ${pending.checkoutSessionId}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "PaymentTransaction" payment
+          WHERE payment."stripeCheckoutSessionId" = ${pending.checkoutSessionId}
+        )
+    `);
+
+    return "released";
+  } catch (error) {
+    console.error("Could not cancel captain collected remittance checkout", {
+      teamId,
+      checkoutSessionId: pending.checkoutSessionId,
+      error,
+    });
+    return "processing";
+  }
 }
 
 async function handleCancellation(teamId: string) {
   await requireCaptain(teamId);
-  const state = await cancelPendingCheckouts(teamId);
+  const state = await cancelLatestPendingCheckout(teamId);
   return NextResponse.redirect(paymentsUrl(teamId, state), 303);
 }
 

--- a/src/app/captain/team/[teamid]/payments/remit-collected/cancel/route.ts
+++ b/src/app/captain/team/[teamid]/payments/remit-collected/cancel/route.ts
@@ -1,0 +1,98 @@
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { ensureCaptainCollectedRemittanceTable } from "@/lib/payments/captain-collected-remittance";
+import { getTeamPaymentLedger } from "@/lib/payments/team-payment-ledger";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getPublicSiteUrl, getStripeServerClient } from "@/lib/stripe/client";
+
+export const dynamic = "force-dynamic";
+
+function paymentsUrl(teamId: string, state: string) {
+  const url = new URL(`/captain/team/${teamId}/payments`, `${getPublicSiteUrl()}/`);
+  url.searchParams.set("remit", state);
+  return url;
+}
+
+async function cancelPendingCheckouts(teamId: string) {
+  await ensureCaptainCollectedRemittanceTable();
+
+  const ledger = await getTeamPaymentLedger(teamId);
+  if (!ledger) return "not_available";
+
+  const chargeIds = Array.from(
+    new Set(ledger.entries.filter((entry) => Boolean(entry.fixtureId)).map((entry) => entry.chargeId)),
+  );
+  if (chargeIds.length === 0 || ledger.relatedTeamIds.length === 0) return "cancelled";
+
+  const pendingRows = await prisma.$queryRaw<Array<{ checkoutSessionId: string }>>(Prisma.sql`
+    SELECT remittance."checkoutSessionId"
+    FROM "CaptainCollectedRemittanceCheckout" remittance
+    LEFT JOIN "PaymentTransaction" payment
+      ON payment."stripeCheckoutSessionId" = remittance."checkoutSessionId"
+    WHERE remittance."chargeId" IN (${Prisma.join(chargeIds)})
+      AND remittance."teamId" IN (${Prisma.join(ledger.relatedTeamIds)})
+      AND payment."id" IS NULL
+  `);
+
+  if (pendingRows.length === 0) return "cancelled";
+
+  const stripe = getStripeServerClient();
+  let released = 0;
+
+  for (const row of pendingRows) {
+    try {
+      const session = await stripe.checkout.sessions.retrieve(row.checkoutSessionId);
+
+      if (session.payment_status === "paid" || session.status === "complete") {
+        continue;
+      }
+
+      if (session.status === "open") {
+        await stripe.checkout.sessions.expire(row.checkoutSessionId);
+      }
+
+      await prisma.$executeRaw(Prisma.sql`
+        DELETE FROM "CaptainCollectedRemittanceCheckout"
+        WHERE "checkoutSessionId" = ${row.checkoutSessionId}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "PaymentTransaction" payment
+            WHERE payment."stripeCheckoutSessionId" = ${row.checkoutSessionId}
+          )
+      `);
+      released += 1;
+    } catch (error) {
+      console.error("Could not cancel captain collected remittance checkout", {
+        teamId,
+        checkoutSessionId: row.checkoutSessionId,
+        error,
+      });
+    }
+  }
+
+  return released > 0 ? "cancelled" : "processing";
+}
+
+async function handleCancellation(teamId: string) {
+  await requireCaptain(teamId);
+  const state = await cancelPendingCheckouts(teamId);
+  return NextResponse.redirect(paymentsUrl(teamId, state), 303);
+}
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await context.params;
+  return handleCancellation(teamid);
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await context.params;
+  return handleCancellation(teamid);
+}

--- a/src/app/captain/team/[teamid]/payments/template.tsx
+++ b/src/app/captain/team/[teamid]/payments/template.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+
+const RECOVERY_MARKER = "sixfl-collected-remittance-cancel-recovery";
+
+export default function PaymentsTemplate({ children }: { children: React.ReactNode }) {
+  const params = useParams<{ teamid: string }>();
+  const teamId = String(params?.teamid ?? "");
+  const [showBackRecovery, setShowBackRecovery] = useState(false);
+
+  useEffect(() => {
+    if (!teamId) return;
+
+    const query = new URLSearchParams(window.location.search);
+    const remitState = query.get("remit");
+
+    if (remitState === "cancelled") {
+      const alreadyRecovering = window.sessionStorage.getItem(RECOVERY_MARKER) === teamId;
+
+      if (!alreadyRecovering) {
+        window.sessionStorage.setItem(RECOVERY_MARKER, teamId);
+        window.location.replace(
+          `/captain/team/${encodeURIComponent(teamId)}/payments/remit-collected/cancel`,
+        );
+        return;
+      }
+
+      window.sessionStorage.removeItem(RECOVERY_MARKER);
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+
+    const navigation = performance.getEntriesByType("navigation")[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+    if (navigation?.type === "back_forward") {
+      setShowBackRecovery(true);
+    }
+
+    function handlePageShow(event: PageTransitionEvent) {
+      if (event.persisted) setShowBackRecovery(true);
+    }
+
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, [teamId]);
+
+  return (
+    <>
+      {showBackRecovery && teamId ? (
+        <div className="mb-5 rounded-2xl border border-amber-300/20 bg-amber-400/10 px-4 py-4 text-sm text-amber-50">
+          <p className="font-semibold">Returned from Stripe without paying?</p>
+          <p className="mt-1 leading-5 text-amber-50/75">
+            If you used your browser Back button, Stripe may still show the collected-money checkout as active. Cancel it here to release the amount and make the payment button available again.
+          </p>
+          <form
+            action={`/captain/team/${teamId}/payments/remit-collected/cancel`}
+            method="post"
+            className="mt-3"
+          >
+            <button
+              type="submit"
+              className="inline-flex h-10 items-center justify-center rounded-xl border border-amber-200/25 bg-black/20 px-4 text-xs font-semibold text-amber-50 transition hover:bg-black/30"
+            >
+              Cancel pending Stripe checkout
+            </button>
+          </form>
+        </div>
+      ) : null}
+      {children}
+    </>
+  );
+}

--- a/src/app/captain/team/[teamid]/payments/template.tsx
+++ b/src/app/captain/team/[teamid]/payments/template.tsx
@@ -34,7 +34,7 @@ export default function PaymentsTemplate({ children }: { children: React.ReactNo
     const navigation = performance.getEntriesByType("navigation")[0] as
       | PerformanceNavigationTiming
       | undefined;
-    if (navigation?.type === "back_forward") {
+    if (navigation?.type === "back_forward" || navigation?.type === "reload") {
       setShowBackRecovery(true);
     }
 
@@ -52,7 +52,7 @@ export default function PaymentsTemplate({ children }: { children: React.ReactNo
         <div className="mb-5 rounded-2xl border border-amber-300/20 bg-amber-400/10 px-4 py-4 text-sm text-amber-50">
           <p className="font-semibold">Returned from Stripe without paying?</p>
           <p className="mt-1 leading-5 text-amber-50/75">
-            If you used your browser Back button, Stripe may still show the collected-money checkout as active. Cancel it here to release the amount and make the payment button available again.
+            If you came back without completing the payment, Stripe may still show the collected-money checkout as active. Cancel it here to release the amount and make the payment button available again.
           </p>
           <form
             action={`/captain/team/${teamId}/payments/remit-collected/cancel`}


### PR DESCRIPTION
Adds a recovery route for unpaid captain-collected Stripe checkouts and a payments-page recovery control. Completed/paid sessions are preserved; only unpaid open sessions are expired and released.