### PR TITLE
Move squad players directly into PlayerPool

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
+      - name: Check managed squad to PlayerPool handoff
+        run: node scripts/check-managed-squad-playerpool-handoff.mjs
+
       - name: Snapshot protected kit source
         run: |
           git diff --binary -- \

--- a/scripts/check-managed-squad-playerpool-handoff.mjs
+++ b/scripts/check-managed-squad-playerpool-handoff.mjs
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const moveRoutePath =
+  "src/app/api/captain/team/[teamid]/move-player-to-prospect/route.ts";
+const prospectRoutePath =
+  "src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts";
+const servicePath = "src/lib/player-pool/sendProspectToPlayerPool.ts";
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+const moveRoute = read(moveRoutePath);
+const prospectRoute = read(prospectRoutePath);
+const service = read(servicePath);
+const failures = [];
+
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+expect(
+  moveRoute,
+  'import { sendProspectToPlayerPool } from "@/lib/player-pool/sendProspectToPlayerPool";',
+  "Managed squad PlayerPool move must use the shared PlayerPool service.",
+);
+expect(
+  moveRoute,
+  "memberContext.user.email?.trim()",
+  "Managed squad PlayerPool move must reject missing email before removing the squad member.",
+);
+expect(
+  moveRoute,
+  "const result = await moveTeamMemberToProspect",
+  "Managed squad PlayerPool move must still remove the player from the active squad safely.",
+);
+expect(
+  moveRoute,
+  "const playerPool = await sendProspectToPlayerPool",
+  "Managed squad PlayerPool move must immediately create/reuse the PlayerPool profile.",
+);
+expect(
+  moveRoute,
+  "requestedLeagueId: memberContext.team.league?.id ?? null",
+  "Managed squad PlayerPool move must preserve the original team's league context.",
+);
+expect(
+  moveRoute,
+  'revalidatePath("/admin/player-pool")',
+  "Managed squad PlayerPool move must refresh the admin PlayerPool.",
+);
+expect(
+  prospectRoute,
+  "sendProspectToPlayerPool({",
+  "The player-prospects PlayerPool action must use the same shared service.",
+);
+expect(
+  service,
+  'FROM "PlayerPoolProfile"',
+  "Shared PlayerPool service must reuse existing profiles before creating another one.",
+);
+expect(
+  service,
+  "queueNotificationFromTemplate({",
+  "Shared PlayerPool service must preserve the normal profile-form invitation.",
+);
+
+if (failures.length) {
+  console.error("\nMANAGED SQUAD → PLAYERPOOL HANDOFF CHECK FAILED\n");
+  failures.forEach((failure) => console.error(` - ${failure}`));
+  process.exit(1);
+}
+
+console.log("Managed squad → PlayerPool handoff check passed.");

--- a/src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts
+++ b/src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts
@@ -2,40 +2,19 @@
 // File: src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts
 // ========================================
 
-import {
-  NotificationAudience,
-  NotificationRecipientSourceType,
-} from "@prisma/client";
 import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 
-import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
-import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
-import { queueNotificationFromTemplate } from "@/lib/notifications/service";
 import {
-  PLAYER_POOL_PROFILE_STATUSES,
-  createPlayerPoolId,
-  createPlayerPoolPublicCode,
-  createPlayerPoolToken,
   ensurePlayerPoolTables,
-  getPlayerPoolBaseUrl,
   normalizePlayerPoolEmail,
 } from "@/lib/player-pool/storage";
