### PR TITLE
Show raising team with fixture issue reporter

### DIFF
--- a/src/app/api/admin/night-board/team-issues/route.ts
+++ b/src/app/api/admin/night-board/team-issues/route.ts
@@ -96,9 +96,17 @@ export async function GET(request: Request) {
     },
   });
 
+  const issuesWithRaisingTeam = issues.map((issue) => ({
+    ...issue,
+    confirmedByUser: {
+      name: `${issue.confirmedByUser?.name?.trim() || "Captain"} · Team: ${issue.team.name}`,
+      email: issue.confirmedByUser?.email ?? null,
+    },
+  }));
+
   return NextResponse.json({
     selectedDate,
     emailReplyConfigured: Boolean(process.env.EMAIL_REPLY_DOMAIN?.trim()),
-    issues,
+    issues: issuesWithRaisingTeam,
   });
 }


### PR DESCRIPTION
Makes the Night Board issue reporter label explicit by including the team that raised the issue alongside the logged-in user's name, so admins do not need to know every captain by name.