### PR TITLE
Fix admin referral player lookup crash

### DIFF
--- a/src/app/(admin)/admin/referrals/page.tsx
+++ b/src/app/(admin)/admin/referrals/page.tsx
@@ -84,11 +84,15 @@ export default async function AdminReferralsPage({ searchParams }: { searchParam
       LIMIT 250
     `,
     prisma.$queryRaw<PlayerOptionRow[]>`
-      SELECT DISTINCT u."id", u."name", u."email"
+      SELECT u."id", u."name", u."email"
       FROM "User" u
-      INNER JOIN "TeamMember" member ON member."userId" = u."id"
       WHERE u."email" IS NOT NULL
         AND BTRIM(u."email") <> ''
+        AND EXISTS (
+          SELECT 1
+          FROM "TeamMember" member
+          WHERE member."userId" = u."id"
+        )
       ORDER BY COALESCE(NULLIF(BTRIM(u."name"), ''), u."email"), u."email"
     `,
   ]);


### PR DESCRIPTION
Fixes the server-side exception on Admin → Team referrals introduced by the existing-lead referral form.

Root cause:
- the referring-player dropdown used `SELECT DISTINCT` while ordering by a calculated name/email expression that was not in the select list
- PostgreSQL rejects that query at runtime, even though TypeScript/build checks pass

Fix:
- remove the join/`DISTINCT`
- use `EXISTS` to require at least one TeamMember row for the user
- keep the same player eligibility and name/email ordering

No referral records, reward rules or lead data are changed.