### PR TITLE
Allow captains to remove privately resolved collections

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Check admin referral email status
         run: node scripts/check-admin-referral-email-status.mjs
 
+      - name: Check captain collection removal
+        run: node scripts/check-captain-collected-removal.mjs
+
       - name: Snapshot protected kit source
         run: |
           git diff --binary -- \

--- a/scripts/check-captain-collected-removal.mjs
+++ b/scripts/check-captain-collected-removal.mjs
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+const panelPath = "src/components/captain/CaptainCollectedRemittancePanel.tsx";
+const routePath = "src/app/captain/team/[teamid]/payments/remove-collected/route.ts";
+const remittancePath = "src/lib/payments/captain-collected-remittance.ts";
+
+const panel = read(panelPath);
+const route = read(routePath);
+const remittance = read(remittancePath);
+
+expect(panel, "Remove from captain collection", "Captain payments must expose the removal action.");
+expect(panel, "sorted that money out between yourselves", "Captain payments must explain when removal should be used.");
+expect(panel, "remittedPence === 0", "The UI must hide removal after money has reached SIXFL.");
+expect(panel, "!hasPendingCheckout", "The UI must hide removal while Stripe checkout is pending.");
+expect(panel, "Previously removed from captain collection", "Removed collections must stay visible in audit history.");
+expect(panel, "did not reduce the fixture balance", "Audit history must say removal does not reduce the fixture balance.");
+
+expect(route, "snapshot.pendingPence > 0", "Server must block removal while Stripe checkout is pending.");
+expect(route, "snapshot.remittedPence > 0", "Server must block removal after money has reached SIXFL.");
+expect(route, "CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER", "Server must append an auditable private-resolution marker.");
+expect(route, "Captain and player resolved this privately", "Server audit must record the private resolution reason.");
+expect(route, "the SIXFL fixture balance was not reduced", "Server audit must preserve the fixture-balance meaning.");
+
+expect(remittance, "isCaptainCollectionActiveNote", "Captain-collected totals must distinguish active from removed history.");
+expect(remittance, "isCaptainCollectionRemovedNote", "Captain-collected totals must retain removed history.");
+expect(remittance, "removedPence", "Captain-collected snapshots must expose removed amounts for audit display.");
+expect(remittance, "removalNotes", "Captain-collected snapshots must expose the removal audit notes.");
+
+if (route.includes("paymentCharge.update") || route.includes('UPDATE "PaymentCharge"')) {
+  failures.push("Removing captain collection must never rewrite the fixture PaymentCharge.");
+}
+
+if (failures.length) {
+  console.error("\nCAPTAIN COLLECTION REMOVAL CHECK FAILED\n");
+  failures.forEach((failure) => console.error(` - ${failure}`));
+  process.exit(1);
+}
+
+console.log("Captain collection removal safeguards passed.");

