### PR TITLE
Fix website prospective league matching

### DIFF
--- a/prisma/migrations/20260817165500_backfill_harrogate_prospective_leads/migration.sql
+++ b/prisma/migrations/20260817165500_backfill_harrogate_prospective_leads/migration.sql
@@ -1,0 +1,27 @@
+-- Website registrations use the customer-facing area "Harrogate", while the
+-- operational league has historically used more specific Harrogate/Rossett
+-- wording. Attach existing unassigned Harrogate Tuesday men's leads to the
+-- current Rossett Tuesday league without overwriting any manual assignment.
+WITH harrogate_league AS (
+  SELECT league."id"
+  FROM "League" league
+  WHERE league."isActive" = TRUE
+    AND league."slug" = 'rossett-mens-tuesday'
+  ORDER BY league."createdAt" DESC
+  LIMIT 1
+)
+UPDATE "InterestLead" AS lead
+SET
+  "leagueId" = harrogate_league."id",
+  "updatedAt" = CURRENT_TIMESTAMP
+FROM harrogate_league
+WHERE lead."leagueId" IS NULL
+  AND lead."interestType" IN ('TEAM', 'PLAYER')
+  AND lead."leagueType" = 'MENS'
+  AND LOWER(TRIM(COALESCE(lead."area", ''))) IN ('harrogate', 'harrogate west')
+  AND EXISTS (
+    SELECT 1
+    FROM "InterestLeadPreferredNight" preferred_night
+    WHERE preferred_night."leadId" = lead."id"
+      AND preferred_night."night" = 'TUESDAY'
+  );

--- a/src/lib/leads/prospectiveLeague.ts
+++ b/src/lib/leads/prospectiveLeague.ts
@@ -13,6 +13,10 @@ export type ProspectiveLeagueMatchInput = {
   preferredNights?: PreferredNight[];
 };
 
+const AREA_FALLBACKS: Record<string, string[]> = {
+  richmond: ["Catterick"],
+};
+
 function clean(value?: string | null) {
   return value?.trim() || "";
 }
@@ -20,6 +24,13 @@ function clean(value?: string | null) {
 function normaliseNights(values?: PreferredNight[]) {
   const nights = Array.from(new Set((values ?? []).filter(Boolean)));
   return nights.includes("ANY") ? [] : nights;
+}
+
+function getAreaSearchTerms(area: string) {
+  if (!area) return [];
+
+  const fallbackTerms = AREA_FALLBACKS[area.toLowerCase()] ?? [];
+  return Array.from(new Set([area, ...fallbackTerms]));
 }
 
 export async function resolveProspectiveLeagueId(input: ProspectiveLeagueMatchInput) {
@@ -51,27 +62,32 @@ export async function resolveProspectiveLeagueId(input: ProspectiveLeagueMatchIn
 
   const area = clean(input.area);
   const nights = normaliseNights(input.preferredNights);
+  const sharedWhere = {
+    isActive: true,
+    leagueType: input.leagueType,
+    OR: [
+      { competitionId: null },
+      { currentForCompetitions: { some: { isActive: true } } },
+    ],
+    ...(nights.length > 0
+      ? {
+          dayOfWeek: {
+            in: nights,
+          },
+        }
+      : {}),
+  } as const;
 
-  const matches = await prisma.league.findMany({
+  // Prefer an exact area match. This keeps the normal case deterministic when
+  // the public form and league record use the same customer-facing area name.
+  const exactMatches = await prisma.league.findMany({
     where: {
-      isActive: true,
-      leagueType: input.leagueType,
-      OR: [
-        { competitionId: null },
-        { currentForCompetitions: { some: { isActive: true } } },
-      ],
+      ...sharedWhere,
       ...(area
         ? {
             area: {
               equals: area,
-              mode: "insensitive",
-            },
-          }
-        : {}),
-      ...(nights.length > 0
-        ? {
-            dayOfWeek: {
-              in: nights,
+              mode: "insensitive" as const,
             },
           }
         : {}),
@@ -83,8 +99,43 @@ export async function resolveProspectiveLeagueId(input: ProspectiveLeagueMatchIn
     take: 2,
   });
 
-  if (matches.length === 1) {
-    return matches[0].id;
+  if (exactMatches.length === 1) {
+    return exactMatches[0].id;
+  }
+
+  if (!area) {
+    return null;
+  }
+
+  // Marketing areas and operational league areas do not always use identical
+  // wording (for example "Harrogate" on the website and "Harrogate West" on
+  // the league). If the exact match failed, accept one unambiguous current
+  // league whose area/name/slug/venue contains the requested area. Known
+  // recruitment catchments such as Richmond -> Catterick are included here too.
+  const areaSearchTerms = getAreaSearchTerms(area);
+  const fuzzyMatches = await prisma.league.findMany({
+    where: {
+      ...sharedWhere,
+      AND: [
+        {
+          OR: areaSearchTerms.flatMap((term) => [
+            { area: { contains: term, mode: "insensitive" as const } },
+            { name: { contains: term, mode: "insensitive" as const } },
+            { slug: { contains: term, mode: "insensitive" as const } },
+            { venueName: { contains: term, mode: "insensitive" as const } },
+          ]),
+        },
+      ],
+    },
+    orderBy: [{ createdAt: "desc" }],
+    select: {
+      id: true,
+    },
+    take: 2,
+  });
+
+  if (fuzzyMatches.length === 1) {
+    return fuzzyMatches[0].id;
   }
 
   return null;

--- a/src/lib/leads/prospectiveLeague.ts
+++ b/src/lib/leads/prospectiveLeague.ts
@@ -2,7 +2,7 @@
 // File: src/lib/leads/prospectiveLeague.ts
 // ========================================
 
-import { InterestType, LeagueType, PreferredNight } from "@prisma/client";
+import { InterestType, LeagueType, PreferredNight, Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
 export type ProspectiveLeagueMatchInput = {
@@ -62,7 +62,7 @@ export async function resolveProspectiveLeagueId(input: ProspectiveLeagueMatchIn
 
   const area = clean(input.area);
   const nights = normaliseNights(input.preferredNights);
-  const sharedWhere = {
+  const sharedWhere: Prisma.LeagueWhereInput = {
     isActive: true,
     leagueType: input.leagueType,
     OR: [
@@ -76,7 +76,7 @@ export async function resolveProspectiveLeagueId(input: ProspectiveLeagueMatchIn
           },
         }
       : {}),
-  } as const;
+  };
 
   // Prefer an exact area match. This keeps the normal case deterministic when
   // the public form and league record use the same customer-facing area name.


### PR DESCRIPTION
## Summary
- keep exact prospective-league matching as the first choice for website registrations
- add a safe fuzzy fallback for cases where the public area name is broader than the operational league area/name, e.g. `Harrogate` -> `Harrogate West` / Rossett
- preserve ambiguity safety: a fallback is only used when exactly one current active league matches the submitted type/night
- include the agreed Richmond recruitment fallback to Catterick when no exact Richmond league exists
- backfill existing unassigned Harrogate Tuesday men's leads to the active `rossett-mens-tuesday` league without overwriting manual assignments

This fixes website-created leads rather than the Meta CSV importer.