### PR TITLE
Fix AI prediction matchup integrity

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Check last-minute replacement resolution
         run: node scripts/check-last-minute-replacement-resolution.mjs
 
+      - name: Check AI prediction matchup integrity
+        run: node scripts/check-ai-prediction-matchup-integrity.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -86,6 +89,7 @@ jobs:
           node scripts/check-team-confirmation-contract.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
+          node scripts/check-ai-prediction-matchup-integrity.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/prisma/migrations/20260819000000_ai_prediction_matchup_integrity/migration.sql
+++ b/prisma/migrations/20260819000000_ai_prediction_matchup_integrity/migration.sql
@@ -1,0 +1,65 @@
+ALTER TABLE "FixtureAiPrediction"
+  ADD COLUMN IF NOT EXISTS "homeTeamIdSnapshot" TEXT,
+  ADD COLUMN IF NOT EXISTS "awayTeamIdSnapshot" TEXT;
+
+CREATE OR REPLACE FUNCTION sixfl_stamp_fixture_ai_prediction_matchup()
+RETURNS TRIGGER AS $$
+BEGIN
+  SELECT fixture."homeTeamId", fixture."awayTeamId"
+  INTO NEW."homeTeamIdSnapshot", NEW."awayTeamIdSnapshot"
+  FROM "Fixture" fixture
+  WHERE fixture."id" = NEW."fixtureId";
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "FixtureAiPrediction_stamp_matchup" ON "FixtureAiPrediction";
+CREATE TRIGGER "FixtureAiPrediction_stamp_matchup"
+BEFORE INSERT OR UPDATE ON "FixtureAiPrediction"
+FOR EACH ROW
+EXECUTE FUNCTION sixfl_stamp_fixture_ai_prediction_matchup();
+
+CREATE OR REPLACE FUNCTION sixfl_invalidate_fixture_ai_prediction_on_team_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF (
+    OLD."homeTeamId" IS DISTINCT FROM NEW."homeTeamId"
+    OR OLD."awayTeamId" IS DISTINCT FROM NEW."awayTeamId"
+  ) AND NEW."status"::text = 'SCHEDULED'
+    AND NEW."kickoffAt" > CURRENT_TIMESTAMP
+  THEN
+    DELETE FROM "FixtureAiPrediction"
+    WHERE "fixtureId" = NEW."id";
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "Fixture_invalidate_ai_prediction_on_team_change" ON "Fixture";
+CREATE TRIGGER "Fixture_invalidate_ai_prediction_on_team_change"
+AFTER UPDATE OF "homeTeamId", "awayTeamId" ON "Fixture"
+FOR EACH ROW
+EXECUTE FUNCTION sixfl_invalidate_fixture_ai_prediction_on_team_change();
+
+-- Historical predictions keep the teams currently attached to the completed/past fixture.
+UPDATE "FixtureAiPrediction" prediction
+SET
+  "homeTeamIdSnapshot" = fixture."homeTeamId",
+  "awayTeamIdSnapshot" = fixture."awayTeamId"
+FROM "Fixture" fixture
+WHERE fixture."id" = prediction."fixtureId"
+  AND (
+    fixture."status"::text <> 'SCHEDULED'
+    OR fixture."kickoffAt" <= CURRENT_TIMESTAMP
+  );
+
+-- Existing future prediction rows pre-date matchup snapshots, so we cannot prove
+-- that their prose and score belong to the teams currently attached to the fixture.
+-- Remove them once and let the normal pre-match predictor rebuild them before kick-off.
+DELETE FROM "FixtureAiPrediction" prediction
+USING "Fixture" fixture
+WHERE fixture."id" = prediction."fixtureId"
+  AND fixture."status"::text = 'SCHEDULED'
+  AND fixture."kickoffAt" > CURRENT_TIMESTAMP;

