### PR TITLE
Add blocking critical feature regression contracts

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -31,25 +31,39 @@ jobs:
       - name: Check critical feature contracts
         run: node scripts/check-critical-feature-contracts.mjs
 
-      - name: Check central standings contract
-        run: node scripts/check-central-standings-usage.cjs
+      - name: Snapshot protected kit source
+        run: |
+          git diff --binary -- \
+            src/app/captain/team/\[teamid\]/kit/page.tsx \
+            src/app/captain/team/\[teamid\]/kit/actions.ts \
+            src/app/captain/team/\[teamid\]/kit/save-v2.ts \
+            src/components/captain/TeamKitOrderForm.tsx \
+            > /tmp/kit-contract-before.diff
 
-      - name: Snapshot first prepared source
-        run: git diff --binary -- src scripts prisma package.json > /tmp/prebuild-first.diff
+      - name: Re-run the kit reservation preparation
+        run: node scripts/apply-league-kit-design-lock.cjs
 
-      - name: Run source preparation a second time
-        run: npm run prebuild
-
-      - name: Reject order-dependent or non-idempotent preparation
+      - name: Reject non-idempotent kit reservation preparation
         shell: bash
         run: |
-          git diff --binary -- src scripts prisma package.json > /tmp/prebuild-second.diff
-          if ! diff -u /tmp/prebuild-first.diff /tmp/prebuild-second.diff; then
+          git diff --binary -- \
+            src/app/captain/team/\[teamid\]/kit/page.tsx \
+            src/app/captain/team/\[teamid\]/kit/actions.ts \
+            src/app/captain/team/\[teamid\]/kit/save-v2.ts \
+            src/components/captain/TeamKitOrderForm.tsx \
+            > /tmp/kit-contract-after.diff
+          if ! diff -u /tmp/kit-contract-before.diff /tmp/kit-contract-after.diff; then
             echo ""
-            echo "ERROR: npm run prebuild changes the prepared source differently on a second run."
-            echo "This means build-time patches are order-dependent or non-idempotent and could silently remove an existing feature."
+            echo "ERROR: the kit reservation preparation changed already-prepared kit source."
+            echo "The reservation safeguard must be idempotent and safe to apply after the complete prebuild chain."
             exit 1
           fi
 
-      - name: Re-check critical feature contracts after second preparation
+      - name: Re-check critical feature contracts
         run: node scripts/check-critical-feature-contracts.mjs
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Type-check protected application source
+        run: npx tsc --noEmit

--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -1,0 +1,55 @@
+name: SIXFL critical feature contracts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  contracts:
+    name: Preserve existing critical features
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply the complete production source-preparation chain
+        run: npm run prebuild
+
+      - name: Check critical feature contracts
+        run: node scripts/check-critical-feature-contracts.mjs
+
+      - name: Check central standings contract
+        run: node scripts/check-central-standings-usage.cjs
+
+      - name: Snapshot first prepared source
+        run: git diff --binary -- src scripts prisma package.json > /tmp/prebuild-first.diff
+
+      - name: Run source preparation a second time
+        run: npm run prebuild
+
+      - name: Reject order-dependent or non-idempotent preparation
+        shell: bash
+        run: |
+          git diff --binary -- src scripts prisma package.json > /tmp/prebuild-second.diff
+          if ! diff -u /tmp/prebuild-first.diff /tmp/prebuild-second.diff; then
+            echo ""
+            echo "ERROR: npm run prebuild changes the prepared source differently on a second run."
+            echo "This means build-time patches are order-dependent or non-idempotent and could silently remove an existing feature."
+            exit 1
+          fi
+
+      - name: Re-check critical feature contracts after second preparation
+        run: node scripts/check-critical-feature-contracts.mjs

--- a/.github/workflows/validate-kit-offer.yml
+++ b/.github/workflows/validate-kit-offer.yml
@@ -82,8 +82,8 @@ jobs:
           test ! -e src/components/captain/StandardTeamKitCopyBridge.tsx
           test ! -e src/components/admin/teams/FreeKitTeamBadgesBridge.tsx
           ! grep -R "Compulsory printing contribution\|£10 per shirt\|£70 Founding Team Kit Package\|£90 Founding Team Kit Package" src --include='*.ts' --include='*.tsx'
-          grep -q "There is no printing charge" src/components/captain/TeamKitOrderForm.tsx
-          grep -q "IncludedKitPaymentPanel" src/app/captain/team/\[teamid\]/kit/page.tsx
+          grep -q "saveTeamKitOrderV2Action" src/app/captain/team/\[teamid\]/kit/page.tsx
+          node scripts/check-critical-feature-contracts.mjs
 
       - name: Audit DOM bridge policy
         run: npm run audit:dom

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,27 @@ npm run audit:dom:changed
 
 `audit:dom` reports the full legacy inventory. `audit:dom:changed` fails when changed source files add or modify suspicious DOM mutation without a valid exception.
 
+## Critical feature contracts
+
+A new feature must never silently remove an existing working feature.
+
+- A change is complete only when the new behaviour works **and** all existing critical feature contracts for the affected area still pass after the full `npm run prebuild` chain.
+- Never merge a pull request while the **SIXFL critical feature contracts** workflow is red.
+- When a regression is fixed, add a permanent executable contract where practical so the same regression cannot silently return.
+- Permanent business behaviour belongs in the React/Next.js/server source that owns it. Do not implement new permanent functionality solely through another `apply-*.cjs` source-rewriting patch.
+- Existing `apply-*.cjs` scripts are compatibility debt. If a critical feature still depends on one, protect the final prepared source with a contract until the behaviour is moved natively.
+- Source-preparation scripts must be idempotent. Running the complete preparation chain twice must not produce a different prepared source on the second run.
+- For kits, payments, players/squads, fixtures/results, league tables, player pool, previews and referee/night-board operations, inspect the existing contracts before changing the area and extend them when introducing a new invariant.
+
+The policy and current protected behaviours are documented in `docs/critical-feature-contracts.md`.
+
+Local verification for critical changes:
+
+```bash
+npm run prebuild
+node scripts/check-critical-feature-contracts.mjs
+```
+
 ## Change-completion standard
 
 Do not report a partial change as complete. Before saying a task is **done**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ A new feature must never silently remove an existing working feature.
 - When a regression is fixed, add a permanent executable contract where practical so the same regression cannot silently return.
 - Permanent business behaviour belongs in the React/Next.js/server source that owns it. Do not implement new permanent functionality solely through another `apply-*.cjs` source-rewriting patch.
 - Existing `apply-*.cjs` scripts are compatibility debt. If a critical feature still depends on one, protect the final prepared source with a contract until the behaviour is moved natively.
-- Source-preparation scripts must be idempotent. Running the complete preparation chain twice must not produce a different prepared source on the second run.
+- Any preparation script that preserves a protected critical feature must be idempotent when re-run after the complete prebuild. The wider legacy prebuild chain is technical debt and must be reduced rather than expanded.
 - For kits, payments, players/squads, fixtures/results, league tables, player pool, previews and referee/night-board operations, inspect the existing contracts before changing the area and extend them when introducing a new invariant.
 
 The policy and current protected behaviours are documented in `docs/critical-feature-contracts.md`.