--- a/src/app/captain/team/[teamid]/payments/remove-collected/route.ts
+++ b/src/app/captain/team/[teamid]/payments/remove-collected/route.ts
@@ -1,0 +1,130 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import {
+  CAPTAIN_COLLECTED_NOTE_MARKERS,
+  CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER,
+  getCaptainCollectedRemittanceSnapshot,
+  isCaptainCollectionActiveNote,
+} from "@/lib/payments/captain-collected-remittance";
+import { formatPaymentMoney, getTeamPaymentLedger } from "@/lib/payments/team-payment-ledger";
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getPublicSiteUrl } from "@/lib/stripe/client";
+
+export const dynamic = "force-dynamic";
+
+function paymentsUrl(teamId: string, values?: Record<string, string>) {
+  const url = new URL(`/captain/team/${teamId}/payments`, `${getPublicSiteUrl()}/`);
+  for (const [key, value] of Object.entries(values ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  return url;
+}
+
+function actorLabel(access: Awaited<ReturnType<typeof requireCaptain>>) {
+  return access.user?.name?.trim() || access.user?.email?.trim() || "captain";
+}
+
+function appendAuditNote(existingNote: string | null, auditLine: string) {
+  const current = existingNote?.trim();
+  return current ? `${current}\n${auditLine}` : auditLine;
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await context.params;
+  const access = await requireCaptain(teamid);
+  const formData = await request.formData();
+  const chargeId = String(formData.get("chargeId") ?? "").trim();
+
+  if (!chargeId) {
+    return NextResponse.redirect(paymentsUrl(teamid, { captainCollection: "invalid" }), 303);
+  }
+
+  const ledger = await getTeamPaymentLedger(teamid);
+  const entry = ledger?.entries.find((candidate) => candidate.chargeId === chargeId) ?? null;
+
+  if (!ledger || !entry || !entry.fixtureId || entry.displayStatus === "VOID") {
+    return NextResponse.redirect(paymentsUrl(teamid, { captainCollection: "invalid" }), 303);
+  }
+
+  const snapshot = await getCaptainCollectedRemittanceSnapshot({
+    chargeId: entry.chargeId,
+    teamId: entry.teamId,
+    fixtureId: entry.fixtureId,
+  });
+
+  if (snapshot.pendingPence > 0) {
+    return NextResponse.redirect(paymentsUrl(teamid, { captainCollection: "pending" }), 303);
+  }
+
+  if (snapshot.remittedPence > 0) {
+    return NextResponse.redirect(
+      paymentsUrl(teamid, { captainCollection: "already_remitted" }),
+      303,
+    );
+  }
+
+  if (snapshot.collectedPence <= 0 || snapshot.unremittedPence <= 0) {
+    return NextResponse.redirect(
+      paymentsUrl(teamid, { captainCollection: "not_available" }),
+      303,
+    );
+  }
+
+  const collectedFees = await prisma.playerMatchFee.findMany({
+    where: {
+      teamId: entry.teamId,
+      fixtureId: entry.fixtureId,
+      status: "WAIVED",
+      OR: CAPTAIN_COLLECTED_NOTE_MARKERS.map((marker) => ({
+        note: { contains: marker, mode: "insensitive" as const },
+      })),
+    },
+    select: { id: true, amountPence: true, note: true },
+  });
+
+  const activeFees = collectedFees.filter((fee) => isCaptainCollectionActiveNote(fee.note));
+  if (activeFees.length === 0) {
+    return NextResponse.redirect(
+      paymentsUrl(teamid, { captainCollection: "not_available" }),
+      303,
+    );
+  }
+
+  const removedAt = new Date();
+  const removedAtLabel = formatDateTimeInLondon(removedAt, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const actionedBy = actorLabel(access);
+
+  await prisma.$transaction(
+    activeFees.map((fee) => {
+      const auditLine = `${CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER}. ${formatPaymentMoney(fee.amountPence)} was removed by ${actionedBy} on ${removedAtLabel}. Captain and player resolved this privately; the SIXFL fixture balance was not reduced.`;
+      return prisma.playerMatchFee.update({
+        where: { id: fee.id },
+        data: { note: appendAuditNote(fee.note, auditLine) },
+      });
+    }),
+  );
+
+  revalidatePath(`/captain/team/${teamid}/payments`);
+  revalidatePath(`/captain/team/${teamid}/player-payments`);
+  revalidatePath(`/captain/team/${teamid}`);
+
+  return NextResponse.redirect(
+    paymentsUrl(teamid, {
+      captainCollection: "removed",
+      collectionAmount: String(snapshot.unremittedPence),
+    }),
+    303,
+  );
+}

--- a/src/components/captain/CaptainCollectedRemittancePanel.tsx
+++ b/src/components/captain/CaptainCollectedRemittancePanel.tsx
@@ -35,7 +35,12 @@ export default async function CaptainCollectedRemittancePanel({
   const rows = fixtureEntries
     .map((entry) => {
       const snapshot = snapshots.get(entry.chargeId);
-      if (!snapshot || snapshot.collectedPence <= 0) return null;
+      if (
+        !snapshot ||
+        (snapshot.collectedPence <= 0 && snapshot.removedPence <= 0)
+      ) {
+        return null;
+      }
 
       const amountAvailableToRemitPence = Math.min(
         snapshot.availablePence,
@@ -56,7 +61,10 @@ export default async function CaptainCollectedRemittancePanel({
     })
     .filter((row): row is NonNullable<typeof row> => Boolean(row));
 
-  if (rows.length === 0) return null;
+  const activeRows = rows.filter((row) => row.snapshot.collectedPence > 0);
+  const removedRows = rows.filter((row) => row.snapshot.removedPence > 0);
+
+  if (activeRows.length === 0 && removedRows.length === 0) return null;
 
   return (
     <section className="rounded-3xl border border-cyan-400/25 bg-cyan-500/[0.08] p-5 sm:p-6">
@@ -64,228 +72,280 @@ export default async function CaptainCollectedRemittancePanel({
         Money collected by captain
       </p>
       <h2 className="mt-2 text-2xl font-semibold text-white">
-        Settle player money collected by the captain
+        {activeRows.length > 0
+          ? "Settle player money collected by the captain"
+          : "Captain-collected money history"}
       </h2>
       <p className="mt-2 max-w-4xl text-sm leading-6 text-cyan-50/70">
         These amounts come from players marked <strong>Paid captain directly</strong>. For each fixture, either pass the collected money to SIXFL or use available team credit instead. Your own player link and any other open player links stay separate.
       </p>
 
-      <div className="mt-4 max-w-4xl rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/65">
-        <strong className="text-white/85">When to use “Remove from captain collection”:</strong>{" "}
-        use it only if you and the player have sorted that money out between yourselves — for example, you returned the money or agreed a different private arrangement — so you no longer hold it to pass to SIXFL. Removing it does <strong>not</strong> reduce the fixture balance and is not a refund. If a Stripe checkout is pending, cancel that first; money already passed to SIXFL cannot be removed this way.
-      </div>
+      {activeRows.length > 0 ? (
+        <div className="mt-4 max-w-4xl rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/65">
+          <strong className="text-white/85">When to use “Remove from captain collection”:</strong>{" "}
+          use it only if you and the player have sorted that money out between yourselves — for example, you returned the money or agreed a different private arrangement — so you no longer hold it to pass to SIXFL. Removing it does <strong>not</strong> reduce the fixture balance and is not a refund. If a Stripe checkout is pending, cancel that first; money already passed to SIXFL cannot be removed this way.
+        </div>
+      ) : null}
 
-      {creditBalancePence > 0 ? (
+      {creditBalancePence > 0 && activeRows.length > 0 ? (
         <div className="mt-3 inline-flex rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-50">
           Team credit available: {formatMoney(creditBalancePence)}
         </div>
       ) : null}
 
-      <div className="mt-5 space-y-4">
-        {rows.map(({ entry, snapshot, amountAvailableToRemitPence, creditAvailableForCollectedPence }) => {
-          const heldButNotRemittedPence = snapshot.unremittedPence;
-          const cappedByOutstanding =
-            snapshot.availablePence > amountAvailableToRemitPence;
-          const hasPendingCheckout = snapshot.pendingPence > 0;
-          const canRemoveFromCaptainCollection =
-            snapshot.remittedPence === 0 &&
-            !hasPendingCheckout &&
-            snapshot.unremittedPence > 0;
+      {activeRows.length > 0 ? (
+        <div className="mt-5 space-y-4">
+          {activeRows.map(({ entry, snapshot, amountAvailableToRemitPence, creditAvailableForCollectedPence }) => {
+            const heldButNotRemittedPence = snapshot.unremittedPence;
+            const cappedByOutstanding =
+              snapshot.availablePence > amountAvailableToRemitPence;
+            const hasPendingCheckout = snapshot.pendingPence > 0;
+            const canRemoveFromCaptainCollection =
+              snapshot.remittedPence === 0 &&
+              !hasPendingCheckout &&
+              snapshot.unremittedPence > 0;
 
-          return (
-            <article
-              key={entry.chargeId}
-              className="rounded-2xl border border-white/10 bg-black/25 p-4 sm:p-5"
-            >
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                <div className="min-w-0">
-                  <div className="font-semibold text-white">{entry.fixtureLabel}</div>
-                  <div className="mt-1 text-sm text-white/50">
-                    {entry.kickoffAt
-                      ? formatPaymentFixtureDate(entry.kickoffAt)
-                      : "Fixture date not set"}
-                  </div>
-
-                  <div className="mt-4 flex flex-wrap gap-2 text-xs">
-                    <span className="rounded-full border border-cyan-300/20 bg-cyan-400/10 px-3 py-1 text-cyan-50">
-                      Captain collected {formatMoney(snapshot.collectedPence)} from {snapshot.collectedPlayerCount} player{snapshot.collectedPlayerCount === 1 ? "" : "s"}
-                    </span>
-                    {snapshot.remittedPence > 0 ? (
-                      <span className="rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-emerald-50">
-                        Already passed to SIXFL {formatMoney(snapshot.remittedPence)}
-                      </span>
-                    ) : null}
-                    {snapshot.pendingPence > 0 ? (
-                      <span className="rounded-full border border-amber-300/20 bg-amber-400/10 px-3 py-1 text-amber-50">
-                        Stripe checkout pending {formatMoney(snapshot.pendingPence)}
-                      </span>
-                    ) : null}
-                    {creditAvailableForCollectedPence > 0 ? (
-                      <span className="rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-emerald-50">
-                        Credit can cover {formatMoney(creditAvailableForCollectedPence)}
-                      </span>
-                    ) : null}
-                    <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-white/65">
-                      Fixture outstanding {formatMoney(entry.outstandingPence)}
-                    </span>
-                  </div>
-
-                  {cappedByOutstanding ? (
-                    <p className="mt-3 text-xs leading-5 text-amber-100/80">
-                      {amountAvailableToRemitPence > 0 ? (
-                        <>
-                          You still hold {formatMoney(heldButNotRemittedPence)} recorded as collected. Only {formatMoney(amountAvailableToRemitPence)} needs to be settled against this fixture. {hasPendingCheckout
-                            ? "The rest of the balance is already covered or has a Stripe checkout pending."
-                            : "The rest of the fixture balance has already been covered."}
-                        </>
-                      ) : (
-                        <>
-                          You still hold {formatMoney(heldButNotRemittedPence)} recorded as collected. {hasPendingCheckout
-                            ? "No further payment is due while a Stripe checkout is holding the remaining amount. You can cancel that checkout below if you want to pay a different way."
-                            : "No further payment is due for this fixture because its balance has already been fully covered."}
-                        </>
-                      )}
-                    </p>
-                  ) : null}
-                </div>
-
-                <div className="w-full shrink-0 lg:w-[310px]">
-                  {hasPendingCheckout ? (
-                    <div className="rounded-2xl border border-amber-300/20 bg-amber-400/10 p-3 text-sm text-amber-50">
-                      <p>
-                        A Stripe checkout for this collected money is still in progress. Cancel it to release the amount and choose again.
-                      </p>
-                      <form
-                        action={`/captain/team/${teamId}/payments/remit-collected/cancel`}
-                        method="post"
-                        className="mt-3"
-                      >
-                        <input type="hidden" name="chargeId" value={entry.chargeId} />
-                        <button
-                          type="submit"
-                          className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-amber-200/30 bg-amber-300 px-4 py-2.5 text-sm font-black text-black transition hover:bg-amber-200"
-                        >
-                          Cancel pending checkout
-                        </button>
-                      </form>
+            return (
+              <article
+                key={entry.chargeId}
+                className="rounded-2xl border border-white/10 bg-black/25 p-4 sm:p-5"
+              >
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="font-semibold text-white">{entry.fixtureLabel}</div>
+                    <div className="mt-1 text-sm text-white/50">
+                      {entry.kickoffAt
+                        ? formatPaymentFixtureDate(entry.kickoffAt)
+                        : "Fixture date not set"}
                     </div>
-                  ) : amountAvailableToRemitPence > 0 ? (
-                    <>
-                      {creditAvailableForCollectedPence > 0 ? (
-                        <>
-                          <form
-                            action={`/captain/team/${teamId}/payments/use-credit-for-collected`}
-                            method="post"
-                          >
-                            <input type="hidden" name="chargeId" value={entry.chargeId} />
-                            <button
-                              type="submit"
-                              className="inline-flex min-h-12 w-full items-center justify-center rounded-2xl bg-emerald-300 px-4 py-3 text-sm font-black text-black transition hover:bg-emerald-200"
-                            >
-                              Use {formatMoney(creditAvailableForCollectedPence)} team credit instead
-                            </button>
-                          </form>
-                          <div className="my-2 text-center text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">
-                            or
-                          </div>
-                        </>
+
+                    <div className="mt-4 flex flex-wrap gap-2 text-xs">
+                      <span className="rounded-full border border-cyan-300/20 bg-cyan-400/10 px-3 py-1 text-cyan-50">
+                        Captain collected {formatMoney(snapshot.collectedPence)} from {snapshot.collectedPlayerCount} player{snapshot.collectedPlayerCount === 1 ? "" : "s"}
+                      </span>
+                      {snapshot.remittedPence > 0 ? (
+                        <span className="rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-emerald-50">
+                          Already passed to SIXFL {formatMoney(snapshot.remittedPence)}
+                        </span>
                       ) : null}
+                      {snapshot.pendingPence > 0 ? (
+                        <span className="rounded-full border border-amber-300/20 bg-amber-400/10 px-3 py-1 text-amber-50">
+                          Stripe checkout pending {formatMoney(snapshot.pendingPence)}
+                        </span>
+                      ) : null}
+                      {creditAvailableForCollectedPence > 0 ? (
+                        <span className="rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-emerald-50">
+                          Credit can cover {formatMoney(creditAvailableForCollectedPence)}
+                        </span>
+                      ) : null}
+                      <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-white/65">
+                        Fixture outstanding {formatMoney(entry.outstandingPence)}
+                      </span>
+                    </div>
 
-                      <form
-                        action={`/captain/team/${teamId}/payments/remit-collected`}
-                        method="post"
-                      >
-                        <input type="hidden" name="chargeId" value={entry.chargeId} />
-                        <input
-                          type="hidden"
-                          name="amount"
-                          value={(amountAvailableToRemitPence / 100).toFixed(2)}
-                        />
-                        <button
-                          type="submit"
-                          className="inline-flex min-h-12 w-full items-center justify-center rounded-2xl bg-cyan-300 px-4 py-3 text-sm font-black text-black transition hover:bg-cyan-200"
+                    {cappedByOutstanding ? (
+                      <p className="mt-3 text-xs leading-5 text-amber-100/80">
+                        {amountAvailableToRemitPence > 0 ? (
+                          <>
+                            You still hold {formatMoney(heldButNotRemittedPence)} recorded as collected. Only {formatMoney(amountAvailableToRemitPence)} needs to be settled against this fixture. {hasPendingCheckout
+                              ? "The rest of the balance is already covered or has a Stripe checkout pending."
+                              : "The rest of the fixture balance has already been covered."}
+                          </>
+                        ) : (
+                          <>
+                            You still hold {formatMoney(heldButNotRemittedPence)} recorded as collected. {hasPendingCheckout
+                              ? "No further payment is due while a Stripe checkout is holding the remaining amount. You can cancel that checkout below if you want to pay a different way."
+                              : "No further payment is due for this fixture because its balance has already been fully covered."}
+                          </>
+                        )}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div className="w-full shrink-0 lg:w-[310px]">
+                    {hasPendingCheckout ? (
+                      <div className="rounded-2xl border border-amber-300/20 bg-amber-400/10 p-3 text-sm text-amber-50">
+                        <p>
+                          A Stripe checkout for this collected money is still in progress. Cancel it to release the amount and choose again.
+                        </p>
+                        <form
+                          action={`/captain/team/${teamId}/payments/remit-collected/cancel`}
+                          method="post"
+                          className="mt-3"
                         >
-                          Pay collected money to SIXFL — {formatMoney(amountAvailableToRemitPence)}
-                        </button>
-                      </form>
+                          <input type="hidden" name="chargeId" value={entry.chargeId} />
+                          <button
+                            type="submit"
+                            className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-amber-200/30 bg-amber-300 px-4 py-2.5 text-sm font-black text-black transition hover:bg-amber-200"
+                          >
+                            Cancel pending checkout
+                          </button>
+                        </form>
+                      </div>
+                    ) : amountAvailableToRemitPence > 0 ? (
+                      <>
+                        {creditAvailableForCollectedPence > 0 ? (
+                          <>
+                            <form
+                              action={`/captain/team/${teamId}/payments/use-credit-for-collected`}
+                              method="post"
+                            >
+                              <input type="hidden" name="chargeId" value={entry.chargeId} />
+                              <button
+                                type="submit"
+                                className="inline-flex min-h-12 w-full items-center justify-center rounded-2xl bg-emerald-300 px-4 py-3 text-sm font-black text-black transition hover:bg-emerald-200"
+                              >
+                                Use {formatMoney(creditAvailableForCollectedPence)} team credit instead
+                              </button>
+                            </form>
+                            <div className="my-2 text-center text-[11px] font-semibold uppercase tracking-[0.16em] text-white/35">
+                              or
+                            </div>
+                          </>
+                        ) : null}
 
-                      <details className="mt-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
-                        <summary className="cursor-pointer text-sm font-semibold text-white/70">
-                          Pay a different amount
-                        </summary>
                         <form
                           action={`/captain/team/${teamId}/payments/remit-collected`}
                           method="post"
-                          className="mt-3 space-y-3"
                         >
                           <input type="hidden" name="chargeId" value={entry.chargeId} />
-                          <label className="block text-xs text-white/55">
-                            Amount to pass to SIXFL
-                            <div className="mt-1 flex items-center rounded-xl border border-white/10 bg-black/25 px-3">
-                              <span className="text-white/50">£</span>
-                              <input
-                                type="number"
-                                name="amount"
-                                min="0.01"
-                                step="0.01"
-                                max={(amountAvailableToRemitPence / 100).toFixed(2)}
-                                defaultValue={(amountAvailableToRemitPence / 100).toFixed(2)}
-                                required
-                                className="h-11 min-w-0 flex-1 bg-transparent px-2 text-white outline-none"
-                              />
-                            </div>
-                          </label>
-                          <p className="text-xs leading-5 text-white/45">
-                            Maximum right now: {formatMoney(amountAvailableToRemitPence)}. This payment is applied only to this fixture charge.
-                          </p>
+                          <input
+                            type="hidden"
+                            name="amount"
+                            value={(amountAvailableToRemitPence / 100).toFixed(2)}
+                          />
                           <button
                             type="submit"
-                            className="inline-flex h-11 w-full items-center justify-center rounded-xl border border-cyan-300/25 bg-cyan-400/10 px-4 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-400/15"
+                            className="inline-flex min-h-12 w-full items-center justify-center rounded-2xl bg-cyan-300 px-4 py-3 text-sm font-black text-black transition hover:bg-cyan-200"
                           >
-                            Pay this amount
+                            Pay collected money to SIXFL — {formatMoney(amountAvailableToRemitPence)}
+                          </button>
+                        </form>
+
+                        <details className="mt-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+                          <summary className="cursor-pointer text-sm font-semibold text-white/70">
+                            Pay a different amount
+                          </summary>
+                          <form
+                            action={`/captain/team/${teamId}/payments/remit-collected`}
+                            method="post"
+                            className="mt-3 space-y-3"
+                          >
+                            <input type="hidden" name="chargeId" value={entry.chargeId} />
+                            <label className="block text-xs text-white/55">
+                              Amount to pass to SIXFL
+                              <div className="mt-1 flex items-center rounded-xl border border-white/10 bg-black/25 px-3">
+                                <span className="text-white/50">£</span>
+                                <input
+                                  type="number"
+                                  name="amount"
+                                  min="0.01"
+                                  step="0.01"
+                                  max={(amountAvailableToRemitPence / 100).toFixed(2)}
+                                  defaultValue={(amountAvailableToRemitPence / 100).toFixed(2)}
+                                  required
+                                  className="h-11 min-w-0 flex-1 bg-transparent px-2 text-white outline-none"
+                                />
+                              </div>
+                            </label>
+                            <p className="text-xs leading-5 text-white/45">
+                              Maximum right now: {formatMoney(amountAvailableToRemitPence)}. This payment is applied only to this fixture charge.
+                            </p>
+                            <button
+                              type="submit"
+                              className="inline-flex h-11 w-full items-center justify-center rounded-xl border border-cyan-300/25 bg-cyan-400/10 px-4 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-400/15"
+                            >
+                              Pay this amount
+                            </button>
+                          </form>
+                        </details>
+                      </>
+                    ) : (
+                      <div className="rounded-2xl border border-emerald-300/20 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-50">
+                        This fixture balance is fully settled. No collected player money needs to be passed to SIXFL for it.
+                      </div>
+                    )}
+
+                    {canRemoveFromCaptainCollection ? (
+                      <details className="mt-3 rounded-2xl border border-red-300/20 bg-red-500/[0.07] p-3">
+                        <summary className="cursor-pointer text-sm font-semibold text-red-100/85">
+                          Remove from captain collection
+                        </summary>
+                        <p className="mt-3 text-xs leading-5 text-red-50/65">
+                          Use this only if the money has been resolved privately between you and the player and you no longer hold it for SIXFL. The fixture balance will stay exactly as it is.
+                        </p>
+                        <form
+                          action={`/captain/team/${teamId}/payments/remove-collected`}
+                          method="post"
+                          className="mt-3"
+                        >
+                          <input type="hidden" name="chargeId" value={entry.chargeId} />
+                          <button
+                            type="submit"
+                            className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-red-300/30 bg-red-500/15 px-4 py-2.5 text-sm font-bold text-red-50 transition hover:bg-red-500/25"
+                          >
+                            Confirm — remove {formatMoney(snapshot.unremittedPence)} from captain collection
                           </button>
                         </form>
                       </details>
-                    </>
-                  ) : (
-                    <div className="rounded-2xl border border-emerald-300/20 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-50">
-                      This fixture balance is fully settled. No collected player money needs to be passed to SIXFL for it.
-                    </div>
-                  )}
-
-                  {canRemoveFromCaptainCollection ? (
-                    <details className="mt-3 rounded-2xl border border-red-300/20 bg-red-500/[0.07] p-3">
-                      <summary className="cursor-pointer text-sm font-semibold text-red-100/85">
-                        Remove from captain collection
-                      </summary>
-                      <p className="mt-3 text-xs leading-5 text-red-50/65">
-                        Use this only if the money has been resolved privately between you and the player and you no longer hold it for SIXFL. The fixture balance will stay exactly as it is.
+                    ) : snapshot.remittedPence > 0 ? (
+                      <p className="mt-3 text-xs leading-5 text-white/40">
+                        Money already passed to SIXFL cannot be removed from captain collection.
                       </p>
-                      <form
-                        action={`/captain/team/${teamId}/payments/remove-collected`}
-                        method="post"
-                        className="mt-3"
-                      >
-                        <input type="hidden" name="chargeId" value={entry.chargeId} />
-                        <button
-                          type="submit"
-                          className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-red-300/30 bg-red-500/15 px-4 py-2.5 text-sm font-bold text-red-50 transition hover:bg-red-500/25"
-                        >
-                          Confirm — remove {formatMoney(snapshot.unremittedPence)} from captain collection
-                        </button>
-                      </form>
-                    </details>
-                  ) : snapshot.remittedPence > 0 ? (
-                    <p className="mt-3 text-xs leading-5 text-white/40">
-                      Money already passed to SIXFL cannot be removed from captain collection.
-                    </p>
-                  ) : null}
+                    ) : null}
+                  </div>
                 </div>
-              </div>
-            </article>
-          );
-        })}
-      </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {removedRows.length > 0 ? (
+        <div className={`${activeRows.length > 0 ? "mt-7 border-t border-white/10 pt-6" : "mt-5"}`}>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+            Previously removed from captain collection
+          </p>
+          <p className="mt-2 max-w-4xl text-sm leading-6 text-white/55">
+            These records remain visible for audit. They no longer count as money the captain holds for SIXFL, and removing them did not reduce the fixture balance.
+          </p>
+          <div className="mt-4 space-y-3">
+            {removedRows.map(({ entry, snapshot }) => (
+              <article
+                key={`removed-${entry.chargeId}`}
+                className="rounded-2xl border border-white/10 bg-black/20 p-4"
+              >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="font-semibold text-white/85">{entry.fixtureLabel}</div>
+                    <div className="mt-1 text-xs text-white/45">
+                      {entry.kickoffAt
+                        ? formatPaymentFixtureDate(entry.kickoffAt)
+                        : "Fixture date not set"}
+                    </div>
+                  </div>
+                  <span className="inline-flex w-fit rounded-full border border-white/10 bg-white/[0.05] px-3 py-1 text-xs font-semibold text-white/65">
+                    Removed {formatMoney(snapshot.removedPence)} from {snapshot.removedPlayerCount} player{snapshot.removedPlayerCount === 1 ? "" : "s"}
+                  </span>
+                </div>
+                {snapshot.removalNotes.length > 0 ? (
+                  <div className="mt-3 space-y-1.5">
+                    {snapshot.removalNotes.map((note) => (
+                      <p key={note} className="text-xs leading-5 text-white/50">
+                        {note}
+                      </p>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-3 text-xs leading-5 text-white/50">
+                    Captain and player resolved this privately. The SIXFL fixture balance was unchanged.
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/captain/CaptainCollectedRemittancePanel.tsx
+++ b/src/components/captain/CaptainCollectedRemittancePanel.tsx
@@ -69,6 +69,12 @@ export default async function CaptainCollectedRemittancePanel({
       <p className="mt-2 max-w-4xl text-sm leading-6 text-cyan-50/70">
         These amounts come from players marked <strong>Paid captain directly</strong>. For each fixture, either pass the collected money to SIXFL or use available team credit instead. Your own player link and any other open player links stay separate.
       </p>
+
+      <div className="mt-4 max-w-4xl rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/65">
+        <strong className="text-white/85">When to use “Remove from captain collection”:</strong>{" "}
+        use it only if you and the player have sorted that money out between yourselves — for example, you returned the money or agreed a different private arrangement — so you no longer hold it to pass to SIXFL. Removing it does <strong>not</strong> reduce the fixture balance and is not a refund. If a Stripe checkout is pending, cancel that first; money already passed to SIXFL cannot be removed this way.
+      </div>
+
       {creditBalancePence > 0 ? (
         <div className="mt-3 inline-flex rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-50">
           Team credit available: {formatMoney(creditBalancePence)}
@@ -81,6 +87,10 @@ export default async function CaptainCollectedRemittancePanel({
           const cappedByOutstanding =
             snapshot.availablePence > amountAvailableToRemitPence;
           const hasPendingCheckout = snapshot.pendingPence > 0;
+          const canRemoveFromCaptainCollection =
+            snapshot.remittedPence === 0 &&
+            !hasPendingCheckout &&
+            snapshot.unremittedPence > 0;
 
           return (
             <article
@@ -242,6 +252,34 @@ export default async function CaptainCollectedRemittancePanel({
                       This fixture balance is fully settled. No collected player money needs to be passed to SIXFL for it.
                     </div>
                   )}
+
+                  {canRemoveFromCaptainCollection ? (
+                    <details className="mt-3 rounded-2xl border border-red-300/20 bg-red-500/[0.07] p-3">
+                      <summary className="cursor-pointer text-sm font-semibold text-red-100/85">
+                        Remove from captain collection
+                      </summary>
+                      <p className="mt-3 text-xs leading-5 text-red-50/65">
+                        Use this only if the money has been resolved privately between you and the player and you no longer hold it for SIXFL. The fixture balance will stay exactly as it is.
+                      </p>
+                      <form
+                        action={`/captain/team/${teamId}/payments/remove-collected`}
+                        method="post"
+                        className="mt-3"
+                      >
+                        <input type="hidden" name="chargeId" value={entry.chargeId} />
+                        <button
+                          type="submit"
+                          className="inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-red-300/30 bg-red-500/15 px-4 py-2.5 text-sm font-bold text-red-50 transition hover:bg-red-500/25"
+                        >
+                          Confirm — remove {formatMoney(snapshot.unremittedPence)} from captain collection
+                        </button>
+                      </form>
+                    </details>
+                  ) : snapshot.remittedPence > 0 ? (
+                    <p className="mt-3 text-xs leading-5 text-white/40">
+                      Money already passed to SIXFL cannot be removed from captain collection.
+                    </p>
+                  ) : null}
                 </div>
               </div>
             </article>

--- a/src/lib/payments/captain-collected-remittance.ts
+++ b/src/lib/payments/captain-collected-remittance.ts
@@ -19,6 +19,9 @@ export type CaptainCollectedRemittanceEntry = {
 export type CaptainCollectedRemittanceSnapshot = {
   collectedPence: number;
   collectedPlayerCount: number;
+  removedPence: number;
+  removedPlayerCount: number;
+  removalNotes: string[];
   remittedPence: number;
   pendingPence: number;
   unremittedPence: number;
@@ -111,6 +114,9 @@ function emptySnapshot(): CaptainCollectedRemittanceSnapshot {
   return {
     collectedPence: 0,
     collectedPlayerCount: 0,
+    removedPence: 0,
+    removedPlayerCount: 0,
+    removalNotes: [],
     remittedPence: 0,
     pendingPence: 0,
     unremittedPence: 0,
@@ -183,18 +189,39 @@ export async function getCaptainCollectedRemittanceSnapshots(
     string,
     { amountPence: number; playerCount: number }
   >();
+  const removedByTeamFixture = new Map<
+    string,
+    { amountPence: number; playerCount: number; notes: string[] }
+  >();
 
   for (const fee of collectedFees) {
-    if (!isCaptainCollectionActiveNote(fee.note)) continue;
-
     const feeKey = key(fee.teamId, fee.fixtureId);
-    const current = collectedByTeamFixture.get(feeKey) ?? {
-      amountPence: 0,
-      playerCount: 0,
-    };
-    current.amountPence += fee.amountPence;
-    current.playerCount += 1;
-    collectedByTeamFixture.set(feeKey, current);
+
+    if (isCaptainCollectionActiveNote(fee.note)) {
+      const current = collectedByTeamFixture.get(feeKey) ?? {
+        amountPence: 0,
+        playerCount: 0,
+      };
+      current.amountPence += fee.amountPence;
+      current.playerCount += 1;
+      collectedByTeamFixture.set(feeKey, current);
+      continue;
+    }
+
+    if (isCaptainCollectionRemovedNote(fee.note)) {
+      const current = removedByTeamFixture.get(feeKey) ?? {
+        amountPence: 0,
+        playerCount: 0,
+        notes: [],
+      };
+      current.amountPence += fee.amountPence;
+      current.playerCount += 1;
+      const removalNote = getLatestCaptainCollectionRemovalNote(fee.note);
+      if (removalNote && !current.notes.includes(removalNote)) {
+        current.notes.push(removalNote);
+      }
+      removedByTeamFixture.set(feeKey, current);
+    }
   }
 
   const remittanceByCharge = new Map(
@@ -208,9 +235,15 @@ export async function getCaptainCollectedRemittanceSnapshots(
   );
 
   for (const entry of uniqueEntries) {
-    const collected = collectedByTeamFixture.get(key(entry.teamId, entry.fixtureId)) ?? {
+    const entryKey = key(entry.teamId, entry.fixtureId);
+    const collected = collectedByTeamFixture.get(entryKey) ?? {
       amountPence: 0,
       playerCount: 0,
+    };
+    const removed = removedByTeamFixture.get(entryKey) ?? {
+      amountPence: 0,
+      playerCount: 0,
+      notes: [],
     };
     const remittance = remittanceByCharge.get(entry.chargeId) ?? {
       remittedPence: 0,
@@ -228,6 +261,9 @@ export async function getCaptainCollectedRemittanceSnapshots(
     snapshots.set(entry.chargeId, {
       collectedPence: collected.amountPence,
       collectedPlayerCount: collected.playerCount,
+      removedPence: removed.amountPence,
+      removedPlayerCount: removed.playerCount,
+      removalNotes: removed.notes,
       remittedPence: remittance.remittedPence,
       pendingPence: remittance.pendingPence,
       unremittedPence,

--- a/src/lib/payments/captain-collected-remittance.ts
+++ b/src/lib/payments/captain-collected-remittance.ts
@@ -7,6 +7,9 @@ export const CAPTAIN_COLLECTED_NOTE_MARKERS = [
   "Paid captain directly: captain collected",
 ] as const;
 
+export const CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER =
+  "Removed from captain collection: resolved privately";
+
 export type CaptainCollectedRemittanceEntry = {
   chargeId: string;
   teamId: string;
@@ -24,6 +27,60 @@ export type CaptainCollectedRemittanceSnapshot = {
 
 function key(teamId: string, fixtureId: string) {
   return `${teamId}:${fixtureId}`;
+}
+
+function lastIndexOfInsensitive(value: string, marker: string) {
+  return value.toLowerCase().lastIndexOf(marker.toLowerCase());
+}
+
+function latestCaptainCollectedIndex(note?: string | null) {
+  const value = note ?? "";
+  return Math.max(
+    ...CAPTAIN_COLLECTED_NOTE_MARKERS.map((marker) =>
+      lastIndexOfInsensitive(value, marker),
+    ),
+  );
+}
+
+export function isCaptainCollectionRemovedNote(note?: string | null) {
+  const value = note ?? "";
+  const removedIndex = lastIndexOfInsensitive(
+    value,
+    CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER,
+  );
+  const collectedIndex = latestCaptainCollectedIndex(value);
+
+  return removedIndex >= 0 && removedIndex > collectedIndex;
+}
+
+export function isCaptainCollectionActiveNote(note?: string | null) {
+  const value = note ?? "";
+  const collectedIndex = latestCaptainCollectedIndex(value);
+  const removedIndex = lastIndexOfInsensitive(
+    value,
+    CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER,
+  );
+
+  return collectedIndex >= 0 && collectedIndex > removedIndex;
+}
+
+export function getLatestCaptainCollectionRemovalNote(note?: string | null) {
+  const lines = (note ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (
+      lines[index]
+        .toLowerCase()
+        .includes(CAPTAIN_COLLECTION_REMOVED_NOTE_MARKER.toLowerCase())
+    ) {
+      return lines[index];
+    }
+  }
+
+  return null;
 }
 
 export async function ensureCaptainCollectedRemittanceTable() {
@@ -95,6 +152,7 @@ export async function getCaptainCollectedRemittanceSnapshots(
         teamId: true,
         fixtureId: true,
         amountPence: true,
+        note: true,
       },
     }),
     prisma.$queryRaw<
@@ -127,6 +185,8 @@ export async function getCaptainCollectedRemittanceSnapshots(
   >();
 
   for (const fee of collectedFees) {
+    if (!isCaptainCollectionActiveNote(fee.note)) continue;
+
     const feeKey = key(fee.teamId, fee.fixtureId);
     const current = collectedByTeamFixture.get(feeKey) ?? {
       amountPence: 0,


### PR DESCRIPTION
Adds an audited **Remove from captain collection** option for captain-collected player money.

- explains when to use it: only when captain and player have resolved the money privately and the captain no longer holds it for SIXFL
- removal does **not** reduce the fixture balance and is not a refund
- blocks removal while a Stripe remittance checkout is pending
- blocks removal once any collected money has already been passed to SIXFL
- preserves the original player-fee record and appends an audit note with amount, actor and time
- removed money stops appearing as active captain-collected money
- keeps a **Previously removed from captain collection** history on the captain Payments page
- adds a blocking regression check for the financial safeguards

No fixture charge, payment transaction, team credit or settled SIXFL payment is changed.