### PR TITLE
Allow existing team leads to be added to referrals

### DIFF
--- a/src/app/(admin)/admin/referrals/actions.ts
+++ b/src/app/(admin)/admin/referrals/actions.ts
@@ -1,9 +1,106 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
-import { getTeamReferrals } from "@/lib/team-referrals";
+import {
+  attachReferralToLead,
+  getOrCreateReferralCode,
+  getTeamReferrals,
+} from "@/lib/team-referrals";
+
+function referralRedirect(params: Record<string, string>) {
+  const searchParams = new URLSearchParams(params);
+  redirect(`/admin/referrals?${searchParams.toString()}`);
+}
+
+export async function attachExistingLeadReferralAction(formData: FormData) {
+  await requireAdmin();
+
+  const leadId = String(formData.get("leadId") ?? "").trim();
+  const referrerUserId = String(formData.get("referrerUserId") ?? "").trim();
+
+  if (!leadId || !referrerUserId) {
+    referralRedirect({ error: "missing" });
+  }
+
+  const leadRows = await prisma.$queryRaw<
+    Array<{ id: string; email: string; interestType: string }>
+  >`
+    SELECT "id", "email", "interestType"::text AS "interestType"
+    FROM "InterestLead"
+    WHERE "id" = ${leadId}
+    LIMIT 1
+  `;
+  const lead = leadRows[0];
+
+  if (!lead || lead.interestType !== "TEAM") {
+    referralRedirect({ error: "lead_not_found" });
+  }
+
+  const playerRows = await prisma.$queryRaw<
+    Array<{ id: string; email: string; name: string | null }>
+  >`
+    SELECT u."id", u."email", u."name"
+    FROM "User" u
+    WHERE u."id" = ${referrerUserId}
+      AND u."email" IS NOT NULL
+      AND BTRIM(u."email") <> ''
+      AND EXISTS (
+        SELECT 1
+        FROM "TeamMember" member
+        WHERE member."userId" = u."id"
+      )
+    LIMIT 1
+  `;
+  const player = playerRows[0];
+
+  if (!player) {
+    referralRedirect({ error: "player_not_found" });
+  }
+
+  const existingRows = await prisma.$queryRaw<Array<{ referrerUserId: string }>>`
+    SELECT "referrerUserId"
+    FROM "TeamReferral"
+    WHERE "interestLeadId" = ${lead.id}
+    LIMIT 1
+  `;
+
+  if (existingRows[0]) {
+    referralRedirect({ error: "already_referred" });
+  }
+
+  if (lead.email.trim().toLowerCase() === player.email.trim().toLowerCase()) {
+    referralRedirect({ error: "same_email" });
+  }
+
+  const referralCode = await getOrCreateReferralCode(player.id);
+  const attached = await attachReferralToLead({
+    interestLeadId: lead.id,
+    referralCode,
+    leadEmail: lead.email,
+  });
+
+  if (!attached) {
+    referralRedirect({ error: "attach_failed" });
+  }
+
+  const linkedRows = await prisma.$queryRaw<Array<{ referrerUserId: string }>>`
+    SELECT "referrerUserId"
+    FROM "TeamReferral"
+    WHERE "interestLeadId" = ${lead.id}
+    LIMIT 1
+  `;
+
+  if (linkedRows[0]?.referrerUserId !== player.id) {
+    referralRedirect({ error: "already_referred" });
+  }
+
+  revalidatePath("/admin/referrals");
+  revalidatePath("/player/referrals");
+  referralRedirect({ added: "1" });
+}
 
 export async function markReferralPaidAction(formData: FormData) {
   const { user } = await requireAdmin();

--- a/src/app/(admin)/admin/referrals/page.tsx
+++ b/src/app/(admin)/admin/referrals/page.tsx
@@ -1,12 +1,34 @@
 import Link from "next/link";
+import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { getTeamReferrals, referralStatus } from "@/lib/team-referrals";
-import { markReferralPaidAction } from "./actions";
+import { attachExistingLeadReferralAction, markReferralPaidAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata = { title: "Team Referrals | SIXFL Admin" };
+
+type SearchParams = Promise<{
+  added?: string;
+  error?: string;
+}>;
+
+type AvailableLeadRow = {
+  id: string;
+  contactName: string;
+  email: string;
+  teamName: string | null;
+  area: string | null;
+  status: string;
+  convertedTeamName: string | null;
+};
+
+type PlayerOptionRow = {
+  id: string;
+  name: string | null;
+  email: string;
+};
 
 function money(pence: number) {
   return new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(pence / 100);
@@ -16,13 +38,66 @@ function date(value: Date) {
   return new Intl.DateTimeFormat("en-GB", { day: "2-digit", month: "short", year: "numeric" }).format(value);
 }
 
-export default async function AdminReferralsPage() {
+function errorMessage(value?: string) {
+  switch (value) {
+    case "missing":
+      return "Choose both the existing team lead and the player who referred them.";
+    case "lead_not_found":
+      return "That team lead could not be found, or it is not a team lead.";
+    case "player_not_found":
+      return "That referrer is not a current SIXFL player account with an email address.";
+    case "already_referred":
+      return "That lead is already linked to a referral and cannot be assigned twice.";
+    case "same_email":
+      return "A player cannot refer a team lead using the same email address as their own account.";
+    case "attach_failed":
+      return "SIXFL could not attach that referral. No referral record was created.";
+    default:
+      return null;
+  }
+}
+
+export default async function AdminReferralsPage({ searchParams }: { searchParams?: SearchParams }) {
   await requireAdmin();
-  const referrals = await getTeamReferrals();
+  const sp = (await searchParams) ?? {};
+
+  const [referrals, availableLeads, playerOptions] = await Promise.all([
+    getTeamReferrals(),
+    prisma.$queryRaw<AvailableLeadRow[]>`
+      SELECT
+        lead."id",
+        lead."contactName",
+        lead."email",
+        lead."teamName",
+        lead."area",
+        lead."status"::text AS "status",
+        team."name" AS "convertedTeamName"
+      FROM "InterestLead" lead
+      LEFT JOIN "Team" team ON team."id" = lead."convertedTeamId"
+      WHERE lead."interestType"::text = 'TEAM'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "TeamReferral" referral
+          WHERE referral."interestLeadId" = lead."id"
+        )
+      ORDER BY lead."createdAt" DESC
+      LIMIT 250
+    `,
+    prisma.$queryRaw<PlayerOptionRow[]>`
+      SELECT DISTINCT u."id", u."name", u."email"
+      FROM "User" u
+      INNER JOIN "TeamMember" member ON member."userId" = u."id"
+      WHERE u."email" IS NOT NULL
+        AND BTRIM(u."email") <> ''
+      ORDER BY COALESCE(NULLIF(BTRIM(u."name"), ''), u."email"), u."email"
+    `,
+  ]);
+
   const readyCount = referrals.filter((row) => referralStatus(row) === "READY").length;
   const unpaidValue = referrals
     .filter((row) => referralStatus(row) === "READY")
     .reduce((total, row) => total + row.rewardPence, 0);
+  const attachError = errorMessage(sp.error);
 
   return (
     <div className="space-y-6">
@@ -38,6 +113,89 @@ export default async function AdminReferralsPage() {
           View team leads
         </Link>
       </div>
+
+      {sp.added === "1" ? (
+        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm font-bold text-emerald-800">
+          Referral added. SIXFL will now track that team towards the player&apos;s £75 reward.
+        </div>
+      ) : null}
+
+      {attachError ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm font-bold text-red-800">
+          {attachError}
+        </div>
+      ) : null}
+
+      <section className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-5 shadow-sm sm:p-6">
+        <div className="max-w-3xl">
+          <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Existing lead</p>
+          <h2 className="mt-2 text-xl font-black text-slate-950">Attach an existing team lead to a referral</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Use this when a team was already in SIXFL Leads before they used the player&apos;s referral link. This does not recreate or change the lead — it simply links the existing lead to the referring player and starts the normal three-completed-match reward tracking.
+          </p>
+        </div>
+
+        {availableLeads.length === 0 ? (
+          <div className="mt-5 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
+            There are no unlinked team leads available to add to the referral system.
+          </div>
+        ) : playerOptions.length === 0 ? (
+          <div className="mt-5 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
+            No eligible player accounts with email addresses were found.
+          </div>
+        ) : (
+          <form action={attachExistingLeadReferralAction} className="mt-5 grid gap-4 lg:grid-cols-[1.3fr_1fr_auto] lg:items-end">
+            <label className="block">
+              <span className="text-xs font-black uppercase tracking-[0.12em] text-slate-600">Existing team lead</span>
+              <select
+                name="leadId"
+                required
+                defaultValue=""
+                className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-900 outline-none focus:border-emerald-500"
+              >
+                <option value="" disabled>Select a team lead…</option>
+                {availableLeads.map((lead) => {
+                  const teamLabel = lead.convertedTeamName ?? lead.teamName ?? "Unnamed team";
+                  const area = lead.area ? ` · ${lead.area}` : "";
+                  return (
+                    <option key={lead.id} value={lead.id}>
+                      {teamLabel} · {lead.contactName} · {lead.email}{area}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-black uppercase tracking-[0.12em] text-slate-600">Referring player</span>
+              <select
+                name="referrerUserId"
+                required
+                defaultValue=""
+                className="mt-2 h-12 w-full rounded-xl border border-slate-300 bg-white px-3 text-sm font-semibold text-slate-900 outline-none focus:border-emerald-500"
+              >
+                <option value="" disabled>Select a player…</option>
+                {playerOptions.map((player) => (
+                  <option key={player.id} value={player.id}>
+                    {player.name?.trim() || "Player"} · {player.email}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <button
+              type="submit"
+              className="inline-flex h-12 items-center justify-center rounded-xl bg-emerald-600 px-5 text-sm font-black text-white shadow-sm transition hover:bg-emerald-500"
+            >
+              Add referral
+            </button>
+          </form>
+        )}
+
+        <p className="mt-4 text-xs leading-5 text-slate-500">
+          A lead can only be linked to one referrer. The player and lead cannot use the same email address.
+        </p>
+      </section>
 
       <div className="grid gap-4 sm:grid-cols-3">
         <Summary label="Total referrals" value={String(referrals.length)} />

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -258,6 +258,12 @@ const navigationGroups = [
         description: "Inbound",
       },
       {
+        name: "Team referrals",
+        href: "/admin/referrals",
+        icon: CreditCardIcon,
+        description: "£75 rewards",
+      },
+      {
         name: "Player pool",
         href: "/admin/player-pool",
         icon: UserGroupIcon,


### PR DESCRIPTION
Adds an admin-only way to attach a team lead that already exists in SIXFL Leads to the player who referred them.

Changes:
- adds an **Attach an existing team lead to a referral** form on Admin → Team referrals
- lists only TEAM leads that are not already linked to a referral
- lists only SIXFL player accounts that have an email and at least one team membership
- prevents self-referral where the player and lead use the same email
- prevents a lead from being attached to a second referrer
- uses the existing personal referral-code and TeamReferral creation logic, so the normal 3 completed matches → £75 tracking starts immediately
- does not recreate, convert or otherwise alter the existing lead/team
- makes **Team referrals** a permanent native item under Admin → Recruitment instead of relying on the legacy build-time navigation injection

No reward amount, completed-match counting or payment rules are changed.