### PR TITLE
Use team credit for captain-collected money

### DIFF
--- a/src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx
+++ b/src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx
@@ -1,11 +1,169 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
-export default async function TeamCreditLedgerPage({ params }: { params: Promise<{ teamid: string }> }) {
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { getTeamCreditLedger } from "@/lib/payments/team-credits";
+import { formatPaymentMoney, getTeamPaymentLedger } from "@/lib/payments/team-payment-ledger";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Team Credit Ledger | SIXFL",
+};
+
+function signedAmount(entryType: string, amountPence: number) {
+  return entryType === "CREDIT_ADDED" ? amountPence : -amountPence;
+}
+
+function entryLabel(entryType: string) {
+  if (entryType === "CREDIT_ADDED") return "Credit added";
+  if (entryType === "CREDIT_USED") return "Credit used";
+  if (entryType === "CREDIT_REVERSED") return "Credit reversed";
+  return entryType.replaceAll("_", " ");
+}
+
+function formatDate(value: Date) {
+  return formatDateTimeInLondon(value, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default async function TeamCreditLedgerPage({
+  params,
+}: {
+  params: Promise<{ teamid: string }>;
+}) {
   const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const [team, paymentLedger] = await Promise.all([
+    prisma.team.findUnique({
+      where: { id: teamid },
+      select: { id: true, name: true },
+    }),
+    getTeamPaymentLedger(teamid),
+  ]);
+
+  if (!team || !paymentLedger) notFound();
+
+  const creditLedger = await getTeamCreditLedger(paymentLedger.relatedTeamIds);
+  const chronological = [...creditLedger.entries].sort((a, b) => {
+    const dateDifference = a.createdAt.getTime() - b.createdAt.getTime();
+    return dateDifference || a.id.localeCompare(b.id);
+  });
+
+  let balancePence = 0;
+  const balanceAfterEntry = new Map<string, number>();
+  for (const entry of chronological) {
+    balancePence += signedAmount(entry.entryType, entry.amountPence);
+    balanceAfterEntry.set(entry.id, balancePence);
+  }
+
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-semibold text-white">Team credit ledger</h1>
-      <Link href={`/captain/team/${teamid}/payments`}>Back to payments</Link>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200/60">
+            Team finances
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold text-white">Team credit ledger</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">
+            A clear audit trail of credit added to {team.name}, credit used against fixture charges, and the balance after each movement.
+          </p>
+        </div>
+        <Link
+          href={`/captain/team/${teamid}/payments`}
+          className="inline-flex min-h-11 items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white/75 transition hover:bg-white/[0.08]"
+        >
+          Back to payments
+        </Link>
+      </div>
+
+      <section className="rounded-3xl border border-emerald-400/25 bg-emerald-500/10 p-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/70">
+          Current team credit
+        </p>
+        <p className="mt-3 text-4xl font-semibold text-white">
+          {formatPaymentMoney(Math.max(creditLedger.balancePence, 0))}
+        </p>
+        <p className="mt-2 text-sm text-emerald-50/70">
+          This is money already held by SIXFL for the team and available to use against eligible fixture charges.
+        </p>
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-black/20">
+        <div className="border-b border-white/10 px-5 py-4 sm:px-6">
+          <h2 className="text-xl font-semibold text-white">Credit movements</h2>
+          <p className="mt-1 text-sm text-white/50">
+            Newest first. Every row shows the resulting credit balance after that movement.
+          </p>
+        </div>
+
+        {creditLedger.entries.length === 0 ? (
+          <div className="px-6 py-8 text-sm text-white/50">
+            No team credit movements have been recorded yet.
+          </div>
+        ) : (
+          <div className="divide-y divide-white/10">
+            {creditLedger.entries.map((entry) => {
+              const amount = signedAmount(entry.entryType, entry.amountPence);
+              const balanceAfter = balanceAfterEntry.get(entry.id) ?? 0;
+
+              return (
+                <article
+                  key={entry.id}
+                  className="grid gap-4 px-5 py-5 sm:px-6 lg:grid-cols-[minmax(0,1fr)_150px_170px] lg:items-center"
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-semibold text-white">{entryLabel(entry.entryType)}</span>
+                      {entry.chargeTitle ? (
+                        <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] text-white/55">
+                          {entry.chargeTitle}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-2 text-sm leading-5 text-white/65">
+                      {entry.description || "No additional note recorded."}
+                    </p>
+                    <p className="mt-2 text-xs text-white/40">{formatDate(entry.createdAt)}</p>
+                  </div>
+
+                  <div className="lg:text-right">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                      Movement
+                    </p>
+                    <p className={amount >= 0 ? "mt-1 text-lg font-semibold text-emerald-200" : "mt-1 text-lg font-semibold text-amber-100"}>
+                      {amount >= 0 ? "+" : "−"}{formatPaymentMoney(Math.abs(amount))}
+                    </p>
+                  </div>
+
+                  <div className="lg:text-right">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-white/35">
+                      Balance after
+                    </p>
+                    <p className="mt-1 text-lg font-semibold text-white">
+                      {formatPaymentMoney(Math.max(balanceAfter, 0))}
+                    </p>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {creditLedger.entries.length >= 100 ? (
+        <p className="text-xs text-white/35">
+          Showing the 100 most recent credit movements.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx
+++ b/src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default async function TeamCreditLedgerPage({ params }: { params: Promise<{ teamid: string }> }) {
+  const { teamid } = await params;
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-semibold text-white">Team credit ledger</h1>
+      <Link href={`/captain/team/${teamid}/payments`}>Back to payments</Link>
+    </div>
+  );
+}

--- a/src/app/captain/team/[teamid]/payments/layout.tsx
+++ b/src/app/captain/team/[teamid]/payments/layout.tsx
@@ -1,5 +1,7 @@
+import Link from "next/link";
 import { Suspense, type ReactNode } from "react";
 
+import CaptainCollectedCreditOptions from "@/components/captain/CaptainCollectedCreditOptions";
 import CaptainCollectedRemittanceNotice from "@/components/captain/CaptainCollectedRemittanceNotice";
 import CaptainCollectedRemittancePanel from "@/components/captain/CaptainCollectedRemittancePanel";
 
@@ -17,6 +19,15 @@ export default async function CaptainPaymentsLayout({
       <Suspense>
         <CaptainCollectedRemittanceNotice />
       </Suspense>
+      <div className="flex justify-end">
+        <Link
+          href={`/captain/team/${teamid}/payments/credit-ledger`}
+          className="inline-flex min-h-10 items-center justify-center rounded-xl border border-emerald-300/20 bg-emerald-400/10 px-4 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-400/15"
+        >
+          View team credit ledger
+        </Link>
+      </div>
+      <CaptainCollectedCreditOptions teamId={teamid} />
       <CaptainCollectedRemittancePanel teamId={teamid} />
       {children}
     </div>

--- a/src/app/captain/team/[teamid]/payments/use-credit-for-collected/route.ts
+++ b/src/app/captain/team/[teamid]/payments/use-credit-for-collected/route.ts
@@ -1,0 +1,261 @@
+import { randomUUID } from "crypto";
+import { PaymentChargeStatus, PaymentMethod, Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { getDisplayChargeStatus } from "@/lib/payments/charge-summary";
+import {
+  CAPTAIN_COLLECTED_NOTE_MARKERS,
+  ensureCaptainCollectedRemittanceTable,
+} from "@/lib/payments/captain-collected-remittance";
+import { getTeamCreditLedger } from "@/lib/payments/team-credits";
+import { getTeamPaymentLedger } from "@/lib/payments/team-payment-ledger";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getPublicSiteUrl } from "@/lib/stripe/client";
+
+export const dynamic = "force-dynamic";
+
+function paymentsUrl(teamId: string, values?: Record<string, string>) {
+  const url = new URL(`/captain/team/${teamId}/payments`, `${getPublicSiteUrl()}/`);
+  for (const [key, value] of Object.entries(values ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  return url;
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await context.params;
+  await requireCaptain(teamid);
+
+  const formData = await request.formData();
+  const chargeId = String(formData.get("chargeId") ?? "").trim();
+
+  if (!chargeId) {
+    return NextResponse.redirect(
+      paymentsUrl(teamid, { collectedCredit: "invalid" }),
+      303,
+    );
+  }
+
+  const ledger = await getTeamPaymentLedger(teamid);
+  const entry = ledger?.entries.find((candidate) => candidate.chargeId === chargeId) ?? null;
+
+  if (!ledger || !entry || !entry.fixtureId || entry.displayStatus === "PAID" || entry.displayStatus === "VOID") {
+    return NextResponse.redirect(
+      paymentsUrl(teamid, { collectedCredit: "not_available" }),
+      303,
+    );
+  }
+
+  await ensureCaptainCollectedRemittanceTable();
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      await tx.$queryRaw(Prisma.sql`
+        SELECT pg_advisory_xact_lock(hashtext(${`captain-collected-credit:${chargeId}`}))
+      `);
+
+      const chargeRows = await tx.$queryRaw<
+        Array<{
+          id: string;
+          teamId: string;
+          fixtureId: string;
+          amountPence: number;
+          status: PaymentChargeStatus;
+        }>
+      >(Prisma.sql`
+        SELECT
+          pc."id",
+          pc."teamId",
+          pc."fixtureId",
+          pc."amountPence",
+          pc."status"
+        FROM "PaymentCharge" pc
+        JOIN "Team" team ON team."id" = pc."teamId"
+        LEFT JOIN "Fixture" fixture ON fixture."id" = pc."fixtureId"
+        WHERE pc."id" = ${chargeId}
+          AND pc."fixtureId" IS NOT NULL
+          AND pc."status" <> 'VOID'::"PaymentChargeStatus"
+          AND team."teamMode"::text = 'STANDARD'
+          AND (
+            team."standardCreditStartedAt" IS NULL
+            OR COALESCE(fixture."kickoffAt", pc."dueDate", pc."createdAt") >= team."standardCreditStartedAt"
+          )
+        FOR UPDATE OF pc
+      `);
+
+      const charge = chargeRows[0];
+      if (!charge || !ledger.relatedTeamIds.includes(charge.teamId)) {
+        return { amountUsedPence: 0, reason: "not_available" as const };
+      }
+
+      const creditLedger = await getTeamCreditLedger(ledger.relatedTeamIds, tx);
+      const creditBalancePence = Math.max(creditLedger.balancePence, 0);
+
+      if (!creditLedger.teamIds.includes(charge.teamId) || creditBalancePence <= 0) {
+        return { amountUsedPence: 0, reason: "no_credit" as const };
+      }
+
+      const [directPaid, playerPaid, collected] = await Promise.all([
+        tx.paymentTransaction.aggregate({
+          where: { chargeId: charge.id },
+          _sum: { amountPence: true },
+        }),
+        tx.playerMatchFee.aggregate({
+          where: {
+            teamId: charge.teamId,
+            fixtureId: charge.fixtureId,
+            status: "PAID",
+          },
+          _sum: { amountPence: true },
+        }),
+        tx.playerMatchFee.aggregate({
+          where: {
+            teamId: charge.teamId,
+            fixtureId: charge.fixtureId,
+            status: "WAIVED",
+            OR: CAPTAIN_COLLECTED_NOTE_MARKERS.map((marker) => ({
+              note: { contains: marker, mode: "insensitive" as const },
+            })),
+          },
+          _sum: { amountPence: true },
+        }),
+      ]);
+
+      const [remittanceTotals] = await tx.$queryRaw<
+        Array<{ settledPence: number; pendingPence: number }>
+      >(Prisma.sql`
+        SELECT
+          COALESCE(SUM(
+            CASE WHEN payment."id" IS NOT NULL THEN remittance."amountPence" ELSE 0 END
+          ), 0)::int AS "settledPence",
+          COALESCE(SUM(
+            CASE
+              WHEN payment."id" IS NULL
+                AND remittance."createdAt" >= CURRENT_TIMESTAMP - INTERVAL '24 hours'
+              THEN remittance."amountPence"
+              ELSE 0
+            END
+          ), 0)::int AS "pendingPence"
+        FROM "CaptainCollectedRemittanceCheckout" remittance
+        LEFT JOIN "PaymentTransaction" payment
+          ON payment."stripeCheckoutSessionId" = remittance."checkoutSessionId"
+        WHERE remittance."chargeId" = ${charge.id}
+      `);
+
+      const paidPence = Number(directPaid._sum.amountPence ?? 0);
+      const playerPaidPence = Number(playerPaid._sum.amountPence ?? 0);
+      const collectedPence = Number(collected._sum.amountPence ?? 0);
+      const settledPence = Number(remittanceTotals?.settledPence ?? 0);
+      const pendingPence = Number(remittanceTotals?.pendingPence ?? 0);
+      const currentOutstandingPence = Math.max(
+        charge.amountPence - paidPence - playerPaidPence,
+        0,
+      );
+      const availableCollectedPence = Math.max(
+        collectedPence - settledPence - pendingPence,
+        0,
+      );
+      const amountUsedPence = Math.min(
+        creditBalancePence,
+        currentOutstandingPence,
+        availableCollectedPence,
+      );
+
+      if (amountUsedPence <= 0) {
+        return {
+          amountUsedPence: 0,
+          reason: pendingPence > 0 ? ("pending_checkout" as const) : ("not_available" as const),
+        };
+      }
+
+      const creditEntryId = `tcred_${randomUUID()}`;
+      const settlementId = `team_credit:${randomUUID()}`;
+      const description = `Team credit used instead of asking the captain to pass on collected player money for ${entry.title}.`;
+
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO "TeamCreditLedgerEntry" (
+          "id",
+          "teamId",
+          "fixtureId",
+          "chargeId",
+          "entryType",
+          "amountPence",
+          "description"
+        ) VALUES (
+          ${creditEntryId},
+          ${charge.teamId},
+          ${charge.fixtureId},
+          ${charge.id},
+          'CREDIT_USED'::"TeamCreditLedgerEntryType",
+          ${amountUsedPence},
+          ${description}
+        )
+      `);
+
+      await tx.paymentTransaction.create({
+        data: {
+          teamId: charge.teamId,
+          chargeId: charge.id,
+          amountPence: amountUsedPence,
+          method: PaymentMethod.OTHER,
+          reference: "TEAM_CREDIT",
+          notes: `Team credit used. Credit ledger entry: ${creditEntryId}. Captain-collected player money retained by the team instead of being remitted as new cash.`,
+          paidAt: new Date(),
+          stripeCheckoutSessionId: settlementId,
+        },
+      });
+
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO "CaptainCollectedRemittanceCheckout" (
+          "checkoutSessionId",
+          "teamId",
+          "chargeId",
+          "fixtureId",
+          "amountPence"
+        ) VALUES (
+          ${settlementId},
+          ${charge.teamId},
+          ${charge.id},
+          ${charge.fixtureId},
+          ${amountUsedPence}
+        )
+      `);
+
+      const paidPenceAfterCredit = paidPence + playerPaidPence + amountUsedPence;
+      const nextStatus = getDisplayChargeStatus({
+        storedStatus: charge.status,
+        amountPence: charge.amountPence,
+        paidPence: paidPenceAfterCredit,
+      }) as PaymentChargeStatus;
+
+      await tx.paymentCharge.update({
+        where: { id: charge.id },
+        data: { status: nextStatus },
+      });
+
+      return {
+        amountUsedPence,
+        remainingCreditPence: creditBalancePence - amountUsedPence,
+        reason: "used" as const,
+      };
+    });
+
+    return NextResponse.redirect(
+      paymentsUrl(teamid, {
+        collectedCredit: result.reason,
+        ...(result.amountUsedPence > 0 ? { amount: String(result.amountUsedPence) } : {}),
+      }),
+      303,
+    );
+  } catch (error) {
+    console.error("Could not use team credit for captain-collected money", error);
+    return NextResponse.redirect(
+      paymentsUrl(teamid, { collectedCredit: "error" }),
+      303,
+    );
+  }
+}

--- a/src/components/captain/CaptainCollectedCreditOptions.tsx
+++ b/src/components/captain/CaptainCollectedCreditOptions.tsx
@@ -1,0 +1,148 @@
+import { getCaptainCollectedRemittanceSnapshots } from "@/lib/payments/captain-collected-remittance";
+import { getTeamCreditLedger } from "@/lib/payments/team-credits";
+import {
+  formatPaymentFixtureDate,
+  formatPaymentMoney,
+  getTeamPaymentLedger,
+} from "@/lib/payments/team-payment-ledger";
+
+export default async function CaptainCollectedCreditOptions({
+  teamId,
+}: {
+  teamId: string;
+}) {
+  const ledger = await getTeamPaymentLedger(teamId);
+  if (!ledger) return null;
+
+  const fixtureEntries = ledger.entries
+    .filter(
+      (entry) =>
+        Boolean(entry.fixtureId) &&
+        entry.outstandingPence > 0 &&
+        entry.displayStatus !== "PAID" &&
+        entry.displayStatus !== "VOID",
+    )
+    .map((entry) => ({ ...entry, fixtureId: entry.fixtureId as string }));
+
+  if (fixtureEntries.length === 0) return null;
+
+  const [creditLedger, snapshots] = await Promise.all([
+    getTeamCreditLedger(ledger.relatedTeamIds),
+    getCaptainCollectedRemittanceSnapshots(
+      fixtureEntries.map((entry) => ({
+        chargeId: entry.chargeId,
+        teamId: entry.teamId,
+        fixtureId: entry.fixtureId,
+      })),
+    ),
+  ]);
+
+  const creditBalancePence = Math.max(creditLedger.balancePence, 0);
+  if (creditBalancePence <= 0) return null;
+
+  const rows = fixtureEntries
+    .map((entry) => {
+      const snapshot = snapshots.get(entry.chargeId);
+      if (!snapshot || snapshot.unremittedPence <= 0) return null;
+
+      const creditAvailableForCollectedPence = Math.min(
+        creditBalancePence,
+        snapshot.unremittedPence,
+        entry.outstandingPence,
+      );
+
+      if (creditAvailableForCollectedPence <= 0) return null;
+
+      return {
+        entry,
+        snapshot,
+        creditAvailableForCollectedPence,
+      };
+    })
+    .filter((row): row is NonNullable<typeof row> => Boolean(row));
+
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="rounded-3xl border border-emerald-400/25 bg-emerald-500/[0.08] p-5 sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/70">
+            Team credit available
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            Use team credit before sending collected cash to SIXFL
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-emerald-50/75">
+            Your team currently has {formatPaymentMoney(creditBalancePence)} credit. If you have collected player money, you can use existing team credit against the fixture instead of sending the same amount to SIXFL again.
+          </p>
+        </div>
+        <a
+          href={`/captain/team/${teamId}/payments/credit-ledger`}
+          className="inline-flex shrink-0 items-center justify-center rounded-xl border border-emerald-300/25 bg-emerald-400/10 px-4 py-2.5 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-400/15"
+        >
+          View credit ledger
+        </a>
+      </div>
+
+      <div className="mt-5 space-y-3">
+        {rows.map(({ entry, snapshot, creditAvailableForCollectedPence }) => {
+          const blockedByPendingCheckout = snapshot.pendingPence > 0;
+
+          return (
+            <article
+              key={entry.chargeId}
+              className="rounded-2xl border border-white/10 bg-black/20 p-4"
+            >
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <div className="font-semibold text-white">{entry.fixtureLabel}</div>
+                  <div className="mt-1 text-sm text-white/50">
+                    {entry.kickoffAt
+                      ? formatPaymentFixtureDate(entry.kickoffAt)
+                      : "Fixture date not set"}
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                    <span className="rounded-full border border-cyan-300/20 bg-cyan-400/10 px-3 py-1 text-cyan-50">
+                      Captain still holds {formatPaymentMoney(snapshot.unremittedPence)}
+                    </span>
+                    <span className="rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-emerald-50">
+                      Credit can cover {formatPaymentMoney(creditAvailableForCollectedPence)}
+                    </span>
+                    <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-white/65">
+                      Fixture outstanding {formatPaymentMoney(entry.outstandingPence)}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="w-full shrink-0 lg:w-[320px]">
+                  {blockedByPendingCheckout ? (
+                    <div className="rounded-2xl border border-amber-300/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-50">
+                      Cancel the pending Stripe checkout first, then you can use team credit instead.
+                    </div>
+                  ) : (
+                    <form
+                      action={`/captain/team/${teamId}/payments/use-credit-for-collected`}
+                      method="post"
+                    >
+                      <input type="hidden" name="chargeId" value={entry.chargeId} />
+                      <button
+                        type="submit"
+                        className="inline-flex min-h-12 w-full items-center justify-center rounded-2xl bg-emerald-300 px-4 py-3 text-sm font-black text-black transition hover:bg-emerald-200"
+                      >
+                        Use {formatPaymentMoney(creditAvailableForCollectedPence)} team credit instead
+                      </button>
+                    </form>
+                  )}
+                  <p className="mt-2 text-xs leading-5 text-white/45">
+                    The captain keeps the same amount of collected player money and the team credit is reduced by that amount.
+                  </p>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Tightens the captain payment flow. When a standard team already has SIXFL credit and the captain has collected player money, the captain can use available team credit against that fixture instead of sending the same amount to SIXFL again. The action is capped to the lesser of available credit, unremitted collected money, and the fixture balance; pending Stripe checkouts block the credit action until cancelled. Also adds a captain-visible team credit ledger with movement history and running balances.