+import { sendProspectToPlayerPool } from "@/lib/player-pool/sendProspectToPlayerPool";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
-
-const PLAYER_POOL_PROFILE_INVITE_TEMPLATE_KEY =
-  "player-pool-profile-invite-email";
-
-type ExistingProfileRow = {
-  id: string;
-  prospectId: string;
-  profileToken: string;
-  publicCode: string;
-};
 
 type PlayerPoolStatusRow = {
   id: string;
@@ -55,19 +34,6 @@ function routeError(error: unknown) {
   return error instanceof Error && error.message.trim()
     ? error.message
     : "Something went wrong.";
-}
-
-function fullName(firstName: string, lastName: string | null) {
-  return [firstName, lastName].filter(Boolean).join(" ").trim();
-}
-
-function extractArea(...values: Array<string | null | undefined>) {
-  const text = values.filter(Boolean).join(" ");
-  const match = text.match(
-    /\bArea:\s*(.+?)(?=\s+(?:League type|Preferred nights|Source lead ID|Lead message):|$)/i,
-  );
-
-  return match?.[1]?.trim() || null;
 }
 
 export async function GET(
@@ -151,192 +117,39 @@ export async function POST(
 
   try {
     const { user } = await requireAdmin();
-    await ensurePlayerPoolTables();
-
     const body = (await request.json().catch(() => null)) as RequestBody | null;
     const requestedLeagueId =
       typeof body?.leagueId === "string" ? body.leagueId.trim() : "";
 
-    const [prospect, requestedLeague] = await Promise.all([
-      prisma.teamPlayerProspect.findUnique({
-        where: { id: prospectId },
-        select: {
-          id: true,
-          teamId: true,
-          firstName: true,
-          lastName: true,
-          email: true,
-          phone: true,
-          status: true,
-          notes: true,
-          availabilitySummary: true,
-          team: {
-            select: {
-              id: true,
-              name: true,
-              league: {
-                select: {
-                  id: true,
-                  name: true,
-                  area: true,
-                },
-              },
-            },
-          },
-        },
-      }),
-      requestedLeagueId
-        ? prisma.league.findUnique({
-            where: { id: requestedLeagueId },
-            select: { id: true, name: true, area: true },
-          })
-        : Promise.resolve(null),
-    ]);
-
-    if (!prospect) {
-      return NextResponse.json({ error: "Prospect not found." }, { status: 404 });
-    }
-
-    if (["DECLINED", "DUPLICATE"].includes(prospect.status)) {
-      return NextResponse.json(
-        { error: "This record is not currently eligible for PlayerPool." },
-        { status: 409 },
-      );
-    }
-
-    if (!prospect.email?.trim()) {
-      return NextResponse.json(
-        { error: "Add an email address before sending this player to PlayerPool." },
-        { status: 400 },
-      );
-    }
-
-    const effectiveLeague = requestedLeague ?? prospect.team?.league ?? null;
-    const email = normalizePlayerPoolEmail(prospect.email);
-    const displayName = fullName(prospect.firstName, prospect.lastName) || email;
-    const firstName = prospect.firstName.trim() || "there";
-    const area =
-      effectiveLeague?.area?.trim() ||
-      extractArea(prospect.notes, prospect.availabilitySummary);
-
-    const existingRows = await prisma.$queryRaw<ExistingProfileRow[]>`
-      SELECT "id", "prospectId", "profileToken", "publicCode"
-      FROM "PlayerPoolProfile"
-      WHERE "prospectId" = ${prospect.id}
-         OR "emailNormalized" = ${email}
-      ORDER BY CASE WHEN "prospectId" = ${prospect.id} THEN 0 ELSE 1 END
-      LIMIT 1
-    `;
-    const existingProfile = existingRows[0] ?? null;
-
-    const profileId = existingProfile?.id ?? createPlayerPoolId();
-    const profileToken = existingProfile?.profileToken ?? createPlayerPoolToken();
-    const publicCode = existingProfile?.publicCode ?? createPlayerPoolPublicCode();
-    const profileProspectId = existingProfile?.prospectId ?? prospect.id;
-
-    if (existingProfile) {
-      await prisma.$executeRaw`
-        UPDATE "PlayerPoolProfile"
-        SET
-          "emailNormalized" = ${email},
-          "area" = COALESCE("area", ${area}),
-          "leagueId" = COALESCE("leagueId", ${effectiveLeague?.id ?? null}),
-          "invitedAt" = NOW(),
-          "updatedAt" = NOW()
-        WHERE "id" = ${profileId}
-      `;
-    } else {
-      await prisma.$executeRaw`
-        INSERT INTO "PlayerPoolProfile" (
-          "id", "prospectId", "leadId", "profileToken", "publicCode",
-          "emailNormalized", "area", "leagueId", "status",
-          "invitedAt", "createdAt", "updatedAt"
-        ) VALUES (
-          ${profileId}, ${prospect.id}, NULL, ${profileToken}, ${publicCode},
-          ${email}, ${area}, ${effectiveLeague?.id ?? null}, ${PLAYER_POOL_PROFILE_STATUSES.INVITED},
-          NOW(), NOW(), NOW()
-        )
-      `;
-    }
-
-    const profileUrl = `${getPlayerPoolBaseUrl()}/player-pool/profile/${profileToken}`;
-    const leagueName = effectiveLeague?.name || "SIXFL PlayerPool";
-    const recipient = await upsertNotificationRecipient({
-      sourceType: NotificationRecipientSourceType.GENERAL,
-      sourceId: `player-pool-profile:${profileId}`,
-      audience: NotificationAudience.PLAYER,
-      displayName,
-      email,
-      phone: prospect.phone,
-      transactionalEmailOptIn: true,
-      transactionalSmsOptIn: true,
-      marketingEmailOptIn: false,
-      marketingSmsOptIn: false,
-      metadata: {
-        entityType: "PLAYER_POOL_PROFILE",
-        profileId,
-        prospectId: profileProspectId,
-        requestedProspectId: prospect.id,
-        publicCode,
-        leagueId: effectiveLeague?.id ?? null,
-        currentTeamId: prospect.teamId,
-        currentTeamName: prospect.team?.name ?? null,
-      },
-    });
-
-    const dispatch = await queueNotificationFromTemplate({
-      templateKey: PLAYER_POOL_PROFILE_INVITE_TEMPLATE_KEY,
-      recipientId: recipient.id,
-      variables: {
-        firstName,
-        fullName: displayName,
-        profileUrl,
-        publicCode,
-        area: area || "",
-        leagueName,
-      },
-      sourceType: "PLAYER_POOL_PROFILE_INVITE",
-      sourceId: profileId,
-      metadata: {
-        origin: "player_pool_profile_invite_from_prospect",
-        originLabel: "PlayerPool profile invitation sent from player prospects",
-        profileId,
-        prospectId: profileProspectId,
-        requestedProspectId: prospect.id,
-        publicCode,
-        leagueId: effectiveLeague?.id ?? null,
-        currentTeamId: prospect.teamId,
-        currentTeamName: prospect.team?.name ?? null,
-        ctaUrl: profileUrl,
-      },
+    const result = await sendProspectToPlayerPool({
+      prospectId,
+      requestedLeagueId: requestedLeagueId || null,
       createdByUserId: user?.id ?? null,
     });
 
-    await logNotificationDispatchToThread({ dispatch, recipient });
-    await prisma.teamPlayerProspect.update({
-      where: { id: prospect.id },
-      data: {
-        lastContactedAt: new Date(),
-        status: prospect.status === "NEW" ? "CONTACTED" : undefined,
-      },
-    });
-
     revalidatePath("/admin/player-prospects");
-    revalidatePath(`/admin/player-prospects/${prospect.id}/communications`);
+    revalidatePath(`/admin/player-prospects/${prospectId}/communications`);
     revalidatePath("/admin/player-pool");
     revalidatePath("/admin/messaging");
-    if (prospect.teamId) {
-      revalidatePath(`/captain/team/${prospect.teamId}/prospects`);
+    if (result.prospectTeamId) {
+      revalidatePath(`/captain/team/${result.prospectTeamId}/prospects`);
     }
 
     return NextResponse.json({
       ok: true,
-      created: !existingProfile,
-      message: existingProfile
-        ? `PlayerPool profile form resent.${prospect.teamId ? " Their current squad place has been kept." : ""}`
-        : `PlayerPool profile created and form sent.${prospect.teamId ? " Their current squad place has been kept." : ""}`,
+      created: result.created,
+      message: result.message,
     });
   } catch (error) {
-    return NextResponse.json({ error: routeError(error) }, { status: 500 });
+    const message = routeError(error);
+    const status = message === "Prospect not found."
+      ? 404
+      : message.includes("not currently eligible")
+        ? 409
+        : message.includes("Add an email address")
+          ? 400
+          : 500;
+
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/captain/team/[teamid]/move-player-to-prospect/route.ts
+++ b/src/app/api/captain/team/[teamid]/move-player-to-prospect/route.ts
@@ -6,9 +6,9 @@ import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 
 import { moveTeamMemberToProspect } from "@/lib/managed-squad/movePlayerToProspect";
+import { requireAdmin } from "@/lib/requireAdmin";
 import { sendProspectToPlayerPool } from "@/lib/player-pool/sendProspectToPlayerPool";
 import { prisma } from "@/lib/prisma";
-import { requireAdmin } from "@/lib/requireAdmin";
 
 type MoveBody = {
   membershipId?: unknown;
@@ -87,7 +87,7 @@ export async function POST(
 
     if (!result.ok) {
       return NextResponse.json(
-        { error: "Squad member could not be moved to PlayerPool." },
+        { error: "Squad member could not be moved to prospects." },
         { status: 404 },
       );
     }

--- a/src/app/api/captain/team/[teamid]/move-player-to-prospect/route.ts
+++ b/src/app/api/captain/team/[teamid]/move-player-to-prospect/route.ts
@@ -6,6 +6,8 @@ import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 
 import { moveTeamMemberToProspect } from "@/lib/managed-squad/movePlayerToProspect";
+import { sendProspectToPlayerPool } from "@/lib/player-pool/sendProspectToPlayerPool";
+import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 type MoveBody = {
@@ -28,13 +30,54 @@ export async function POST(
   const teamId = teamid;
 
   try {
-    await requireAdmin();
+    const { user } = await requireAdmin();
 
     const body = (await request.json().catch(() => null)) as MoveBody | null;
     const membershipId = String(body?.membershipId ?? "").trim();
 
     if (!membershipId) {
       return NextResponse.json({ error: "Missing player id." }, { status: 400 });
+    }
+
+    const memberContext = await prisma.teamMember.findFirst({
+      where: {
+        id: membershipId,
+        teamId,
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            email: true,
+          },
+        },
+        team: {
+          select: {
+            league: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!memberContext) {
+      return NextResponse.json(
+        { error: "Squad member could not be moved to PlayerPool." },
+        { status: 404 },
+      );
+    }
+
+    if (!memberContext.user.email?.trim()) {
+      return NextResponse.json(
+        {
+          error:
+            "Add an email address to this player before moving them to PlayerPool.",
+        },
+        { status: 400 },
+      );
     }
 
     const result = await moveTeamMemberToProspect({
@@ -44,16 +87,34 @@ export async function POST(
 
     if (!result.ok) {
       return NextResponse.json(
-        { error: "Squad member could not be moved to prospects." },
+        { error: "Squad member could not be moved to PlayerPool." },
         { status: 404 },
       );
     }
 
+    const playerPool = await sendProspectToPlayerPool({
+      prospectId: result.prospectId,
+      requestedLeagueId: memberContext.team.league?.id ?? null,
+      createdByUserId: user?.id ?? null,
+      origin: "player_pool_profile_invite_from_active_squad",
+      originLabel:
+        "PlayerPool profile invitation sent while moving a player from an active squad",
+    });
+
     revalidatePath(`/captain/team/${teamId}/squad`);
     revalidatePath(`/captain/team/${teamId}/prospects`);
-    revalidatePath(`/admin/player-prospects`);
+    revalidatePath(`/admin/teams/${teamId}/squad`);
+    revalidatePath("/admin/player-prospects");
+    revalidatePath("/admin/player-pool");
+    revalidatePath("/admin/messaging");
 
-    return NextResponse.json({ ok: true, prospectId: result.prospectId });
+    return NextResponse.json({
+      ok: true,
+      prospectId: result.prospectId,
+      playerPoolProfileId: playerPool.profileId,
+      playerPoolCreated: playerPool.created,
+      message: playerPool.message,
+    });
   } catch (error) {
     return NextResponse.json({ error: getRouteError(error) }, { status: 500 });
   }

--- a/src/lib/player-pool/sendProspectToPlayerPool.ts
+++ b/src/lib/player-pool/sendProspectToPlayerPool.ts
@@ -1,0 +1,224 @@
+import {
+  NotificationAudience,
+  NotificationRecipientSourceType,
+} from "@prisma/client";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import {
+  PLAYER_POOL_PROFILE_STATUSES,
+  createPlayerPoolId,
+  createPlayerPoolPublicCode,
+  createPlayerPoolToken,
+  ensurePlayerPoolTables,
+  getPlayerPoolBaseUrl,
+  normalizePlayerPoolEmail,
+} from "@/lib/player-pool/storage";
+import { prisma } from "@/lib/prisma";
+
+const PLAYER_POOL_PROFILE_INVITE_TEMPLATE_KEY =
+  "player-pool-profile-invite-email";
+
+type ExistingProfileRow = {
+  id: string;
+  prospectId: string;
+  profileToken: string;
+  publicCode: string;
+};
+
+function fullName(firstName: string, lastName: string | null) {
+  return [firstName, lastName].filter(Boolean).join(" ").trim();
+}
+
+function extractArea(...values: Array<string | null | undefined>) {
+  const text = values.filter(Boolean).join(" ");
+  const match = text.match(
+    /\bArea:\s*(.+?)(?=\s+(?:League type|Preferred nights|Source lead ID|Lead message):|$)/i,
+  );
+
+  return match?.[1]?.trim() || null;
+}
+
+export async function sendProspectToPlayerPool(input: {
+  prospectId: string;
+  requestedLeagueId?: string | null;
+  createdByUserId?: string | null;
+  origin?: string;
+  originLabel?: string;
+}) {
+  await ensurePlayerPoolTables();
+
+  const requestedLeagueId = input.requestedLeagueId?.trim() ?? "";
+  const [prospect, requestedLeague] = await Promise.all([
+    prisma.teamPlayerProspect.findUnique({
+      where: { id: input.prospectId },
+      select: {
+        id: true,
+        teamId: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        phone: true,
+        status: true,
+        notes: true,
+        availabilitySummary: true,
+        team: {
+          select: {
+            id: true,
+            name: true,
+            league: {
+              select: {
+                id: true,
+                name: true,
+                area: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    requestedLeagueId
+      ? prisma.league.findUnique({
+          where: { id: requestedLeagueId },
+          select: { id: true, name: true, area: true },
+        })
+      : Promise.resolve(null),
+  ]);
+
+  if (!prospect) {
+    throw new Error("Prospect not found.");
+  }
+
+  if (["DECLINED", "DUPLICATE"].includes(prospect.status)) {
+    throw new Error("This record is not currently eligible for PlayerPool.");
+  }
+
+  if (!prospect.email?.trim()) {
+    throw new Error(
+      "Add an email address before sending this player to PlayerPool.",
+    );
+  }
+
+  const effectiveLeague = requestedLeague ?? prospect.team?.league ?? null;
+  const email = normalizePlayerPoolEmail(prospect.email);
+  const displayName = fullName(prospect.firstName, prospect.lastName) || email;
+  const firstName = prospect.firstName.trim() || "there";
+  const area =
+    effectiveLeague?.area?.trim() ||
+    extractArea(prospect.notes, prospect.availabilitySummary);
+
+  const existingRows = await prisma.$queryRaw<ExistingProfileRow[]>`
+    SELECT "id", "prospectId", "profileToken", "publicCode"
+    FROM "PlayerPoolProfile"
+    WHERE "prospectId" = ${prospect.id}
+       OR "emailNormalized" = ${email}
+    ORDER BY CASE WHEN "prospectId" = ${prospect.id} THEN 0 ELSE 1 END
+    LIMIT 1
+  `;
+  const existingProfile = existingRows[0] ?? null;
+
+  const profileId = existingProfile?.id ?? createPlayerPoolId();
+  const profileToken = existingProfile?.profileToken ?? createPlayerPoolToken();
+  const publicCode = existingProfile?.publicCode ?? createPlayerPoolPublicCode();
+  const profileProspectId = existingProfile?.prospectId ?? prospect.id;
+
+  if (existingProfile) {
+    await prisma.$executeRaw`
+      UPDATE "PlayerPoolProfile"
+      SET
+        "emailNormalized" = ${email},
+        "area" = COALESCE("area", ${area}),
+        "leagueId" = COALESCE("leagueId", ${effectiveLeague?.id ?? null}),
+        "invitedAt" = NOW(),
+        "updatedAt" = NOW()
+      WHERE "id" = ${profileId}
+    `;
+  } else {
+    await prisma.$executeRaw`
+      INSERT INTO "PlayerPoolProfile" (
+        "id", "prospectId", "leadId", "profileToken", "publicCode",
+        "emailNormalized", "area", "leagueId", "status",
+        "invitedAt", "createdAt", "updatedAt"
+      ) VALUES (
+        ${profileId}, ${prospect.id}, NULL, ${profileToken}, ${publicCode},
+        ${email}, ${area}, ${effectiveLeague?.id ?? null}, ${PLAYER_POOL_PROFILE_STATUSES.INVITED},
+        NOW(), NOW(), NOW()
+      )
+    `;
+  }
+
+  const profileUrl = `${getPlayerPoolBaseUrl()}/player-pool/profile/${profileToken}`;
+  const leagueName = effectiveLeague?.name || "SIXFL PlayerPool";
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.GENERAL,
+    sourceId: `player-pool-profile:${profileId}`,
+    audience: NotificationAudience.PLAYER,
+    displayName,
+    email,
+    phone: prospect.phone,
+    transactionalEmailOptIn: true,
+    transactionalSmsOptIn: true,
+    marketingEmailOptIn: false,
+    marketingSmsOptIn: false,
+    metadata: {
+      entityType: "PLAYER_POOL_PROFILE",
+      profileId,
+      prospectId: profileProspectId,
+      requestedProspectId: prospect.id,
+      publicCode,
+      leagueId: effectiveLeague?.id ?? null,
+      currentTeamId: prospect.teamId,
+      currentTeamName: prospect.team?.name ?? null,
+    },
+  });
+
+  const dispatch = await queueNotificationFromTemplate({
+    templateKey: PLAYER_POOL_PROFILE_INVITE_TEMPLATE_KEY,
+    recipientId: recipient.id,
+    variables: {
+      firstName,
+      fullName: displayName,
+      profileUrl,
+      publicCode,
+      area: area || "",
+      leagueName,
+    },
+    sourceType: "PLAYER_POOL_PROFILE_INVITE",
+    sourceId: profileId,
+    metadata: {
+      origin: input.origin ?? "player_pool_profile_invite_from_prospect",
+      originLabel:
+        input.originLabel ??
+        "PlayerPool profile invitation sent from player prospects",
+      profileId,
+      prospectId: profileProspectId,
+      requestedProspectId: prospect.id,
+      publicCode,
+      leagueId: effectiveLeague?.id ?? null,
+      currentTeamId: prospect.teamId,
+      currentTeamName: prospect.team?.name ?? null,
+      ctaUrl: profileUrl,
+    },
+    createdByUserId: input.createdByUserId ?? null,
+  });
+
+  await logNotificationDispatchToThread({ dispatch, recipient });
+  await prisma.teamPlayerProspect.update({
+    where: { id: prospect.id },
+    data: {
+      lastContactedAt: new Date(),
+      status: prospect.status === "NEW" ? "CONTACTED" : undefined,
+    },
+  });
+
+  return {
+    created: !existingProfile,
+    profileId,
+    prospectId: prospect.id,
+    prospectTeamId: prospect.teamId,
+    message: existingProfile
+      ? `PlayerPool profile form resent.${prospect.teamId ? " Their current squad place has been kept." : ""}`
+      : `PlayerPool profile created and form sent.${prospect.teamId ? " Their current squad place has been kept." : ""}`,
+  };
+}


### PR DESCRIPTION
Fixes the managed-squad **Move to player pool** flow so it completes the PlayerPool handoff instead of stopping at an unassigned player prospect.

What changes:
- validates the squad member has an email before removing them from the team
- preserves the original team's league context
- removes the player from the active squad using the existing safe prospect conversion
- immediately creates or reuses their PlayerPool profile and queues the normal PlayerPool profile-form invitation
- refreshes Admin PlayerPool as part of the same operation
- extracts the existing prospect → PlayerPool implementation into one shared service, so both entry points use identical duplicate/reuse and invite behaviour
- adds a blocking regression contract for this exact squad → PlayerPool handoff

This does **not** alter Sam Logan or any existing prospect/player records. It fixes future uses of the button only.