### PR TITLE
Add Thirsk and Catterick to footer

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -32,6 +32,8 @@ const footerGroups: Array<{ title: string; links: FooterLink[] }> = [
       { label: "All leagues", href: "/leagues" },
       { label: "Harrogate 6-a-side", href: "/harrogate-6-a-side-football", featured: true },
       { label: "Northallerton 6-a-side", href: "/northallerton-6-a-side-football" },
+      { label: "Thirsk 6-a-side", href: "/north-yorkshire-heartlands-6-a-side-football" },
+      { label: "Catterick 6-a-side", href: "/north-yorkshire-heartlands-6-a-side-football" },
       { label: "Wetherby 6-a-side", href: "/wetherby-6-a-side-football" },
       { label: "Venues", href: "/venues" },
     ],
@@ -149,7 +151,7 @@ export default function SiteFooter() {
               <nav className="mt-4 flex flex-col gap-1 text-sm text-white/80" aria-label={`${group.title} footer links`}>
                 {group.links.map((link) => (
                   <Link
-                    key={link.href}
+                    key={`${link.href}-${link.label}`}
                     href={link.href}
                     className={[
                       "inline-flex min-h-9 items-center leading-5 transition hover:text-emerald-400",


### PR DESCRIPTION
Adds Thirsk and Catterick to the public footer under **Find football**.

- adds **Thirsk 6-a-side**
- adds **Catterick 6-a-side**
- both point to the existing North Yorkshire Heartlands public area route
- updates the footer React key so two location labels can intentionally share the same Heartlands destination without duplicate-key warnings

No league, registration or fixture logic is changed.