--- a/prisma/migrations/20260819000000_ai_prediction_matchup_integrity/migration.sql
+++ b/prisma/migrations/20260819000000_ai_prediction_matchup_integrity/migration.sql
@@ -26,8 +26,7 @@ BEGIN
   IF (
     OLD."homeTeamId" IS DISTINCT FROM NEW."homeTeamId"
     OR OLD."awayTeamId" IS DISTINCT FROM NEW."awayTeamId"
-  ) AND NEW."status"::text = 'SCHEDULED'
-    AND NEW."kickoffAt" > CURRENT_TIMESTAMP
+  ) AND NEW."kickoffAt" > CURRENT_TIMESTAMP
   THEN
     DELETE FROM "FixtureAiPrediction"
     WHERE "fixtureId" = NEW."id";

--- a/scripts/apply-ai-prediction-matchup-integrity.cjs
+++ b/scripts/apply-ai-prediction-matchup-integrity.cjs
@@ -1,0 +1,417 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, relativePath), source, "utf8");
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found.`);
+  }
+  return source.replace(before, after);
+}
+
+function ensureImport(source, anchor, importLine, label) {
+  if (source.includes(importLine)) return source;
+  if (!source.includes(anchor)) {
+    throw new Error(`Expected ${label} import anchor was not found.`);
+  }
+  return source.replace(anchor, `${anchor}\n${importLine}`);
+}
+
+// ---------------------------------------------------------------------------
+// Stored prediction rows carry the exact home/away team IDs they were created
+// for. Any mismatch is repaired before display; a stale row is never rendered.
+// ---------------------------------------------------------------------------
+const storedPath = "src/lib/fixtures/storedAiPredictions.ts";
+let stored = read(storedPath);
+
+if (!stored.includes('ADD COLUMN IF NOT EXISTS "homeTeamIdSnapshot" TEXT')) {
+  stored = replaceRequired(
+    stored,
+    [
+      '      await prisma.$executeRawUnsafe(',
+      '        \'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "predictedAwayScore" INTEGER\',',
+      '      );',
+    ].join("\n"),
+    [
+      '      await prisma.$executeRawUnsafe(',
+      '        \'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "predictedAwayScore" INTEGER\',',
+      '      );',
+      '      await prisma.$executeRawUnsafe(',
+      '        \'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "homeTeamIdSnapshot" TEXT\',',
+      '      );',
+      '      await prisma.$executeRawUnsafe(',
+      '        \'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "awayTeamIdSnapshot" TEXT\',',
+      '      );',
+    ].join("\n"),
+    "AI prediction matchup snapshot columns",
+  );
+}
+
+stored = replaceRequired(
+  stored,
+  [
+    'async function savePrediction(input: {',
+    '  fixtureId: string;',
+    '  preview: FixtureAiPreview;',
+    '  inputHash: string;',
+    '  winChance: FixtureWinChance;',
+    '}) {',
+  ].join("\n"),
+  [
+    'async function savePrediction(input: {',
+    '  fixtureId: string;',
+    '  homeTeamIdSnapshot: string;',
+    '  awayTeamIdSnapshot: string;',
+    '  preview: FixtureAiPreview;',
+    '  inputHash: string;',
+    '  winChance: FixtureWinChance;',
+    '}) {',
+  ].join("\n"),
+  "stored prediction matchup snapshot input",
+);
+
+if (!stored.includes('        "homeTeamIdSnapshot",\n        "awayTeamIdSnapshot",')) {
+  stored = replaceRequired(
+    stored,
+    [
+      '        "fixtureId",',
+      '        "headline",',
+    ].join("\n"),
+    [
+      '        "fixtureId",',
+      '        "homeTeamIdSnapshot",',
+      '        "awayTeamIdSnapshot",',
+      '        "headline",',
+    ].join("\n"),
+    "stored prediction snapshot insert columns",
+  );
+}
+
+if (!stored.includes('        ${input.homeTeamIdSnapshot},\n        ${input.awayTeamIdSnapshot},')) {
+  stored = replaceRequired(
+    stored,
+    [
+      '        ${input.fixtureId},',
+      '        ${preview.headline},',
+    ].join("\n"),
+    [
+      '        ${input.fixtureId},',
+      '        ${input.homeTeamIdSnapshot},',
+      '        ${input.awayTeamIdSnapshot},',
+      '        ${preview.headline},',
+    ].join("\n"),
+    "stored prediction snapshot insert values",
+  );
+}
+
+if (!stored.includes('      "homeTeamIdSnapshot" = EXCLUDED."homeTeamIdSnapshot"')) {
+  stored = replaceRequired(
+    stored,
+    [
+      '    ON CONFLICT ("fixtureId") DO UPDATE SET',
+      '      "headline" = EXCLUDED."headline",',
+    ].join("\n"),
+    [
+      '    ON CONFLICT ("fixtureId") DO UPDATE SET',
+      '      "homeTeamIdSnapshot" = EXCLUDED."homeTeamIdSnapshot",',
+      '      "awayTeamIdSnapshot" = EXCLUDED."awayTeamIdSnapshot",',
+      '      "headline" = EXCLUDED."headline",',
+    ].join("\n"),
+    "stored prediction snapshot conflict update",
+  );
+}
+
+stored = replaceRequired(
+  stored,
+  '  await savePrediction({ fixtureId: input.fixture.id, preview, inputHash, winChance });',
+  [
+    '  await savePrediction({',
+    '    fixtureId: input.fixture.id,',
+    '    homeTeamIdSnapshot: input.fixture.homeTeam.id,',
+    '    awayTeamIdSnapshot: input.fixture.awayTeam.id,',
+    '    preview,',
+    '    inputHash,',
+    '    winChance,',
+    '  });',
+  ].join("\n"),
+  "stored prediction snapshot save call",
+);
+
+const repairAnchor = [
+  '  await recoverMissingHistoricalAiPredictions(ids);',
+  '',
+  '  const rows = await prisma.$queryRaw<StoredPredictionRow[]>`',
+].join("\n");
+const repairBlock = [
+  '  await recoverMissingHistoricalAiPredictions(ids);',
+  '',
+  '  const upcomingToRepair = await prisma.$queryRaw<Array<{ fixtureId: string }>>(Prisma.sql`',
+  '    SELECT fixture."id" AS "fixtureId"',
+  '    FROM "Fixture" fixture',
+  '    JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"',
+  '    JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"',
+  '    LEFT JOIN "FixtureAiPrediction" prediction ON prediction."fixtureId" = fixture."id"',
+  '    WHERE fixture."id" IN (${Prisma.join(ids)})',
+  '      AND fixture."status" = \'SCHEDULED\'',
+  '      AND fixture."publishedAt" IS NOT NULL',
+  '      AND fixture."kickoffAt" > CURRENT_TIMESTAMP',
+  '      AND COALESCE(home_team."isFixturePlaceholder", FALSE) = FALSE',
+  '      AND COALESCE(away_team."isFixturePlaceholder", FALSE) = FALSE',
+  '      AND (',
+  '        prediction."fixtureId" IS NULL',
+  '        OR prediction."predictedHomeScore" IS NULL',
+  '        OR prediction."predictedAwayScore" IS NULL',
+  '        OR prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"',
+  '        OR prediction."awayTeamIdSnapshot" IS DISTINCT FROM fixture."awayTeamId"',
+  '      )',
+  '  `);',
+  '',
+  '  for (const item of upcomingToRepair) {',
+  '    try {',
+  '      await refreshStoredAiPreviewForFixture(item.fixtureId, { force: true });',
+  '    } catch (error) {',
+  '      console.error("Could not repair stale stored AI prediction before display", {',
+  '        fixtureId: item.fixtureId,',
+  '        error,',
+  '      });',
+  '    }',
+  '  }',
+  '',
+  '  const rows = await prisma.$queryRaw<StoredPredictionRow[]>`',
+].join("\n");
+if (!stored.includes("const upcomingToRepair = await prisma.$queryRaw")) {
+  stored = replaceRequired(
+    stored,
+    repairAnchor,
+    repairBlock,
+    "stored prediction on-read integrity repair",
+  );
+}
+
+if (!stored.includes('prediction."homeTeamIdSnapshot" = fixture."homeTeamId"')) {
+  const preparedVisibilityAnchor = [
+    '    WHERE prediction."fixtureId" IN (${Prisma.join(ids)})',
+    '      AND (fixture."publishedAt" IS NOT NULL OR fixture."status" = \'COMPLETED\')',
+    '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+  ].join("\n");
+  const rawVisibilityAnchor = [
+    '    WHERE prediction."fixtureId" IN (${Prisma.join(ids)})',
+    '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+  ].join("\n");
+  const snapshotLines = [
+    '      AND prediction."homeTeamIdSnapshot" = fixture."homeTeamId"',
+    '      AND prediction."awayTeamIdSnapshot" = fixture."awayTeamId"',
+  ];
+
+  if (stored.includes(preparedVisibilityAnchor)) {
+    stored = stored.replace(
+      preparedVisibilityAnchor,
+      [
+        '    WHERE prediction."fixtureId" IN (${Prisma.join(ids)})',
+        '      AND (fixture."publishedAt" IS NOT NULL OR fixture."status" = \'COMPLETED\')',
+        ...snapshotLines,
+        '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+      ].join("\n"),
+    );
+  } else if (stored.includes(rawVisibilityAnchor)) {
+    stored = stored.replace(
+      rawVisibilityAnchor,
+      [
+        '    WHERE prediction."fixtureId" IN (${Prisma.join(ids)})',
+        ...snapshotLines,
+        '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+      ].join("\n"),
+    );
+  } else {
+    throw new Error("Expected stored prediction display query was not found.");
+  }
+}
+
+write(storedPath, stored);
+
+// ---------------------------------------------------------------------------
+// The admin predictor must actively repair a mismatch, and it must never display
+// a prediction whose stored matchup does not equal the fixture currently shown.
+// ---------------------------------------------------------------------------
+const layoutPath = "src/app/(admin)/admin/ai-predictor/layout.tsx";
+let layout = read(layoutPath);
+
+if (!layout.includes('prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"')) {
+  layout = replaceRequired(
+    layout,
+    [
+      '      AND (',
+      '        prediction."fixtureId" IS NULL',
+      '        OR prediction."predictedHomeScore" IS NULL',
+      '        OR prediction."predictedAwayScore" IS NULL',
+      '      )',
+    ].join("\n"),
+    [
+      '      AND (',
+      '        prediction."fixtureId" IS NULL',
+      '        OR prediction."predictedHomeScore" IS NULL',
+      '        OR prediction."predictedAwayScore" IS NULL',
+      '        OR prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"',
+      '        OR prediction."awayTeamIdSnapshot" IS DISTINCT FROM fixture."awayTeamId"',
+      '      )',
+    ].join("\n"),
+    "admin predictor stale matchup detection",
+  );
+}
+
+layout = replaceRequired(
+  layout,
+  '      batch.map((row) => refreshStoredAiPreviewForFixture(row.fixtureId)),',
+  '      batch.map((row) => refreshStoredAiPreviewForFixture(row.fixtureId, { force: true })),',
+  "admin predictor forced stale repair",
+);
+
+if (!layout.includes('prediction."homeTeamIdSnapshot" = fixture."homeTeamId"')) {
+  layout = replaceRequired(
+    layout,
+    [
+      '      AND prediction."predictedHomeScore" IS NOT NULL',
+      '      AND prediction."predictedAwayScore" IS NOT NULL',
+      '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+    ].join("\n"),
+    [
+      '      AND prediction."predictedHomeScore" IS NOT NULL',
+      '      AND prediction."predictedAwayScore" IS NOT NULL',
+      '      AND prediction."homeTeamIdSnapshot" = fixture."homeTeamId"',
+      '      AND prediction."awayTeamIdSnapshot" = fixture."awayTeamId"',
+      '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+    ].join("\n"),
+    "admin predictor current-matchup display gate",
+  );
+}
+
+write(layoutPath, layout);
+
+// ---------------------------------------------------------------------------
+// Full fixture editing is a separate mutation path from the legacy fixture
+// wrapper. Refresh the prediction whenever a published matchup changes there.
+// ---------------------------------------------------------------------------
+const fullEditPath = "src/app/(admin)/admin/fixtures/[id]/edit/actions.ts";
+let fullEdit = read(fullEditPath);
+fullEdit = ensureImport(
+  fullEdit,
+  'import { queueInitialFixtureConfirmationEmailForTeam } from "@/lib/fixtures/confirmation-emails";',
+  'import { refreshStoredAiPreviewForFixture } from "@/lib/fixtures/storedAiPredictions";',
+  "full fixture edit AI predictor",
+);
+
+if (!fullEdit.includes("Failed to regenerate AI prediction after full fixture team change")) {
+  const fullEditAnchor =
+    '    const previousTeamIds = new Set([fixture.homeTeamId, fixture.awayTeamId]);';
+  if (!fullEdit.includes(fullEditAnchor)) {
+    throw new Error("Expected full fixture edit team-change anchor was not found.");
+  }
+
+  fullEdit = fullEdit.replace(
+    fullEditAnchor,
+    [
+      '    const teamsChanged =',
+      '      fixture.homeTeamId !== homeTeamId || fixture.awayTeamId !== awayTeamId;',
+      '',
+      '    if (',
+      '      fixture.publishedAt &&',
+      '      status === FixtureStatus.SCHEDULED &&',
+      '      !hasFixturePlaceholder &&',
+      '      kickoffAt > new Date() &&',
+      '      teamsChanged',
+      '    ) {',
+      '      try {',
+      '        await refreshStoredAiPreviewForFixture(fixtureId, { force: true });',
+      '      } catch (predictionError) {',
+      '        console.error("Failed to regenerate AI prediction after full fixture team change", {',
+      '          fixtureId,',
+      '          error: predictionError,',
+      '        });',
+      '      }',
+      '    }',
+      '',
+      fullEditAnchor,
+    ].join("\n"),
+  );
+}
+write(fullEditPath, fullEdit);
+
+// ---------------------------------------------------------------------------
+// Bulk future-team replacement is another direct fixture mutation path.
+// Refresh every published fixture changed by that operation.
+// ---------------------------------------------------------------------------
+const replaceTeamPath = "src/app/(admin)/admin/fixtures/replace-team/actions.ts";
+let replaceTeam = read(replaceTeamPath);
+replaceTeam = ensureImport(
+  replaceTeam,
+  'import { prisma } from "@/lib/prisma";',
+  'import { refreshStoredAiPreviewForFixture } from "@/lib/fixtures/storedAiPredictions";',
+  "bulk replacement AI predictor",
+);
+
+if (!replaceTeam.includes("publishedAt: true")) {
+  replaceTeam = replaceRequired(
+    replaceTeam,
+    [
+      '      homeTeamId: true,',
+      '      awayTeamId: true,',
+      '      kickoffAt: true,',
+    ].join("\n"),
+    [
+      '      homeTeamId: true,',
+      '      awayTeamId: true,',
+      '      kickoffAt: true,',
+      '      publishedAt: true,',
+    ].join("\n"),
+    "bulk replacement published fixture selection",
+  );
+}
+
+if (!replaceTeam.includes("Failed to regenerate AI prediction after future team replacement")) {
+  const replaceRefreshAnchor = [
+    '  });',
+    '',
+    '  revalidatePath("/admin/fixtures");',
+  ].join("\n");
+  const replaceRefreshBlock = [
+    '  });',
+    '',
+    '  for (const fixture of targetFixtures) {',
+    '    if (!fixture.publishedAt) continue;',
+    '    try {',
+    '      await refreshStoredAiPreviewForFixture(fixture.id, { force: true });',
+    '    } catch (predictionError) {',
+    '      console.error("Failed to regenerate AI prediction after future team replacement", {',
+    '        fixtureId: fixture.id,',
+    '        error: predictionError,',
+    '      });',
+    '    }',
+    '  }',
+    '',
+    '  revalidatePath("/admin/fixtures");',
+  ].join("\n");
+
+  const anchorIndex = replaceTeam.lastIndexOf(replaceRefreshAnchor);
+  if (anchorIndex < 0) {
+    throw new Error("Expected bulk replacement refresh anchor was not found.");
+  }
+  replaceTeam =
+    replaceTeam.slice(0, anchorIndex) +
+    replaceRefreshBlock +
+    replaceTeam.slice(anchorIndex + replaceRefreshAnchor.length);
+}
+write(replaceTeamPath, replaceTeam);
+
+console.log(
+  "AI prediction matchup integrity applied: stale scores/text are blocked, repaired on read, and regenerated after team changes.",
+);

--- a/scripts/check-ai-prediction-matchup-integrity.mjs
+++ b/scripts/check-ai-prediction-matchup-integrity.mjs
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const stored = read("src/lib/fixtures/storedAiPredictions.ts");
+const predictorLayout = read("src/app/(admin)/admin/ai-predictor/layout.tsx");
+const fullEdit = read("src/app/(admin)/admin/fixtures/[id]/edit/actions.ts");
+const replaceTeam = read("src/app/(admin)/admin/fixtures/replace-team/actions.ts");
+const cron = read("src/app/api/cron/notifications/route.ts");
+const repairService = read("src/lib/fixtures/aiPredictionIntegrity.ts");
+const migration = read(
+  "prisma/migrations/20260819000000_ai_prediction_matchup_integrity/migration.sql",
+);
+const preparation = read("scripts/apply-ai-prediction-matchup-integrity.cjs");
+const preparationChain = read("scripts/check-central-standings-usage.cjs");
+
+expect(
+  migration.includes('"homeTeamIdSnapshot" TEXT') &&
+    migration.includes('"awayTeamIdSnapshot" TEXT'),
+  "prediction rows must persist the exact home and away team IDs used for the stored call",
+);
+expect(
+  migration.includes('"Fixture_invalidate_ai_prediction_on_team_change"') &&
+    migration.includes('DELETE FROM "FixtureAiPrediction"'),
+  "changing a future fixture matchup must invalidate its old prediction at database level",
+);
+expect(
+  migration.includes("fixture.\"kickoffAt\" > CURRENT_TIMESTAMP") &&
+    migration.includes("Existing future prediction rows pre-date matchup snapshots"),
+  "deployment must discard unverifiable future prediction rows so stale scores/text cannot survive",
+);
+expect(
+  stored.includes('homeTeamIdSnapshot: input.fixture.homeTeam.id') &&
+    stored.includes('awayTeamIdSnapshot: input.fixture.awayTeam.id'),
+  "new stored predictions must save their actual matchup IDs",
+);
+expect(
+  stored.includes('prediction."homeTeamIdSnapshot" = fixture."homeTeamId"') &&
+    stored.includes('prediction."awayTeamIdSnapshot" = fixture."awayTeamId"'),
+  "stored prediction display must reject rows for a different current matchup",
+);
+expect(
+  stored.includes("const upcomingToRepair = await prisma.$queryRaw") &&
+    stored.includes('refreshStoredAiPreviewForFixture(item.fixtureId, { force: true })'),
+  "captain/public reads must repair missing or stale upcoming predictions before display",
+);
+expect(
+  predictorLayout.includes(
+    'prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"',
+  ) &&
+    predictorLayout.includes(
+      'prediction."awayTeamIdSnapshot" IS DISTINCT FROM fixture."awayTeamId"',
+    ) &&
+    predictorLayout.includes(
+      'refreshStoredAiPreviewForFixture(row.fixtureId, { force: true })',
+    ),
+  "admin predictor must detect and force-repair a changed matchup",
+);
+expect(
+  predictorLayout.includes('prediction."homeTeamIdSnapshot" = fixture."homeTeamId"') &&
+    predictorLayout.includes('prediction."awayTeamIdSnapshot" = fixture."awayTeamId"'),
+  "admin predictor must never render stale score/text beside current fixture teams",
+);
+expect(
+  fullEdit.includes("Failed to regenerate AI prediction after full fixture team change") &&
+    fullEdit.includes('refreshStoredAiPreviewForFixture(fixtureId, { force: true })'),
+  "full fixture editing must regenerate a published prediction when teams change",
+);
+expect(
+  replaceTeam.includes("Failed to regenerate AI prediction after future team replacement") &&
+    replaceTeam.includes('refreshStoredAiPreviewForFixture(fixture.id, { force: true })'),
+  "bulk future-team replacement must regenerate affected published predictions",
+);
+expect(
+  repairService.includes("repairUpcomingAiPredictionIntegrity") &&
+    repairService.includes('IS DISTINCT FROM fixture."homeTeamId"') &&
+    repairService.includes("force: true"),
+  "shared repair service must find and rebuild missing/stale upcoming predictions",
+);
+expect(
+  cron.includes("repairUpcomingAiPredictionIntegrity") &&
+    cron.includes("aiPredictionIntegrity"),
+  "normal Railway notification cron must repair prediction integrity without requiring an admin page visit",
+);
+expect(
+  preparationChain.includes('require("./apply-ai-prediction-matchup-integrity.cjs")'),
+  "AI matchup integrity preparation must run after the existing prediction publication preparation",
+);
+expect(
+  preparation.includes("stale scores/text are blocked") &&
+    preparation.includes("stored prediction on-read integrity repair"),
+  "the production source-preparation safeguard must remain present and explicit",
+);
+
+if (failures.length) {
+  console.error("\nAI PREDICTION MATCHUP INTEGRITY CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  console.error(
+    "\nDo not merge while a prediction can show score/text from a different fixture matchup.\n",
+  );
+  process.exit(1);
+}
+
+console.log("AI prediction matchup integrity contract passed.");

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -69,6 +69,7 @@ require("./apply-team-credit-replenishment-fix.cjs");
 require("./apply-free-kit-expiry-paid-kit-mode.cjs");
 require("./apply-ai-prediction-publication-snapshot.cjs");
 require("./fix-ai-prediction-publication-selects.cjs");
+require("./apply-ai-prediction-matchup-integrity.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");

--- a/src/app/(admin)/admin/fixtures/replace-team/actions.ts
+++ b/src/app/(admin)/admin/fixtures/replace-team/actions.ts
@@ -8,6 +8,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { Prisma } from "@prisma/client";
 
+import { refreshStoredAiPreviewForFixture } from "@/lib/fixtures/storedAiPredictions";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
@@ -86,6 +87,7 @@ export async function replaceTeamInFutureFixturesAction(formData: FormData) {
       homeTeamId: true,
       awayTeamId: true,
       kickoffAt: true,
+      publishedAt: true,
     },
     orderBy: [{ kickoffAt: "asc" }],
   });
@@ -188,6 +190,18 @@ export async function replaceTeamInFutureFixturesAction(formData: FormData) {
       },
     });
   });
