### PR TITLE
Group footer navigation and add referral link

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -9,13 +9,70 @@ import Link from "next/link";
 import { FaFacebookF, FaInstagram } from "react-icons/fa";
 import { track } from "@vercel/analytics";
 
+type FooterLink = {
+  label: string;
+  href: string;
+  featured?: boolean;
+};
+
+const footerGroups: Array<{ title: string; links: FooterLink[] }> = [
+  {
+    title: "Get involved",
+    links: [
+      { label: "Register your team", href: "/register-team", featured: true },
+      { label: "Join as a player", href: "/register-interest?type=player" },
+      { label: "Refer a team · Earn £75", href: "/player/referrals", featured: true },
+      { label: "Bring SIXFL to your area", href: "/bring-sixfl-to-your-area" },
+      { label: "Founding Kit Package", href: "/founding-teams" },
+    ],
+  },
+  {
+    title: "Find football",
+    links: [
+      { label: "All leagues", href: "/leagues" },
+      { label: "Harrogate 6-a-side", href: "/harrogate-6-a-side-football", featured: true },
+      { label: "Northallerton 6-a-side", href: "/northallerton-6-a-side-football" },
+      { label: "Wetherby 6-a-side", href: "/wetherby-6-a-side-football" },
+      { label: "Heartlands 6-a-side", href: "/north-yorkshire-heartlands-6-a-side-football" },
+      { label: "Venues", href: "/venues" },
+    ],
+  },
+  {
+    title: "Help & information",
+    links: [
+      { label: "Pricing", href: "/pricing" },
+      { label: "FAQ", href: "/faq" },
+    ],
+  },
+  {
+    title: "Rules & terms",
+    links: [
+      { label: "League Rules", href: "/league-rules" },
+      { label: "Match Rules", href: "/match-rules" },
+      { label: "League Agreement", href: "/league-agreement" },
+      { label: "Privacy Policy", href: "/privacy-policy" },
+      { label: "Kit Package Terms", href: "/founding-team-kit-terms" },
+      { label: "Referee Agreement", href: "/referee-agreement" },
+    ],
+  },
+  {
+    title: "Safeguarding",
+    links: [
+      { label: "Safeguarding Policy", href: "/safeguarding/safeguarding-policy" },
+      { label: "Code of Conduct", href: "/safeguarding/code-of-conduct" },
+      { label: "Anti-Bullying Policy", href: "/safeguarding/anti-bullying" },
+      { label: "Reporting Concerns", href: "/safeguarding/reporting-concerns" },
+    ],
+  },
+];
+
 export default function SiteFooter() {
   return (
     <footer className="border-t border-white/10 bg-black text-white">
       <div className="h-[3px] w-full bg-emerald-500"></div>
 
       <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-12 lg:px-8">
-        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-[1.4fr_1fr_1fr_1fr] lg:gap-10">
+        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-[1.35fr_repeat(5,minmax(0,1fr))] xl:gap-8">
           <div className="max-w-md sm:col-span-2 lg:col-span-1">
             <Link href="/" className="inline-flex items-center">
               <Image
@@ -84,131 +141,28 @@ export default function SiteFooter() {
             </div>
           </div>
 
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/50">
-              Navigation
+          {footerGroups.map((group) => (
+            <div key={group.title}>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/50">
+                {group.title}
+              </div>
+
+              <nav className="mt-4 flex flex-col gap-1 text-sm text-white/80" aria-label={`${group.title} footer links`}>
+                {group.links.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className={[
+                      "inline-flex min-h-9 items-center leading-5 transition hover:text-emerald-400",
+                      link.featured ? "font-semibold text-emerald-200" : "",
+                    ].join(" ")}
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </nav>
             </div>
-
-            <nav className="mt-4 flex flex-col gap-1 text-sm text-white/80">
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/leagues">
-                Leagues
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center font-semibold text-emerald-200 transition hover:text-emerald-400" href="/harrogate-6-a-side-football">
-                Harrogate 6-a-side football
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/northallerton-6-a-side-football">
-                Northallerton 6-a-side football
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/wetherby-6-a-side-football">
-                Wetherby 6-a-side football
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/north-yorkshire-heartlands-6-a-side-football">
-                Heartlands 6-a-side football
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/venues">
-                Venues
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/pricing">
-                Pricing
-              </Link>
-
-              <Link
-                className="inline-flex min-h-9 items-center font-semibold text-emerald-200 transition hover:text-emerald-400"
-                href="/bring-sixfl-to-your-area"
-              >
-                Bring SIXFL to your area
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/founding-teams">
-                Founding Kit Package
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/faq">
-                FAQ
-              </Link>
-
-              <Link
-                className="inline-flex min-h-9 items-center font-semibold text-white transition hover:text-emerald-400"
-                href="/register-team"
-              >
-                Register
-              </Link>
-            </nav>
-          </div>
-
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/50">
-              Legal
-            </div>
-
-            <nav className="mt-4 flex flex-col gap-1 text-sm text-white/80">
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/privacy-policy">
-                Privacy Policy
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/league-rules">
-                League Rules
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/league-agreement">
-                League Agreement
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/founding-team-kit-terms">
-                Kit Package Terms
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/referee-agreement">
-                Referee Agreement
-              </Link>
-
-              <Link className="inline-flex min-h-9 items-center transition hover:text-emerald-400" href="/match-rules">
-                Match Rules
-              </Link>
-            </nav>
-          </div>
-
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-white/50">
-              Safeguarding
-            </div>
-
-            <nav className="mt-4 flex flex-col gap-1 text-sm text-white/80">
-              <Link
-                className="inline-flex min-h-9 items-center transition hover:text-emerald-400"
-                href="/safeguarding/safeguarding-policy"
-              >
-                Safeguarding Policy
-              </Link>
-
-              <Link
-                className="inline-flex min-h-9 items-center transition hover:text-emerald-400"
-                href="/safeguarding/code-of-conduct"
-              >
-                Code of Conduct
-              </Link>
-
-              <Link
-                className="inline-flex min-h-9 items-center transition hover:text-emerald-400"
-                href="/safeguarding/anti-bullying"
-              >
-                Anti-Bullying Policy
-              </Link>
-
-              <Link
-                className="inline-flex min-h-9 items-center transition hover:text-emerald-400"
-                href="/safeguarding/reporting-concerns"
-              >
-                Reporting Concerns
-              </Link>
-            </nav>
-          </div>
+          ))}
         </div>
 
         <div className="mt-10 h-[2px] w-full bg-emerald-500/40"></div>


### PR DESCRIPTION
Reorganises the public footer into clearer navigation groups and adds the £75 referral scheme as a permanent footer link.

Changes:
- replaces the long mixed `Navigation` column with **Get involved**, **Find football**, **Help & information**, **Rules & terms**, and **Safeguarding** groups
- adds **Refer a team · Earn £75** under Get involved
- adds the existing player registration route alongside team registration
- preserves every existing footer destination, including all league-area, legal and safeguarding links
- updates the responsive grid so the extra headings remain readable across mobile, tablet and desktop

No referral logic, registration logic, league data or legal content is changed.