### PR TITLE
Support direct Meta lead CSV imports

### DIFF
--- a/src/app/(admin)/admin/leads/import/actions.ts
+++ b/src/app/(admin)/admin/leads/import/actions.ts
@@ -1,5 +1,5 @@
 // ========================================
-// File: src/app/admin/leads/import/actions.ts
+// File: src/app/(admin)/admin/leads/import/actions.ts
 // ========================================
 
 "use server";
@@ -14,6 +14,7 @@ import { normalizeUkMobileNumber } from "@/lib/phone/normalize";
 export type ImportLeadsState = {
   success: boolean;
   message: string;
+  processed: number;
   created: number;
   skipped: number;
   errors: string[];
@@ -22,6 +23,7 @@ export type ImportLeadsState = {
 const INITIAL_STATE: ImportLeadsState = {
   success: false,
   message: "",
+  processed: 0,
   created: 0,
   skipped: 0,
   errors: [],
@@ -29,6 +31,10 @@ const INITIAL_STATE: ImportLeadsState = {
 
 function normalizeHeader(value: string) {
   return value.trim().toLowerCase().replace(/[\s_-]+/g, "");
+}
+
+function compactHeader(value: string) {
+  return normalizeHeader(value).replace(/[^a-z0-9]/g, "");
 }
 
 function parseCsvLine(line: string): string[] {
@@ -75,7 +81,12 @@ function parseCsv(text: string): { headers: string[]; rows: Record<string, strin
     return { headers: [], rows: [] };
   }
 
-  const headers = parseCsvLine(lines[0]).map(normalizeHeader);
+  // Meta currently exports the email column with a blank heading. Give every
+  // blank heading a stable synthetic key so its value is not lost.
+  const headers = parseCsvLine(lines[0]).map((header, index) => {
+    const normalized = normalizeHeader(header);
+    return normalized || `column${index + 1}`;
+  });
 
   const rows = lines.slice(1).map((line) => {
     const values = parseCsvLine(line);
@@ -101,8 +112,22 @@ function getFirstNonEmpty(row: Record<string, string>, keys: string[]) {
   return "";
 }
 
+function getFirstByHeaderContains(row: Record<string, string>, needles: string[]) {
+  const compactNeedles = needles.map(compactHeader);
+
+  for (const [key, value] of Object.entries(row)) {
+    if (!value?.trim()) continue;
+    const compactKey = compactHeader(key);
+    if (compactNeedles.some((needle) => compactKey.includes(needle))) {
+      return value.trim();
+    }
+  }
+
+  return "";
+}
+
 function buildContactName(row: Record<string, string>) {
-  const explicitContactName = getFirstNonEmpty(row, ["contactName", "name", "fullName"]);
+  const explicitContactName = getFirstNonEmpty(row, ["contactName", "name", "fullName", "full_name"]);
   if (explicitContactName) return explicitContactName;
 
   const firstName = getFirstNonEmpty(row, ["firstName", "firstname", "first"]);
@@ -111,7 +136,7 @@ function buildContactName(row: Record<string, string>) {
   const combined = `${firstName} ${lastName}`.trim();
   if (combined) return combined;
 
-  const email = getFirstNonEmpty(row, ["email"]);
+  const email = findEmail(row);
   if (!email) return "";
 
   return email.split("@")[0];
@@ -125,24 +150,163 @@ function toInterestType(value: FormDataEntryValue | null): InterestType {
   return InterestType.TEAM;
 }
 
-function isTruthy(value: FormDataEntryValue | null) {
-  return value === "on" || value === "true" || value === "1";
-}
-
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
 
+function isValidEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function findEmail(row: Record<string, string>) {
+  const namedEmail = getFirstNonEmpty(row, ["email", "emailAddress", "email_address"]);
+  if (namedEmail) return normalizeEmail(namedEmail);
+
+  // Meta's lead export can contain the email value under a blank column heading.
+  const inferredEmail = Object.values(row).find((value) => isValidEmail(value.trim()));
+  return inferredEmail ? normalizeEmail(inferredEmail) : "";
+}
+
+function cleanPhone(value: string) {
+  return value.trim().replace(/^p:\s*/i, "");
+}
+
+function findPhone(row: Record<string, string>) {
+  return cleanPhone(
+    getFirstNonEmpty(row, ["phone", "phoneNumber", "phone_number", "mobile", "telephone"]),
+  );
+}
+
+function normalizeAnswer(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[’']/g, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function humanizeAnswer(value: string) {
+  const text = value.trim().replace(/_/g, " ").replace(/\s+/g, " ");
+  if (!text) return "";
+
+  const withContractions = text.replace(/^i[’']?m\b/i, "I'm");
+  return withContractions.charAt(0).toUpperCase() + withContractions.slice(1);
+}
+
+function inferInterestType(row: Record<string, string>, fallback: InterestType) {
+  const answer = getFirstByHeaderContains(row, ["what are you looking for"]);
+  if (!answer) return fallback;
+
+  const normalized = normalizeAnswer(answer);
+
+  if (normalized.includes("individual") && normalized.includes("team")) {
+    return InterestType.PLAYER;
+  }
+
+  if (normalized.includes("player") && normalized.includes("looking")) {
+    return InterestType.PLAYER;
+  }
+
+  if (normalized.includes("team")) {
+    return InterestType.TEAM;
+  }
+
+  if (normalized.includes("referee")) {
+    return InterestType.REFEREE;
+  }
+
+  return fallback;
+}
+
+function isMetaRow(row: Record<string, string>) {
+  const leadId = getFirstNonEmpty(row, ["id"]);
+  const platform = getFirstNonEmpty(row, ["platform"]);
+  const adName = getFirstNonEmpty(row, ["adName", "ad_name"]);
+  const campaignName = getFirstNonEmpty(row, ["campaignName", "campaign_name"]);
+
+  return leadId.startsWith("l:") || Boolean(platform && (adName || campaignName));
+}
+
+function platformLabel(value: string) {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "fb" || normalized === "facebook") return "Facebook";
+  if (normalized === "ig" || normalized === "instagram") return "Instagram";
+  return value.trim() || "Meta";
+}
+
+function inferMetaArea(row: Record<string, string>) {
+  const adName = getFirstNonEmpty(row, ["adName", "ad_name"]);
+  const adSetName = getFirstNonEmpty(row, ["adsetName", "adset_name"]);
+
+  for (const candidate of [adName, adSetName]) {
+    if (!candidate) continue;
+    const parts = candidate
+      .split(/\s+[–—-]\s+/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+
+    if (parts.length >= 2 && /^heartlands$/i.test(parts[0])) {
+      return parts[1];
+    }
+  }
+
+  return "";
+}
+
+function parseCreatedAt(row: Record<string, string>) {
+  const raw = getFirstNonEmpty(row, ["createdTime", "created_time"]);
+  if (!raw) return null;
+
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function buildMetaMessage(row: Record<string, string>) {
+  if (!isMetaRow(row)) return "";
+
+  const leadId = getFirstNonEmpty(row, ["id"]);
+  const platform = getFirstNonEmpty(row, ["platform"]);
+  const campaignName = getFirstNonEmpty(row, ["campaignName", "campaign_name"]);
+  const adName = getFirstNonEmpty(row, ["adName", "ad_name"]);
+  const intent = getFirstByHeaderContains(row, ["what are you looking for"]);
+  const startTiming = getFirstByHeaderContains(row, ["when would you like to start playing"]);
+
+  return [
+    intent ? `Interest: ${humanizeAnswer(intent)}` : "",
+    startTiming ? `Start: ${humanizeAnswer(startTiming)}` : "",
+    leadId ? `Meta lead ID: ${leadId}` : "",
+    platform ? `Platform: ${platformLabel(platform)}` : "",
+    campaignName ? `Campaign: ${campaignName}` : "",
+    adName ? `Ad: ${adName}` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function buildSource(row: Record<string, string>, sourceOverride: string) {
+  const explicitSource = getFirstNonEmpty(row, ["source"]);
+  if (explicitSource) return explicitSource;
+  if (sourceOverride) return sourceOverride;
+
+  if (isMetaRow(row)) {
+    const platform = getFirstNonEmpty(row, ["platform"]);
+    return `Meta - ${platformLabel(platform)}`;
+  }
+
+  return "Legacy import";
+}
+
 export async function importLeadsAction(
   _prevState: ImportLeadsState,
-  formData: FormData
+  formData: FormData,
 ): Promise<ImportLeadsState> {
   await requireAdmin();
 
   const file = formData.get("file");
   const defaultInterestType = toInterestType(formData.get("defaultInterestType"));
-  const defaultSource = String(formData.get("defaultSource") ?? "Legacy import").trim() || "Legacy import";
-  const skipExisting = isTruthy(formData.get("skipExisting"));
+  const sourceOverride = String(formData.get("defaultSource") ?? "").trim();
+  const areaOverride = String(formData.get("defaultArea") ?? "").trim();
 
   if (!(file instanceof File) || file.size === 0) {
     return {
@@ -169,12 +333,13 @@ export async function importLeadsAction(
   }
 
   const parsedRows = rows.map((row, index) => {
-    const email = normalizeEmail(getFirstNonEmpty(row, ["email"]));
+    const email = findEmail(row);
     const contactName = buildContactName(row);
     const teamName = getFirstNonEmpty(row, ["teamName", "teamname", "team"]);
-    const phone = getFirstNonEmpty(row, ["phone", "mobile", "telephone"]);
-    const area = getFirstNonEmpty(row, ["area", "location"]);
-    const source = getFirstNonEmpty(row, ["source"]) || defaultSource;
+    const phone = findPhone(row);
+    const phoneNormalized = normalizeUkMobileNumber(phone);
+    const area = areaOverride || getFirstNonEmpty(row, ["area", "location"]) || inferMetaArea(row);
+    const source = buildSource(row, sourceOverride);
 
     return {
       rowNumber: index + 2,
@@ -182,14 +347,18 @@ export async function importLeadsAction(
       contactName,
       teamName,
       phone,
-      phoneNormalized: normalizeUkMobileNumber(phone),
+      phoneNormalized,
       area,
       source,
+      interestType: inferInterestType(row, defaultInterestType),
+      message: buildMetaMessage(row),
+      createdAt: parseCreatedAt(row),
     };
   });
 
   const errors: string[] = [];
-  const seenInCsv = new Set<string>();
+  const seenEmails = new Set<string>();
+  const seenPhones = new Set<string>();
 
   const validRows = parsedRows.filter((row) => {
     if (!row.email) {
@@ -197,7 +366,7 @@ export async function importLeadsAction(
       return false;
     }
 
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(row.email)) {
+    if (!isValidEmail(row.email)) {
       errors.push(`Row ${row.rowNumber}: invalid email "${row.email}".`);
       return false;
     }
@@ -207,12 +376,18 @@ export async function importLeadsAction(
       return false;
     }
 
-    if (seenInCsv.has(row.email)) {
+    if (seenEmails.has(row.email)) {
       errors.push(`Row ${row.rowNumber}: duplicate email "${row.email}" within CSV.`);
       return false;
     }
 
-    seenInCsv.add(row.email);
+    if (row.phoneNormalized && seenPhones.has(row.phoneNormalized)) {
+      errors.push(`Row ${row.rowNumber}: duplicate phone "${row.phone}" within CSV.`);
+      return false;
+    }
+
+    seenEmails.add(row.email);
+    if (row.phoneNormalized) seenPhones.add(row.phoneNormalized);
     return true;
   });
 
@@ -220,39 +395,63 @@ export async function importLeadsAction(
     return {
       success: false,
       message: "No valid rows were found to import.",
+      processed: rows.length,
       created: 0,
-      skipped: 0,
+      skipped: rows.length,
       errors,
     };
   }
 
-  const existingLeads = await prisma.interestLead.findMany({
-    where: {
-      email: {
-        in: validRows.map((row) => row.email),
-        mode: "insensitive",
-      },
-    },
-    select: {
-      email: true,
-    },
-  });
+  const emails = validRows.map((row) => row.email);
+  const phones = validRows.flatMap((row) => (row.phoneNormalized ? [row.phoneNormalized] : []));
+  const duplicateWhere: Prisma.InterestLeadWhereInput[] = [
+    ...(emails.length
+      ? [
+          {
+            email: {
+              in: emails,
+              mode: "insensitive" as const,
+            },
+          },
+        ]
+      : []),
+    ...(phones.length ? [{ phoneNormalized: { in: phones } }] : []),
+  ];
 
-  const existingEmailSet = new Set(existingLeads.map((lead) => lead.email?.trim().toLowerCase()).filter(Boolean));
+  const existingLeads = duplicateWhere.length
+    ? await prisma.interestLead.findMany({
+        where: { OR: duplicateWhere },
+        select: {
+          email: true,
+          phoneNormalized: true,
+        },
+      })
+    : [];
 
-  const rowsToCreate = validRows.filter((row) => {
-    if (skipExisting && existingEmailSet.has(row.email)) {
-      return false;
-    }
-    return true;
-  });
+  const existingEmailSet = new Set(
+    existingLeads.flatMap((lead) => (lead.email ? [normalizeEmail(lead.email)] : [])),
+  );
+  const existingPhoneSet = new Set(
+    existingLeads.flatMap((lead) => (lead.phoneNormalized ? [lead.phoneNormalized] : [])),
+  );
 
-  const skipped = validRows.length - rowsToCreate.length;
+  // Imports are deliberately duplicate-safe. A matching email OR normalized
+  // phone is skipped so re-uploading a Meta export cannot create duplicate leads.
+  const rowsToCreate = validRows.filter(
+    (row) =>
+      !existingEmailSet.has(row.email) &&
+      !(row.phoneNormalized && existingPhoneSet.has(row.phoneNormalized)),
+  );
+
+  const invalidCount = rows.length - validRows.length;
+  const existingCount = validRows.length - rowsToCreate.length;
+  const skipped = invalidCount + existingCount;
 
   if (rowsToCreate.length === 0) {
     return {
-      success: false,
-      message: "All valid rows were skipped because they already exist.",
+      success: true,
+      message: `Import checked ${rows.length} row${rows.length === 1 ? "" : "s"}. Nothing new was added.`,
+      processed: rows.length,
       created: 0,
       skipped,
       errors,
@@ -260,7 +459,7 @@ export async function importLeadsAction(
   }
 
   const createData: Prisma.InterestLeadCreateManyInput[] = rowsToCreate.map((row) => ({
-    interestType: defaultInterestType,
+    interestType: row.interestType,
     status: LeadStatus.NEW,
     contactName: row.contactName,
     email: row.email,
@@ -268,7 +467,9 @@ export async function importLeadsAction(
     phoneNormalized: row.phoneNormalized,
     teamName: row.teamName || null,
     area: row.area || null,
-    source: row.source || defaultSource,
+    message: row.message || null,
+    source: row.source,
+    ...(row.createdAt ? { createdAt: row.createdAt } : {}),
   }));
 
   const result = await prisma.interestLead.createMany({
@@ -280,7 +481,8 @@ export async function importLeadsAction(
 
   return {
     success: true,
-    message: `Import complete. Created ${result.count} lead${result.count === 1 ? "" : "s"}.`,
+    message: `Import complete. Created ${result.count} lead${result.count === 1 ? "" : "s"} from ${rows.length} row${rows.length === 1 ? "" : "s"}.`,
+    processed: rows.length,
     created: result.count,
     skipped,
     errors,

--- a/src/app/(admin)/admin/leads/import/page.tsx
+++ b/src/app/(admin)/admin/leads/import/page.tsx
@@ -14,13 +14,13 @@ export default async function AdminLeadImportPage() {
     <div className="space-y-8">
       <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
-        <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-400">
-  <span className="h-2 w-2 rounded-full bg-emerald-400" />
-  Admin console
-</div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-400">
+            <span className="h-2 w-2 rounded-full bg-emerald-400" />
+            Admin console
+          </div>
           <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white">Import leads</h1>
           <p className="mt-2 max-w-2xl text-sm text-white/65">
-            Upload a CSV of legacy or campaign leads and import them into the SIXFL CRM.
+            Upload a CSV of legacy or Meta campaign leads and import them into the SIXFL CRM.
           </p>
         </div>
 
@@ -36,16 +36,21 @@ export default async function AdminLeadImportPage() {
         <ImportLeadsForm />
 
         <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-          <h2 className="text-lg font-semibold text-white">CSV example</h2>
-          <pre className="mt-4 overflow-x-auto rounded-xl border border-white/10 bg-black/30 p-4 text-xs text-white/75">
+          <h2 className="text-lg font-semibold text-white">What can I upload?</h2>
+          <p className="mt-3 text-sm text-white/65">
+            You can upload the CSV downloaded directly from Meta/Facebook. It does not need cleaning first.
+          </p>
+
+          <h3 className="mt-6 text-sm font-semibold text-white">Standard CSV example</h3>
+          <pre className="mt-3 overflow-x-auto rounded-xl border border-white/10 bg-black/30 p-4 text-xs text-white/75">
 {`email,firstName,lastName,teamName,source
 joe@example.com,Joe,Levy,Six Offenders,Legacy import
 adam@example.com,Adam,Smith,Carajo Utd,Legacy import`}
           </pre>
 
-          <p className="mt-4 text-sm text-white/65">
-            Your current cleaned file should work well here.
-          </p>
+          <div className="mt-5 rounded-xl border border-emerald-400/15 bg-emerald-500/10 p-4 text-xs leading-5 text-emerald-100/80">
+            Duplicate protection is always on: SIXFL skips a row when its email address or normalised phone number is already in Leads.
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/admin/leads/ImportLeadsForm.tsx
+++ b/src/components/admin/leads/ImportLeadsForm.tsx
@@ -88,7 +88,7 @@ export default function ImportLeadsForm() {
             <label className="text-sm text-white/70">Area override (optional)</label>
             <input
               name="defaultArea"
-              placeholder="Leave blank to infer Catterick/Richmond from the Meta ad"
+              placeholder="Leave blank to infer the area from the Meta ad"
               className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-white placeholder:text-white/30"
             />
           </div>

--- a/src/components/admin/leads/ImportLeadsForm.tsx
+++ b/src/components/admin/leads/ImportLeadsForm.tsx
@@ -16,6 +16,7 @@ import {
 const initialState: ImportLeadsState = {
   success: false,
   message: "",
+  processed: 0,
   created: 0,
   skipped: 0,
   errors: [],
@@ -30,7 +31,7 @@ function SubmitButton() {
       disabled={pending}
       className="inline-flex items-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
     >
-      {pending ? "Importing..." : "Import leads"}
+      {pending ? "Importing..." : "Import CSV"}
     </button>
   );
 }
@@ -44,6 +45,14 @@ export default function ImportLeadsForm() {
         action={formAction}
         className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-6"
       >
+        <div className="rounded-xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm text-sky-100">
+          <div className="font-semibold">Meta / Facebook lead exports are recognised automatically.</div>
+          <div className="mt-1 text-sky-100/75">
+            SIXFL will read the Meta name, blank-headed email column, phone number, Facebook/Instagram source,
+            team-vs-player answer and start timing. Existing leads are skipped automatically by email or phone.
+          </div>
+        </div>
+
         <div className="space-y-2">
           <label className="block text-sm font-medium text-white">
             CSV file
@@ -61,7 +70,7 @@ export default function ImportLeadsForm() {
           <div className="space-y-2">
             <AdminSelect
               name="defaultInterestType"
-              label="Default interest type"
+              label="Fallback interest type"
               defaultValue="TEAM"
               options={[
                 { value: "TEAM", label: "TEAM" },
@@ -70,14 +79,26 @@ export default function ImportLeadsForm() {
               ]}
               placeholder="Select an option"
             />
+            <p className="text-xs text-white/45">
+              Meta files override this per row when the form answer identifies a team or individual player.
+            </p>
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm text-white/70">Default source</label>
+            <label className="text-sm text-white/70">Area override (optional)</label>
+            <input
+              name="defaultArea"
+              placeholder="Leave blank to infer Catterick/Richmond from the Meta ad"
+              className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-white placeholder:text-white/30"
+            />
+          </div>
+
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm text-white/70">Source override (optional)</label>
             <input
               name="defaultSource"
-              defaultValue="Legacy import"
-              className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-white"
+              placeholder="Leave blank for Meta - Facebook / Meta - Instagram"
+              className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-white placeholder:text-white/30"
             />
           </div>
         </div>
@@ -86,8 +107,33 @@ export default function ImportLeadsForm() {
       </form>
 
       {state.message ? (
-        <div className="rounded-xl border border-white/10 bg-black/20 p-4 text-sm text-white">
-          {state.message}
+        <div
+          className={[
+            "rounded-xl border p-4 text-sm",
+            state.success
+              ? "border-emerald-400/20 bg-emerald-500/10 text-emerald-100"
+              : "border-amber-400/20 bg-amber-500/10 text-amber-100",
+          ].join(" ")}
+        >
+          <div className="font-semibold">{state.message}</div>
+          {state.processed > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2 text-xs">
+              <span className="rounded-full border border-white/10 bg-black/15 px-3 py-1">{state.processed} processed</span>
+              <span className="rounded-full border border-white/10 bg-black/15 px-3 py-1">{state.created} created</span>
+              <span className="rounded-full border border-white/10 bg-black/15 px-3 py-1">{state.skipped} skipped</span>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {state.errors.length > 0 ? (
+        <div className="rounded-xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">
+          <div className="font-semibold">Rows needing attention</div>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-amber-100/80">
+            {state.errors.map((error) => (
+              <li key={error}>{error}</li>
+            ))}
+          </ul>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- recognise Meta/Facebook lead CSV exports directly, including the blank-headed email column
- infer TEAM vs PLAYER per Meta response
- strip Meta `p:` phone prefixes and normalise phone numbers
- infer campaign area per row from Heartlands ad names, with optional admin override
- preserve Meta timing, lead ID, platform, campaign and ad metadata in the lead message
- preserve original Meta lead creation time
- always skip duplicate leads by email or normalised phone
- show processed/created/skipped counts and row errors in the admin importer

## Checked against the uploaded Catterick export
The file contains 20 rows, all with names, email addresses and phone numbers. It also contains both Catterick and Thirsk ad rows, so per-row area inference is intentional.