+
+  for (const fixture of targetFixtures) {
+    if (!fixture.publishedAt) continue;
+    try {
+      await refreshStoredAiPreviewForFixture(fixture.id, { force: true });
+    } catch (predictionError) {
+      console.error("Failed to regenerate AI prediction after future team replacement", {
+        fixtureId: fixture.id,
+        error: predictionError,
+      });
+    }
+  }
 
   revalidatePath("/admin/fixtures");
   revalidatePath("/admin/fixtures/replace-team");

--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { runCaptainOnboardingEmailJob } from "@/lib/captain/onboarding-emails";
+import { repairUpcomingAiPredictionIntegrity } from "@/lib/fixtures/aiPredictionIntegrity";
 import { runFixtureConfirmationEmailJob } from "@/lib/fixtures/confirmation-emails";
 import { runFixtureConfirmationReminderJob } from "@/lib/fixtures/confirmation-reminder-job";
 import { backfillUpcomingFixtureConfirmationWarningEmails } from "@/lib/fixtures/confirmation-warning-emails";
@@ -69,6 +70,7 @@ export async function GET(request: NextRequest) {
     const fixtureConfirmationEmails = await runFixtureConfirmationEmailJob();
     const fixtureConfirmationWarnings =
       await backfillUpcomingFixtureConfirmationWarningEmails();
+    const aiPredictionIntegrity = await repairUpcomingAiPredictionIntegrity();
     const lastMinuteReplacements = await reconcilePendingLastMinuteReplacements();
     const refereeAssignmentSync = await syncUpcomingRefereeAssignmentsForConfirmations();
     const refereeNights = await queueDueRefereeNightReminderEmails();
@@ -106,6 +108,7 @@ export async function GET(request: NextRequest) {
       fixtureConfirmations,
       fixtureConfirmationEmails,
       fixtureConfirmationWarnings,
+      aiPredictionIntegrity,
       lastMinuteReplacements,
       refereeAssignmentSync,
       refereeNights,

--- a/src/lib/fixtures/aiPredictionIntegrity.ts
+++ b/src/lib/fixtures/aiPredictionIntegrity.ts
@@ -1,0 +1,90 @@
+import { Prisma } from "@prisma/client";
+
+import { refreshStoredAiPreviewForFixture } from "@/lib/fixtures/storedAiPredictions";
+import { prisma } from "@/lib/prisma";
+
+type PredictionRepairRow = {
+  fixtureId: string;
+  homeTeamId: string;
+  awayTeamId: string;
+};
+
+async function ensureMatchupSnapshotColumns() {
+  await prisma.$executeRawUnsafe(
+    'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "homeTeamIdSnapshot" TEXT',
+  );
+  await prisma.$executeRawUnsafe(
+    'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "awayTeamIdSnapshot" TEXT',
+  );
+}
+
+export async function repairUpcomingAiPredictionIntegrity(limit = 60) {
+  await ensureMatchupSnapshotColumns();
+
+  const safeLimit = Math.max(1, Math.min(Math.trunc(limit), 120));
+  const rows = await prisma.$queryRaw<PredictionRepairRow[]>(Prisma.sql`
+    SELECT
+      fixture."id" AS "fixtureId",
+      fixture."homeTeamId" AS "homeTeamId",
+      fixture."awayTeamId" AS "awayTeamId"
+    FROM "Fixture" fixture
+    JOIN "Team" home_team ON home_team."id" = fixture."homeTeamId"
+    JOIN "Team" away_team ON away_team."id" = fixture."awayTeamId"
+    LEFT JOIN "FixtureAiPrediction" prediction ON prediction."fixtureId" = fixture."id"
+    WHERE fixture."status"::text = 'SCHEDULED'
+      AND fixture."publishedAt" IS NOT NULL
+      AND fixture."kickoffAt" > CURRENT_TIMESTAMP
+      AND COALESCE(home_team."isFixturePlaceholder", FALSE) = FALSE
+      AND COALESCE(away_team."isFixturePlaceholder", FALSE) = FALSE
+      AND (
+        prediction."fixtureId" IS NULL
+        OR prediction."predictedHomeScore" IS NULL
+        OR prediction."predictedAwayScore" IS NULL
+        OR prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"
+        OR prediction."awayTeamIdSnapshot" IS DISTINCT FROM fixture."awayTeamId"
+      )
+    ORDER BY fixture."kickoffAt" ASC
+    LIMIT ${safeLimit}
+  `);
+
+  let repaired = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    try {
+      const preview = await refreshStoredAiPreviewForFixture(row.fixtureId, {
+        force: true,
+      });
+
+      if (!preview) {
+        failed += 1;
+        continue;
+      }
+
+      // The database trigger normally stamps this automatically. Keep this
+      // explicit update as a recovery fallback for environments deployed while
+      // a migration is still being applied.
+      await prisma.$executeRaw(Prisma.sql`
+        UPDATE "FixtureAiPrediction"
+        SET
+          "homeTeamIdSnapshot" = ${row.homeTeamId},
+          "awayTeamIdSnapshot" = ${row.awayTeamId}
+        WHERE "fixtureId" = ${row.fixtureId}
+      `);
+
+      repaired += 1;
+    } catch (error) {
+      failed += 1;
+      console.error("Could not repair stale upcoming AI prediction", {
+        fixtureId: row.fixtureId,
+        error,
+      });
+    }
+  }
+
+  return {
+    checked: rows.length,
+    repaired,
+    failed,
+  };
+}


### PR DESCRIPTION
## Summary
- stop stored AI scores/headlines/summaries being shown beside different current fixture teams
- persist the exact home/away team IDs used for every stored prediction
- invalidate future predictions at database level whenever either fixture team changes
- one-time remove existing future prediction rows that cannot be proven to match the current fixture, then rebuild them before kick-off
- self-heal missing/stale predictions on captain/public reads and on the AI Predictor page
- regenerate predictions after full fixture edits and bulk future-team replacements
- run a background integrity repair from the existing Railway notifications cron
- add a blocking regression contract

The key rule is now: if the stored matchup IDs do not exactly match the fixture currently being displayed, that prediction cannot be rendered.