### PR TITLE
Let confirmed teams provide team name later

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check critical feature contracts
         run: node scripts/check-critical-feature-contracts.mjs
 
+      - name: Check team confirmation workflow
+        run: node scripts/check-team-confirmation-contract.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -72,7 +75,9 @@ jobs:
           fi
 
       - name: Re-check critical feature contracts
-        run: node scripts/check-critical-feature-contracts.mjs
+        run: |
+          node scripts/check-critical-feature-contracts.mjs
+          node scripts/check-team-confirmation-contract.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/docs/critical-feature-contracts.md
+++ b/docs/critical-feature-contracts.md
@@ -84,7 +84,7 @@ When a critical feature currently depends on a preparation script, its final beh
 - the lead can explicitly choose to confirm the team name later and return to the same link without losing the reserved place;
 - once the lead has been converted into an actual team, the public confirmation page must not allow the lead team name to be changed.
 
-These assertions live in `scripts/check-critical-feature-contracts.mjs` and are checked after the complete production source-preparation chain.
+These assertions live in `scripts/check-critical-feature-contracts.mjs` and dedicated executable contract scripts such as `scripts/check-team-confirmation-contract.mjs`; the critical-feature workflow runs them after the complete production source-preparation chain.
 
 ## Areas to add next
 

--- a/docs/critical-feature-contracts.md
+++ b/docs/critical-feature-contracts.md
@@ -76,6 +76,14 @@ When a critical feature currently depends on a preparation script, its final beh
 - captains retain the introduction-request action;
 - approved introductions retain the add-to-squad action.
 
+### Team lead confirmation
+
+- the public confirmation page must read league name, start date, match length, fee, venue and kick-off context from the lead's current prospective league rather than hard-coded launch details;
+- confirming a place reserves/qualifies the lead but does not automatically create a `Team` or fixtures;
+- after confirmation, an unconverted team lead can save or update its team name on the same signed confirmation link;
+- the lead can explicitly choose to confirm the team name later and return to the same link without losing the reserved place;
+- once the lead has been converted into an actual team, the public confirmation page must not allow the lead team name to be changed.
+
 These assertions live in `scripts/check-critical-feature-contracts.mjs` and are checked after the complete production source-preparation chain.
 
 ## Areas to add next

