### PR TITLE
Restore permanent referral entry points

### DIFF
--- a/scripts/check-critical-feature-contracts.mjs
+++ b/scripts/check-critical-feature-contracts.mjs
@@ -175,6 +175,29 @@ expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "Players for {team.
 expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "requestPlayerPoolIntroductionAction", "captains must retain the introduction-request action");
 expectText("PlayerPool", playerPoolPagePath, playerPoolPage, "addPlayerPoolPlayerToSquadAction", "approved PlayerPool introductions must retain the add-to-squad action");
 
+// ---------------------------------------------------------------------------
+// TEAM REFERRALS — the £75 scheme must stay discoverable and the registration
+// handoff must continue carrying the referring player's code into the lead.
+// ---------------------------------------------------------------------------
+const playerReferralPagePath = "src/app/player/referrals/page.tsx";
+const playerTeamNavPath = "src/components/player/PlayerTeamNav.tsx";
+const homepagePath = "src/app/(public)/page.tsx";
+const referralPreparationPath = "scripts/apply-team-referral-rewards.cjs";
+
+const playerReferralPage = read(playerReferralPagePath);
+const playerTeamNav = read(playerTeamNavPath);
+const homepage = read(homepagePath);
+const referralPreparation = read(referralPreparationPath);
+
+expectText("team referrals", playerReferralPagePath, playerReferralPage, "Refer a team and earn £75", "player referral reward page must remain available");
+expectText("team referrals", playerReferralPagePath, playerReferralPage, "register-interest?type=team&ref=", "player referral page must generate a team-registration link containing the referral code");
+expectText("team referrals", playerTeamNavPath, playerTeamNav, 'href: "/player/referrals"', "player navigation must permanently expose the referral page");
+expectText("team referrals", playerTeamNavPath, playerTeamNav, "Refer a team · £75", "player navigation must clearly advertise the £75 team referral reward");
+expectText("team referrals", homepagePath, homepage, 'href: "/player/referrals"', "public homepage must expose the referral scheme");
+expectText("team referrals", homepagePath, homepage, "Refer a team · Earn £75", "homepage referral entry point must explain the reward");
+expectText("team referrals", referralPreparationPath, referralPreparation, "attachReferralToLead", "registration preparation must continue attaching valid referral codes to team leads");
+expectText("team referrals", referralPreparationPath, referralPreparation, 'name="referralCode"', "team registration must continue carrying the referral code through the form");
+
 if (failures.length) {
   console.error("\nSIXFL CRITICAL FEATURE CONTRACTS FAILED\n");
   for (const failure of failures) console.error(` - ${failure}`);

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -61,6 +61,12 @@ const joinRoutes = [
     href: generalRefereeLink,
     cta: "Referee interest",
   },
+  {
+    title: "Refer a team · Earn £75",
+    desc: "Already play in SIXFL? Refer a new team and earn £75 after they complete three league matches.",
+    href: "/player/referrals",
+    cta: "Get my referral link",
+  },
 ];
 
 function normaliseTeamName(name: string) {

--- a/src/components/player/PlayerTeamNav.tsx
+++ b/src/components/player/PlayerTeamNav.tsx
@@ -49,6 +49,11 @@ const tabs = (teamId: string, previewMembershipId: string | null) => [
     label: "Goal of the Week",
     exact: false,
   },
+  {
+    href: "/player/referrals",
+    label: "Refer a team · £75",
+    exact: false,
+  },
 ];
 
 export default function PlayerTeamNav({ teamId }: { teamId: string }) {


### PR DESCRIPTION
Restores the £75 team referral scheme as a clearly discoverable feature.

Changes:
- adds `Refer a team · £75` permanently to the shared player navigation, so it appears throughout the player area rather than depending on a dashboard source patch
- adds `Refer a team · Earn £75` to the public homepage Join SIXFL section
- extends the blocking critical-feature contracts so the player referral page, generated referral URL, player navigation link, homepage link and registration referral handoff cannot silently disappear again

The existing referral page, reward tracking and registration handoff remain unchanged.