### PR TITLE
Restore greyed-out taken kit designs

### DIFF
--- a/scripts/apply-kit-player-assignments.cjs
+++ b/scripts/apply-kit-player-assignments.cjs
@@ -145,3 +145,4 @@ console.log(
 );
 
 require("./apply-admin-kit-draft-visibility.cjs");
+require("./apply-league-kit-design-lock.cjs");


### PR DESCRIPTION
Restores the existing per-league kit design reservation step after the captain kit source-preparation scripts run.

The existing `apply-league-kit-design-lock.cjs` already implements the intended behaviour: kit designs submitted by another team in the same league are shown as greyed out / Taken, cannot be selected, and are also rejected server-side if a stale page tries to submit one. Draft and cancelled orders do not reserve a design.

The regression happened because that lock script was no longer being run after the newer kit-player-assignment source prep rewrote the kit page/form. This PR invokes the lock at the end of that prep chain so it is present in both dev and production builds.