--- a/scripts/check-team-confirmation-contract.mjs
+++ b/scripts/check-team-confirmation-contract.mjs
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const pagePath = "src/app/(public)/team-confirmation/[token]/page.tsx";
+const confirmationPath = "src/lib/leads/teamPlaceConfirmation.ts";
+const page = read(pagePath);
+const confirmation = read(confirmationPath);
+
+expect(
+  page.includes("getLeagueConfirmationDetails") && page.includes("const effectiveLeague ="),
+  "team confirmation page must load live prospective/current league details",
+);
+expect(
+  !page.includes("Tuesday 8 July") && !page.includes("£40 per team per match"),
+  "team confirmation page must not reintroduce hard-coded launch date or fee details",
+);
+expect(
+  page.includes("async function saveTeamNameAction") && page.includes("data: { teamName }"),
+  "confirmed leads must be able to save their team name back to the lead",
+);
+expect(
+  page.includes("I’ll confirm the team name later") && page.includes("teamNameLater"),
+  "confirmed leads must retain an explicit option to provide the team name later",
+);
+expect(
+  page.includes("convertedTeamId") && page.includes('teamNameError=team-created'),
+  "team-name editing must stop once an actual SIXFL team has been created",
+);
+expect(
+  page.includes("No team or fixtures have been created automatically"),
+  "confirmation page must clearly state that reserving a place does not auto-create a team or fixtures",
+);
+
+const confirmStart = confirmation.indexOf("export async function confirmTeamPlaceFromLead");
+const declineStart = confirmation.indexOf("export async function declineTeamPlaceFromLead");
+const confirmSource =
+  confirmStart >= 0 && declineStart > confirmStart
+    ? confirmation.slice(confirmStart, declineStart)
+    : "";
+
+expect(
+  confirmSource.includes("status: LeadStatus.QUALIFIED"),
+  "confirming a team place must continue qualifying the lead",
+);
+expect(
+  !confirmSource.includes("team.create") && !confirmSource.includes("tx.team.create"),
+  "confirming a team place must not automatically create a Team record",
+);
+
+if (failures.length) {
+  console.error("\nTEAM CONFIRMATION CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  console.error("\nDo not merge until the team confirmation workflow is restored.\n");
+  process.exit(1);
+}
+
+console.log("Team confirmation contract passed.");

--- a/src/app/(public)/team-confirmation/[token]/page.tsx
+++ b/src/app/(public)/team-confirmation/[token]/page.tsx
@@ -3,6 +3,7 @@
 // ========================================
 
 import { Prisma } from "@prisma/client";
+import Link from "next/link";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
@@ -23,7 +24,13 @@ export const metadata = {
 
 type PageProps = {
   params: Promise<{ token: string }>;
-  searchParams?: Promise<{ confirmed?: string; declined?: string }>;
+  searchParams?: Promise<{
+    confirmed?: string;
+    declined?: string;
+    teamNameSaved?: string;
+    teamNameLater?: string;
+    teamNameError?: string;
+  }>;
 };
 
 type LeagueConfirmationDetails = {
@@ -31,10 +38,6 @@ type LeagueConfirmationDetails = {
   minutesPerGame: number | null;
   costPerTeamPerMatchPence: number | null;
 };
-
-function getLeadTitle(input: { teamName: string | null; contactName: string }) {
-  return input.teamName?.trim() || `${input.contactName}'s team`;
-}
 
 function formatLongDate(value: Date) {
   return new Intl.DateTimeFormat("en-GB", {
@@ -114,6 +117,65 @@ async function declineTeamPlaceAction(formData: FormData) {
   redirect(`/team-confirmation/${encodeURIComponent(token)}?declined=1`);
 }
 
+async function saveTeamNameAction(formData: FormData) {
+  "use server";
+
+  const token = String(formData.get("token") ?? "").trim();
+  const leadId = verifyTeamPlaceConfirmationToken(token);
+  const teamName = String(formData.get("teamName") ?? "")
+    .trim()
+    .replace(/\s+/g, " ");
+
+  if (!leadId) {
+    throw new Error("This confirmation link is not valid.");
+  }
+
+  if (teamName.length < 2 || teamName.length > 80) {
+    redirect(
+      `/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameError=invalid`,
+    );
+  }
+
+  const [lead, confirmation] = await Promise.all([
+    prisma.interestLead.findUnique({
+      where: { id: leadId },
+      select: {
+        id: true,
+        status: true,
+        convertedTeamId: true,
+      },
+    }),
+    getTeamPlaceConfirmationStatus(leadId),
+  ]);
+
+  if (!lead) {
+    throw new Error("Lead not found.");
+  }
+
+  if (lead.convertedTeamId) {
+    redirect(
+      `/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameError=team-created`,
+    );
+  }
+
+  const placeConfirmed = confirmation?.status === "CONFIRMED" || lead.status === "QUALIFIED";
+  if (!placeConfirmed) {
+    throw new Error("Confirm the team place before saving a team name.");
+  }
+
+  await prisma.interestLead.update({
+    where: { id: lead.id },
+    data: { teamName },
+  });
+
+  revalidatePath("/admin/leads");
+  revalidatePath(`/admin/leads/${lead.id}`);
+  revalidatePath(`/team-confirmation/${encodeURIComponent(token)}`);
+  redirect(
+    `/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameSaved=1`,
+  );
+}
+
 function InvalidLinkCard() {
   return (
     <main className="min-h-screen bg-[#07130f] px-4 py-10 text-white">
@@ -147,6 +209,7 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
         area: true,
         leagueType: true,
         status: true,
+        convertedTeamId: true,
         league: {
           select: {
             id: true,
@@ -203,9 +266,17 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
     null;
   const kickoffLabel = effectiveLeague?.kickoffInfo?.trim() || null;
 
-  const isConfirmed = sp.confirmed === "1" || confirmation?.status === "CONFIRMED" || lead.status === "QUALIFIED";
-  const isDeclined = sp.declined === "1" || confirmation?.status === "DECLINED" || lead.status === "CLOSED";
-  const leadTitle = getLeadTitle(lead);
+  const isConfirmed =
+    sp.confirmed === "1" ||
+    confirmation?.status === "CONFIRMED" ||
+    lead.status === "QUALIFIED";
+  const isDeclined =
+    sp.declined === "1" ||
+    confirmation?.status === "DECLINED" ||
+    lead.status === "CLOSED";
+  const savedTeamName = lead.teamName?.trim() || "";
+  const leadTitle = savedTeamName || "your team";
+  const leadCardTitle = savedTeamName || "Your team";
   const confirmationPrompt = startDateLabel
     ? `Please confirm whether ${leadTitle} would like a place in ${leagueName}, planned to start ${startDateLabel}.`
     : `Please confirm whether ${leadTitle} would like a place in ${leagueName}.`;
@@ -216,6 +287,12 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
     locationLabel,
     kickoffLabel,
   ].filter((value): value is string => Boolean(value));
+  const teamNameError =
+    sp.teamNameError === "invalid"
+      ? "Please enter a team name between 2 and 80 characters."
+      : sp.teamNameError === "team-created"
+        ? "This team has already been created in SIXFL, so the lead name can no longer be changed here."
+        : null;
 
   return (
     <main className="min-h-screen bg-[#07130f] px-4 py-10 text-white">
@@ -225,13 +302,21 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
             SIXFL team confirmation
           </p>
           <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
-            {isConfirmed ? "Your team place is confirmed" : isDeclined ? "Your place has been released" : "Confirm your team place"}
+            {isConfirmed
+              ? lead.convertedTeamId
+                ? "Your SIXFL team is set up"
+                : "Your place is reserved"
+              : isDeclined
+                ? "Your place has been released"
+                : "Confirm your team place"}
           </h1>
           <p className="mt-3 text-sm leading-6 text-white/70">
             {isConfirmed
-              ? `Thanks — ${leadTitle} is confirmed for ${leagueName}.`
+              ? lead.convertedTeamId
+                ? `${leadCardTitle} has now been set up for ${leagueName}.`
+                : `Thanks — we’ve reserved a place for ${leadTitle} in ${leagueName}. No team or fixtures have been created automatically.`
               : isDeclined
-                ? `Thanks for letting us know. We’ll release the space for another team.`
+                ? "Thanks for letting us know. We’ll release the space for another team."
                 : confirmationPrompt}
           </p>
 
@@ -251,9 +336,86 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
 
         <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
           {isConfirmed ? (
-            <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100/85">
-              Confirmed. SIXFL will now include your team in the planning list and send the next steps.
-            </div>
+            lead.convertedTeamId ? (
+              <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100/85">
+                Your team has been set up by SIXFL. We’ll use the captain details already provided for the next steps.
+              </div>
+            ) : (
+              <div className="space-y-5">
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100/85">
+                  Your place is reserved. SIXFL will review the lead and create the team manually when the details are ready.
+                </div>
+
+                {sp.teamNameSaved === "1" && savedTeamName ? (
+                  <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm leading-6 text-sky-100/90">
+                    Team name saved as <strong>{savedTeamName}</strong>. This has updated your SIXFL enquiry but has not created a team yet.
+                  </div>
+                ) : null}
+
+                {sp.teamNameLater === "1" ? (
+                  <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+                    <h2 className="text-lg font-semibold text-white">Team name not decided yet?</h2>
+                    <p className="mt-2 text-sm leading-6 text-white/65">
+                      No problem. Your place remains reserved. Keep this confirmation link and come back when you have decided your team name.
+                    </p>
+                    <Link
+                      href={`/team-confirmation/${encodeURIComponent(token)}?confirmed=1`}
+                      className="mt-4 inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-semibold text-white/85 transition hover:bg-white/[0.09]"
+                    >
+                      Add team name now
+                    </Link>
+                  </div>
+                ) : (
+                  <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+                    <h2 className="text-lg font-semibold text-white">
+                      {savedTeamName ? "Confirm or update your team name" : "Confirm your team name"}
+                    </h2>
+                    <p className="mt-2 text-sm leading-6 text-white/60">
+                      {savedTeamName
+                        ? "Check the name below. You can update it here while SIXFL is still preparing your team."
+                        : "If you already know the team name, add it now. If not, you can come back to this same link and confirm it later."}
+                    </p>
+
+                    {teamNameError ? (
+                      <div className="mt-4 rounded-xl border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                        {teamNameError}
+                      </div>
+                    ) : null}
+
+                    <form action={saveTeamNameAction} className="mt-5 space-y-4">
+                      <input type="hidden" name="token" value={token} />
+                      <label className="block">
+                        <span className="text-sm font-semibold text-white/80">Team name</span>
+                        <input
+                          name="teamName"
+                          type="text"
+                          required
+                          minLength={2}
+                          maxLength={80}
+                          defaultValue={savedTeamName}
+                          placeholder="e.g. Richmond Rovers"
+                          className="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition placeholder:text-white/30 focus:border-emerald-400/50"
+                        />
+                      </label>
+                      <div className="flex flex-col gap-3 sm:flex-row">
+                        <button
+                          type="submit"
+                          className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(16,185,129,0.2)] transition hover:bg-emerald-500"
+                        >
+                          {savedTeamName ? "Update team name" : "Save team name"}
+                        </button>
+                        <Link
+                          href={`/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameLater=1`}
+                          className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/75 transition hover:bg-white/[0.08]"
+                        >
+                          I’ll confirm the team name later
+                        </Link>
+                      </div>
+                    </form>
+                  </div>
+                )}
+              </div>
+            )
           ) : isDeclined ? (
             <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm leading-6 text-amber-100/85">
               No problem. Your team will not be included in fixture planning unless you contact SIXFL again.
@@ -261,9 +423,9 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
           ) : (
             <div className="space-y-5">
               <div>
-                <h2 className="text-lg font-semibold text-white">{leadTitle}</h2>
+                <h2 className="text-lg font-semibold text-white">{leadCardTitle}</h2>
                 <p className="mt-2 text-sm leading-6 text-white/60">
-                  We will not create fixtures for your team until the place is confirmed.
+                  Confirming reserves a place only. SIXFL will create the actual team manually once the team details are ready.
                 </p>
               </div>
 
@@ -274,7 +436,7 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
                     type="submit"
                     className="inline-flex w-full items-center justify-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(16,185,129,0.24)] transition hover:bg-emerald-500 sm:w-auto"
                   >
-                    Yes, confirm our team place
+                    Yes, reserve our team place
                   </button>
                 </form>
 

--- a/src/lib/managed-squad/prospectJoinConfirmation.ts
+++ b/src/lib/managed-squad/prospectJoinConfirmation.ts
@@ -8,6 +8,7 @@ import {
   NotificationDispatchStatus,
   NotificationRecipientSourceType,
   NotificationTemplateKind,
+  Prisma,
 } from "@prisma/client";
 
 import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
@@ -67,19 +68,105 @@ export function getManagedSquadJoinConfirmationUrl(prospectId: string) {
   return `${getSiteUrl()}/squad/join/${encodeURIComponent(token)}`;
 }
 
-function getTeamContextLine(team: {
-  name: string;
-  league: { dayOfWeek: string | null; venueName: string | null } | null;
+function formatLongDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  }).format(value);
+}
+
+function getUkDateKey(value: Date) {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
+
+  const year = parts.find((part) => part.type === "year")?.value ?? "0000";
+  const month = parts.find((part) => part.type === "month")?.value ?? "00";
+  const day = parts.find((part) => part.type === "day")?.value ?? "00";
+
+  return `${year}-${month}-${day}`;
+}
+
+function getStartDateTiming(value: Date | null) {
+  if (!value) return "unknown" as const;
+
+  const startDateKey = getUkDateKey(value);
+  const todayKey = getUkDateKey(new Date());
+
+  if (startDateKey === todayKey) return "today" as const;
+  return startDateKey < todayKey ? ("past" as const) : ("future" as const);
+}
+
+function getVenueName(value: string | null | undefined) {
+  const venueName = value?.trim();
+  if (!venueName || venueName.toUpperCase() === "TBC") return null;
+  return venueName;
+}
+
+function getNewLeagueLabel(area: string | null | undefined) {
+  const cleanArea = area?.trim();
+  return cleanArea ? `the new SIXFL ${cleanArea} league` : "the new SIXFL league";
+}
+
+function getMatchScheduleLine(input: {
+  night: string | null;
+  venueName: string | null;
+  futureTense: boolean;
 }) {
+  const verb = input.futureTense ? "will be played" : "are played";
+
+  if (input.night && input.venueName) {
+    return `Matches ${verb} on ${input.night} nights at ${input.venueName}.`;
+  }
+
+  if (input.night) {
+    return `Matches ${verb} on ${input.night} nights.`;
+  }
+
+  if (input.venueName) {
+    return `Matches ${verb} at ${input.venueName}.`;
+  }
+
+  return null;
+}
+
+function getTeamContextLine(
+  team: {
+    name: string;
+    league: {
+      area: string | null;
+      dayOfWeek: string | null;
+      venueName: string | null;
+    } | null;
+  },
+  proposedStartDate: Date | null,
+) {
   const night = formatPreferredNight(team.league?.dayOfWeek);
-  const venueName = team.league?.venueName?.trim();
+  const venueName = getVenueName(team.league?.venueName);
+  const timing = getStartDateTiming(proposedStartDate);
+  const newLeagueLabel = getNewLeagueLabel(team.league?.area);
+
+  if (timing === "future" && proposedStartDate) {
+    const scheduleLine = getMatchScheduleLine({ night, venueName, futureTense: true });
+    return `${newLeagueLabel.charAt(0).toUpperCase()}${newLeagueLabel.slice(1)} is due to start on ${formatLongDate(proposedStartDate)}.${scheduleLine ? ` ${scheduleLine}` : ""}`;
+  }
+
+  if (timing === "today") {
+    const scheduleLine = getMatchScheduleLine({ night, venueName, futureTense: true });
+    return `${newLeagueLabel.charAt(0).toUpperCase()}${newLeagueLabel.slice(1)} starts today.${scheduleLine ? ` ${scheduleLine}` : ""}`;
+  }
 
   if (night && venueName) {
-    return `${team.name} plays on a ${night} night at ${venueName}.`;
+    return `${team.name} plays on ${night} nights at ${venueName}.`;
   }
 
   if (night) {
-    return `${team.name} plays on a ${night} night.`;
+    return `${team.name} plays on ${night} nights.`;
   }
 
   if (venueName) {
@@ -89,11 +176,35 @@ function getTeamContextLine(team: {
   return `${team.name} is a SIXFL squad.`;
 }
 
+function getSquadInviteIntroLine(input: {
+  teamName: string;
+  area: string | null | undefined;
+  proposedStartDate: Date | null;
+}) {
+  const timing = getStartDateTiming(input.proposedStartDate);
+
+  if (timing === "future" || timing === "today") {
+    return `You’ve been added to the ${input.teamName} squad for ${getNewLeagueLabel(input.area)}.`;
+  }
+
+  return `You’ve been added to the ${input.teamName} squad on SIXFL.`;
+}
+
+function getSquadAccessLine(proposedStartDate: Date | null) {
+  const timing = getStartDateTiming(proposedStartDate);
+
+  if (timing === "future" || timing === "today") {
+    return "Once confirmed, you’ll receive squad updates and, when fixtures begin, you’ll be included in match availability checks and other team messages.";
+  }
+
+  return "Once confirmed, you’ll be included in squad messages and fixture availability checks when games are coming up.";
+}
+
 function getSquadInviteBody() {
   return [
     "Hi {{firstName}},",
     "",
-    "You’ve been added to the {{teamName}} squad on SIXFL.",
+    "{{squadInviteIntroLine}}",
     "",
     "{{teamContextLine}}",
     "",
@@ -101,7 +212,7 @@ function getSquadInviteBody() {
     "",
     "{{cta}}",
     "",
-    "Once confirmed, you’ll be included in squad messages and fixture availability checks when games are coming up.",
+    "{{squadAccessLine}}",
     "",
     "Thanks,",
     "SIXFL",
@@ -257,6 +368,23 @@ async function alreadyQueuedOrSent(prospectId: string) {
 
 type LoadedProspect = NonNullable<Awaited<ReturnType<typeof loadProspectForSquadEmail>>>;
 
+type LeagueStartRow = {
+  proposedStartDate: Date | null;
+};
+
+async function getLeagueProposedStartDate(leagueId: string | null | undefined) {
+  if (!leagueId) return null;
+
+  const rows = await prisma.$queryRaw<Array<LeagueStartRow>>(Prisma.sql`
+    SELECT "proposedStartDate" AS "proposedStartDate"
+    FROM "League"
+    WHERE id = ${leagueId}
+    LIMIT 1
+  `);
+
+  return rows[0]?.proposedStartDate ?? null;
+}
+
 async function loadProspectForSquadEmail(prospectId: string) {
   return prisma.teamPlayerProspect.findUnique({
     where: { id: prospectId },
@@ -275,8 +403,10 @@ async function loadProspectForSquadEmail(prospectId: string) {
           logoUrl: true,
           league: {
             select: {
+              id: true,
               name: true,
               season: true,
+              area: true,
               dayOfWeek: true,
               venueName: true,
             },
@@ -287,7 +417,7 @@ async function loadProspectForSquadEmail(prospectId: string) {
   });
 }
 
-function buildProspectEmailContext(prospect: LoadedProspect) {
+async function buildProspectEmailContext(prospect: LoadedProspect) {
   if (!prospect.teamId || !prospect.team) return null;
 
   const email = prospect.email?.trim().toLowerCase() || null;
@@ -300,6 +430,7 @@ function buildProspectEmailContext(prospect: LoadedProspect) {
         prospect.team.league.season ? ` · ${prospect.team.league.season}` : ""
       }`
     : "";
+  const proposedStartDate = await getLeagueProposedStartDate(prospect.team.league?.id);
 
   return {
     email,
@@ -313,7 +444,13 @@ function buildProspectEmailContext(prospect: LoadedProspect) {
       leagueName,
       venueName: prospect.team.league?.venueName ?? "",
       preferredNight: formatPreferredNight(prospect.team.league?.dayOfWeek) ?? "",
-      teamContextLine: getTeamContextLine(prospect.team),
+      squadInviteIntroLine: getSquadInviteIntroLine({
+        teamName: prospect.team.name,
+        area: prospect.team.league?.area,
+        proposedStartDate,
+      }),
+      teamContextLine: getTeamContextLine(prospect.team, proposedStartDate),
+      squadAccessLine: getSquadAccessLine(proposedStartDate),
       joinConfirmationUrl,
       teamJoinUrl: joinConfirmationUrl,
     },
@@ -342,7 +479,7 @@ export async function queueManagedSquadJoinConfirmationEmail(input: {
     return { ok: false as const, status: "prospect_not_found" as const };
   }
 
-  const context = buildProspectEmailContext(prospect);
+  const context = await buildProspectEmailContext(prospect);
 
   if (!context) {
     return { ok: false as const, status: "no_email" as const };
@@ -449,7 +586,7 @@ export async function queueManagedSquadJoinChaseEmail(input: {
     return { ok: false as const, status: "prospect_not_found" as const };
   }
 
-  const context = buildProspectEmailContext(prospect);
+  const context = await buildProspectEmailContext(prospect);
 
   if (!context) {
     return { ok: false as const, status: "no_email" as const };


### PR DESCRIPTION
## Summary
- change team-place confirmation wording so YES reserves a place rather than implying the actual team has already been created
- after confirmation, allow the lead to save/update the team name on the same signed confirmation link
- add an explicit “I’ll confirm the team name later” option; reopening the same link lets them add it later without losing the reserved place
- keep team creation manual in Admin and block public team-name edits once a real Team has been created
- add a permanent team-confirmation contract and run it in the critical-feature workflow

The existing confirmation/decline status behaviour remains unchanged.