### PR TITLE
Add managed squad action to player leads

### DIFF
--- a/docs/placeholder-never-create.md
+++ b/docs/placeholder-never-create.md
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/placeholder-never-create.md
+++ b/docs/placeholder-never-create.md
@@ -1,1 +1,0 @@
-placeholder

--- a/src/app/(admin)/admin/leads/page.tsx
+++ b/src/app/(admin)/admin/leads/page.tsx
@@ -21,7 +21,7 @@ import {
   sendBulkLeadEmailAction,
   sendBulkLeadSmsAction,
 } from "./guarded-bulk-actions";
-import { sendPlayerPoolProfileInviteAction } from "../player-pool/actions";
+import { convertLeadToManagedSquadPlayerAction } from "./managed-squad-actions";
 
 type SearchParams = Promise<{
   type?: string;
@@ -307,10 +307,9 @@ export default async function AdminLeadsPage({ searchParams }: { searchParams: S
       where: {
         teamMode: "MANAGED",
         isRecruiting: true,
-        joinSlug: { not: null },
       },
       orderBy: { name: "asc" },
-      select: { id: true, name: true, joinSlug: true },
+      select: { id: true, name: true, leagueId: true },
     }),
   ]);
 
@@ -467,7 +466,28 @@ export default async function AdminLeadsPage({ searchParams }: { searchParams: S
                   const confirmation = confirmationByLeadId.get(lead.id) ?? null;
                   const confirmationMeta = getConfirmationMeta(confirmation);
                   const canSendConfirmation = lead.interestType === "TEAM" && Boolean(lead.email?.trim()) && Boolean(lead.league);
-                  const canSendPlayerPoolInvite = lead.interestType === "PLAYER" && Boolean(lead.email?.trim());
+                  const managedTeamsForLeague = lead.leagueId
+                    ? managedTeams.filter((team) => team.leagueId === lead.leagueId)
+                    : [];
+                  const managedTeamForLeague =
+                    managedTeamsForLeague.length === 1 ? managedTeamsForLeague[0] : null;
+                  const canAddToManagedSquad =
+                    lead.interestType === "PLAYER" &&
+                    lead.status !== "CLOSED" &&
+                    Boolean(lead.email?.trim()) &&
+                    Boolean(managedTeamForLeague);
+                  const managedSquadActionTitle =
+                    lead.status === "CLOSED"
+                      ? "This lead is already closed"
+                      : !lead.email?.trim()
+                        ? "Add an email address before sending the squad signup form"
+                        : !lead.leagueId
+                          ? "Set a prospective league before adding this player to a managed squad"
+                          : managedTeamsForLeague.length === 0
+                            ? "No recruiting managed squad is set up for this prospective league"
+                            : managedTeamsForLeague.length > 1
+                              ? "More than one managed squad exists for this league. Open the lead to choose the correct squad."
+                              : `Add to ${managedTeamForLeague?.name ?? "managed squad"} and email the signup form`;
 
                   return (
                     <tr key={lead.id} className="align-top transition hover:bg-white/[0.035]">
@@ -519,17 +539,29 @@ export default async function AdminLeadsPage({ searchParams }: { searchParams: S
                             </>
                           ) : null}
                           {lead.interestType === "PLAYER" ? (
-                            <form action={sendPlayerPoolProfileInviteAction}>
-                              <input type="hidden" name="leadId" value={lead.id} />
+                            managedTeamForLeague ? (
+                              <form action={convertLeadToManagedSquadPlayerAction}>
+                                <input type="hidden" name="leadId" value={lead.id} />
+                                <input type="hidden" name="teamId" value={managedTeamForLeague.id} />
+                                <button
+                                  type="submit"
+                                  disabled={!canAddToManagedSquad}
+                                  title={managedSquadActionTitle}
+                                  className="inline-flex min-h-9 max-w-[150px] items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-center text-xs font-bold leading-4 text-emerald-100 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-white/30"
+                                >
+                                  Add to managed squad
+                                </button>
+                              </form>
+                            ) : (
                               <button
-                                type="submit"
-                                disabled={!canSendPlayerPoolInvite}
-                                title={canSendPlayerPoolInvite ? "Create or update the PlayerPool profile and send the invitation email" : "Add an email address before sending a PlayerPool invitation"}
-                                className="inline-flex h-9 items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 text-xs font-bold text-emerald-100 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-white/30"
+                                type="button"
+                                disabled
+                                title={managedSquadActionTitle}
+                                className="inline-flex min-h-9 max-w-[150px] cursor-not-allowed items-center justify-center rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-center text-xs font-bold leading-4 text-white/30"
                               >
-                                Send to PlayerPool
+                                Add to managed squad
                               </button>
-                            </form>
+                            )
                           ) : null}
                           <Link href={`/admin/leads/${lead.id}`} className="inline-flex h-9 items-center justify-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3 text-xs font-bold tracking-[0.12em] text-emerald-300 transition hover:bg-emerald-500/20">
                             Open


### PR DESCRIPTION
## Summary
- replace the player-lead `Send to PlayerPool` quick action on Admin → Leads with `Add to managed squad`
- match the lead's prospective league to exactly one recruiting managed squad in that league
- reuse the existing managed-squad lead conversion action, which creates/updates the prospect and queues the existing editable squad signup/confirmation email
- require an email before the quick action is enabled, because this flow is intended to send the player their signup form
- keep ambiguous/no-squad cases safe: the list button is disabled and the admin can open the lead to resolve or choose the squad
- leave the existing PlayerPool workflow available elsewhere rather than deleting it

No new customer-facing email copy is hard-coded; this uses the existing managed-squad notification template and signed signup link.