### PR TITLE
Clarify team place reservations are non-binding

### DIFF
--- a/src/app/(public)/team-confirmation/[token]/page.tsx
+++ b/src/app/(public)/team-confirmation/[token]/page.tsx
@@ -429,6 +429,10 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
                 </p>
               </div>
 
+              <div className="rounded-2xl border border-emerald-400/15 bg-emerald-500/[0.06] px-4 py-3 text-sm leading-6 text-white/70">
+                By reserving a place, you’re simply letting us know you’d like us to hold a place for your team while we finalise the league. There’s no payment due and you’re not committing to take part at this stage.
+              </div>
+
               <div className="flex flex-col gap-3 sm:flex-row">
                 <form action={confirmTeamPlaceAction}>
                   <input type="hidden" name="token" value={token} />


### PR DESCRIPTION
## Summary
- add a reassurance directly above the team confirmation buttons explaining that reserving a place is only an expression of interest
- make clear that no payment is due and the team is not committing to take part at this stage
- keep the existing reserve/release actions and manual team-creation flow unchanged