### PR TITLE
Email players when their team referral is recorded

### DIFF
--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -13,6 +13,7 @@ import { queueDueRefereeNightConfirmationChasers } from "@/lib/referee-night-con
 import { queueDueRefereeNightReminderEmails } from "@/lib/referee-night-emails";
 import { syncPublishedFixtureRefereeNightAssignmentsAndRecalculate } from "@/lib/referee-night-assignment-sync";
 import { prisma } from "@/lib/prisma";
+import { queueMissingReferralRecordedEmails } from "@/lib/team-referral-notifications";
 
 export const dynamic = "force-dynamic";
 
@@ -70,13 +71,15 @@ export async function GET(request: NextRequest) {
     const refereeAssignmentSync = await syncUpcomingRefereeAssignmentsForConfirmations();
     const refereeNights = await queueDueRefereeNightReminderEmails();
     const refereeConfirmations = await queueDueRefereeNightConfirmationChasers();
+    const referralEmails = await queueMissingReferralRecordedEmails();
     const queuedDispatches =
       onboarding.queuedDispatches +
       fixtureConfirmations.queued +
       fixtureConfirmationEmails.queued +
       fixtureConfirmationWarnings.queued +
       refereeNights.queued +
-      refereeConfirmations.queued;
+      refereeConfirmations.queued +
+      referralEmails.queued;
     const result = await processNotificationQueue(
       Math.max(25, queuedDispatches + 25),
     );
@@ -104,6 +107,7 @@ export async function GET(request: NextRequest) {
       refereeAssignmentSync,
       refereeNights,
       refereeConfirmations,
+      referralEmails,
       matchdayAutoPay,
       ...result,
     });

