### PR TITLE
Close the loop on last-minute replacement fixtures

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check standard-team player payment links
         run: node scripts/check-standard-team-player-payment-links.mjs
 
+      - name: Check last-minute replacement resolution
+        run: node scripts/check-last-minute-replacement-resolution.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -82,6 +85,7 @@ jobs:
           node scripts/check-critical-feature-contracts.mjs
           node scripts/check-team-confirmation-contract.mjs
           node scripts/check-standard-team-player-payment-links.mjs
+          node scripts/check-last-minute-replacement-resolution.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/prisma/migrations/20260818170000_last_minute_replacement_resolution/migration.sql
+++ b/prisma/migrations/20260818170000_last_minute_replacement_resolution/migration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "LastMinuteReplacementResolution" (
+  "id" TEXT NOT NULL,
+  "fixtureId" TEXT NOT NULL,
+  "droppedTeamId" TEXT NOT NULL,
+  "replacementTeamId" TEXT NOT NULL,
+  "opponentTeamId" TEXT NOT NULL,
+  "resolvedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdByUserId" TEXT,
+  CONSTRAINT "LastMinuteReplacementResolution_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "LastMinuteReplacementResolution_fixture_drop_replacement_key"
+  ON "LastMinuteReplacementResolution"("fixtureId", "droppedTeamId", "replacementTeamId");
+
+CREATE INDEX IF NOT EXISTS "LastMinuteReplacementResolution_fixture_resolved_idx"
+  ON "LastMinuteReplacementResolution"("fixtureId", "resolvedAt");

--- a/scripts/check-last-minute-replacement-resolution.mjs
+++ b/scripts/check-last-minute-replacement-resolution.mjs
@@ -34,7 +34,7 @@ for (const marker of [
   "reconcileLastMinuteReplacement",
   "replacementTeamId",
   "opponentTeamId",
-  'role: "not_selected"',
+  '"not_selected"',
   "There is no charge for this extra game.",
   "are not required for this extra game",
   "Your normal fixture arrangements remain in place.",

--- a/scripts/check-last-minute-replacement-resolution.mjs
+++ b/scripts/check-last-minute-replacement-resolution.mjs
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+const servicePath = "src/lib/fixtures/last-minute-replacement-resolution.ts";
+const controlPath = "src/components/admin/night-board/LastMinuteReplacementControl.tsx";
+const reconcileRoutePath = "src/app/api/admin/night-board/last-minute-replacement/reconcile/route.ts";
+const cronPath = "src/app/api/cron/notifications/route.ts";
+const migrationPath = "prisma/migrations/20260818170000_last_minute_replacement_resolution/migration.sql";
+
+const service = read(servicePath);
+const control = read(controlPath);
+const reconcileRoute = read(reconcileRoutePath);
+const cron = read(cronPath);
+const migration = read(migrationPath);
+
+for (const marker of [
+  "LastMinuteReplacementResolution",
+  "reconcileLastMinuteReplacement",
+  "replacementTeamId",
+  "opponentTeamId",
+  'role: "not_selected"',
+  "There is no charge for this extra game.",
+  "are not required for this extra game",
+  "Your normal fixture arrangements remain in place.",
+  "ON CONFLICT",
+]) {
+  expect(service, marker, `Last-minute replacement resolution service is missing: ${marker}`);
+}
+
+expect(
+  control,
+  "/last-minute-replacement/reconcile",
+  "Night Board replacement controls must reconcile an allocated replacement when the board loads.",
+);
+expect(
+  control,
+  "Last-minute replacement confirmed",
+  "Night Board must visibly show the selected replacement as confirmed.",
+);
+expect(
+  control,
+  "Replacement confirmed ·",
+  "Night Board must visibly show the original opponent which replacement team is playing.",
+);
+expect(
+  reconcileRoute,
+  "reconcileLastMinuteReplacement",
+  "Admin reconcile endpoint must use the shared replacement-resolution service.",
+);
+expect(
+  cron,
+  "reconcilePendingLastMinuteReplacements",
+  "Notification cron must reconcile replacements even if the Night Board is not reopened immediately.",
+);
+expect(
+  migration,
+  'CREATE TABLE IF NOT EXISTS "LastMinuteReplacementResolution"',
+  "Replacement resolutions must be persisted for audit and duplicate-send protection.",
+);
+expect(
+  migration,
+  'UNIQUE INDEX IF NOT EXISTS "LastMinuteReplacementResolution_fixture_drop_replacement_key"',
+  "Replacement resolution persistence must prevent duplicate resolved-message cycles.",
+);
+
+if (failures.length) {
+  console.error("\nLAST-MINUTE REPLACEMENT RESOLUTION CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log("Last-minute replacement resolution contract passed.");

--- a/src/app/api/admin/night-board/last-minute-replacement/reconcile/route.ts
+++ b/src/app/api/admin/night-board/last-minute-replacement/reconcile/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { reconcileLastMinuteReplacement } from "@/lib/fixtures/last-minute-replacement-resolution";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const access = await requireAdmin();
+
+  const payload = (await request.json().catch(() => null)) as
+    | { fixtureId?: string }
+    | null;
+  const fixtureId = payload?.fixtureId?.trim() ?? "";
+
+  if (!fixtureId) {
+    return NextResponse.json(
+      { ok: false, error: "Fixture is required." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await reconcileLastMinuteReplacement({
+      fixtureId,
+      createdByUserId: access.user?.id ?? null,
+    });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "The replacement could not be reconciled.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/night-board/last-minute-replacement/route.ts
+++ b/src/app/api/admin/night-board/last-minute-replacement/route.ts
@@ -1,9 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { sendLastMinuteReplacementAlert } from "@/lib/fixtures/last-minute-replacement";
+import { getLastMinuteReplacementControlState } from "@/lib/fixtures/last-minute-replacement-resolution";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  await requireAdmin();
+
+  const fixtureId = request.nextUrl.searchParams.get("fixtureId")?.trim() ?? "";
+  const currentTeamId = request.nextUrl.searchParams.get("currentTeamId")?.trim() ?? "";
+
+  if (!fixtureId || !currentTeamId) {
+    return NextResponse.json(
+      { ok: false, error: "Fixture and team are required." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const state = await getLastMinuteReplacementControlState({
+      fixtureId,
+      currentTeamId,
+    });
+    return NextResponse.json({ ok: true, state });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "The replacement status could not be loaded.",
+      },
+      { status: 500 },
+    );
+  }
+}
 
 export async function POST(request: NextRequest) {
   const access = await requireAdmin();

--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -7,6 +7,7 @@ import { runCaptainOnboardingEmailJob } from "@/lib/captain/onboarding-emails";
 import { runFixtureConfirmationEmailJob } from "@/lib/fixtures/confirmation-emails";
 import { runFixtureConfirmationReminderJob } from "@/lib/fixtures/confirmation-reminder-job";
 import { backfillUpcomingFixtureConfirmationWarningEmails } from "@/lib/fixtures/confirmation-warning-emails";
+import { reconcilePendingLastMinuteReplacements } from "@/lib/fixtures/last-minute-replacement-resolution";
 import { processNotificationQueue } from "@/lib/notifications/processor";
 import { chargeDueMatchdayAutoPayments } from "@/lib/payments/team-autopay";
 import { queueDueRefereeNightConfirmationChasers } from "@/lib/referee-night-confirmations";
@@ -68,6 +69,7 @@ export async function GET(request: NextRequest) {
     const fixtureConfirmationEmails = await runFixtureConfirmationEmailJob();
     const fixtureConfirmationWarnings =
       await backfillUpcomingFixtureConfirmationWarningEmails();
+    const lastMinuteReplacements = await reconcilePendingLastMinuteReplacements();
     const refereeAssignmentSync = await syncUpcomingRefereeAssignmentsForConfirmations();
     const refereeNights = await queueDueRefereeNightReminderEmails();
     const refereeConfirmations = await queueDueRefereeNightConfirmationChasers();
@@ -104,6 +106,7 @@ export async function GET(request: NextRequest) {
       fixtureConfirmations,
       fixtureConfirmationEmails,
       fixtureConfirmationWarnings,
+      lastMinuteReplacements,
       refereeAssignmentSync,
       refereeNights,
       refereeConfirmations,

--- a/src/components/admin/night-board/LastMinuteReplacementControl.tsx
+++ b/src/components/admin/night-board/LastMinuteReplacementControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type Result = {
   ok?: boolean;
@@ -9,6 +9,19 @@ type Result = {
   email?: { sent: number; skipped: number; failed: number; queued: number };
   sms?: { sent: number; skipped: number; failed: number; queued: number };
 };
+
+type ControlState =
+  | { status: "idle" }
+  | { status: "alert_sent"; droppedTeamId: string }
+  | {
+      status: "resolved";
+      droppedTeamId: string;
+      replacementTeamId: string;
+      replacementTeamName: string;
+      opponentTeamId: string;
+      opponentTeamName: string;
+      resolvedAt: string;
+    };
 
 export default function LastMinuteReplacementControl({
   fixtureId,
@@ -20,11 +33,51 @@ export default function LastMinuteReplacementControl({
   teamName: string;
 }) {
   const [sending, setSending] = useState(false);
-  const [sent, setSent] = useState(false);
+  const [controlState, setControlState] = useState<ControlState>({ status: "idle" });
   const [message, setMessage] = useState<string | null>(null);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadState() {
+      try {
+        // If the fixture teams have already been changed after an alert was sent,
+        // reconcile it now. The server is idempotent, so both team controls can
+        // safely ask without creating duplicate messages.
+        await fetch("/api/admin/night-board/last-minute-replacement/reconcile", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fixtureId }),
+          cache: "no-store",
+        });
+
+        const params = new URLSearchParams({ fixtureId, currentTeamId: droppedTeamId });
+        const response = await fetch(
+          `/api/admin/night-board/last-minute-replacement?${params.toString()}`,
+          { cache: "no-store" },
+        );
+        const payload = (await response.json().catch(() => null)) as
+          | { ok?: boolean; state?: ControlState }
+          | null;
+
+        if (!cancelled && response.ok && payload?.ok && payload.state) {
+          setControlState(payload.state);
+        }
+      } catch {
+        // Keep the manual alert control available if the status check cannot be loaded.
+      }
+    }
+
+    void loadState();
+    return () => {
+      cancelled = true;
+    };
+  }, [fixtureId, droppedTeamId]);
+
+  const sent = controlState.status === "alert_sent";
+
   async function sendAlert() {
-    if (sending || sent) return;
+    if (sending || sent || controlState.status === "resolved") return;
 
     const confirmed = window.confirm(
       `Send a last-minute FREE fixture alert by email and SMS to every eligible team in this league because ${teamName} has dropped out?`,
@@ -56,7 +109,9 @@ export default function LastMinuteReplacementControl({
         (payload.email?.skipped ?? 0) +
         (payload.sms?.skipped ?? 0);
 
-      setSent(true);
+      if (eligible > 0) {
+        setControlState({ status: "alert_sent", droppedTeamId });
+      }
       setMessage(
         eligible === 0
           ? "No eligible teams were available to contact."
@@ -71,6 +126,22 @@ export default function LastMinuteReplacementControl({
     } finally {
       setSending(false);
     }
+  }
+
+  if (controlState.status === "resolved") {
+    const isReplacement = controlState.replacementTeamId === droppedTeamId;
+    const isOpponent = controlState.opponentTeamId === droppedTeamId;
+    const label = isReplacement
+      ? "✓ Last-minute replacement confirmed"
+      : isOpponent
+        ? `Replacement confirmed · ${controlState.replacementTeamName}`
+        : `Replacement resolved · ${controlState.replacementTeamName}`;
+
+    return (
+      <div className="mt-1 inline-flex max-w-full rounded-lg border border-emerald-400/25 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-emerald-100">
+        {label}
+      </div>
+    );
   }
 
   return (

--- a/src/lib/fixtures/last-minute-replacement-resolution.ts
+++ b/src/lib/fixtures/last-minute-replacement-resolution.ts
@@ -1,0 +1,450 @@
+import { randomUUID } from "node:crypto";
+import { NotificationChannel, Prisma } from "@prisma/client";
+
+import { sendTeamBroadcastMessage } from "@/lib/communications/send-team-broadcast";
+import { processNotificationQueue } from "@/lib/notifications/processor";
+import { prisma } from "@/lib/prisma";
+
+const INITIAL_ORIGIN = "night-board-last-minute-replacement";
+const RESOLVED_ORIGIN = "night-board-last-minute-replacement-resolved";
+
+const LIVE_DISPATCH_STATUSES = ["QUEUED", "PROCESSING", "SENT"] as const;
+
+type InitialAlertCycle = {
+  fixtureId: string;
+  droppedTeamId: string;
+  opponentTeamId: string;
+  createdAt: Date;
+};
+
+type ResolutionRow = {
+  id: string;
+  fixtureId: string;
+  droppedTeamId: string;
+  replacementTeamId: string;
+  opponentTeamId: string;
+  resolvedAt: Date;
+  replacementTeamName: string;
+  opponentTeamName: string;
+};
+
+export type LastMinuteReplacementControlState =
+  | { status: "idle" }
+  | { status: "alert_sent"; droppedTeamId: string }
+  | {
+      status: "resolved";
+      droppedTeamId: string;
+      replacementTeamId: string;
+      replacementTeamName: string;
+      opponentTeamId: string;
+      opponentTeamName: string;
+      resolvedAt: string;
+    };
+
+function formatDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  }).format(value);
+}
+
+function formatTime(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(value);
+}
+
+function formatMoney(pence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: pence % 100 === 0 ? 0 : 2,
+  }).format(pence / 100);
+}
+
+async function getLatestInitialAlertCycle(fixtureId: string) {
+  const rows = await prisma.$queryRaw<InitialAlertCycle[]>(Prisma.sql`
+    SELECT
+      dispatch."metadata"->>'fixtureId' AS "fixtureId",
+      dispatch."metadata"->>'droppedTeamId' AS "droppedTeamId",
+      dispatch."metadata"->>'opponentTeamId' AS "opponentTeamId",
+      dispatch."createdAt" AS "createdAt"
+    FROM "NotificationDispatch" dispatch
+    WHERE dispatch."metadata"->>'origin' = ${INITIAL_ORIGIN}
+      AND dispatch."metadata"->>'fixtureId' = ${fixtureId}
+      AND dispatch."status"::text IN (${Prisma.join([...LIVE_DISPATCH_STATUSES])})
+      AND COALESCE(dispatch."metadata"->>'droppedTeamId', '') <> ''
+      AND COALESCE(dispatch."metadata"->>'opponentTeamId', '') <> ''
+    ORDER BY dispatch."createdAt" DESC
+    LIMIT 1
+  `);
+  return rows[0] ?? null;
+}
+
+async function getResolution(fixtureId: string, droppedTeamId?: string | null) {
+  const rows = await prisma.$queryRaw<ResolutionRow[]>(Prisma.sql`
+    SELECT
+      resolution."id",
+      resolution."fixtureId",
+      resolution."droppedTeamId",
+      resolution."replacementTeamId",
+      resolution."opponentTeamId",
+      resolution."resolvedAt",
+      replacement."name" AS "replacementTeamName",
+      opponent."name" AS "opponentTeamName"
+    FROM "LastMinuteReplacementResolution" resolution
+    JOIN "Team" replacement ON replacement."id" = resolution."replacementTeamId"
+    JOIN "Team" opponent ON opponent."id" = resolution."opponentTeamId"
+    WHERE resolution."fixtureId" = ${fixtureId}
+      ${droppedTeamId ? Prisma.sql`AND resolution."droppedTeamId" = ${droppedTeamId}` : Prisma.empty}
+    ORDER BY resolution."resolvedAt" DESC
+    LIMIT 1
+  `);
+  return rows[0] ?? null;
+}
+
+async function getContactedTeamIds(input: {
+  fixtureId: string;
+  droppedTeamId: string;
+}) {
+  const rows = await prisma.$queryRaw<Array<{ teamId: string }>>(Prisma.sql`
+    SELECT DISTINCT dispatch."metadata"->>'teamId' AS "teamId"
+    FROM "NotificationDispatch" dispatch
+    WHERE dispatch."metadata"->>'origin' = ${INITIAL_ORIGIN}
+      AND dispatch."metadata"->>'fixtureId' = ${input.fixtureId}
+      AND dispatch."metadata"->>'droppedTeamId' = ${input.droppedTeamId}
+      AND dispatch."status"::text IN (${Prisma.join([...LIVE_DISPATCH_STATUSES])})
+      AND COALESCE(dispatch."metadata"->>'teamId', '') <> ''
+  `);
+  return rows.map((row) => row.teamId);
+}
+
+function toControlState(row: ResolutionRow): LastMinuteReplacementControlState {
+  return {
+    status: "resolved",
+    droppedTeamId: row.droppedTeamId,
+    replacementTeamId: row.replacementTeamId,
+    replacementTeamName: row.replacementTeamName,
+    opponentTeamId: row.opponentTeamId,
+    opponentTeamName: row.opponentTeamName,
+    resolvedAt: row.resolvedAt.toISOString(),
+  };
+}
+
+export async function getLastMinuteReplacementControlState(input: {
+  fixtureId: string;
+  currentTeamId: string;
+}): Promise<LastMinuteReplacementControlState> {
+  const resolution = await getResolution(input.fixtureId);
+  if (resolution) return toControlState(resolution);
+
+  const alert = await getLatestInitialAlertCycle(input.fixtureId);
+  if (alert?.droppedTeamId === input.currentTeamId) {
+    return { status: "alert_sent", droppedTeamId: alert.droppedTeamId };
+  }
+
+  return { status: "idle" };
+}
+
+async function sendResolutionMessage(input: {
+  teamId: string;
+  role: "replacement" | "opponent" | "not_selected";
+  fixtureId: string;
+  droppedTeamId: string;
+  replacementTeamId: string;
+  replacementTeamName: string;
+  opponentTeamId: string;
+  opponentTeamName: string;
+  kickoffAt: Date;
+  venueName: string;
+  pitch: string;
+  replacementFeePence: number | null;
+  createdByUserId?: string | null;
+}) {
+  const date = formatDate(input.kickoffAt);
+  const time = formatTime(input.kickoffAt);
+  const details = [
+    `Date: ${date}`,
+    `Kick-off: ${time}`,
+    `Venue: ${input.venueName}`,
+    `Pitch: ${input.pitch}`,
+  ].join("\n");
+
+  let subject: string;
+  let body: string;
+  let sms: string;
+
+  if (input.role === "replacement") {
+    const feeLine =
+      input.replacementFeePence === null || input.replacementFeePence === 0
+        ? "There is no charge for this extra game."
+        : `The fixture fee currently showing for your team is ${formatMoney(input.replacementFeePence)}.`;
+    subject = `Confirmed: your extra SIXFL fixture at ${time}`;
+    body = [
+      "Hi {{firstName}},",
+      "",
+      `Confirmed — {{teamName}} have been allocated the extra fixture against ${input.opponentTeamName}.`,
+      "",
+      details,
+      "",
+      feeLine,
+      "",
+      "Please make sure your players know they are playing this extra fixture.",
+      "",
+      "Thanks,",
+      "SIXFL",
+    ].join("\n");
+    sms = `SIXFL: Confirmed — {{teamName}} have the extra ${time} fixture v ${input.opponentTeamName}. ${feeLine}`;
+  } else if (input.role === "opponent") {
+    subject = `Replacement confirmed for your ${time} SIXFL fixture`;
+    body = [
+      "Hi {{firstName}},",
+      "",
+      `Replacement confirmed — your ${time} fixture will now be against ${input.replacementTeamName}.`,
+      "",
+      details,
+      "",
+      "Your normal fixture arrangements remain in place.",
+      "",
+      "Thanks,",
+      "SIXFL",
+    ].join("\n");
+    sms = `SIXFL: Replacement confirmed for ${time}. You will now play ${input.replacementTeamName}. Your normal fixture arrangements remain in place.`;
+  } else {
+    subject = `SIXFL extra fixture now covered at ${time}`;
+    body = [
+      "Hi {{firstName}},",
+      "",
+      `Thanks — the extra ${time} fixture has now been allocated to ${input.replacementTeamName}.`,
+      "",
+      `{{teamName}} are not required for this extra game.`,
+      "",
+      `Date: ${date}`,
+      `Kick-off: ${time}`,
+      "",
+      "Thanks for being available to help.",
+      "",
+      "SIXFL",
+    ].join("\n");
+    sms = `SIXFL: The extra ${time} fixture has now been allocated to ${input.replacementTeamName}. {{teamName}} are not required for this extra game. Thanks for being available.`;
+  }
+
+  const metadata = {
+    event: "fixture.last_minute_replacement.resolved",
+    fixtureId: input.fixtureId,
+    droppedTeamId: input.droppedTeamId,
+    replacementTeamId: input.replacementTeamId,
+    opponentTeamId: input.opponentTeamId,
+    role: input.role,
+  };
+
+  const [emailResult, smsResult] = await Promise.all([
+    sendTeamBroadcastMessage({
+      teamId: input.teamId,
+      channel: NotificationChannel.EMAIL,
+      subject,
+      body,
+      origin: RESOLVED_ORIGIN,
+      originLabel: "Last-minute replacement resolved",
+      metadata,
+      createdByUserId: input.createdByUserId ?? null,
+    }),
+    sendTeamBroadcastMessage({
+      teamId: input.teamId,
+      channel: NotificationChannel.SMS,
+      body: sms,
+      origin: RESOLVED_ORIGIN,
+      originLabel: "Last-minute replacement resolved",
+      metadata,
+      createdByUserId: input.createdByUserId ?? null,
+    }),
+  ]);
+
+  return [emailResult.dispatchId, smsResult.dispatchId];
+}
+
+export async function reconcileLastMinuteReplacement(input: {
+  fixtureId: string;
+  createdByUserId?: string | null;
+}) {
+  const alert = await getLatestInitialAlertCycle(input.fixtureId);
+  if (!alert) {
+    return { resolved: false as const, reason: "no_alert" as const, state: null };
+  }
+
+  const existing = await getResolution(input.fixtureId, alert.droppedTeamId);
+  if (existing) {
+    return { resolved: false as const, reason: "already_resolved" as const, state: toControlState(existing) };
+  }
+
+  const fixture = await prisma.fixture.findUnique({
+    where: { id: input.fixtureId },
+    select: {
+      id: true,
+      status: true,
+      kickoffAt: true,
+      pitch: true,
+      matchFeePence: true,
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+      venue: { select: { name: true } },
+      league: { select: { venueName: true } },
+      paymentCharges: {
+        where: { status: { not: "VOID" } },
+        select: { teamId: true, amountPence: true },
+      },
+    },
+  });
+
+  if (!fixture || fixture.status !== "SCHEDULED" || fixture.kickoffAt <= new Date()) {
+    return { resolved: false as const, reason: "fixture_not_active" as const, state: null };
+  }
+
+  const currentTeamIds = [fixture.homeTeam.id, fixture.awayTeam.id];
+  if (currentTeamIds.includes(alert.droppedTeamId)) {
+    return { resolved: false as const, reason: "not_allocated_yet" as const, state: null };
+  }
+
+  if (!currentTeamIds.includes(alert.opponentTeamId)) {
+    return { resolved: false as const, reason: "opponent_changed" as const, state: null };
+  }
+
+  const replacementTeam =
+    fixture.homeTeam.id === alert.opponentTeamId ? fixture.awayTeam : fixture.homeTeam;
+  const opponentTeam =
+    fixture.homeTeam.id === alert.opponentTeamId ? fixture.homeTeam : fixture.awayTeam;
+
+  const inserted = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    INSERT INTO "LastMinuteReplacementResolution" (
+      "id", "fixtureId", "droppedTeamId", "replacementTeamId", "opponentTeamId", "createdByUserId"
+    ) VALUES (
+      ${randomUUID()}, ${fixture.id}, ${alert.droppedTeamId}, ${replacementTeam.id}, ${opponentTeam.id}, ${input.createdByUserId ?? null}
+    )
+    ON CONFLICT ("fixtureId", "droppedTeamId", "replacementTeamId") DO NOTHING
+    RETURNING "id"
+  `);
+
+  if (!inserted[0]) {
+    const concurrent = await getResolution(fixture.id, alert.droppedTeamId);
+    return {
+      resolved: false as const,
+      reason: "already_resolved" as const,
+      state: concurrent ? toControlState(concurrent) : null,
+    };
+  }
+
+  const contactedTeamIds = await getContactedTeamIds({
+    fixtureId: fixture.id,
+    droppedTeamId: alert.droppedTeamId,
+  });
+  const recipientRoles = new Map<string, "replacement" | "opponent" | "not_selected">();
+  recipientRoles.set(replacementTeam.id, "replacement");
+  recipientRoles.set(opponentTeam.id, "opponent");
+  for (const teamId of contactedTeamIds) {
+    if (
+      teamId !== replacementTeam.id &&
+      teamId !== opponentTeam.id &&
+      teamId !== alert.droppedTeamId
+    ) {
+      recipientRoles.set(teamId, "not_selected");
+    }
+  }
+
+  const replacementCharge = fixture.paymentCharges.find(
+    (charge) => charge.teamId === replacementTeam.id,
+  );
+  const venueName = fixture.venue?.name || fixture.league.venueName || "Venue TBC";
+  const pitch = fixture.pitch?.trim() || "TBC";
+  const dispatchIds: string[] = [];
+  let failedTeams = 0;
+
+  for (const [teamId, role] of recipientRoles) {
+    try {
+      dispatchIds.push(
+        ...(await sendResolutionMessage({
+          teamId,
+          role,
+          fixtureId: fixture.id,
+          droppedTeamId: alert.droppedTeamId,
+          replacementTeamId: replacementTeam.id,
+          replacementTeamName: replacementTeam.name,
+          opponentTeamId: opponentTeam.id,
+          opponentTeamName: opponentTeam.name,
+          kickoffAt: fixture.kickoffAt,
+          venueName,
+          pitch,
+          replacementFeePence: replacementCharge?.amountPence ?? null,
+          createdByUserId: input.createdByUserId ?? null,
+        })),
+      );
+    } catch (error) {
+      failedTeams += 1;
+      console.error("Could not queue last-minute replacement resolution message", {
+        fixtureId: fixture.id,
+        teamId,
+        role,
+        error,
+      });
+    }
+  }
+
+  if (dispatchIds.length > 0) {
+    await processNotificationQueue(Math.min(500, Math.max(50, dispatchIds.length + 20)));
+  }
+
+  const state: LastMinuteReplacementControlState = {
+    status: "resolved",
+    droppedTeamId: alert.droppedTeamId,
+    replacementTeamId: replacementTeam.id,
+    replacementTeamName: replacementTeam.name,
+    opponentTeamId: opponentTeam.id,
+    opponentTeamName: opponentTeam.name,
+    resolvedAt: new Date().toISOString(),
+  };
+
+  return {
+    resolved: true as const,
+    reason: "resolved" as const,
+    state,
+    contactedTeams: recipientRoles.size,
+    failedTeams,
+  };
+}
+
+export async function reconcilePendingLastMinuteReplacements(limit = 40) {
+  const safeLimit = Math.max(1, Math.min(Math.trunc(limit), 100));
+  const rows = await prisma.$queryRaw<Array<{ fixtureId: string }>>(Prisma.sql`
+    SELECT DISTINCT dispatch."metadata"->>'fixtureId' AS "fixtureId"
+    FROM "NotificationDispatch" dispatch
+    WHERE dispatch."metadata"->>'origin' = ${INITIAL_ORIGIN}
+      AND dispatch."status"::text IN (${Prisma.join([...LIVE_DISPATCH_STATUSES])})
+      AND dispatch."createdAt" >= CURRENT_TIMESTAMP - INTERVAL '14 days'
+      AND COALESCE(dispatch."metadata"->>'fixtureId', '') <> ''
+    LIMIT ${safeLimit}
+  `);
+
+  let resolved = 0;
+  let waiting = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    try {
+      const result = await reconcileLastMinuteReplacement({ fixtureId: row.fixtureId });
+      if (result.resolved) resolved += 1;
+      else waiting += 1;
+    } catch (error) {
+      failed += 1;
+      console.error("Last-minute replacement reconciliation failed", {
+        fixtureId: row.fixtureId,
+        error,
+      });
+    }
+  }
+
+  return { checked: rows.length, resolved, waiting, failed };
+}


### PR DESCRIPTION
## Summary
- persist when a last-minute replacement fixture has been resolved
- automatically detect when the originally dropped team has been replaced in the fixture
- message the selected replacement team, the original opponent, and every other team that received the initial free-fixture alert
- tell the selected replacement that the extra game is free when no charge is present
- tell the other contacted teams that they are not required for the extra fixture
- reconcile immediately when the Night Board loads and also from the normal notifications cron, so the close-out is not browser-session dependent
- keep the Night Board replacement control persistent across refreshes and show the confirmed replacement instead of leaving the old checkbox state ambiguous
- add a blocking regression contract for the whole workflow

This does not alter the normal opponent's fee or automatically rewrite any fixture charge.