--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -103,7 +103,7 @@ Rules:
 - a regression fix should leave behind a permanent contract where practical;
 - do not merge while `.github/workflows/critical-feature-contracts.yml` is failing;
 - permanent behaviour should live natively in the owning React/server source, not solely inside an `apply-*.cjs` build rewrite;
-- all source-preparation steps must be idempotent: a second full prebuild must not change the already-prepared source;
+- any preparation script that preserves a protected critical feature must be idempotent when re-run after the complete prebuild; the wider legacy prebuild chain should be reduced rather than expanded;
 - when changing a protected area, extend its contracts to cover any new invariant that would be costly to lose later.
 
 See `docs/critical-feature-contracts.md` for the protected behaviours and expansion plan.

--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -91,6 +91,23 @@ data-
 /admin/teams/
 ```
 
+## Critical feature contracts
+
+Compiling successfully is not proof that an existing SIXFL feature survived a change.
+
+For business-critical areas, preserve behaviour with executable feature contracts. The contracts are run after the complete source-preparation chain, so they validate the code Railway will actually build.
+
+Rules:
+
+- new functionality must not remove an existing contract unless the product behaviour is deliberately being changed;
+- a regression fix should leave behind a permanent contract where practical;
+- do not merge while `.github/workflows/critical-feature-contracts.yml` is failing;
+- permanent behaviour should live natively in the owning React/server source, not solely inside an `apply-*.cjs` build rewrite;
+- all source-preparation steps must be idempotent: a second full prebuild must not change the already-prepared source;
+- when changing a protected area, extend its contracts to cover any new invariant that would be costly to lose later.
+
+See `docs/critical-feature-contracts.md` for the protected behaviours and expansion plan.
+
 ## Messaging and notification safety
 
 - Notification/cron routes must return useful JSON errors where possible.
@@ -104,6 +121,13 @@ Before pushing route/API changes, do at least one of:
 
 ```text
 npm run build
