### PR TITLE
Self-heal missing upcoming AI predictions

### DIFF
--- a/src/app/(admin)/admin/ai-predictor/layout.tsx
+++ b/src/app/(admin)/admin/ai-predictor/layout.tsx
@@ -1,0 +1,64 @@
+// ========================================
+// File: src/app/(admin)/admin/ai-predictor/layout.tsx
+// ========================================
+
+import type { ReactNode } from "react";
+import { Prisma } from "@prisma/client";
+
+import { refreshStoredAiPreviewForFixture } from "@/lib/fixtures/storedAiPredictions";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type MissingUpcomingPredictionRow = {
+  fixtureId: string;
+};
+
+async function repairMissingUpcomingPredictions() {
+  const missing = await prisma.$queryRaw<MissingUpcomingPredictionRow[]>(Prisma.sql`
+    SELECT fixture."id" AS "fixtureId"
+    FROM "Fixture" fixture
+    JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+    JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+    LEFT JOIN "FixtureAiPrediction" prediction ON prediction."fixtureId" = fixture."id"
+    WHERE fixture."status" = 'SCHEDULED'
+      AND fixture."kickoffAt" >= CURRENT_TIMESTAMP
+      AND COALESCE(home_team."isFixturePlaceholder", false) = false
+      AND COALESCE(away_team."isFixturePlaceholder", false) = false
+      AND (
+        prediction."fixtureId" IS NULL
+        OR prediction."predictedHomeScore" IS NULL
+        OR prediction."predictedAwayScore" IS NULL
+      )
+    ORDER BY fixture."kickoffAt" ASC
+    LIMIT 48
+  `);
+
+  // Repair only fixtures that are still genuinely in the future. Work in small
+  // batches so one broken fixture cannot block the rest and we do not create a
+  // large burst of predictor requests when an old coverage gap is discovered.
+  for (let index = 0; index < missing.length; index += 4) {
+    const batch = missing.slice(index, index + 4);
+    const results = await Promise.allSettled(
+      batch.map((row) => refreshStoredAiPreviewForFixture(row.fixtureId)),
+    );
+
+    results.forEach((result, resultIndex) => {
+      if (result.status === "rejected") {
+        console.error("Could not self-heal missing upcoming AI prediction", {
+          fixtureId: batch[resultIndex]?.fixtureId,
+          error: result.reason,
+        });
+      }
+    });
+  }
+}
+
+export default async function AiPredictorLayout({ children }: { children: ReactNode }) {
+  await requireAdmin();
+  await repairMissingUpcomingPredictions();
+
+  return children;
+}


### PR DESCRIPTION
## What changed
- adds an admin-only layout around `/admin/ai-predictor`
- before the monitoring dashboard renders, it finds future real `SCHEDULED` fixtures with no permanent predicted score
- repairs only those missing future predictions using the existing stored-prediction service
- works in batches of four and isolates failures per fixture, so one bad fixture cannot prevent the remaining missing predictions from being stored

## Why
The bulk fixture generator now stores predictions for newly-created fixtures, but fixtures that already existed before that fix can still have historic coverage gaps. The monitoring page correctly exposed four such Harrogate fixtures. This makes the monitoring page self-healing instead of requiring a manual repair button.

## Integrity safeguards
- completed fixtures are never touched
- past fixtures are excluded by kickoff time
- placeholder fixtures are excluded
- existing stored predictions with complete scores are not regenerated
- the existing predictor service still verifies the fixture is `SCHEDULED` before saving

This should turn old upcoming coverage gaps such as 8/12 into full coverage when an admin opens the predictor monitor, while preserving the validity of the later accuracy test.