### PR TITLE
Show why imported leads were skipped

### DIFF
--- a/scripts/apply-division-aware-dashboard-tables.cjs
+++ b/scripts/apply-division-aware-dashboard-tables.cjs
@@ -83,9 +83,11 @@ patchFile(
       );
     }
 
+    // Remove only the legacy local table calculator. Keep any helper functions
+    // that now sit between it and buildSeoLocation (for example venue helpers).
     source = source.replace(
-      /function buildLeagueTable\([\s\S]*?\n}\n\nfunction buildSeoLocation/,
-      "function buildSeoLocation",
+      /function buildLeagueTable\([\s\S]*?\n}\n\n(?=function (?:isVenueToBeConfirmed|buildSeoLocation))/, 
+      "",
     );
 
     const leagueFoundAnchor = `  if (!league) {\n    notFound();\n  }\n\n  const nightLabel = formatPreferredNight(league.dayOfWeek);`;

--- a/src/app/(admin)/admin/leads/import/actions.ts
+++ b/src/app/(admin)/admin/leads/import/actions.ts
@@ -17,6 +17,7 @@ export type ImportLeadsState = {
   processed: number;
   created: number;
   skipped: number;
+  skippedDetails: string[];
   errors: string[];
 };
 
@@ -26,6 +27,7 @@ const INITIAL_STATE: ImportLeadsState = {
   processed: 0,
   created: 0,
   skipped: 0,
+  skippedDetails: [],
   errors: [],
 };
 
@@ -398,6 +400,7 @@ export async function importLeadsAction(
       processed: rows.length,
       created: 0,
       skipped: rows.length,
+      skippedDetails: [],
       errors,
     };
   }
@@ -422,27 +425,60 @@ export async function importLeadsAction(
     ? await prisma.interestLead.findMany({
         where: { OR: duplicateWhere },
         select: {
+          id: true,
+          contactName: true,
           email: true,
+          phone: true,
           phoneNormalized: true,
         },
       })
     : [];
 
-  const existingEmailSet = new Set(
-    existingLeads.flatMap((lead) => (lead.email ? [normalizeEmail(lead.email)] : [])),
-  );
-  const existingPhoneSet = new Set(
-    existingLeads.flatMap((lead) => (lead.phoneNormalized ? [lead.phoneNormalized] : [])),
+  const duplicateMatches = validRows.flatMap((row) => {
+    const emailMatch = existingLeads.find(
+      (lead) => lead.email && normalizeEmail(lead.email) === row.email,
+    );
+    const phoneMatch = row.phoneNormalized
+      ? existingLeads.find((lead) => lead.phoneNormalized === row.phoneNormalized)
+      : undefined;
+
+    if (!emailMatch && !phoneMatch) return [];
+
+    const matchedLead = emailMatch ?? phoneMatch;
+    const sameExistingLead = Boolean(
+      emailMatch && phoneMatch && emailMatch.id === phoneMatch.id,
+    );
+
+    let reason = "matching existing lead";
+    if (emailMatch && phoneMatch && sameExistingLead) reason = "same email and phone";
+    else if (emailMatch && phoneMatch) reason = "email and phone match existing leads";
+    else if (emailMatch) reason = "same email";
+    else if (phoneMatch) reason = "same phone";
+
+    const existingName = matchedLead?.contactName?.trim() || "Existing lead";
+
+    return [
+      {
+        rowNumber: row.rowNumber,
+        detail:
+          existingName.toLowerCase() === row.contactName.trim().toLowerCase()
+            ? `${row.contactName} — skipped (${reason}).`
+            : `${row.contactName} — skipped (${reason}; existing lead: ${existingName}).`,
+      },
+    ];
+  });
+
+  const duplicateRowNumbers = new Set(
+    duplicateMatches.map((match) => match.rowNumber),
   );
 
   // Imports are deliberately duplicate-safe. A matching email OR normalized
   // phone is skipped so re-uploading a Meta export cannot create duplicate leads.
   const rowsToCreate = validRows.filter(
-    (row) =>
-      !existingEmailSet.has(row.email) &&
-      !(row.phoneNormalized && existingPhoneSet.has(row.phoneNormalized)),
+    (row) => !duplicateRowNumbers.has(row.rowNumber),
   );
 
+  const skippedDetails = duplicateMatches.map((match) => match.detail);
   const invalidCount = rows.length - validRows.length;
   const existingCount = validRows.length - rowsToCreate.length;
   const skipped = invalidCount + existingCount;
@@ -454,6 +490,7 @@ export async function importLeadsAction(
       processed: rows.length,
       created: 0,
       skipped,
+      skippedDetails,
       errors,
     };
   }
@@ -485,6 +522,7 @@ export async function importLeadsAction(
     processed: rows.length,
     created: result.count,
     skipped,
+    skippedDetails,
     errors,
   };
 }

--- a/src/components/admin/leads/ImportLeadsForm.tsx
+++ b/src/components/admin/leads/ImportLeadsForm.tsx
@@ -19,6 +19,7 @@ const initialState: ImportLeadsState = {
   processed: 0,
   created: 0,
   skipped: 0,
+  skippedDetails: [],
   errors: [],
 };
 
@@ -123,6 +124,20 @@ export default function ImportLeadsForm() {
               <span className="rounded-full border border-white/10 bg-black/15 px-3 py-1">{state.skipped} skipped</span>
             </div>
           ) : null}
+        </div>
+      ) : null}
+
+      {state.skippedDetails.length > 0 ? (
+        <div className="rounded-xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm text-sky-100">
+          <div className="font-semibold">Skipped existing leads</div>
+          <p className="mt-1 text-xs text-sky-100/65">
+            These rows were not imported because SIXFL found an existing lead with the same email address or phone number.
+          </p>
+          <ul className="mt-3 list-disc space-y-1.5 pl-5 text-sky-100/85">
+            {state.skippedDetails.map((detail, index) => (
+              <li key={`${index}-${detail}`}>{detail}</li>
+            ))}
+          </ul>
         </div>
       ) : null}
 


### PR DESCRIPTION
## Summary
- add detailed duplicate-skip information to CSV lead imports
- show the imported lead name and whether the existing match was by email, phone, or both
- show the existing lead name when it differs
- keep invalid CSV rows separate under Rows needing attention

Example: `Joe Bloggs — skipped (same phone; existing lead: Joseph Bloggs).`