### PR TITLE
Guarantee AI preview text matches fixture teams

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check AI prediction matchup integrity
         run: node scripts/check-ai-prediction-matchup-integrity.mjs
 
+      - name: Check AI prediction text/team integrity
+        run: node scripts/check-ai-prediction-text-team-integrity.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -90,6 +93,7 @@ jobs:
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
           node scripts/check-ai-prediction-matchup-integrity.mjs
+          node scripts/check-ai-prediction-text-team-integrity.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/scripts/apply-ai-prediction-text-team-integrity.cjs
+++ b/scripts/apply-ai-prediction-text-team-integrity.cjs
@@ -1,0 +1,152 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, relativePath), source, "utf8");
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found.`);
+  }
+  return source.replace(before, after);
+}
+
+// Make the local fallback wording explicitly identify both current teams.
+const predictorPath = "src/lib/fixtures/aiPredictor.ts";
+let predictor = read(predictorPath);
+const oldFallbackSummary = [
+  '    summary:',
+  '      favourite === "a draw"',
+  '        ? `The numbers point towards ${input.winChance.predictedResult.label}, with both teams still in the mix.`',
+  '        : `The numbers favour ${favouriteLabel}, but there is still plenty to play for on match night.`,',
+].join("\n");
+const newFallbackSummary = [
+  '    summary:',
+  '      favourite === "a draw"',
+  '        ? `${input.homeTeamName} face ${input.awayTeamName}. The numbers point towards ${input.winChance.predictedResult.label}, with both teams still in the mix.`',
+  '        : `${input.homeTeamName} face ${input.awayTeamName}. The numbers favour ${favouriteLabel}, but there is still plenty to play for on match night.`,',
+].join("\n");
+predictor = replaceRequired(
+  predictor,
+  oldFallbackSummary,
+  newFallbackSummary,
+  "fixture-aware fallback preview wording",
+);
+write(predictorPath, predictor);
+
+// Stored prediction reads must not trust a row merely because its ID snapshots
+// look current. The written preview itself must name both teams now attached to
+// the upcoming fixture. If it does not, force a new prediction before display.
+const storedPath = "src/lib/fixtures/storedAiPredictions.ts";
+let stored = read(storedPath);
+
+const repairSnapshotAnchor = [
+  '        OR prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"',
+  '        OR prediction."awayTeamIdSnapshot" IS DISTINCT FROM fixture."awayTeamId"',
+  '      )',
+].join("\n");
+const repairSemanticBlock = [
+  '        OR prediction."homeTeamIdSnapshot" IS DISTINCT FROM fixture."homeTeamId"',
+  '        OR prediction."awayTeamIdSnapshot" IS DISTINCT FROM fixture."awayTeamId"',
+  '        OR POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) = 0',
+  '        OR POSITION(LOWER(away_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) = 0',
+  '      )',
+].join("\n");
+if (!stored.includes('POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline"')) {
+  stored = replaceRequired(
+    stored,
+    repairSnapshotAnchor,
+    repairSemanticBlock,
+    "stored prediction semantic team repair",
+  );
+}
+
+const displaySnapshotAnchor = [
+  '      AND prediction."homeTeamIdSnapshot" = fixture."homeTeamId"',
+  '      AND prediction."awayTeamIdSnapshot" = fixture."awayTeamId"',
+  '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+].join("\n");
+const displaySemanticBlock = [
+  '      AND prediction."homeTeamIdSnapshot" = fixture."homeTeamId"',
+  '      AND prediction."awayTeamIdSnapshot" = fixture."awayTeamId"',
+  '      AND (',
+  '        fixture."status"::text <> \'SCHEDULED\'',
+  '        OR fixture."kickoffAt" <= CURRENT_TIMESTAMP',
+  '        OR (',
+  '          POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) > 0',
+  '          AND POSITION(LOWER(away_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) > 0',
+  '        )',
+  '      )',
+  '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+].join("\n");
+if (!stored.includes('fixture."status"::text <> \'SCHEDULED\'')) {
+  stored = replaceRequired(
+    stored,
+    displaySnapshotAnchor,
+    displaySemanticBlock,
+    "stored prediction semantic display gate",
+  );
+}
+
+write(storedPath, stored);
+
+// The admin prediction list has its own SQL path, so apply the same semantic
+// repair and display gates there as well.
+const layoutPath = "src/app/(admin)/admin/ai-predictor/layout.tsx";
+let layout = read(layoutPath);
+if (!layout.includes('POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline"')) {
+  layout = replaceRequired(
+    layout,
+    repairSnapshotAnchor,
+    repairSemanticBlock,
+    "admin predictor semantic team repair",
+  );
+}
+
+const adminDisplaySnapshotAnchor = [
+  '      AND prediction."homeTeamIdSnapshot" = fixture."homeTeamId"',
+  '      AND prediction."awayTeamIdSnapshot" = fixture."awayTeamId"',
+  '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+].join("\n");
+const adminDisplaySemanticBlock = [
+  '      AND prediction."homeTeamIdSnapshot" = fixture."homeTeamId"',
+  '      AND prediction."awayTeamIdSnapshot" = fixture."awayTeamId"',
+  '      AND POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) > 0',
+  '      AND POSITION(LOWER(away_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) > 0',
+  '      AND COALESCE(home_team."isFixturePlaceholder", false) = false',
+].join("\n");
+if (!layout.includes('AND POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline"')) {
+  layout = replaceRequired(
+    layout,
+    adminDisplaySnapshotAnchor,
+    adminDisplaySemanticBlock,
+    "admin predictor semantic display gate",
+  );
+}
+write(layoutPath, layout);
+
+// Background integrity repair must also recognise semantically stale text even
+// when a previous deployment incorrectly stamped current team IDs onto it.
+const repairServicePath = "src/lib/fixtures/aiPredictionIntegrity.ts";
+let repairService = read(repairServicePath);
+if (!repairService.includes('POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline"')) {
+  repairService = replaceRequired(
+    repairService,
+    repairSnapshotAnchor,
+    repairSemanticBlock,
+    "background AI semantic team repair",
+  );
+}
+write(repairServicePath, repairService);
+
+console.log(
+  "AI prediction text integrity applied: upcoming previews must name both current fixture teams or they are rebuilt/hidden.",
+);

--- a/scripts/check-ai-prediction-text-team-integrity.mjs
+++ b/scripts/check-ai-prediction-text-team-integrity.mjs
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const predictor = read("src/lib/fixtures/aiPredictor.ts");
+const stored = read("src/lib/fixtures/storedAiPredictions.ts");
+const adminLayout = read("src/app/(admin)/admin/ai-predictor/layout.tsx");
+const repairService = read("src/lib/fixtures/aiPredictionIntegrity.ts");
+const preparation = read("scripts/apply-ai-prediction-text-team-integrity.cjs");
+const chain = read("scripts/check-central-standings-usage.cjs");
+
+const semanticRepairMarker =
+  'POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) = 0';
+const semanticDisplayMarker =
+  'POSITION(LOWER(home_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) > 0';
+const awayDisplayMarker =
+  'POSITION(LOWER(away_team."name") IN LOWER(COALESCE(prediction."headline", \'\') || \' \' || COALESCE(prediction."summary", \'\'))) > 0';
+
+expect(
+  predictor.includes('${input.homeTeamName} face ${input.awayTeamName}. The numbers'),
+  "fallback prediction wording must explicitly name both teams in the current fixture",
+);
+expect(
+  stored.includes(semanticRepairMarker) &&
+    stored.includes(semanticDisplayMarker) &&
+    stored.includes(awayDisplayMarker),
+  "captain/public stored prediction reads must rebuild and block preview text that does not name both current teams",
+);
+expect(
+  adminLayout.includes(semanticRepairMarker) &&
+    adminLayout.includes(semanticDisplayMarker) &&
+    adminLayout.includes(awayDisplayMarker),
+  "admin predictor must rebuild and refuse to display text for different teams",
+);
+expect(
+  repairService.includes(semanticRepairMarker),
+  "background prediction repair must detect semantically stale team names even when ID snapshots look current",
+);
+expect(
+  preparation.includes("upcoming previews must name both current fixture teams") &&
+    preparation.includes("semantic display gate"),
+  "production source preparation must preserve the semantic team-name safeguard",
+);
+expect(
+  chain.includes('require("./apply-ai-prediction-text-team-integrity.cjs")'),
+  "semantic prediction integrity preparation must run after matchup integrity preparation",
+);
+
+if (failures.length) {
+  console.error("\nAI PREDICTION TEXT/TEAM INTEGRITY CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  console.error("\nDo not merge while prediction prose can describe teams other than the fixture being displayed.\n");
+  process.exit(1);
+}
+
+console.log("AI prediction text/team integrity contract passed.");

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -70,6 +70,7 @@ require("./apply-free-kit-expiry-paid-kit-mode.cjs");
 require("./apply-ai-prediction-publication-snapshot.cjs");
 require("./fix-ai-prediction-publication-selects.cjs");
 require("./apply-ai-prediction-matchup-integrity.cjs");
+require("./apply-ai-prediction-text-team-integrity.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");


### PR DESCRIPTION
## Summary
- add a second semantic integrity guard for upcoming AI predictions
- require upcoming prediction headline/summary text to name both teams currently in the fixture
- if stored text describes different teams, force a rebuild before display
- if the AI wording still does not match, omit it so captain/public pages use a safe current-fixture fallback instead of stale prose
- make fallback wording explicitly name both current teams
- apply the same repair/display rule to Admin AI Predictor and the background integrity job
- add a blocking regression contract

This specifically fixes cases like Pink Pony Girl v AHC AFC displaying prediction prose about Taking Part FC v The Units even when the score/percentages belong to the current fixture.