### PR TITLE
Add direct league results link to captain navigation

### DIFF
--- a/src/app/captain/team/[teamid]/layout.tsx
+++ b/src/app/captain/team/[teamid]/layout.tsx
@@ -250,6 +250,7 @@ export default async function CaptainTeamLayout({
         select: {
           id: true,
           name: true,
+          slug: true,
           season: true,
           isActive: true,
           competition: {
@@ -260,6 +261,7 @@ export default async function CaptainTeamLayout({
                 select: {
                   id: true,
                   name: true,
+                  slug: true,
                   season: true,
                   isActive: true,
                 },
@@ -280,6 +282,7 @@ export default async function CaptainTeamLayout({
   const displayCompetition = team.league?.competition ?? null;
   const displayLeague = displayCompetition?.currentLeague ?? team.league;
   const displayLeagueName = displayCompetition?.name ?? displayLeague?.name ?? "No competition assigned";
+  const displayLeagueSlug = displayLeague?.slug ?? null;
   const displaySeason = displayLeague?.season ?? null;
   const displayIsLive = displayLeague?.isActive ?? false;
 
@@ -367,7 +370,10 @@ export default async function CaptainTeamLayout({
           href: `/captain/team/${teamid}#captain-league-table`,
           label: "Table",
         },
-        { href: `/captain/team/${teamid}/results-history`, label: "Results" },
+        { href: `/captain/team/${teamid}/results-history`, label: "Team results" },
+        ...(displayLeagueSlug
+          ? [{ href: `/leagues/${displayLeagueSlug}/results`, label: "League results" }]
+          : []),
         { href: `/captain/team/${teamid}/player-stats`, label: "Player stats" },
         {
           href: `/captain/team/${teamid}/tv`,


### PR DESCRIPTION
Makes full league results directly accessible from the captain dashboard.

Changes:
- adds the current league slug to the captain layout query
- renames the existing `Results` nav item to `Team results`
- adds a separate `League results` item beside it under `League & media`
- uses the current competition season where one exists, so captains are not sent to an old season

No result data or calculations are changed.