### PR TITLE
Recover missed referral confirmation emails

### DIFF
--- a/src/lib/team-referral-notifications.ts
+++ b/src/lib/team-referral-notifications.ts
@@ -11,6 +11,7 @@ import {
 import { queueDirectNotification } from "@/lib/notifications/service";
 
 const REFERRAL_RECORDED_SOURCE = "team-referral-recorded";
+const RECOVERABLE_MISSING_EMAIL_REASON = "Recipient has no email address.";
 
 type ReferralNotificationRow = {
   id: string;
@@ -35,20 +36,89 @@ function money(pence: number) {
   }).format(pence / 100);
 }
 
+async function getReferralNotificationRecipient(referral: ReferralNotificationRow) {
+  const currentEmail = referral.referrerEmail?.trim() || null;
+  if (!currentEmail) return null;
+
+  const existingRecipient = await getNotificationRecipientBySource({
+    sourceType: NotificationRecipientSourceType.USER,
+    sourceId: referral.referrerUserId,
+  });
+
+  if (!existingRecipient) {
+    return upsertNotificationRecipient({
+      sourceType: NotificationRecipientSourceType.USER,
+      sourceId: referral.referrerUserId,
+      audience: NotificationAudience.USER,
+      displayName: referral.referrerName,
+      email: currentEmail,
+      transactionalEmailOptIn: true,
+      metadata: {
+        referralId: referral.id,
+      },
+    });
+  }
+
+  const storedEmail = existingRecipient.email?.trim() || null;
+  const storedName = existingRecipient.displayName?.trim() || null;
+  const currentName = referral.referrerName?.trim() || null;
+  const emailChanged = storedEmail?.toLowerCase() !== currentEmail.toLowerCase();
+  const nameChanged = storedName !== currentName;
+
+  if (!emailChanged && !nameChanged) return existingRecipient;
+
+  // Keep suppression and notification preferences exactly as they are. Only
+  // refresh identity fields from the current User record so transactional
+  // messages are not sent to a stale or missing recipient email address.
+  return prisma.notificationRecipient.update({
+    where: { id: existingRecipient.id },
+    data: {
+      displayName: currentName,
+      email: currentEmail,
+      emailNormalized: currentEmail.toLowerCase(),
+      lastSyncedAt: new Date(),
+    },
+    include: {
+      preferences: true,
+    },
+  });
+}
+
 export async function queueReferralRecordedEmail(referralId: string) {
   const id = referralId.trim();
   if (!id) return { queued: false, reason: "missing_referral_id" as const };
 
-  const alreadyQueued = await prisma.notificationDispatch.findFirst({
+  // Only a live/successful dispatch should make this referral permanently
+  // idempotent. A FAILED dispatch or a recoverable SKIPPED dispatch must be
+  // allowed to try again after the underlying problem has been corrected.
+  const activeOrSentDispatch = await prisma.notificationDispatch.findFirst({
     where: {
       sourceType: REFERRAL_RECORDED_SOURCE,
       sourceId: id,
+      status: { in: ["QUEUED", "PROCESSING", "SENT"] },
     },
     select: { id: true },
   });
 
-  if (alreadyQueued) {
+  if (activeOrSentDispatch) {
     return { queued: false, reason: "already_queued" as const };
+  }
+
+  const latestSkippedDispatch = await prisma.notificationDispatch.findFirst({
+    where: {
+      sourceType: REFERRAL_RECORDED_SOURCE,
+      sourceId: id,
+      status: "SKIPPED",
+    },
+    orderBy: { createdAt: "desc" },
+    select: { failureReason: true },
+  });
+
+  if (
+    latestSkippedDispatch &&
+    latestSkippedDispatch.failureReason !== RECOVERABLE_MISSING_EMAIL_REASON
+  ) {
+    return { queued: false, reason: "recipient_blocked" as const };
   }
 
   const rows = await prisma.$queryRaw<ReferralNotificationRow[]>`
@@ -74,29 +144,18 @@ export async function queueReferralRecordedEmail(referralId: string) {
     return { queued: false, reason: "missing_email" as const };
   }
 
-  const teamLabel = referral.leadTeamName?.trim() || referral.leadName?.trim() || "the team you referred";
+  const teamLabel =
+    referral.leadTeamName?.trim() ||
+    referral.leadName?.trim() ||
+    "the team you referred";
   const reward = money(referral.rewardPence);
+  const recipient = await getReferralNotificationRecipient(referral);
 
-  const existingRecipient = await getNotificationRecipientBySource({
-    sourceType: NotificationRecipientSourceType.USER,
-    sourceId: referral.referrerUserId,
-  });
+  if (!recipient) {
+    return { queued: false, reason: "missing_email" as const };
+  }
 
-  const recipient =
-    existingRecipient ??
-    (await upsertNotificationRecipient({
-      sourceType: NotificationRecipientSourceType.USER,
-      sourceId: referral.referrerUserId,
-      audience: NotificationAudience.USER,
-      displayName: referral.referrerName,
-      email: referral.referrerEmail,
-      transactionalEmailOptIn: true,
-      metadata: {
-        referralId: referral.id,
-      },
-    }));
-
-  await queueDirectNotification({
+  const dispatch = await queueDirectNotification({
     recipientId: recipient.id,
     channel: NotificationChannel.EMAIL,
     audience: NotificationAudience.USER,
@@ -131,6 +190,13 @@ export async function queueReferralRecordedEmail(referralId: string) {
     },
   });
 
+  if (dispatch.status !== "QUEUED") {
+    return {
+      queued: false,
+      reason: dispatch.status === "SKIPPED" ? "recipient_blocked" : "not_queued",
+    } as const;
+  }
+
   return { queued: true, reason: null };
 }
 
@@ -148,6 +214,15 @@ export async function queueMissingReferralRecordedEmails(limit = 100) {
         FROM "NotificationDispatch" dispatch
         WHERE dispatch."sourceType" = ${REFERRAL_RECORDED_SOURCE}
           AND dispatch."sourceId" = r."id"
+          AND dispatch."status" IN ('QUEUED', 'PROCESSING', 'SENT')
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${REFERRAL_RECORDED_SOURCE}
+          AND dispatch."sourceId" = r."id"
+          AND dispatch."status" = 'SKIPPED'
+          AND COALESCE(dispatch."failureReason", '') <> ${RECOVERABLE_MISSING_EMAIL_REASON}
       )
     ORDER BY r."createdAt" ASC
     LIMIT ${safeLimit}


### PR DESCRIPTION
Fixes referral confirmation emails that can become permanently stuck after a skipped or failed first attempt.

What changes:
- refreshes the notification-recipient email/name from the current SIXFL User record before queuing the referral email
- preserves the recipient's existing suppression state and notification preferences
- only treats QUEUED, PROCESSING or SENT referral dispatches as successfully handled
- allows a previous missing-email SKIPPED dispatch to recover once the account has a valid email
- allows failed attempts to be picked up again by the normal notifications backfill
- keeps deliberately blocked/suppressed/disabled email states blocked rather than repeatedly retrying them
- checks the dispatch result instead of claiming an email was queued when the notification service actually skipped it

This does not change the £75 referral reward or three-match rule.