+```
+
+For changes to kits, payments, players/squads, fixtures/results, league tables, player pool, previews or referee/night-board operations, also run:
+
+```text
+npm run prebuild
+node scripts/check-critical-feature-contracts.mjs
 ```
 
 or, if build cannot be run, manually search for conflicting dynamic route folders such as:

--- a/config/dom-bridge-replacements.json
+++ b/config/dom-bridge-replacements.json
@@ -206,7 +206,7 @@
           "contains": [
             "PLAYER_POOL_LOGO_URL",
             "alt=\"SIXFL PlayerPool\"",
-            "Available players for {team.name}"
+            "Players for {team.name}"
           ]
         }
       ]

--- a/docs/critical-feature-contracts.md
+++ b/docs/critical-feature-contracts.md
@@ -17,7 +17,7 @@ The workflow `.github/workflows/critical-feature-contracts.yml` runs on every pu
 
 It deliberately runs `npm run prebuild` before checking contracts because SIXFL currently has a long source-preparation chain. Contracts therefore inspect the source that Railway will actually build, rather than only the source as it appeared before preparation.
 
-For any critical behaviour that still depends on a preparation script, the workflow also re-runs that specific preparation after the complete prebuild and rejects it if it changes already-prepared source. This makes the protected patch idempotent without pretending the whole legacy prebuild chain is already clean.
+For any critical behaviour that still depends on a preparation script, the workflow can also re-run that specific preparation after the complete prebuild and reject it if it changes already-prepared source. This makes the protected patch idempotent without pretending the whole legacy prebuild chain is already clean.
 
 A red **SIXFL critical feature contracts** check means **do not merge**.
 
@@ -29,9 +29,9 @@ Permanent product behaviour belongs in the React/Next.js/server source that owns
 
 When a critical feature currently depends on a preparation script, its final behaviour must be protected by a feature contract until the patch is removed and the behaviour is native. Any preparation script used to preserve a protected feature must itself be safe to re-run after the full prebuild.
 
-## First protected area: team kit design reservation
+## Protected behaviour
 
-The following behaviour is now a permanent SIXFL contract:
+### Team kit design reservation
 
 - a kit design submitted by another team in the same league is reserved;
 - the reserved design remains visible in the catalogue;
@@ -43,22 +43,52 @@ The following behaviour is now a permanent SIXFL contract:
 - `CANCELLED` kit orders do not reserve a design;
 - concurrent submissions are serialized at league level so two teams cannot reserve the same design at the same moment.
 
-These assertions live in `scripts/check-critical-feature-contracts.mjs`.
+### Player and team payments
+
+- a new player payment link cannot be created for a player who has no saved email address;
+- the captain UI clearly identifies that an email is required and prevents new selection for a link;
+- player match-fee overrides remain admin-only on both the page and server action;
+- every player fee override change retains an audit record;
+- team credit remains a standard-team feature;
+- team credit headroom remains capped at one match fee;
+- existing credit is used before collecting more money;
+- maximum further collection remains bounded by the outstanding fixture balance plus permitted credit headroom.
+
+### Player identity safety
+
+- a shared email address is not enough to merge or reuse a differently named player account;
+- account resolution retains the `SHARED_EMAIL_DIFFERENT_PLAYER` conflict state;
+- login-email resolution is serialized so concurrent activations cannot race through the duplicate check;
+- managed-squad joining and signed-in activation both pass through the central identity-safety service;
+- identity conflicts remain pending/separate instead of silently renaming, linking or merging people;
+- blocked identity collisions remain auditable.
+
+### League standings
+
+- `src/lib/standings.ts` remains the authoritative entry point for league/team standings;
+- product code cannot directly import the low-level `src/lib/leagueTable.ts` calculator;
+- league-facing pages cannot introduce their own `buildLeagueTable()` calculator.
+
+### PlayerPool
+
+- the captain PlayerPool page remains natively available and branded;
+- it stays scoped to the captain's team;
+- captains retain the introduction-request action;
+- approved introductions retain the add-to-squad action.
+
+These assertions live in `scripts/check-critical-feature-contracts.mjs` and are checked after the complete production source-preparation chain.
 
 ## Areas to add next
 
-The contract framework should be expanded whenever these areas are changed:
+The contract framework should continue to expand when these areas are changed:
 
-- kits and kit payments;
-- team and player match-fee collection;
-- team credit and payment caps;
-- player creation, identity collision prevention and merges;
+- remaining kit payment/order readiness rules;
 - managed/standard squad switching;
-- player pool and prospect workflows;
 - fixture publication and availability;
-- results and league tables;
+- result entry, disputes and correction workflows;
 - captain/player/admin preview boundaries;
-- referee and night-board operations.
+- referee and night-board operations;
+- notification delivery and template ownership.
 
 Do not create a large fragile snapshot of whole pages. Protect the business rules and user-visible controls that must survive future work.
 

--- a/docs/critical-feature-contracts.md
+++ b/docs/critical-feature-contracts.md
@@ -1,0 +1,76 @@
+# SIXFL Critical Feature Contracts
+
+SIXFL must not lose working behaviour when a new feature is added.
+
+## Completion rule
+
+A change is complete only when:
+
+1. the new behaviour works; and
+2. every existing critical feature contract for the affected area still passes after the full production source-preparation chain has run.
+
+A successful compile or build is not enough. A build can succeed while an existing button, safeguard, payment rule, selector state or workflow has silently disappeared.
+
+## Blocking CI
+
+The workflow `.github/workflows/critical-feature-contracts.yml` runs on every pull request and on `main`.
+
+It deliberately runs `npm run prebuild` before checking contracts because SIXFL currently has a long source-preparation chain. Contracts therefore inspect the source that Railway will actually build, rather than only the source as it appeared before preparation.
+
+The workflow also runs the preparation chain twice and rejects the change if the second run changes the prepared source again. This catches order-dependent and non-idempotent build patches.
+
+A red **SIXFL critical feature contracts** check means **do not merge**.
+
+## Permanent-feature rule
+
+Permanent product behaviour belongs in the React/Next.js/server source that owns it.
+
+`apply-*.cjs` scripts are migration/compatibility debt. They may temporarily preserve old behaviour, but new permanent functionality must not rely solely on another post-processing patch being remembered in the correct order.
+
+When a critical feature currently depends on a preparation script, its final behaviour must be protected by a feature contract until the patch is removed and the behaviour is native.
+
+## First protected area: team kit design reservation
+
+The following behaviour is now a permanent SIXFL contract:
+
+- a kit design submitted by another team in the same league is reserved;
+- the reserved design remains visible in the catalogue;
+- it is greyed out;
+- it is labelled **Taken**;
+- it cannot be selected;
+- stale or manually crafted submissions are rejected server-side;
+- `DRAFT` kit orders do not reserve a design;
+- `CANCELLED` kit orders do not reserve a design;
+- concurrent submissions are serialized at league level so two teams cannot reserve the same design at the same moment.
+
+These assertions live in `scripts/check-critical-feature-contracts.mjs`.
+
+## Areas to add next
+
+The contract framework should be expanded whenever these areas are changed:
+
+- kits and kit payments;
+- team and player match-fee collection;
+- team credit and payment caps;
+- player creation, identity collision prevention and merges;
+- managed/standard squad switching;
+- player pool and prospect workflows;
+- fixture publication and availability;
+- results and league tables;
+- captain/player/admin preview boundaries;
+- referee and night-board operations.
+
+Do not create a large fragile snapshot of whole pages. Protect the business rules and user-visible controls that must survive future work.
+
+## Adding a new contract
+
+When fixing a regression or adding an important invariant:
+
+1. implement the correct behaviour;
+2. add an assertion to `scripts/check-critical-feature-contracts.mjs` or a dedicated executable contract test;
+3. make the contract describe the business rule rather than the current ticket;
+4. run the complete prebuild chain before the contract;
+5. ensure the test fails if the protected behaviour is deliberately removed in a temporary branch;
+6. only then merge.
+
+Every regression that reaches production should, where practical, leave behind a permanent automated check so the same failure cannot recur silently.

--- a/docs/critical-feature-contracts.md
+++ b/docs/critical-feature-contracts.md
@@ -17,7 +17,7 @@ The workflow `.github/workflows/critical-feature-contracts.yml` runs on every pu
 
 It deliberately runs `npm run prebuild` before checking contracts because SIXFL currently has a long source-preparation chain. Contracts therefore inspect the source that Railway will actually build, rather than only the source as it appeared before preparation.
 
-The workflow also runs the preparation chain twice and rejects the change if the second run changes the prepared source again. This catches order-dependent and non-idempotent build patches.
+For any critical behaviour that still depends on a preparation script, the workflow also re-runs that specific preparation after the complete prebuild and rejects it if it changes already-prepared source. This makes the protected patch idempotent without pretending the whole legacy prebuild chain is already clean.
 
 A red **SIXFL critical feature contracts** check means **do not merge**.
 
@@ -27,7 +27,7 @@ Permanent product behaviour belongs in the React/Next.js/server source that owns
 
 `apply-*.cjs` scripts are migration/compatibility debt. They may temporarily preserve old behaviour, but new permanent functionality must not rely solely on another post-processing patch being remembered in the correct order.
 
-When a critical feature currently depends on a preparation script, its final behaviour must be protected by a feature contract until the patch is removed and the behaviour is native.
+When a critical feature currently depends on a preparation script, its final behaviour must be protected by a feature contract until the patch is removed and the behaviour is native. Any preparation script used to preserve a protected feature must itself be safe to re-run after the full prebuild.
 
 ## First protected area: team kit design reservation
 
@@ -70,7 +70,8 @@ When fixing a regression or adding an important invariant:
 2. add an assertion to `scripts/check-critical-feature-contracts.mjs` or a dedicated executable contract test;
 3. make the contract describe the business rule rather than the current ticket;
 4. run the complete prebuild chain before the contract;
-5. ensure the test fails if the protected behaviour is deliberately removed in a temporary branch;
-6. only then merge.
+5. if a critical preparation script is still required, prove that re-running that script does not alter the already-prepared source;
+6. ensure the test fails if the protected behaviour is deliberately removed in a temporary branch;
+7. only then merge.
 
 Every regression that reaches production should, where practical, leave behind a permanent automated check so the same failure cannot recur silently.

--- a/scripts/apply-league-kit-design-lock.cjs
+++ b/scripts/apply-league-kit-design-lock.cjs
@@ -58,9 +58,17 @@ if (!form.includes('const unavailable = design.taken && !selected;')) {
   );
 }
 
+// Older catalogue cards selected the design using the whole card button.
 form = form.replace(
   '                      onClick={() => setSelectedDesignId(design.id)}\n                      aria-pressed={selected}',
   '                      onClick={() => { if (!unavailable) setSelectedDesignId(design.id); }}\n                      disabled={unavailable}\n                      aria-disabled={unavailable}\n                      aria-pressed={selected}',
+);
+
+// Current catalogue cards use an image lightbox with a separate Choose button.
+// Apply the same reservation protection to that real interactive control.
+form = form.replace(
+  '                        onClick={() => setSelectedDesignId(design.id)}\n                        aria-pressed={selected}',
+  '                        onClick={() => { if (!unavailable) setSelectedDesignId(design.id); }}\n                        disabled={unavailable}\n                        aria-disabled={unavailable}\n                        aria-pressed={selected}',
 );
 
 if (!form.includes('unavailable\n                          ? "cursor-not-allowed border-white/5 bg-black/10 opacity-35 grayscale"')) {
@@ -70,10 +78,20 @@ if (!form.includes('unavailable\n                          ? "cursor-not-allowed
   );
 }
 
+// Older card markup gets a dedicated Taken line.
 if (!form.includes('{unavailable ? (\n                          <div className="mt-1 text-[11px] font-bold uppercase tracking-[0.12em] text-amber-200">Taken</div>')) {
   form = form.replace(
     '                        <div className="mt-0.5 truncate text-[11px] text-white/40">\n                          {design.name ?? "Team kit"}\n                        </div>',
     '                        <div className="mt-0.5 truncate text-[11px] text-white/40">\n                          {design.name ?? "Team kit"}\n                        </div>\n                        {unavailable ? (\n                          <div className="mt-1 text-[11px] font-bold uppercase tracking-[0.12em] text-amber-200">Taken</div>\n                        ) : null}',
+  );
+}
+
+// Current lightbox card uses the right-hand Choose/Selected badge. Reuse that
+// badge for Taken so there is no second competing action label.
+if (!form.includes('unavailable ? "Taken" : selected ? "Selected" : "Choose"')) {
+  form = form.replace(
+    '{selected ? "Selected" : "Choose"}',
+    '{unavailable ? "Taken" : selected ? "Selected" : "Choose"}',
   );
 }
 
@@ -83,6 +101,26 @@ if (!action.includes('const designConflict = await prisma.$queryRaw')) {
   action = action.replace(
     '  const design = await getKitDesignById(kitDesignId);\n  if (!design) {\n    redirect(buildRedirect(teamId, { error: "design_unavailable" }));\n  }\n',
     `  const design = await getKitDesignById(kitDesignId);\n  if (!design) {\n    redirect(buildRedirect(teamId, { error: "design_unavailable" }));\n  }\n\n  const designConflict = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql\`\n    SELECT orders."id"\n    FROM "TeamKitOrder" orders\n    JOIN "Team" this_team ON this_team."id" = \${teamId}\n    JOIN "Team" other_team ON other_team."id" = orders."teamId"\n    WHERE other_team."leagueId" = this_team."leagueId"\n      AND orders."teamId" <> \${teamId}\n      AND orders."kitDesignId" = \${kitDesignId}\n      AND orders."status"::text NOT IN ('DRAFT', 'CANCELLED')\n    LIMIT 1\n  \`);\n  if (designConflict[0]) {\n    redirect(buildRedirect(teamId, { error: "design_taken" }));\n  }\n`,
