### PR TITLE
Fix queue email preview and team confirmation wording

### DIFF
--- a/src/app/(admin)/admin/leads/[id]/response-email-actions.ts
+++ b/src/app/(admin)/admin/leads/[id]/response-email-actions.ts
@@ -85,20 +85,44 @@ function getFirstName(value: string | null | undefined) {
 
 function formatLongDate(value: Date) {
   return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
     weekday: "long",
     day: "numeric",
     month: "long",
   }).format(value);
 }
 
-function isDateInPast(value: Date) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+function getUkDateKey(value: Date) {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
 
-  const proposed = new Date(value);
-  proposed.setHours(0, 0, 0, 0);
+  const year = parts.find((part) => part.type === "year")?.value ?? "0000";
+  const month = parts.find((part) => part.type === "month")?.value ?? "00";
+  const day = parts.find((part) => part.type === "day")?.value ?? "00";
 
-  return proposed.getTime() < today.getTime();
+  return `${year}-${month}-${day}`;
+}
+
+function getStartDateTiming(value: Date) {
+  const startDateKey = getUkDateKey(value);
+  const todayKey = getUkDateKey(new Date());
+
+  if (startDateKey === todayKey) return "today";
+  return startDateKey < todayKey ? "past" : "future";
+}
+
+function formatVenueName(value: string | null | undefined) {
+  const venueName = value?.trim();
+
+  if (!venueName || venueName.toUpperCase() === "TBC") {
+    return "To be confirmed";
+  }
+
+  return venueName;
 }
 
 function formatCurrencyPence(value: number | null) {
@@ -117,12 +141,17 @@ function buildLeagueStartLine(startDate: Date | null) {
   }
 
   const formattedDate = formatLongDate(startDate);
+  const timing = getStartDateTiming(startDate);
 
-  if (isDateInPast(startDate)) {
-    return `This league is already underway and started on ${formattedDate}. We’re currently confirming teams for the remaining available places.`;
+  if (timing === "future") {
+    return `This league is due to start on ${formattedDate}. We’re currently confirming teams for the remaining available places.`;
   }
 
-  return `Proposed start date: ${formattedDate}.`;
+  if (timing === "today") {
+    return `This league is due to start today (${formattedDate}). We’re currently confirming teams for the remaining available places.`;
+  }
+
+  return `The proposed start date was ${formattedDate}. We’re currently confirming teams for the remaining available places.`;
 }
 
 function buildLeagueDetailsBlock(input: {
@@ -134,9 +163,9 @@ function buildLeagueDetailsBlock(input: {
 }) {
   const rows = [
     `League: ${input.leagueName}`,
-    input.venueName?.trim() ? `Venue: ${input.venueName.trim()}` : null,
+    `Venue: ${formatVenueName(input.venueName)}`,
     input.details?.proposedStartDate
-      ? `${isDateInPast(input.details.proposedStartDate) ? "Started" : "Proposed start date"}: ${formatLongDate(input.details.proposedStartDate)}`
+      ? `Proposed start date: ${formatLongDate(input.details.proposedStartDate)}`
       : null,
     input.kickoffInfo?.trim() ? `Kick-off: ${input.kickoffInfo.trim()}` : null,
     input.details?.minutesPerGame
@@ -299,6 +328,7 @@ export async function sendTeamPlaceConfirmationSystemEmailAction(formData: FormD
   const confirmation = await ensureTeamPlaceConfirmationRecord(lead.id);
   const leagueDetails = await getLeagueConfirmationEmailDetails(effectiveLeagueId);
   const leagueName = `${effectiveLeague.name}${effectiveLeague.season ? ` · ${effectiveLeague.season}` : ""}`;
+  const venueName = formatVenueName(effectiveLeague.venueName);
   const displayName = lead.contactName?.trim() || lead.teamName?.trim() || email;
 
   const recipient = await upsertNotificationRecipient({
@@ -328,7 +358,7 @@ export async function sendTeamPlaceConfirmationSystemEmailAction(formData: FormD
     teamName: lead.teamName?.trim() || "",
     area: lead.area?.trim() || "",
     leagueName,
-    venueName: effectiveLeague.venueName?.trim() || "TBC",
+    venueName,
     kickoffInfo: effectiveLeague.kickoffInfo?.trim() || "",
     format: effectiveLeague.format?.trim() || "Weekly 6-a-side fixtures",
     proposedStartDate: leagueDetails?.proposedStartDate
@@ -343,7 +373,7 @@ export async function sendTeamPlaceConfirmationSystemEmailAction(formData: FormD
       : "",
     leagueDetailsBlock: buildLeagueDetailsBlock({
       leagueName,
-      venueName: effectiveLeague.venueName,
+      venueName,
       kickoffInfo: effectiveLeague.kickoffInfo,
       format: effectiveLeague.format,
       details: leagueDetails,

--- a/src/app/(admin)/admin/leads/[id]/response-email-actions.ts
+++ b/src/app/(admin)/admin/leads/[id]/response-email-actions.ts
@@ -242,9 +242,9 @@ export async function sendLeadEmailWithResponseLinksAction(formData: FormData) {
 
   for (const [key, value] of formData.entries()) {
     if (key === "subject" || key === "body") {
-      nextFormData.append(key, replaceLeadResponseTokens(String(value), leadId));
+      nextFormData.set(key, replaceLeadResponseTokens(String(value), leadId));
     } else {
-      nextFormData.append(key, value);
+      nextFormData.set(key, value);
     }
   }
 

--- a/src/app/(admin)/admin/queue/[id]/page.tsx
+++ b/src/app/(admin)/admin/queue/[id]/page.tsx
@@ -64,7 +64,50 @@ function DetailRow({
   );
 }
 
-function CodeBlock({
+function MessagePreview({
+  html,
+  text,
+}: {
+  html: string | null | undefined;
+  text: string | null | undefined;
+}) {
+  const hasHtml = Boolean(html?.trim());
+  const hasText = Boolean(text?.trim());
+
+  if (!hasHtml && !hasText) return null;
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+      <h2 className="text-lg font-semibold text-white">
+        {hasHtml ? "Email preview" : "Message preview"}
+      </h2>
+      <p className="mt-1 text-sm text-white/45">
+        {hasHtml
+          ? "Rendered from the exact HTML saved on this dispatch."
+          : "Preview of the exact text saved on this dispatch."}
+      </p>
+
+      {hasHtml ? (
+        <div className="mt-4 overflow-hidden rounded-2xl border border-white/10 bg-white">
+          <iframe
+            title="Rendered email preview"
+            srcDoc={html ?? ""}
+            sandbox=""
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            className="h-[48rem] w-full bg-white"
+          />
+        </div>
+      ) : (
+        <pre className="mt-4 max-h-[32rem] overflow-auto whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/35 p-4 text-sm leading-6 text-white/75 sixfl-mobile-scroll">
+          {text}
+        </pre>
+      )}
+    </section>
+  );
+}
+
+function SourceDetails({
   title,
   value,
 }: {
@@ -74,12 +117,14 @@ function CodeBlock({
   if (!value?.trim()) return null;
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
-      <h2 className="text-lg font-semibold text-white">{title}</h2>
-      <pre className="mt-4 max-h-[32rem] overflow-auto whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/35 p-4 text-sm leading-6 text-white/75 sixfl-mobile-scroll">
+    <details className="rounded-2xl border border-white/10 bg-black/20">
+      <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-white/70 transition hover:text-white">
+        {title}
+      </summary>
+      <pre className="max-h-[32rem] overflow-auto whitespace-pre-wrap border-t border-white/10 p-4 text-sm leading-6 text-white/65 sixfl-mobile-scroll">
         {value}
       </pre>
-    </section>
+    </details>
   );
 }
 
@@ -146,6 +191,7 @@ export default async function AdminQueueItemPage({
   const recipientName = dispatch.recipient.displayName || "Unknown recipient";
   const recipientContact = dispatch.recipient.email || dispatch.recipient.phone || "No email or phone saved";
   const latestMessage = dispatch.messageEntries[0] ?? null;
+  const hasMessageSource = Boolean(dispatch.bodyText?.trim() || dispatch.bodyHtml?.trim());
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">
@@ -239,8 +285,20 @@ export default async function AdminQueueItemPage({
         </div>
       </section>
 
-      <CodeBlock title="Message text" value={dispatch.bodyText} />
-      <CodeBlock title="Message HTML" value={dispatch.bodyHtml} />
+      <MessagePreview html={dispatch.bodyHtml} text={dispatch.bodyText} />
+
+      {hasMessageSource ? (
+        <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">
+          <h2 className="text-lg font-semibold text-white">Message source</h2>
+          <p className="mt-1 text-sm text-white/45">
+            Raw source is kept here for troubleshooting and stays collapsed by default.
+          </p>
+          <div className="mt-4 space-y-3">
+            <SourceDetails title="Plain text" value={dispatch.bodyText} />
+            <SourceDetails title="HTML source" value={dispatch.bodyHtml} />
+          </div>
+        </section>
+      ) : null}
 
       {dispatch.attempts.length > 0 ? (
         <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-5">


### PR DESCRIPTION
## What changed
- render queued email HTML as a real sandboxed email preview instead of showing raw HTML
- keep plain-text and HTML source available in collapsed troubleshooting sections
- make team confirmation start-date wording distinguish future, today and past proposed dates in Europe/London time
- stop claiming a league is already underway solely from a proposed start date
- show `To be confirmed` instead of `TBC` for the venue

## Expected result
For a league with a proposed start date of Monday 2 November 2026, the confirmation email now says it is due to start on that date, and the queue detail page displays the actual styled email rather than its source code.