### PR TITLE
Finish squad PlayerPool moves on PlayerPool

### DIFF
--- a/scripts/apply-player-removal-unpaid-fee-guard.cjs
+++ b/scripts/apply-player-removal-unpaid-fee-guard.cjs
@@ -314,6 +314,28 @@ patchFile("src/app/api/captain/team/[teamid]/move-managed-player/route.ts", (inp
   return source;
 });
 
+patchFile("src/components/captain/ManagedSquadEditLinks.tsx", (input) => {
+  const functionStart = input.indexOf("async function movePlayerToProspects(");
+  const functionEnd = input.indexOf("\nasync function markPlayerNotInterested(", functionStart);
+
+  if (functionStart < 0 || functionEnd < 0) {
+    throw new Error("Expected managed squad PlayerPool move function was not found.");
+  }
+
+  const beforeBlock = input.slice(0, functionStart);
+  const moveBlock = input.slice(functionStart, functionEnd);
+  const afterBlock = input.slice(functionEnd);
+  const currentDestination = 'window.location.href = "/admin/player-prospects";';
+  const playerPoolDestination = 'window.location.href = "/admin/player-pool";';
+
+  if (moveBlock.includes(playerPoolDestination)) return input;
+  if (!moveBlock.includes(currentDestination)) {
+    throw new Error("Expected managed squad PlayerPool success destination was not found.");
+  }
+
+  return `${beforeBlock}${moveBlock.replace(currentDestination, playerPoolDestination)}${afterBlock}`;
+});
+
 const verificationFiles = [
   "src/app/(admin)/admin/teams/[id]/squad/actions.ts",
   "src/lib/managed-squad/movePlayerToProspect.ts",
@@ -330,6 +352,25 @@ for (const relativePath of verificationFiles) {
   }
 }
 
+const managedSquadLinks = fs.readFileSync(
+  path.join(root, "src/components/captain/ManagedSquadEditLinks.tsx"),
+  "utf8",
+);
+const playerPoolMoveStart = managedSquadLinks.indexOf("async function movePlayerToProspects(");
+const playerPoolMoveEnd = managedSquadLinks.indexOf(
+  "\nasync function markPlayerNotInterested(",
+  playerPoolMoveStart,
+);
+const playerPoolMoveBlock = managedSquadLinks.slice(playerPoolMoveStart, playerPoolMoveEnd);
+if (
+  playerPoolMoveStart < 0 ||
+  playerPoolMoveEnd < 0 ||
+  !playerPoolMoveBlock.includes('window.location.href = "/admin/player-pool";') ||
+  playerPoolMoveBlock.includes('window.location.href = "/admin/player-prospects";')
+) {
+  throw new Error("Managed squad PlayerPool moves must finish on Admin PlayerPool.");
+}
+
 console.log(
-  "Players with open match fees cannot be removed, moved to another team, moved to the player pool, marked not interested or marked as duplicates until those fees are resolved.",
+  "Players with open match fees cannot be removed, moved to another team, moved to the player pool, marked not interested or marked as duplicates until those fees are resolved. Successful PlayerPool moves finish on Admin PlayerPool.",
 );

--- a/scripts/check-managed-squad-playerpool-handoff.mjs
+++ b/scripts/check-managed-squad-playerpool-handoff.mjs
@@ -7,6 +7,8 @@ const moveRoutePath =
 const prospectRoutePath =
   "src/app/api/admin/player-prospects/[prospectId]/player-pool/route.ts";
 const servicePath = "src/lib/player-pool/sendProspectToPlayerPool.ts";
+const managedSquadLinksPath =
+  "src/components/captain/ManagedSquadEditLinks.tsx";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(root, relativePath), "utf8");
@@ -15,6 +17,7 @@ function read(relativePath) {
 const moveRoute = read(moveRoutePath);
 const prospectRoute = read(prospectRoutePath);
 const service = read(servicePath);
+const managedSquadLinks = read(managedSquadLinksPath);
 const failures = [];
 
 function expect(source, marker, message) {
@@ -66,6 +69,34 @@ expect(
   "queueNotificationFromTemplate({",
   "Shared PlayerPool service must preserve the normal profile-form invitation.",
 );
+
+const moveFunctionStart = managedSquadLinks.indexOf(
+  "async function movePlayerToProspects(",
+);
+const moveFunctionEnd = managedSquadLinks.indexOf(
+  "\nasync function markPlayerNotInterested(",
+  moveFunctionStart,
+);
+if (moveFunctionStart < 0 || moveFunctionEnd < 0) {
+  failures.push("Managed squad PlayerPool move UI function must remain available.");
+} else {
+  const moveFunction = managedSquadLinks.slice(moveFunctionStart, moveFunctionEnd);
+  expect(
+    moveFunction,
+    "/move-player-to-prospect",
+    "Managed squad PlayerPool button must call the direct PlayerPool handoff endpoint.",
+  );
+  expect(
+    moveFunction,
+    'window.location.href = "/admin/player-pool";',
+    "Successful managed squad PlayerPool moves must finish on Admin PlayerPool.",
+  );
+  if (moveFunction.includes('window.location.href = "/admin/player-prospects";')) {
+    failures.push(
+      "Successful managed squad PlayerPool moves must not redirect back to Player Prospects.",
+    );
+  }
+}
 
 if (failures.length) {
   console.error("\nMANAGED SQUAD → PLAYERPOOL HANDOFF CHECK FAILED\n");


### PR DESCRIPTION
Completes the managed-squad → PlayerPool fix by correcting the post-success destination.

The backend already now removes the player safely and creates/reuses their PlayerPool profile. This change makes the old managed-squad UI finish on **Admin → PlayerPool** instead of redirecting to **Player Prospects**, which made a successful move look as though it had stopped halfway.

Implementation:
- leaves the legacy DOM-mutating `ManagedSquadEditLinks.tsx` untouched in the PR source diff
- updates it only through the existing production source-preparation compatibility script
- scopes the replacement to the `movePlayerToProspects` function only
- keeps the existing unpaid-fee removal safeguards intact
- expands the post-prebuild regression check to require `/admin/player-pool` and reject the old `/admin/player-prospects` success destination

No player records or PlayerPool data are changed by this PR.