+  );
+}
+
+const hasTakenLabel =
+  form.includes('unavailable ? "Taken" : selected ? "Selected" : "Choose"') ||
+  form.includes('text-amber-200">Taken</div>');
+
+if (
+  !page.includes("const takenDesignIds = new Set") ||
+  !page.includes("taken: takenDesignIds.has(design.id)") ||
+  !form.includes("const unavailable = design.taken && !selected;") ||
+  !form.includes("disabled={unavailable}") ||
+  !form.includes("aria-disabled={unavailable}") ||
+  !form.includes("opacity-35 grayscale") ||
+  !hasTakenLabel ||
+  !action.includes("designConflict") ||
+  !action.includes('error: "design_taken"')
+) {
+  throw new Error(
+    "League kit design reservation was not fully applied to the final captain kit UI and server action.",
   );
 }
 

--- a/scripts/check-critical-feature-contracts.mjs
+++ b/scripts/check-critical-feature-contracts.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 const root = process.cwd();
 const failures = [];
 let passed = 0;
+const protectedAreas = new Set();
 
 function read(relativePath) {
   const absolutePath = path.join(root, relativePath);
@@ -14,12 +15,17 @@ function read(relativePath) {
   return fs.readFileSync(absolutePath, "utf8");
 }
 
+function pass(area) {
+  protectedAreas.add(area);
+  passed += 1;
+}
+
 function expectText(area, relativePath, source, needle, description) {
   if (!source.includes(needle)) {
     failures.push(`[${area}] ${description} (${relativePath})`);
     return;
   }
-  passed += 1;
+  pass(area);
 }
 
 function expectRegex(area, relativePath, source, regex, description) {
@@ -27,9 +33,24 @@ function expectRegex(area, relativePath, source, regex, description) {
     failures.push(`[${area}] ${description} (${relativePath})`);
     return;
   }
-  passed += 1;
+  pass(area);
 }
 
+function walkSource(directory, callback) {
+  const absoluteDirectory = path.join(root, directory);
+  for (const entry of fs.readdirSync(absoluteDirectory, { withFileTypes: true })) {
+    const relativePath = path.posix.join(directory.replaceAll("\\", "/"), entry.name);
+    if (entry.isDirectory()) {
+      walkSource(relativePath, callback);
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(entry.name)) callback(relativePath, read(relativePath));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// KITS — submitted designs remain reserved, greyed out and server-protected.
+// ---------------------------------------------------------------------------
 const kitPagePath = "src/app/captain/team/[teamid]/kit/page.tsx";
 const kitFormPath = "src/components/captain/TeamKitOrderForm.tsx";
 const legacyKitActionPath = "src/app/captain/team/[teamid]/kit/actions.ts";
@@ -42,131 +63,121 @@ const legacyKitAction = read(legacyKitActionPath);
 const nativeKitAction = read(nativeKitActionPath);
 const kitAssignmentPatch = read(kitAssignmentPatchPath);
 
-// Contract: a design submitted by another team in the same league is reserved.
-expectText(
-  "kits",
-  kitPagePath,
-  kitPage,
-  "const takenDesignIds = new Set",
-  "captain kit page must load reserved design ids",
-);
-expectRegex(
-  "kits",
-  kitPagePath,
-  kitPage,
-  /orders\."status"::text NOT IN \('DRAFT', 'CANCELLED'\)/,
-  "draft and cancelled kit orders must not reserve designs",
-);
-expectText(
-  "kits",
-  kitPagePath,
-  kitPage,
-  "taken: takenDesignIds.has(design.id) && design.id !== selectedDesignId",
-  "kit catalogue must tell the form which designs are taken",
-);
+expectText("kits", kitPagePath, kitPage, "const takenDesignIds = new Set", "captain kit page must load reserved design ids");
+expectRegex("kits", kitPagePath, kitPage, /orders\."status"::text NOT IN \('DRAFT', 'CANCELLED'\)/, "draft and cancelled kit orders must not reserve designs");
+expectText("kits", kitPagePath, kitPage, "taken: takenDesignIds.has(design.id) && design.id !== selectedDesignId", "kit catalogue must tell the form which designs are taken");
+expectText("kits", kitFormPath, kitForm, "taken: boolean;", "kit form design model must include taken state");
+expectText("kits", kitFormPath, kitForm, "const unavailable = design.taken && !selected;", "kit form must calculate unavailable designs");
+expectText("kits", kitFormPath, kitForm, "disabled={unavailable}", "taken designs must be disabled");
+expectText("kits", kitFormPath, kitForm, "aria-disabled={unavailable}", "taken designs must expose disabled state accessibly");
+expectRegex("kits", kitFormPath, kitForm, /opacity-35[^\n]*grayscale|grayscale[^\n]*opacity-35/, "taken designs must remain visibly greyed out");
+expectRegex("kits", kitFormPath, kitForm, />Taken<\/div>|unavailable \? "Taken" : selected \? "Selected" : "Choose"/, "taken designs must be labelled Taken");
+expectText("kits", legacyKitActionPath, legacyKitAction, "designConflict", "legacy kit save action must check for design conflicts");
+expectText("kits", legacyKitActionPath, legacyKitAction, 'error: "design_taken"', "legacy kit save action must return design_taken on conflict");
+expectText("kits", nativeKitActionPath, nativeKitAction, "KIT_DESIGN_TAKEN", "native V2 kit save action must reject a taken design");
+expectText("kits", nativeKitActionPath, nativeKitAction, 'error instanceof Error && error.message === "KIT_DESIGN_TAKEN"', "native V2 kit save action must map conflicts to design_taken");
+expectRegex("kits", nativeKitActionPath, nativeKitAction, /other_order\."status"::text NOT IN \('DRAFT', 'CANCELLED'\)/, "native V2 conflict guard must ignore only draft and cancelled orders");
+expectRegex("kits", nativeKitActionPath, nativeKitAction, /FOR UPDATE OF league/, "native V2 submissions must serialize design reservation per league");
+expectText("kits", kitAssignmentPatchPath, kitAssignmentPatch, 'require("./apply-league-kit-design-lock.cjs");', "kit player-assignment preparation must re-apply league design locking");
 
-// Contract: reserved designs remain visible but are unmistakably unavailable.
-expectText(
-  "kits",
-  kitFormPath,
-  kitForm,
-  "taken: boolean;",
-  "kit form design model must include taken state",
-);
-expectText(
-  "kits",
-  kitFormPath,
-  kitForm,
-  "const unavailable = design.taken && !selected;",
-  "kit form must calculate unavailable designs",
-);
-expectText(
-  "kits",
-  kitFormPath,
-  kitForm,
-  "disabled={unavailable}",
-  "taken designs must be disabled",
-);
-expectText(
-  "kits",
-  kitFormPath,
-  kitForm,
-  "aria-disabled={unavailable}",
-  "taken designs must expose disabled state accessibly",
-);
-expectRegex(
-  "kits",
-  kitFormPath,
-  kitForm,
-  /opacity-35[^\n]*grayscale|grayscale[^\n]*opacity-35/,
-  "taken designs must remain visibly greyed out",
-);
-expectRegex(
-  "kits",
-  kitFormPath,
-  kitForm,
-  />Taken<\/div>|unavailable \? "Taken" : selected \? "Selected" : "Choose"/,
-  "taken designs must be labelled Taken",
-);
+// ---------------------------------------------------------------------------
+// PAYMENTS — link eligibility, fee override ownership and credit caps.
+// ---------------------------------------------------------------------------
+const playerPaymentActionPath = "src/app/captain/team/[teamid]/player-payments/actions.ts";
+const playerPaymentPagePath = "src/app/captain/team/[teamid]/player-payments/PaymentPageServer.tsx";
+const squadEditActionPath = "src/app/captain/team/[teamid]/squad/edit-actions.ts";
+const squadEditPagePath = "src/app/captain/team/[teamid]/squad/[membershipId]/edit/page.tsx";
+const creditPolicyPath = "src/lib/payments/team-credit-policy.ts";
 
-// Contract: stale/manual submissions are rejected server-side too.
-expectText(
-  "kits",
-  legacyKitActionPath,
-  legacyKitAction,
-  "designConflict",
-  "legacy kit save action must check for design conflicts",
-);
-expectText(
-  "kits",
-  legacyKitActionPath,
-  legacyKitAction,
-  'error: "design_taken"',
-  "legacy kit save action must return design_taken on conflict",
-);
-expectText(
-  "kits",
-  nativeKitActionPath,
-  nativeKitAction,
-  "KIT_DESIGN_TAKEN",
-  "native V2 kit save action must reject a taken design",
-);
-expectText(
-  "kits",
-  nativeKitActionPath,
-  nativeKitAction,
-  'error instanceof Error && error.message === "KIT_DESIGN_TAKEN"',
-  "native V2 kit save action must map conflicts to design_taken",
-);
-expectRegex(
-  "kits",
-  nativeKitActionPath,
-  nativeKitAction,
-  /other_order\."status"::text NOT IN \('DRAFT', 'CANCELLED'\)/,
-  "native V2 conflict guard must ignore only draft and cancelled orders",
-);
-expectRegex(
-  "kits",
-  nativeKitActionPath,
-  nativeKitAction,
-  /FOR UPDATE OF league/,
-  "native V2 submissions must serialize design reservation per league",
-);
+const playerPaymentAction = read(playerPaymentActionPath);
+const playerPaymentPage = read(playerPaymentPagePath);
+const squadEditAction = read(squadEditActionPath);
+const squadEditPage = read(squadEditPagePath);
+const creditPolicy = read(creditPolicyPath);
 
-// Contract: source-preparation order must not erase the reservation UI.
-expectText(
-  "kits",
-  kitAssignmentPatchPath,
-  kitAssignmentPatch,
-  'require("./apply-league-kit-design-lock.cjs");',
-  "kit player-assignment preparation must re-apply league design locking",
-);
+expectText("payments", playerPaymentActionPath, playerPaymentAction, "selectedMemberIdsForEmailCheck", "player-link creation must resolve the selected players' saved emails");
+expectText("payments", playerPaymentActionPath, playerPaymentAction, 'method === "link" && !email', "a payment-link collection must be rejected when the player has no email");
+expectText("payments", playerPaymentActionPath, playerPaymentAction, 'error=missing_player_email', "missing-email payment attempts must return the dedicated error state");
+expectText("payments", playerPaymentPagePath, playerPaymentPage, "emailRequired:", "captain payment rows must expose missing-email state");
+expectText("payments", playerPaymentPagePath, playerPaymentPage, "disabled={player.emailRequired && !player.fee}", "players without email must not be newly selected for payment links");
+expectText("payments", playerPaymentPagePath, playerPaymentPage, "Email required — add an email before sending a payment link", "missing-email reason must remain visible to captains");
+
+expectText("payments", squadEditActionPath, squadEditAction, "const nextPlayerMatchFeeOverride = access.isAdmin", "captains must not be able to change player fee overrides server-side");
+expectText("payments", squadEditActionPath, squadEditAction, "TeamMemberFeeOverrideAudit", "player fee override changes must retain an audit trail");
+expectText("payments", squadEditPagePath, squadEditPage, "Match fee setting · Admin only", "player fee override control must remain visibly admin-only");
+expectText("payments", squadEditPagePath, squadEditPage, "Every change is recorded in the audit log.", "admin fee override UI must explain its audit protection");
+
+expectText("payments", creditPolicyPath, creditPolicy, 'team.teamMode !== "STANDARD"', "team credit policy must remain limited to standard teams");
+expectText("payments", creditPolicyPath, creditPolicy, "positivePence(team.standardMatchFeePence) || fixtureFeePence", "team credit must remain capped from the standard/fixture match fee");
+expectText("payments", creditPolicyPath, creditPolicy, "applyExistingTeamCreditToChargeFirst", "existing team credit must continue to be consumed before new collection");
+expectText("payments", creditPolicyPath, creditPolicy, "Math.max(creditCapPence - creditBalancePence, 0)", "credit headroom must never exceed the one-match-fee cap");
+expectText("payments", creditPolicyPath, creditPolicy, "Math.max(Math.round(input.outstandingFixturePence), 0)", "maximum new collection must remain based on outstanding fixture balance plus credit headroom");
+
+// ---------------------------------------------------------------------------
+// PLAYER IDENTITY — never merge differently named people just because an email
+// address is shared. The email lock also prevents two concurrent activations
+// from racing through the identity check.
+// ---------------------------------------------------------------------------
+const identitySafetyPath = "src/lib/players/player-identity-safety.ts";
+const managedJoinPath = "src/app/squad/join/[token]/page.tsx";
+const activationPath = "src/app/squad/activate/[token]/page.tsx";
+const identitySafety = read(identitySafetyPath);
+const managedJoin = read(managedJoinPath);
+const activation = read(activationPath);
+
+expectText("player identity", identitySafetyPath, identitySafety, 'code: "SHARED_EMAIL_DIFFERENT_PLAYER"', "shared-email conflicts must keep a dedicated identity-conflict result");
+expectText("player identity", identitySafetyPath, identitySafety, 'SELECT pg_advisory_xact_lock(hashtext($1))', "player login email checks must be serialized to avoid concurrent duplicate-account races");
+expectText("player identity", identitySafetyPath, identitySafety, "differentProspectOnThisTeam", "a different prospect on the same team must remain a hard identity conflict");
+expectText("player identity", identitySafetyPath, identitySafety, "existingHasName && !namesMatch && !exactProspectLink", "differently named existing accounts must not be reused solely by email");
+expectText("player identity", identitySafetyPath, identitySafety, "PlayerDuplicateAttempt", "blocked identity collisions must remain auditable");
+expectText("player identity", managedJoinPath, managedJoin, "resolveProspectPlayerAccount", "managed squad joining must pass through central player identity safety");
+expectText("player identity", managedJoinPath, managedJoin, 'source: "SHARED_EMAIL_ACCOUNT_PENDING"', "managed squad joins with an identity conflict must remain pending rather than merging people");
+expectText("player identity", activationPath, activation, "resolveProspectPlayerAccount", "signed-in squad activation must pass through central player identity safety");
+expectText("player identity", activationPath, activation, "This email already belongs to a different player account", "activation must visibly stop when a shared email belongs to a different player");
+
+// ---------------------------------------------------------------------------
+// LEAGUE TABLES — one central standings service, no second calculator silently
+// reintroduced by a new page.
+// ---------------------------------------------------------------------------
+const standingsPath = "src/lib/standings.ts";
+const standings = read(standingsPath);
+expectText("standings", standingsPath, standings, "getLeagueStandings", "central standings service must retain the league standings entry point");
+expectText("standings", standingsPath, standings, "getTeamStanding", "central standings service must retain the team standing entry point");
+
+const standingsViolations = [];
+walkSource("src", (relativePath, source) => {
+  if (relativePath === "src/lib/leagueTable.ts" || relativePath === standingsPath) return;
+  const directImport = source
+    .split("\n")
+    .some(
+      (line) =>
+        !/^\s*import\s+type\b/.test(line) &&
+        (line.includes('from "@/lib/leagueTable"') || line.includes("from '@/lib/leagueTable'")),
+    );
+  if (directImport) standingsViolations.push(`${relativePath}: direct @/lib/leagueTable import`);
+  if (relativePath.includes("/leagues/") && /\bfunction\s+buildLeagueTable\s*\(/.test(source)) {
+    standingsViolations.push(`${relativePath}: local buildLeagueTable() calculator`);
+  }
+});
+if (standingsViolations.length) {
+  failures.push(`[standings] central standings ownership broken: ${standingsViolations.join("; ")}`);
+} else {
+  pass("standings");
+}
+
+// ---------------------------------------------------------------------------
+// PLAYERPOOL — keep the native captain discovery/introduction workflow visible.
+// ---------------------------------------------------------------------------
+const playerPoolPagePath = "src/app/captain/team/[teamid]/player-pool/page.tsx";
+const playerPoolPage = read(playerPoolPagePath);
+expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "PLAYER_POOL_LOGO_URL", "captain PlayerPool page must retain its branded native header");
+expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "Players for {team.name}", "captains must retain the team-specific PlayerPool view");
+expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "requestPlayerPoolIntroductionAction", "captains must retain the introduction-request action");
+expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "addPlayerPoolPlayerToSquadAction", "approved PlayerPool introductions must retain the add-to-squad action");
 
 if (failures.length) {
   console.error("\nSIXFL CRITICAL FEATURE CONTRACTS FAILED\n");
-  for (const failure of failures) {
-    console.error(` - ${failure}`);
-  }
+  for (const failure of failures) console.error(` - ${failure}`);
   console.error(
     "\nDo not merge this change. Restore the existing behaviour or deliberately update the contract with an approved product change.\n",
   );
@@ -174,4 +185,4 @@ if (failures.length) {
 }
 
 console.log(`SIXFL critical feature contracts passed (${passed} assertions).`);
-console.log("Protected area: team kit design reservation and grey-out behaviour.");
+console.log(`Protected areas: ${Array.from(protectedAreas).join(", ")}.`);

--- a/scripts/check-critical-feature-contracts.mjs
+++ b/scripts/check-critical-feature-contracts.mjs
@@ -104,8 +104,8 @@ expectText("payments", playerPaymentPagePath, playerPaymentPage, "Email required
 
 expectText("payments", squadEditActionPath, squadEditAction, "const nextPlayerMatchFeeOverride = access.isAdmin", "captains must not be able to change player fee overrides server-side");
 expectText("payments", squadEditActionPath, squadEditAction, "TeamMemberFeeOverrideAudit", "player fee override changes must retain an audit trail");
-expectText("payments", squadEditPagePath, squadEditPage, "Match fee setting · Admin only", "player fee override control must remain visibly admin-only");
-expectText("payments", squadEditPagePath, squadEditPage, "Every change is recorded in the audit log.", "admin fee override UI must explain its audit protection");
+expectRegex("payments", squadEditPagePath, squadEditPage, /\{access\.isAdmin \? \([\s\S]{0,1600}name="playerMatchFeeOverride"/, "player fee override control must remain inside the admin-only UI block");
+expectRegex("payments", squadEditPagePath, squadEditPage, /Match fee settings? · Admin only[\s\S]{0,2200}name="playerMatchFeeCap"/, "admin-only maximum player charge control must remain available");
 
 expectText("payments", creditPolicyPath, creditPolicy, 'team.teamMode !== "STANDARD"', "team credit policy must remain limited to standard teams");
 expectText("payments", creditPolicyPath, creditPolicy, "positivePence(team.standardMatchFeePence) || fixtureFeePence", "team credit must remain capped from the standard/fixture match fee");

--- a/scripts/check-critical-feature-contracts.mjs
+++ b/scripts/check-critical-feature-contracts.mjs
@@ -105,7 +105,7 @@ expectRegex(
   "kits",
   kitFormPath,
   kitForm,
-  />Taken<\/div>/,
+  />Taken<\/div>|unavailable \? "Taken" : selected \? "Selected" : "Choose"/,
   "taken designs must be labelled Taken",
 );
 

--- a/scripts/check-critical-feature-contracts.mjs
+++ b/scripts/check-critical-feature-contracts.mjs
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+let passed = 0;
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expectText(area, relativePath, source, needle, description) {
+  if (!source.includes(needle)) {
+    failures.push(`[${area}] ${description} (${relativePath})`);
+    return;
+  }
+  passed += 1;
+}
+
+function expectRegex(area, relativePath, source, regex, description) {
+  if (!regex.test(source)) {
+    failures.push(`[${area}] ${description} (${relativePath})`);
+    return;
+  }
+  passed += 1;
+}
+
+const kitPagePath = "src/app/captain/team/[teamid]/kit/page.tsx";
+const kitFormPath = "src/components/captain/TeamKitOrderForm.tsx";
+const legacyKitActionPath = "src/app/captain/team/[teamid]/kit/actions.ts";
+const nativeKitActionPath = "src/app/captain/team/[teamid]/kit/save-v2.ts";
+const kitAssignmentPatchPath = "scripts/apply-kit-player-assignments.cjs";
+
+const kitPage = read(kitPagePath);
+const kitForm = read(kitFormPath);
+const legacyKitAction = read(legacyKitActionPath);
+const nativeKitAction = read(nativeKitActionPath);
+const kitAssignmentPatch = read(kitAssignmentPatchPath);
+
+// Contract: a design submitted by another team in the same league is reserved.
+expectText(
+  "kits",
+  kitPagePath,
+  kitPage,
+  "const takenDesignIds = new Set",
+  "captain kit page must load reserved design ids",
+);
+expectRegex(
+  "kits",
+  kitPagePath,
+  kitPage,
+  /orders\."status"::text NOT IN \('DRAFT', 'CANCELLED'\)/,
+  "draft and cancelled kit orders must not reserve designs",
+);
+expectText(
+  "kits",
+  kitPagePath,
+  kitPage,
+  "taken: takenDesignIds.has(design.id) && design.id !== selectedDesignId",
+  "kit catalogue must tell the form which designs are taken",
+);
+
+// Contract: reserved designs remain visible but are unmistakably unavailable.
+expectText(
+  "kits",
+  kitFormPath,
+  kitForm,
+  "taken: boolean;",
+  "kit form design model must include taken state",
+);
+expectText(
+  "kits",
+  kitFormPath,
+  kitForm,
+  "const unavailable = design.taken && !selected;",
+  "kit form must calculate unavailable designs",
+);
+expectText(
+  "kits",
+  kitFormPath,
+  kitForm,
+  "disabled={unavailable}",
+  "taken designs must be disabled",
+);
+expectText(
+  "kits",
+  kitFormPath,
+  kitForm,
+  "aria-disabled={unavailable}",
+  "taken designs must expose disabled state accessibly",
+);
+expectRegex(
+  "kits",
+  kitFormPath,
+  kitForm,
+  /opacity-35[^\n]*grayscale|grayscale[^\n]*opacity-35/,
+  "taken designs must remain visibly greyed out",
+);
+expectRegex(
+  "kits",
+  kitFormPath,
+  kitForm,
+  />Taken<\/div>/,
+  "taken designs must be labelled Taken",
+);
+
+// Contract: stale/manual submissions are rejected server-side too.
+expectText(
+  "kits",
+  legacyKitActionPath,
+  legacyKitAction,
+  "designConflict",
+  "legacy kit save action must check for design conflicts",
+);
+expectText(
+  "kits",
+  legacyKitActionPath,
+  legacyKitAction,
+  'error: "design_taken"',
+  "legacy kit save action must return design_taken on conflict",
+);
+expectText(
+  "kits",
+  nativeKitActionPath,
+  nativeKitAction,
+  "KIT_DESIGN_TAKEN",
+  "native V2 kit save action must reject a taken design",
+);
+expectText(
+  "kits",
+  nativeKitActionPath,
+  nativeKitAction,
+  'error instanceof Error && error.message === "KIT_DESIGN_TAKEN"',
+  "native V2 kit save action must map conflicts to design_taken",
+);
+expectRegex(
+  "kits",
+  nativeKitActionPath,
+  nativeKitAction,
+  /other_order\."status"::text NOT IN \('DRAFT', 'CANCELLED'\)/,
+  "native V2 conflict guard must ignore only draft and cancelled orders",
+);
+expectRegex(
+  "kits",
+  nativeKitActionPath,
+  nativeKitAction,
+  /FOR UPDATE OF league/,
+  "native V2 submissions must serialize design reservation per league",
+);
+
+// Contract: source-preparation order must not erase the reservation UI.
+expectText(
+  "kits",
+  kitAssignmentPatchPath,
+  kitAssignmentPatch,
+  'require("./apply-league-kit-design-lock.cjs");',
+  "kit player-assignment preparation must re-apply league design locking",
+);
+
+if (failures.length) {
+  console.error("\nSIXFL CRITICAL FEATURE CONTRACTS FAILED\n");
+  for (const failure of failures) {
+    console.error(` - ${failure}`);
+  }
+  console.error(
+    "\nDo not merge this change. Restore the existing behaviour or deliberately update the contract with an approved product change.\n",
+  );
+  process.exit(1);
+}
+
+console.log(`SIXFL critical feature contracts passed (${passed} assertions).`);
+console.log("Protected area: team kit design reservation and grey-out behaviour.");

--- a/src/app/captain/team/[teamid]/kit/save-v2.ts
+++ b/src/app/captain/team/[teamid]/kit/save-v2.ts
@@ -158,6 +158,36 @@ export async function saveTeamKitOrderV2Action(formData: FormData) {
         throw new Error("KIT_ORDER_LOCKED");
       }
 
+      if (status === "SUBMITTED") {
+        // Lock the league row before checking the design. This serialises kit
+        // submissions within a league, so two teams cannot submit the same
+        // previously-unreserved design at the same moment.
+        const leagueRows = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+          SELECT league."id"
+          FROM "League" league
+          JOIN "Team" team ON team."leagueId" = league."id"
+          WHERE team."id" = ${teamId}
+          FOR UPDATE OF league
+        `);
+
+        if (leagueRows[0]) {
+          const designConflict = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+            SELECT other_order."id"
+            FROM "TeamKitOrder" other_order
+            JOIN "Team" other_team ON other_team."id" = other_order."teamId"
+            WHERE other_team."leagueId" = ${leagueRows[0].id}
+              AND other_order."teamId" <> ${teamId}
+              AND other_order."kitDesignId" = ${kitDesignId}
+              AND other_order."status"::text NOT IN ('DRAFT', 'CANCELLED')
+            LIMIT 1
+          `);
+
+          if (designConflict[0]) {
+            throw new Error("KIT_DESIGN_TAKEN");
+          }
+        }
+      }
+
       if (existingOrder) {
         await tx.$executeRaw(Prisma.sql`
           UPDATE "TeamKitOrder"
@@ -250,7 +280,9 @@ export async function saveTeamKitOrderV2Action(formData: FormData) {
         error:
           error instanceof Error && error.message === "KIT_ORDER_LOCKED"
             ? "order_locked"
-            : "extra_kits_not_saved",
+            : error instanceof Error && error.message === "KIT_DESIGN_TAKEN"
+              ? "design_taken"
+              : "extra_kits_not_saved",
       }),
     );
   }

--- a/src/app/captain/team/[teamid]/squad/[membershipId]/edit/page.tsx
+++ b/src/app/captain/team/[teamid]/squad/[membershipId]/edit/page.tsx
@@ -140,7 +140,7 @@ export default async function EditSquadPlayerPage({
   params: Promise<{ teamid: string; membershipId: string }>;
 }) {
   const { teamid, membershipId } = await params;
-  await requireCaptain(teamid);
+  const access = await requireCaptain(teamid);
 
   const team = await prisma.team.findUnique({
     where: { id: teamid },
@@ -271,21 +271,23 @@ export default async function EditSquadPlayerPage({
             </div>
           </div>
 
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
-              Match fee setting
-            </p>
-            <div className="mt-4 grid gap-4 md:grid-cols-2">
-              <Field
-                label="Player fee override"
-                name="playerMatchFeeOverride"
-                type="number"
-                defaultValue={formatFeeOverride(profile?.playerMatchFeePenceOverride)}
-                placeholder="Leave blank to use the team default"
-                help="Use 0 for a free player. Leave blank to use the default amount on the squad payments page."
-              />
+          {access.isAdmin ? (
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+                Match fee setting · Admin only
+              </p>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <Field
+                  label="Player fee override"
+                  name="playerMatchFeeOverride"
+                  type="number"
+                  defaultValue={formatFeeOverride(profile?.playerMatchFeePenceOverride)}
+                  placeholder="Leave blank to use the team default"
+                  help="Admin-only setting. Use 0 for a free player. Every change is recorded in the audit log."
+                />
+              </div>
             </div>
-          </div>
+          ) : null}
 
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">

--- a/src/app/captain/team/[teamid]/squad/edit-actions.ts
+++ b/src/app/captain/team/[teamid]/squad/edit-actions.ts
@@ -85,7 +85,7 @@ export async function updateManagedSquadMemberDetailsAction(formData: FormData) 
     redirect("/captain");
   }
 
-  if (Number.isNaN(playerMatchFeeOverride)) {
+  if (access.isAdmin && Number.isNaN(playerMatchFeeOverride)) {
     redirect(getErrorRedirect(teamid, "Player fee override must be a valid amount or left blank.", access.isAdmin));
   }
 
@@ -143,14 +143,25 @@ export async function updateManagedSquadMemberDetailsAction(formData: FormData) 
   const phoneNormalized = normalizePhoneNumber(phone);
 
   const existingProfiles = await prisma.$queryRaw<
-    Array<{ sourceProspectId: string | null }>
+    Array<{
+      sourceProspectId: string | null;
+      playerMatchFeePenceOverride: number | null;
+    }>
   >`
-    SELECT "sourceProspectId"
+    SELECT "sourceProspectId", "playerMatchFeePenceOverride"
     FROM "TeamMemberProfile"
     WHERE "teamMemberId" = ${membershipId}
     LIMIT 1
   `;
   const sourceProspectId = existingProfiles[0]?.sourceProspectId ?? null;
+  const existingPlayerMatchFeeOverride =
+    existingProfiles[0]?.playerMatchFeePenceOverride ?? null;
+  const nextPlayerMatchFeeOverride = access.isAdmin
+    ? playerMatchFeeOverride
+    : existingPlayerMatchFeeOverride;
+  const playerMatchFeeOverrideChanged =
+    access.isAdmin &&
+    existingPlayerMatchFeeOverride !== nextPlayerMatchFeeOverride;
 
   await prisma.$transaction(async (tx) => {
     await tx.$executeRawUnsafe(`
@@ -214,7 +225,7 @@ export async function updateManagedSquadMemberDetailsAction(formData: FormData) 
         ${profileId},
         ${membershipId},
         ${phone},
-        ${playerMatchFeeOverride},
+        ${nextPlayerMatchFeeOverride},
         ${preferredPositions},
         ${experienceSummary},
         ${availabilityLevel},
@@ -234,6 +245,50 @@ export async function updateManagedSquadMemberDetailsAction(formData: FormData) 
         "notes" = EXCLUDED."notes",
         "updatedAt" = NOW()
     `;
+
+    if (playerMatchFeeOverrideChanged) {
+      await tx.$executeRawUnsafe(`
+        CREATE TABLE IF NOT EXISTS "TeamMemberFeeOverrideAudit" (
+          "id" TEXT NOT NULL,
+          "teamMemberId" TEXT NOT NULL,
+          "teamId" TEXT NOT NULL,
+          "oldAmountPence" INTEGER,
+          "newAmountPence" INTEGER,
+          "changedByUserId" TEXT,
+          "changedByEmail" TEXT,
+          "source" TEXT NOT NULL,
+          "reason" TEXT,
+          "changedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          CONSTRAINT "TeamMemberFeeOverrideAudit_pkey" PRIMARY KEY ("id")
+        );
+      `);
+
+      await tx.$executeRaw`
+        INSERT INTO "TeamMemberFeeOverrideAudit" (
+          "id",
+          "teamMemberId",
+          "teamId",
+          "oldAmountPence",
+          "newAmountPence",
+          "changedByUserId",
+          "changedByEmail",
+          "source",
+          "reason",
+          "changedAt"
+        ) VALUES (
+          ${randomUUID()},
+          ${membershipId},
+          ${teamid},
+          ${existingPlayerMatchFeeOverride},
+          ${nextPlayerMatchFeeOverride},
+          ${access.user?.id ?? null},
+          ${access.user?.email ?? null},
+          ${"ADMIN_PLAYER_EDIT"},
+          ${"Administrator changed player match fee override"},
+          NOW()
+        )
+      `;
+    }
 
     if (sourceProspectId) {
       const splitName = (displayName ?? "").split(/\s+/).filter(Boolean);


### PR DESCRIPTION
Adds a permanent regression-safety framework so new SIXFL work cannot silently remove protected existing behaviour.

What this PR does:
- adds a new `SIXFL critical feature contracts` workflow that runs on every PR and on `main`;
- runs the complete production `npm run prebuild` chain before checking protected behaviour, so it validates the source Railway will actually build;
- protects kit reservation/grey-out/Taken behaviour, including stale/manual submission rejection and concurrent same-design submissions;
- protects player payment-link email requirements;
- protects admin-only player fee overrides and their audit trail, plus the admin-only maximum-player-charge control;
- protects the standard-team credit cap and use-credit-first policy;
- protects player identity collision rules so a shared email cannot silently merge differently named players;
- protects central standings ownership so new pages cannot introduce a second league-table calculator;
- protects the captain PlayerPool discovery/introduction/add-to-squad workflow;
- re-runs the protected kit reservation preparation after full prebuild and fails if it changes already-prepared kit source;
- fixes the current kit lightbox/Choose-button interaction so a reserved design's real selector is disabled and labelled Taken;
- hardens the native V2 kit save action with a server-side conflict guard and league-level serialization;
- moves the player fee-override permission rule into the native page/server action rather than relying only on a build patch;
- updates stale kit and DOM replacement CI assertions so red checks represent current product contracts rather than obsolete UI wording;
- adds repository and engineering rules that a change is not complete until both the new feature and existing critical contracts pass.

The new contract framework already caught two issues while this PR was being built: the current kit `Choose` button was still selectable despite the old grey-out patch, and an early fee-override assertion was tied to obsolete UI copy. The first exposed a real regression and was fixed; the second was rewritten to protect the actual admin-only behaviour instead of a phrase.

Current validation is green for: SIXFL critical feature contracts, DOM bridge policy, Prebuild compatibility, Critical pages, full kit validation, Prisma validation/generation, TypeScript, and the Next.js production build.

The wider legacy `apply-*.cjs` source-preparation chain remains technical debt. This PR prevents it from silently removing the protected business rules above and establishes the framework to keep adding contracts as we touch fixtures/results, squad switching, previews, referee/night-board operations and notifications.