--- a/src/lib/team-referral-notifications.ts
+++ b/src/lib/team-referral-notifications.ts
@@ -1,0 +1,175 @@
+import {
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+} from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import {
+  getNotificationRecipientBySource,
+  upsertNotificationRecipient,
+} from "@/lib/notifications/recipients";
+import { queueDirectNotification } from "@/lib/notifications/service";
+
+const REFERRAL_RECORDED_SOURCE = "team-referral-recorded";
+
+type ReferralNotificationRow = {
+  id: string;
+  referrerUserId: string;
+  referrerName: string | null;
+  referrerEmail: string | null;
+  leadName: string;
+  leadTeamName: string | null;
+  rewardPence: number;
+  requiredMatches: number;
+};
+
+function firstName(value?: string | null) {
+  return value?.trim().split(/\s+/)[0] || "there";
+}
+
+function money(pence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 0,
+  }).format(pence / 100);
+}
+
+export async function queueReferralRecordedEmail(referralId: string) {
+  const id = referralId.trim();
+  if (!id) return { queued: false, reason: "missing_referral_id" as const };
+
+  const alreadyQueued = await prisma.notificationDispatch.findFirst({
+    where: {
+      sourceType: REFERRAL_RECORDED_SOURCE,
+      sourceId: id,
+    },
+    select: { id: true },
+  });
+
+  if (alreadyQueued) {
+    return { queued: false, reason: "already_queued" as const };
+  }
+
+  const rows = await prisma.$queryRaw<ReferralNotificationRow[]>`
+    SELECT
+      r."id",
+      r."referrerUserId",
+      u."name" AS "referrerName",
+      u."email" AS "referrerEmail",
+      l."contactName" AS "leadName",
+      l."teamName" AS "leadTeamName",
+      r."rewardPence",
+      r."requiredMatches"
+    FROM "TeamReferral" r
+    INNER JOIN "User" u ON u."id" = r."referrerUserId"
+    INNER JOIN "InterestLead" l ON l."id" = r."interestLeadId"
+    WHERE r."id" = ${id}
+    LIMIT 1
+  `;
+
+  const referral = rows[0];
+  if (!referral) return { queued: false, reason: "not_found" as const };
+  if (!referral.referrerEmail?.trim()) {
+    return { queued: false, reason: "missing_email" as const };
+  }
+
+  const teamLabel = referral.leadTeamName?.trim() || referral.leadName?.trim() || "the team you referred";
+  const reward = money(referral.rewardPence);
+
+  const existingRecipient = await getNotificationRecipientBySource({
+    sourceType: NotificationRecipientSourceType.USER,
+    sourceId: referral.referrerUserId,
+  });
+
+  const recipient =
+    existingRecipient ??
+    (await upsertNotificationRecipient({
+      sourceType: NotificationRecipientSourceType.USER,
+      sourceId: referral.referrerUserId,
+      audience: NotificationAudience.USER,
+      displayName: referral.referrerName,
+      email: referral.referrerEmail,
+      transactionalEmailOptIn: true,
+      metadata: {
+        referralId: referral.id,
+      },
+    }));
+
+  await queueDirectNotification({
+    recipientId: recipient.id,
+    channel: NotificationChannel.EMAIL,
+    audience: NotificationAudience.USER,
+    subject: "Your SIXFL team referral has been recorded",
+    body: [
+      `Hi ${firstName(referral.referrerName)},`,
+      "",
+      `Thanks for referring ${teamLabel} to SIXFL. We have recorded your referral and SIXFL will track it automatically.`,
+      "",
+      "How the reward works:",
+      "• The referred team needs to join a SIXFL league.",
+      `• The ${reward} referral reward is payable after the team completes ${referral.requiredMatches} league matches.`,
+      "• Cancelled or postponed fixtures do not count towards the total.",
+      "",
+      "You can see the team's current progress at any time from your SIXFL referral page.",
+      "",
+      "{{cta}}",
+      "",
+      "Referral terms and conditions apply.",
+    ].join("\n"),
+    isTransactional: true,
+    sourceType: REFERRAL_RECORDED_SOURCE,
+    sourceId: referral.id,
+    metadata: {
+      event: "team_referral.recorded.email",
+      referralId: referral.id,
+      referredTeam: teamLabel,
+    },
+    emailCta: {
+      label: "Track my referral",
+      url: "https://www.sixfl.co.uk/player/referrals",
+    },
+  });
+
+  return { queued: true, reason: null };
+}
+
+export async function queueMissingReferralRecordedEmails(limit = 100) {
+  const safeLimit = Math.max(1, Math.min(Math.trunc(limit), 500));
+  const rows = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT r."id"
+    FROM "TeamReferral" r
+    INNER JOIN "User" u ON u."id" = r."referrerUserId"
+    WHERE r."paidAt" IS NULL
+      AND u."email" IS NOT NULL
+      AND BTRIM(u."email") <> ''
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${REFERRAL_RECORDED_SOURCE}
+          AND dispatch."sourceId" = r."id"
+      )
+    ORDER BY r."createdAt" ASC
+    LIMIT ${safeLimit}
+  `;
+
+  let queued = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    try {
+      const result = await queueReferralRecordedEmail(row.id);
+      if (result.queued) queued += 1;
+      else skipped += 1;
+    } catch (error) {
+      skipped += 1;
+      console.error(`Referral recorded email queue failed for ${row.id}:`, error);
+    }
+  }
+
+  return {
+    checked: rows.length,
+    queued,
+    skipped,
+  };
+}

--- a/src/lib/team-referrals.ts
+++ b/src/lib/team-referrals.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import { prisma } from "@/lib/prisma";
+import { queueReferralRecordedEmail } from "@/lib/team-referral-notifications";
 
 export const TEAM_REFERRAL_REWARD_PENCE = 7500;
 export const TEAM_REFERRAL_REQUIRED_MATCHES = 3;
@@ -64,16 +65,26 @@ export async function attachReferralToLead(input: {
   const referrerUserId = rows[0]?.userId;
   if (!referrerUserId) return false;
 
-  await prisma.$executeRaw`
+  const referralId = randomUUID();
+  const inserted = await prisma.$queryRaw<Array<{ id: string }>>`
     INSERT INTO "TeamReferral" (
       "id", "referrerUserId", "interestLeadId", "rewardPence", "requiredMatches", "updatedAt"
     )
     VALUES (
-      ${randomUUID()}, ${referrerUserId}, ${input.interestLeadId},
+      ${referralId}, ${referrerUserId}, ${input.interestLeadId},
       ${TEAM_REFERRAL_REWARD_PENCE}, ${TEAM_REFERRAL_REQUIRED_MATCHES}, CURRENT_TIMESTAMP
     )
     ON CONFLICT ("interestLeadId") DO NOTHING
+    RETURNING "id"
   `;
+
+  if (inserted[0]?.id) {
+    try {
+      await queueReferralRecordedEmail(inserted[0].id);
+    } catch (error) {
+      console.error("Referral confirmation email queue failed:", error);
+    }
+  }
 
   return true;
 }


### PR DESCRIPTION
Adds the missing transactional confirmation email for the SIXFL player who referred a team.

- when a new TeamReferral is created, email the referring player confirming it has been recorded
- explain the £75 reward becomes payable after 3 completed league matches
- explain cancelled/postponed fixtures do not count
- include a **Track my referral** button to `/player/referrals`
- prevent duplicate emails by recording each notification against the referral id
- the normal notifications job backfills existing **unpaid** referrals that have never received this email, so current referrers are included
- reuse an existing user notification recipient when present so this does not overwrite the player's notification/marketing preferences

**No Meta/Facebook/imported lead emails are added or sent by this change.**

No referral reward amount, match-counting, lead-import or payment rules are changed.