### PR TITLE
Add abandoned match fee and notification workflow

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Check AI prediction text/team integrity
         run: node scripts/check-ai-prediction-text-team-integrity.mjs
 
+      - name: Check fixture abandonment workflow
+        run: node scripts/check-fixture-abandonment-workflow.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -94,6 +97,7 @@ jobs:
           node scripts/check-last-minute-replacement-resolution.mjs
           node scripts/check-ai-prediction-matchup-integrity.mjs
           node scripts/check-ai-prediction-text-team-integrity.mjs
+          node scripts/check-fixture-abandonment-workflow.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/docs/fixture-abandonment-workflow.md
+++ b/docs/fixture-abandonment-workflow.md
@@ -1,0 +1,16 @@
+# Fixture abandonment workflow
+
+Referees mark an abandoned match from the referee-night fixture card.
+
+For abandonment caused by one team's conduct, the referee selects the responsible team and the reason. SIXFL then:
+
+- records an auditable abandonment decision without creating an official result;
+- charges the responsible team its own match fee plus the opponent's match fee;
+- waives the innocent team's unpaid fee;
+- cancels any still-open player payment links for the innocent team;
+- if the innocent standard team has already paid, adds the amount actually received as team credit for a future match;
+- emails both teams explaining the abandonment, fee decision and that the league/result outcome remains for SIXFL to decide.
+
+For medical, venue, weather or other no-fault abandonments, the fixture is recorded as abandoned but no automatic fee transfer is made.
+
+The referee-night cashup treats an abandoned fixture as an outcome for submission purposes even though it has no official result.

--- a/scripts/apply-fixture-abandonment-workflow.cjs
+++ b/scripts/apply-fixture-abandonment-workflow.cjs
@@ -1,0 +1,116 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const pagePath = path.join(root, "src", "app", "(public)", "referee", "night", "[id]", "page.tsx");
+
+let source = fs.readFileSync(pagePath, "utf8");
+
+function replaceOnce(before, after, label) {
+  if (source.includes(after)) return;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found in referee night page.`);
+  }
+  source = source.replace(before, after);
+}
+
+if (!source.includes('import AbandonedMatchForm from "@/components/referee/AbandonedMatchForm";')) {
+  replaceOnce(
+    'import DisciplinaryNoteForm from "@/components/referee/DisciplinaryNoteForm";',
+    [
+      'import DisciplinaryNoteForm from "@/components/referee/DisciplinaryNoteForm";',
+      'import AbandonedMatchForm from "@/components/referee/AbandonedMatchForm";',
+    ].join("\n"),
+    "abandonment component import",
+  );
+}
+
+if (!source.includes('import { getFixtureAbandonments } from "@/lib/fixtures/abandonment";')) {
+  replaceOnce(
+    'import { requireReferee } from "@/lib/admin";',
+    [
+      'import { requireReferee } from "@/lib/admin";',
+      'import { getFixtureAbandonments } from "@/lib/fixtures/abandonment";',
+    ].join("\n"),
+    "abandonment data import",
+  );
+}
+
+replaceOnce(
+  '    case "discipline":\n      return "Disciplinary note recorded.";',
+  [
+    '    case "discipline":',
+    '      return "Disciplinary note recorded.";',
+    '    case "abandoned":',
+    '      return "Match marked as abandoned. Fee changes have been applied and both teams have been notified where applicable.";',
+  ].join("\n"),
+  "abandonment saved message",
+);
+
+replaceOnce(
+  '  const disciplinaryNotesByFixture = groupDisciplinaryNotesByFixture(disciplinaryNotes);\n  const allFixturesHaveResults = fixtures.length > 0 && fixtures.every((fixture) => fixture.result);',
+  [
+    '  const disciplinaryNotesByFixture = groupDisciplinaryNotesByFixture(disciplinaryNotes);',
+    '  const abandonmentsByFixture = await getFixtureAbandonments(fixtureIds);',
+    '  const allFixturesHaveResults =',
+    '    fixtures.length > 0 &&',
+    '    fixtures.every((fixture) => fixture.result || abandonmentsByFixture.has(fixture.id));',
+  ].join("\n"),
+  "abandonment completion state",
+);
+
+replaceOnce(
+  '              const fixtureDisciplinaryNotes = disciplinaryNotesByFixture.get(fixture.id) ?? [];\n              const fixtureLabel = `${fixture.homeTeam.name} v ${fixture.awayTeam.name}`;',
+  [
+    '              const fixtureDisciplinaryNotes = disciplinaryNotesByFixture.get(fixture.id) ?? [];',
+    '              const abandonment = abandonmentsByFixture.get(fixture.id) ?? null;',
+    '              const fixtureLabel = `${fixture.homeTeam.name} v ${fixture.awayTeam.name}`;',
+  ].join("\n"),
+  "fixture abandonment lookup",
+);
+
+replaceOnce(
+  '{fixture.result ? `Current result: ${fixture.result.homeScore}-${fixture.result.awayScore}${fixture.result.isDisputed ? " · disputed" : ""}` : "No result entered"}',
+  '{abandonment ? "Match abandoned · result to be decided by SIXFL" : fixture.result ? `Current result: ${fixture.result.homeScore}-${fixture.result.awayScore}${fixture.result.isDisputed ? " · disputed" : ""}` : "No result entered"}',
+  "fixture abandonment status copy",
+);
+
+if (!source.includes("<AbandonedMatchForm")) {
+  replaceOnce(
+    '                  <div className="space-y-3 px-4 py-4 sm:px-6 sm:py-5">\n                    {locked ? (',
+    [
+      '                  <div className="space-y-3 px-4 py-4 sm:px-6 sm:py-5">',
+      '                    <AbandonedMatchForm',
+      '                      refereeNightId={night.id}',
+      '                      fixtureId={fixture.id}',
+      '                      homeTeam={{ id: fixture.homeTeam.id, name: fixture.homeTeam.name }}',
+      '                      awayTeam={{ id: fixture.awayTeam.id, name: fixture.awayTeam.name }}',
+      '                      abandonment={abandonment}',
+      '                      locked={locked}',
+      '                    />',
+      '',
+      '                    {locked || abandonment ? (',
+    ].join("\n"),
+    "abandonment form placement",
+  );
+}
+
+replaceOnce(
+  '<h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-white/45">1. Score locked</h3>\n                        <p className="mt-3 text-sm text-white/65">\n                          {fixture.result ? `Final score recorded: ${fixture.result.homeScore}-${fixture.result.awayScore}.` : "No score was recorded before submission."}\n                        </p>',
+  [
+    '<h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-white/45">',
+    '                          {abandonment ? "1. Match outcome" : "1. Score locked"}',
+    '                        </h3>',
+    '                        <p className="mt-3 text-sm text-white/65">',
+    '                          {abandonment',
+    '                            ? "The referee abandoned this fixture. No official score is recorded; SIXFL will decide the result and league outcome separately."',
+    '                            : fixture.result',
+    '                              ? `Final score recorded: ${fixture.result.homeScore}-${fixture.result.awayScore}.`',
+    '                              : "No score was recorded before submission."}',
+    '                        </p>',
+  ].join("\n"),
+  "abandonment score lock copy",
+);
+
+fs.writeFileSync(pagePath, source, "utf8");
+console.log("Applied referee abandoned-match outcome, fee and notification workflow UI.");

--- a/scripts/apply-fixture-abandonment-workflow.cjs
+++ b/scripts/apply-fixture-abandonment-workflow.cjs
@@ -2,8 +2,69 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = process.cwd();
-const pagePath = path.join(root, "src", "app", "(public)", "referee", "night", "[id]", "page.tsx");
 
+// Keep the native abandonment service compatible with the current payment helper
+// signatures and avoid relying on mutation-based TypeScript narrowing across a
+// transaction callback.
+const servicePath = path.join(root, "src", "lib", "fixtures", "abandonment.ts");
+let service = fs.readFileSync(servicePath, "utf8");
+
+service = service.replace(
+  [
+    "        getPlayerFeeCashReceivedPence({",
+    "          amountPence: fee.amountPence,",
+    "          status: fee.status,",
+    "          note: fee.note,",
+    "        }),",
+  ].join("\n"),
+  [
+    "        getPlayerFeeCashReceivedPence({",
+    "          amountPence: fee.amountPence,",
+    "          status: fee.status,",
+    "        }),",
+  ].join("\n"),
+);
+
+if (!service.includes("const finalResponsibleCharge = responsibleTeam")) {
+  const before = [
+    "  const chargeIds = fixture.paymentCharges.map((charge) => charge.id);",
+    "  if (updatedResponsibleCharge?.id && !chargeIds.includes(updatedResponsibleCharge.id)) {",
+    "    chargeIds.push(updatedResponsibleCharge.id);",
+    "  }",
+  ].join("\n");
+  const after = [
+    "  const finalResponsibleCharge = responsibleTeam",
+    "    ? await prisma.paymentCharge.findUnique({",
+    "        where: {",
+    "          fixtureId_teamId: {",
+    "            fixtureId: fixture.id,",
+    "            teamId: responsibleTeam.id,",
+    "          },",
+    "        },",
+    "        select: { id: true, paymentToken: true, amountPence: true },",
+    "      })",
+    "    : null;",
+    "",
+    "  const chargeIds = fixture.paymentCharges.map((charge) => charge.id);",
+    "  if (finalResponsibleCharge?.id && !chargeIds.includes(finalResponsibleCharge.id)) {",
+    "    chargeIds.push(finalResponsibleCharge.id);",
+    "  }",
+  ].join("\n");
+
+  if (!service.includes(before)) {
+    throw new Error("Expected abandonment responsible-charge post-transaction block was not found.");
+  }
+  service = service.replace(before, after);
+}
+
+service = service.replaceAll(
+  "updatedResponsibleCharge?.paymentToken",
+  "finalResponsibleCharge?.paymentToken",
+);
+
+fs.writeFileSync(servicePath, service, "utf8");
+
+const pagePath = path.join(root, "src", "app", "(public)", "referee", "night", "[id]", "page.tsx");
 let source = fs.readFileSync(pagePath, "utf8");
 
 function replaceOnce(before, after, label) {

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -72,6 +72,7 @@ require("./fix-ai-prediction-publication-selects.cjs");
 require("./apply-ai-prediction-matchup-integrity.cjs");
 require("./apply-ai-prediction-text-team-integrity.cjs");
 require("./apply-fixture-abandonment-workflow.cjs");
+require("./fix-fixture-abandonment-build.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -71,6 +71,7 @@ require("./apply-ai-prediction-publication-snapshot.cjs");
 require("./fix-ai-prediction-publication-selects.cjs");
 require("./apply-ai-prediction-matchup-integrity.cjs");
 require("./apply-ai-prediction-text-team-integrity.cjs");
+require("./apply-fixture-abandonment-workflow.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");
@@ -98,9 +99,6 @@ function walk(directory) {
       violations.push(`${relative}: direct leagueTable import: ${directImports.join(" | ").trim()}`);
     }
 
-    // League-facing pages must never maintain a second standings calculator.
-    // Other pages can have local presentation helpers with the same function
-    // name without representing the canonical league standings contract.
     if (relative.includes("/leagues/") && /\bfunction\s+buildLeagueTable\s*\(/.test(source)) {
       violations.push(`${relative}: local buildLeagueTable() calculator`);
     }

--- a/scripts/check-fixture-abandonment-workflow.mjs
+++ b/scripts/check-fixture-abandonment-workflow.mjs
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolute = path.join(root, relativePath);
+  if (!fs.existsSync(absolute)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolute, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const service = read("src/lib/fixtures/abandonment.ts");
+const action = read("src/app/(public)/referee/abandonment-actions.ts");
+const form = read("src/components/referee/AbandonedMatchForm.tsx");
+const page = read("src/app/(public)/referee/night/[id]/page.tsx");
+const migration = read("prisma/migrations/20260819232000_fixture_abandonment_workflow/migration.sql");
+const rules = read("src/lib/match-rules.ts");
+const preparationChain = read("scripts/check-central-standings-usage.cjs");
+
+expect(
+  migration.includes('CREATE TABLE IF NOT EXISTS "FixtureAbandonment"') &&
+    migration.includes('"responsibleFinalChargePence"') &&
+    migration.includes('"innocentCreditPence"'),
+  "abandoned fixtures must be persisted with an auditable fee decision",
+);
+expect(
+  rules.includes("The team whose conduct caused the abandonment is responsible for payment of both its own match fee and the opposing team's match fee."),
+  "league rules must retain the responsible-team-pays-both abandonment rule",
+);
+expect(
+  service.includes('value: "REFUSED_TO_LEAVE"') &&
+    service.includes("Player / manager refused to leave after referee instruction"),
+  "referees must have an explicit refused-to-leave abandonment reason",
+);
+expect(
+  service.includes("responsibleFinalChargePence") &&
+    service.includes("responsibleOriginalFeePence") &&
+    service.includes("innocentOriginalFeePence"),
+  "team-conduct abandonments must charge the responsible team both match fees",
+);
+expect(
+  service.includes("PaymentChargeStatus.VOID") &&
+    service.includes("innocentPaidPence") &&
+    service.includes("tcred_abandonment_"),
+  "the innocent team's unpaid fee must be waived and paid money must become team credit where applicable",
+);
+expect(
+  service.includes("playerMatchFee.updateMany") &&
+    service.includes('status: "CANCELLED"'),
+  "open player payment links for the innocent team must be cancelled",
+);
+expect(
+  service.includes('channel: NotificationChannel.EMAIL') &&
+    service.includes('role: "responsible_team"') &&
+    service.includes('role: "innocent_team"'),
+  "both the responsible and innocent teams must receive abandonment fee emails",
+);
+expect(
+  service.includes("The league/result outcome is separate") &&
+    service.includes("matchResult.delete"),
+  "financial handling must not automatically decide the abandoned match result",
+);
+expect(
+  action.includes("recordNightFixtureAbandonmentAction") &&
+    action.includes("assertNightAccess") &&
+    action.includes("confirmAbandonment"),
+  "only the assigned referee/admin may record an abandonment and it must require confirmation",
+);
+expect(
+  form.includes("Match abandoned?") &&
+    form.includes("Team responsible") &&
+    form.includes("Mark match abandoned"),
+  "referee night UI must expose the abandonment reason and responsible-team controls",
+);
+expect(
+  page.includes("<AbandonedMatchForm") &&
+    page.includes("getFixtureAbandonments") &&
+    page.includes("fixture.result || abandonmentsByFixture.has(fixture.id)"),
+  "after prebuild the referee night page must render abandonment controls and allow an abandoned fixture to complete the cashup",
+);
+expect(
+  preparationChain.includes('require("./apply-fixture-abandonment-workflow.cjs")'),
+  "abandonment UI preparation must run in the production prebuild chain",
+);
+
+if (failures.length) {
+  console.error("\nFIXTURE ABANDONMENT WORKFLOW CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log("Fixture abandonment workflow contract passed.");

--- a/scripts/fix-fixture-abandonment-build.cjs
+++ b/scripts/fix-fixture-abandonment-build.cjs
@@ -1,0 +1,19 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const servicePath = path.join(
+  process.cwd(),
+  "src",
+  "lib",
+  "fixtures",
+  "abandonment.ts",
+);
+
+let source = fs.readFileSync(servicePath, "utf8");
+source = source.replaceAll(
+  "updatedResponsibleCharge.paymentToken",
+  "finalResponsibleCharge.paymentToken",
+);
+fs.writeFileSync(servicePath, source, "utf8");
+
+console.log("Fixture abandonment payment-link narrowing is build-safe.");

--- a/src/app/(public)/referee/abandonment-actions.ts
+++ b/src/app/(public)/referee/abandonment-actions.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { Prisma, UserRole } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requireReferee } from "@/lib/admin";
+import { recordFixtureAbandonment } from "@/lib/fixtures/abandonment";
+import { getRefereeNightFixtureIds, recalculateRefereeNightCashup } from "@/lib/referee-nights";
+import { prisma } from "@/lib/prisma";
+
+function required(formData: FormData, key: string, label: string) {
+  const value = String(formData.get(key) ?? "").trim();
+  if (!value) throw new Error(`${label} is required.`);
+  return value;
+}
+
+async function assertNightAccess(input: {
+  refereeNightId: string;
+  fixtureId: string;
+  user: { id: string; role: UserRole };
+}) {
+  const rows = await prisma.$queryRaw<Array<{ refereeId: string }>>(Prisma.sql`
+    SELECT "refereeId"
+    FROM "RefereeNight"
+    WHERE "id" = ${input.refereeNightId}
+    LIMIT 1
+  `);
+  const night = rows[0];
+  if (!night) throw new Error("Referee night not found.");
+
+  if (input.user.role !== UserRole.ADMIN && night.refereeId !== input.user.id) {
+    throw new Error("You are not allowed to update this referee night.");
+  }
+
+  const fixtureIds = await getRefereeNightFixtureIds(input.refereeNightId);
+  if (!fixtureIds.includes(input.fixtureId)) {
+    throw new Error("Fixture is not part of this referee night.");
+  }
+}
+
+export async function recordNightFixtureAbandonmentAction(formData: FormData) {
+  const { user } = await requireReferee();
+
+  const refereeNightId = required(formData, "refereeNightId", "Referee night");
+  const fixtureId = required(formData, "fixtureId", "Fixture");
+  const reason = required(formData, "reason", "Abandonment reason");
+  const responsibleTeamId = String(formData.get("responsibleTeamId") ?? "").trim() || null;
+  const details = String(formData.get("details") ?? "").trim() || null;
+  const confirmed = String(formData.get("confirmAbandonment") ?? "") === "yes";
+
+  if (!confirmed) {
+    throw new Error("Confirm that the referee abandoned the match before applying the abandonment decision.");
+  }
+
+  await assertNightAccess({ refereeNightId, fixtureId, user });
+
+  await recordFixtureAbandonment({
+    fixtureId,
+    refereeNightId,
+    reason,
+    responsibleTeamId,
+    details,
+    recordedByUserId: user.id,
+  });
+
+  await recalculateRefereeNightCashup(refereeNightId);
+
+  revalidatePath("/referee");
+  revalidatePath(`/referee/night/${refereeNightId}`);
+  revalidatePath(`/admin/referee-nights/${refereeNightId}`);
+  revalidatePath("/admin/fixtures");
+  revalidatePath("/admin/payments");
+  revalidatePath("/admin/payments/team-credits");
+
+  redirect(`/referee/night/${refereeNightId}?saved=abandoned`);
+}

--- a/src/components/referee/AbandonedMatchForm.tsx
+++ b/src/components/referee/AbandonedMatchForm.tsx
@@ -1,0 +1,145 @@
+import {
+  FIXTURE_ABANDONMENT_REASONS,
+  getFixtureAbandonmentReasonLabel,
+  type FixtureAbandonmentRow,
+} from "@/lib/fixtures/abandonment";
+import { recordNightFixtureAbandonmentAction } from "@/app/(public)/referee/abandonment-actions";
+
+export default function AbandonedMatchForm({
+  refereeNightId,
+  fixtureId,
+  homeTeam,
+  awayTeam,
+  abandonment,
+  locked,
+}: {
+  refereeNightId: string;
+  fixtureId: string;
+  homeTeam: { id: string; name: string };
+  awayTeam: { id: string; name: string };
+  abandonment: FixtureAbandonmentRow | null;
+  locked: boolean;
+}) {
+  if (abandonment) {
+    const responsibleName =
+      abandonment.responsibleTeamId === homeTeam.id
+        ? homeTeam.name
+        : abandonment.responsibleTeamId === awayTeam.id
+          ? awayTeam.name
+          : null;
+    const innocentName =
+      abandonment.innocentTeamId === homeTeam.id
+        ? homeTeam.name
+        : abandonment.innocentTeamId === awayTeam.id
+          ? awayTeam.name
+          : null;
+
+    return (
+      <div className="rounded-2xl border border-red-400/25 bg-red-500/10 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-red-300/25 bg-red-500/15 px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.14em] text-red-100">
+            Match abandoned
+          </span>
+          <span className="text-xs text-white/45">
+            {getFixtureAbandonmentReasonLabel(abandonment.reason)}
+          </span>
+        </div>
+        {abandonment.details ? (
+          <p className="mt-3 text-sm leading-6 text-white/70">{abandonment.details}</p>
+        ) : null}
+        {responsibleName && innocentName ? (
+          <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm leading-6 text-white/70">
+            <strong className="text-white">{responsibleName}</strong> recorded as responsible. Their charge is both teams&apos; match fees. <strong className="text-white">{innocentName}</strong> has no fee due for this match; any payment already received is handled as credit where applicable.
+          </div>
+        ) : (
+          <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm leading-6 text-white/65">
+            No team was recorded as financially responsible. SIXFL will review any fee adjustment separately.
+          </div>
+        )}
+        <p className="mt-3 text-xs leading-5 text-white/45">
+          No official result is created by the abandonment. The result and league outcome remain for SIXFL to decide.
+        </p>
+      </div>
+    );
+  }
+
+  if (locked) return null;
+
+  return (
+    <details className="overflow-hidden rounded-2xl border border-red-400/20 bg-red-500/[0.06]">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-semibold text-red-100 transition hover:bg-red-500/10 [&::-webkit-details-marker]:hidden">
+        <span>Match abandoned?</span>
+        <span className="text-xs font-normal text-red-100/55">Use only if the referee ended the match early</span>
+      </summary>
+      <form action={recordNightFixtureAbandonmentAction} className="space-y-4 border-t border-red-400/15 p-4">
+        <input type="hidden" name="refereeNightId" value={refereeNightId} />
+        <input type="hidden" name="fixtureId" value={fixtureId} />
+
+        <div className="rounded-xl border border-amber-400/20 bg-amber-500/10 p-3 text-sm leading-6 text-amber-50/85">
+          If one team&apos;s conduct caused the abandonment, SIXFL rules make that team responsible for <strong>both match fees</strong>. The other team&apos;s unpaid fee is waived; if it has already paid, the payment is converted to team credit where applicable. Both teams are emailed automatically. The match result is left for SIXFL to decide separately.
+        </div>
+
+        <label className="block text-sm text-white/75">
+          <span className="font-semibold text-white">Reason for abandonment</span>
+          <select
+            name="reason"
+            required
+            defaultValue=""
+            className="mt-2 h-12 w-full rounded-xl border border-white/10 bg-black/50 px-3 text-white outline-none"
+          >
+            <option value="" disabled>Choose reason…</option>
+            {FIXTURE_ABANDONMENT_REASONS.map((reason) => (
+              <option key={reason.value} value={reason.value}>
+                {reason.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block text-sm text-white/75">
+          <span className="font-semibold text-white">Team responsible</span>
+          <span className="ml-2 text-xs text-white/40">Required when one team&apos;s conduct caused it</span>
+          <select
+            name="responsibleTeamId"
+            defaultValue=""
+            className="mt-2 h-12 w-full rounded-xl border border-white/10 bg-black/50 px-3 text-white outline-none"
+          >
+            <option value="">No team / not a team-conduct abandonment</option>
+            <option value={homeTeam.id}>{homeTeam.name}</option>
+            <option value={awayTeam.id}>{awayTeam.name}</option>
+          </select>
+        </label>
+
+        <label className="block text-sm text-white/75">
+          <span className="font-semibold text-white">Referee details</span>
+          <textarea
+            name="details"
+            rows={4}
+            placeholder="e.g. Manager was sent off, refused repeated instructions to leave the playing area, so the referee abandoned the match."
+            className="mt-2 w-full rounded-xl border border-white/10 bg-black/50 px-3 py-3 text-white outline-none placeholder:text-white/30"
+          />
+        </label>
+
+        <label className="flex items-start gap-3 rounded-xl border border-white/10 bg-black/20 p-3 text-sm leading-6 text-white/70">
+          <input
+            type="checkbox"
+            name="confirmAbandonment"
+            value="yes"
+            required
+            className="mt-1 h-4 w-4"
+          />
+          <span>
+            I confirm the referee abandoned this match. I understand this removes any entered score as the official result, applies the fee rule where a responsible team is selected, and emails both teams.
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-red-500 px-4 text-sm font-bold text-white transition hover:bg-red-400 sm:w-auto"
+        >
+          Mark match abandoned
+        </button>
+      </form>
+    </details>
+  );
+}

--- a/src/lib/fixtures/abandonment.ts
+++ b/src/lib/fixtures/abandonment.ts
@@ -1,0 +1,624 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import {
+  FixtureStatus,
+  NotificationChannel,
+  PaymentChargeStatus,
+  Prisma,
+} from "@prisma/client";
+
+import { sendTeamBroadcastMessage } from "@/lib/communications/send-team-broadcast";
+import {
+  getDirectChargePaidTotal,
+} from "@/lib/payments/charge-summary";
+import { getPlayerFeeCashReceivedPence } from "@/lib/payments/player-fee-coverage";
+import {
+  buildChargePaymentUrl,
+  cancelQueuedMatchFeeNotificationDispatches,
+} from "@/lib/payments/fixture-match-fees";
+import { processNotificationQueue } from "@/lib/notifications/processor";
+import { prisma } from "@/lib/prisma";
+
+export const FIXTURE_ABANDONMENT_REASONS = [
+  {
+    value: "REFUSED_TO_LEAVE",
+    label: "Player / manager refused to leave after referee instruction",
+    teamResponsible: true,
+  },
+  {
+    value: "TEAM_CONDUCT",
+    label: "Conduct of one team made the match impossible to continue",
+    teamResponsible: true,
+  },
+  {
+    value: "VIOLENT_OR_THREATENING_CONDUCT",
+    label: "Violent, threatening or aggressive conduct",
+    teamResponsible: true,
+  },
+  {
+    value: "SERIOUS_MISCONDUCT",
+    label: "Other serious player / manager misconduct",
+    teamResponsible: true,
+  },
+  {
+    value: "MEDICAL_EMERGENCY",
+    label: "Medical emergency / serious injury",
+    teamResponsible: false,
+  },
+  {
+    value: "VENUE_OR_PITCH_SAFETY",
+    label: "Venue / pitch safety issue",
+    teamResponsible: false,
+  },
+  {
+    value: "WEATHER",
+    label: "Weather conditions",
+    teamResponsible: false,
+  },
+  {
+    value: "OTHER",
+    label: "Other reason",
+    teamResponsible: false,
+  },
+] as const;
+
+export type FixtureAbandonmentReason =
+  (typeof FIXTURE_ABANDONMENT_REASONS)[number]["value"];
+
+export type FixtureAbandonmentRow = {
+  id: string;
+  fixtureId: string;
+  refereeNightId: string | null;
+  reason: string;
+  responsibleTeamId: string | null;
+  innocentTeamId: string | null;
+  details: string | null;
+  responsibleOriginalFeePence: number | null;
+  innocentOriginalFeePence: number | null;
+  responsibleFinalChargePence: number | null;
+  innocentPaidPence: number;
+  innocentCreditPence: number;
+  homeScoreAtAbandonment: number | null;
+  awayScoreAtAbandonment: number | null;
+  recordedAt: Date;
+};
+
+function formatMoney(pence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(pence / 100);
+}
+
+function getReason(reason: string) {
+  return FIXTURE_ABANDONMENT_REASONS.find((item) => item.value === reason) ?? null;
+}
+
+export function getFixtureAbandonmentReasonLabel(reason: string) {
+  return getReason(reason)?.label ?? "Other reason";
+}
+
+function getPlayerPaidPence(input: {
+  fixtureId: string;
+  teamId: string;
+  fees: Array<{
+    fixtureId: string;
+    teamId: string;
+    amountPence: number;
+    status: string;
+    note: string | null;
+  }>;
+}) {
+  return input.fees
+    .filter(
+      (fee) =>
+        fee.fixtureId === input.fixtureId &&
+        fee.teamId === input.teamId &&
+        fee.status === "PAID",
+    )
+    .reduce(
+      (sum, fee) =>
+        sum +
+        getPlayerFeeCashReceivedPence({
+          amountPence: fee.amountPence,
+          status: fee.status,
+          note: fee.note,
+        }),
+      0,
+    );
+}
+
+function getPaidPence(input: {
+  fixtureId: string;
+  teamId: string;
+  charge:
+    | {
+        transactions: Array<{ amountPence: number; notes: string | null }>;
+      }
+    | null
+    | undefined;
+  fees: Array<{
+    fixtureId: string;
+    teamId: string;
+    amountPence: number;
+    status: string;
+    note: string | null;
+  }>;
+}) {
+  const direct = input.charge
+    ? getDirectChargePaidTotal(input.charge.transactions)
+    : 0;
+  const players = getPlayerPaidPence({
+    fixtureId: input.fixtureId,
+    teamId: input.teamId,
+    fees: input.fees,
+  });
+  return direct + players;
+}
+
+function statusFor(amountPence: number, paidPence: number) {
+  if (amountPence <= 0) return PaymentChargeStatus.PAID;
+  if (paidPence >= amountPence) return PaymentChargeStatus.PAID;
+  if (paidPence > 0) return PaymentChargeStatus.PART_PAID;
+  return PaymentChargeStatus.OPEN;
+}
+
+function createPaymentToken() {
+  return randomBytes(24).toString("hex");
+}
+
+export async function getFixtureAbandonments(fixtureIdsInput: string[]) {
+  const fixtureIds = Array.from(new Set(fixtureIdsInput.filter(Boolean)));
+  if (fixtureIds.length === 0) return new Map<string, FixtureAbandonmentRow>();
+
+  const rows = await prisma.$queryRaw<FixtureAbandonmentRow[]>(Prisma.sql`
+    SELECT
+      "id",
+      "fixtureId",
+      "refereeNightId",
+      "reason",
+      "responsibleTeamId",
+      "innocentTeamId",
+      "details",
+      "responsibleOriginalFeePence",
+      "innocentOriginalFeePence",
+      "responsibleFinalChargePence",
+      "innocentPaidPence",
+      "innocentCreditPence",
+      "homeScoreAtAbandonment",
+      "awayScoreAtAbandonment",
+      "recordedAt"
+    FROM "FixtureAbandonment"
+    WHERE "fixtureId" IN (${Prisma.join(fixtureIds)})
+  `);
+
+  return new Map(rows.map((row) => [row.fixtureId, row]));
+}
+
+export async function recordFixtureAbandonment(input: {
+  fixtureId: string;
+  refereeNightId?: string | null;
+  reason: string;
+  responsibleTeamId?: string | null;
+  details?: string | null;
+  recordedByUserId: string;
+}) {
+  const reason = getReason(input.reason);
+  if (!reason) throw new Error("Choose a valid abandonment reason.");
+
+  const existing = await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT "id" FROM "FixtureAbandonment"
+    WHERE "fixtureId" = ${input.fixtureId}
+    LIMIT 1
+  `);
+  if (existing[0]) {
+    throw new Error("This fixture is already marked as abandoned.");
+  }
+
+  const fixture = await prisma.fixture.findUnique({
+    where: { id: input.fixtureId },
+    include: {
+      league: { select: { id: true, name: true, season: true } },
+      homeTeam: {
+        select: {
+          id: true,
+          name: true,
+          teamMode: true,
+        },
+      },
+      awayTeam: {
+        select: {
+          id: true,
+          name: true,
+          teamMode: true,
+        },
+      },
+      result: {
+        select: { homeScore: true, awayScore: true },
+      },
+      paymentCharges: {
+        include: {
+          transactions: {
+            select: { amountPence: true, notes: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!fixture) throw new Error("Fixture not found.");
+
+  const teamIds = [fixture.homeTeam.id, fixture.awayTeam.id];
+  const responsibleTeamId = input.responsibleTeamId?.trim() || null;
+
+  if (reason.teamResponsible && !responsibleTeamId) {
+    throw new Error("Choose the team whose conduct caused the abandonment.");
+  }
+  if (responsibleTeamId && !teamIds.includes(responsibleTeamId)) {
+    throw new Error("The responsible team must be one of the teams in this fixture.");
+  }
+
+  const responsibleTeam = responsibleTeamId
+    ? responsibleTeamId === fixture.homeTeam.id
+      ? fixture.homeTeam
+      : fixture.awayTeam
+    : null;
+  const innocentTeam = responsibleTeam
+    ? responsibleTeam.id === fixture.homeTeam.id
+      ? fixture.awayTeam
+      : fixture.homeTeam
+    : null;
+
+  const playerFees = await prisma.playerMatchFee.findMany({
+    where: {
+      fixtureId: fixture.id,
+      teamId: { in: teamIds },
+    },
+    select: {
+      fixtureId: true,
+      teamId: true,
+      amountPence: true,
+      status: true,
+      note: true,
+    },
+  });
+
+  const chargeByTeam = new Map(
+    fixture.paymentCharges.map((charge) => [charge.teamId, charge]),
+  );
+
+  const responsibleCharge = responsibleTeam
+    ? chargeByTeam.get(responsibleTeam.id) ?? null
+    : null;
+  const innocentCharge = innocentTeam
+    ? chargeByTeam.get(innocentTeam.id) ?? null
+    : null;
+
+  const responsibleOriginalFeePence = responsibleTeam
+    ? responsibleCharge?.amountPence ?? fixture.matchFeePence ?? 0
+    : null;
+  const innocentOriginalFeePence = innocentTeam
+    ? innocentCharge?.amountPence ?? fixture.matchFeePence ?? 0
+    : null;
+
+  const responsiblePaidPence = responsibleTeam
+    ? getPaidPence({
+        fixtureId: fixture.id,
+        teamId: responsibleTeam.id,
+        charge: responsibleCharge,
+        fees: playerFees,
+      })
+    : 0;
+  const innocentPaidPence = innocentTeam
+    ? getPaidPence({
+        fixtureId: fixture.id,
+        teamId: innocentTeam.id,
+        charge: innocentCharge,
+        fees: playerFees,
+      })
+    : 0;
+
+  const responsibleFinalChargePence =
+    reason.teamResponsible && responsibleTeam && innocentTeam
+      ? (responsibleOriginalFeePence ?? 0) + (innocentOriginalFeePence ?? 0)
+      : null;
+  const innocentCreditPence =
+    reason.teamResponsible && innocentTeam?.teamMode === "STANDARD"
+      ? innocentPaidPence
+      : 0;
+
+  let updatedResponsibleCharge:
+    | { id: string; paymentToken: string | null; amountPence: number }
+    | null = null;
+  let innocentFeeOutcome = "No automatic fee change was made.";
+
+  await prisma.$transaction(async (tx) => {
+    if (reason.teamResponsible && responsibleTeam && innocentTeam) {
+      const finalResponsibleAmount = responsibleFinalChargePence ?? 0;
+      const paymentToken = responsibleCharge?.paymentToken || createPaymentToken();
+
+      updatedResponsibleCharge = await tx.paymentCharge.upsert({
+        where: {
+          fixtureId_teamId: {
+            fixtureId: fixture.id,
+            teamId: responsibleTeam.id,
+          },
+        },
+        update: {
+          amountPence: finalResponsibleAmount,
+          title: `Abandoned match fees • ${responsibleTeam.name} vs ${innocentTeam.name}`,
+          description: `${responsibleTeam.name} is responsible for both match fees following a referee-abandoned fixture.`,
+          paymentToken,
+          status: statusFor(finalResponsibleAmount, responsiblePaidPence),
+        },
+        create: {
+          teamId: responsibleTeam.id,
+          leagueId: fixture.leagueId,
+          fixtureId: fixture.id,
+          title: `Abandoned match fees • ${responsibleTeam.name} vs ${innocentTeam.name}`,
+          description: `${responsibleTeam.name} is responsible for both match fees following a referee-abandoned fixture.`,
+          amountPence: finalResponsibleAmount,
+          dueDate: fixture.kickoffAt,
+          paymentToken,
+          status: statusFor(finalResponsibleAmount, responsiblePaidPence),
+        },
+        select: { id: true, paymentToken: true, amountPence: true },
+      });
+
+      await tx.playerMatchFee.updateMany({
+        where: {
+          fixtureId: fixture.id,
+          teamId: innocentTeam.id,
+          status: "OPEN",
+        },
+        data: {
+          status: "CANCELLED",
+          cancelledAt: new Date(),
+        },
+      });
+
+      if (innocentCharge) {
+        if (innocentPaidPence <= 0) {
+          await tx.paymentCharge.update({
+            where: { id: innocentCharge.id },
+            data: {
+              status: PaymentChargeStatus.VOID,
+              description: "Match fee waived because the opposing team caused the fixture to be abandoned.",
+            },
+          });
+          innocentFeeOutcome = "Their match fee was waived because no payment had been received.";
+        } else {
+          await tx.paymentCharge.update({
+            where: { id: innocentCharge.id },
+            data: {
+              amountPence: innocentPaidPence,
+              status: PaymentChargeStatus.PAID,
+              description: "Match fee neutralised by team credit because the opposing team caused the fixture to be abandoned.",
+            },
+          });
+          innocentFeeOutcome =
+            innocentTeam.teamMode === "STANDARD"
+              ? `${formatMoney(innocentPaidPence)} already paid was returned as team credit.`
+              : `${formatMoney(innocentPaidPence)} had already been paid; SIXFL must account for that payment manually because this is not a standard team.`;
+        }
+      } else {
+        innocentFeeOutcome = "Their match fee was waived; no charge existed to collect.";
+      }
+
+      if (innocentCreditPence > 0) {
+        await tx.$executeRaw(Prisma.sql`
+          INSERT INTO "TeamCreditLedgerEntry" (
+            "id",
+            "teamId",
+            "sourceFixtureId",
+            "chargeId",
+            "entryType",
+            "amountPence",
+            "description",
+            "createdAt"
+          ) VALUES (
+            ${`tcred_abandonment_${fixture.id}_${innocentTeam.id}`},
+            ${innocentTeam.id},
+            ${fixture.id},
+            ${innocentCharge?.id ?? null},
+            'CREDIT_ADDED'::"TeamCreditLedgerEntryType",
+            ${innocentCreditPence},
+            ${`Credit for match abandoned because of ${responsibleTeam.name}'s conduct.`},
+            NOW()
+          )
+          ON CONFLICT ("id") DO UPDATE SET
+            "amountPence" = EXCLUDED."amountPence",
+            "description" = EXCLUDED."description"
+        `);
+      }
+    }
+
+    if (fixture.result) {
+      await tx.matchResult.delete({ where: { fixtureId: fixture.id } });
+    }
+
+    await tx.fixture.update({
+      where: { id: fixture.id },
+      data: { status: FixtureStatus.CANCELLED },
+    });
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "FixtureAbandonment" (
+        "id",
+        "fixtureId",
+        "refereeNightId",
+        "reason",
+        "responsibleTeamId",
+        "innocentTeamId",
+        "details",
+        "responsibleOriginalFeePence",
+        "innocentOriginalFeePence",
+        "responsibleFinalChargePence",
+        "innocentPaidPence",
+        "innocentCreditPence",
+        "homeScoreAtAbandonment",
+        "awayScoreAtAbandonment",
+        "recordedByUserId",
+        "recordedAt",
+        "updatedAt"
+      ) VALUES (
+        ${randomUUID()},
+        ${fixture.id},
+        ${input.refereeNightId ?? null},
+        ${reason.value},
+        ${responsibleTeam?.id ?? null},
+        ${innocentTeam?.id ?? null},
+        ${input.details?.trim() || null},
+        ${responsibleOriginalFeePence},
+        ${innocentOriginalFeePence},
+        ${responsibleFinalChargePence},
+        ${innocentPaidPence},
+        ${innocentCreditPence},
+        ${fixture.result?.homeScore ?? null},
+        ${fixture.result?.awayScore ?? null},
+        ${input.recordedByUserId},
+        NOW(),
+        NOW()
+      )
+    `);
+  });
+
+  const chargeIds = fixture.paymentCharges.map((charge) => charge.id);
+  if (updatedResponsibleCharge?.id && !chargeIds.includes(updatedResponsibleCharge.id)) {
+    chargeIds.push(updatedResponsibleCharge.id);
+  }
+  await cancelQueuedMatchFeeNotificationDispatches(chargeIds, prisma, {
+    reason: "Fixture was abandoned and the match-fee liability was recalculated by SIXFL.",
+  });
+
+  const reasonLabel = reason.label;
+  const fixtureLabel = `${fixture.homeTeam.name} v ${fixture.awayTeam.name}`;
+  const dispatchIds: string[] = [];
+
+  if (reason.teamResponsible && responsibleTeam && innocentTeam) {
+    const total = responsibleFinalChargePence ?? 0;
+    const outstanding = Math.max(0, total - responsiblePaidPence);
+    const payUrl =
+      outstanding > 0 && updatedResponsibleCharge?.paymentToken
+        ? buildChargePaymentUrl(updatedResponsibleCharge.paymentToken)
+        : null;
+
+    const responsibleMessage = [
+      "Hi {{firstName}},",
+      "",
+      `The referee abandoned ${fixtureLabel}.`,
+      `Reason: ${reasonLabel}.`,
+      input.details?.trim() ? `Referee note: ${input.details.trim()}` : null,
+      "",
+      `Under the SIXFL abandoned-match rule, ${responsibleTeam.name} is responsible for both its own match fee (${formatMoney(responsibleOriginalFeePence ?? 0)}) and ${innocentTeam.name}'s match fee (${formatMoney(innocentOriginalFeePence ?? 0)}).`,
+      `Total charge: ${formatMoney(total)}. Amount already covered: ${formatMoney(responsiblePaidPence)}. Outstanding: ${formatMoney(outstanding)}.`,
+      "",
+      "The league/result outcome is separate and will be decided by SIXFL after reviewing the abandonment.",
+      "",
+      payUrl ? "Use the button below to pay the outstanding balance." : "No further payment is currently outstanding.",
+      "",
+      "SIXFL",
+    ].filter(Boolean).join("\n");
+
+    const responsibleDispatch = await sendTeamBroadcastMessage({
+      teamId: responsibleTeam.id,
+      channel: NotificationChannel.EMAIL,
+      subject: `Match abandoned: fee decision for ${fixtureLabel}`,
+      body: responsibleMessage,
+      ctaLabel: payUrl ? "Pay outstanding match fees" : null,
+      ctaUrl: payUrl,
+      origin: "fixture-abandonment-fee-decision",
+      originLabel: "Abandoned match fee decision",
+      metadata: {
+        fixtureId: fixture.id,
+        role: "responsible_team",
+        reason: reason.value,
+        totalChargePence: total,
+        outstandingPence: outstanding,
+      },
+      createdByUserId: input.recordedByUserId,
+    });
+    dispatchIds.push(responsibleDispatch.dispatchId);
+
+    const innocentMessage = [
+      "Hi {{firstName}},",
+      "",
+      `The referee abandoned ${fixtureLabel}.`,
+      `Reason: ${reasonLabel}.`,
+      "",
+      `SIXFL has recorded ${responsibleTeam.name} as the team responsible for the abandonment. You will not be charged for this fixture.`,
+      innocentPaidPence > 0
+        ? innocentCreditPence > 0
+          ? `${formatMoney(innocentCreditPence)} that had already been paid has been added to ${innocentTeam.name}'s SIXFL team credit for a future match.`
+          : `${formatMoney(innocentPaidPence)} had already been paid. SIXFL will account for that payment separately.`
+        : "No payment is due from your team for this abandoned fixture.",
+      "",
+      "The league/result outcome is separate and will be decided by SIXFL after reviewing the abandonment.",
+      "",
+      "SIXFL",
+    ].join("\n");
+
+    const innocentDispatch = await sendTeamBroadcastMessage({
+      teamId: innocentTeam.id,
+      channel: NotificationChannel.EMAIL,
+      subject: `Match abandoned: your fee has been waived for ${fixtureLabel}`,
+      body: innocentMessage,
+      origin: "fixture-abandonment-fee-decision",
+      originLabel: "Abandoned match fee decision",
+      metadata: {
+        fixtureId: fixture.id,
+        role: "innocent_team",
+        reason: reason.value,
+        paidPence: innocentPaidPence,
+        creditPence: innocentCreditPence,
+      },
+      createdByUserId: input.recordedByUserId,
+    });
+    dispatchIds.push(innocentDispatch.dispatchId);
+  } else {
+    for (const team of [fixture.homeTeam, fixture.awayTeam]) {
+      const dispatch = await sendTeamBroadcastMessage({
+        teamId: team.id,
+        channel: NotificationChannel.EMAIL,
+        subject: `Match abandoned: ${fixtureLabel}`,
+        body: [
+          "Hi {{firstName}},",
+          "",
+          `The referee abandoned ${fixtureLabel}.`,
+          `Reason: ${reasonLabel}.`,
+          input.details?.trim() ? `Referee note: ${input.details.trim()}` : null,
+          "",
+          "No automatic fee transfer has been applied because this abandonment was not recorded as being caused by one team's conduct. SIXFL will review any fee adjustment separately.",
+          "",
+          "The league/result outcome will also be decided by SIXFL after review.",
+          "",
+          "SIXFL",
+        ].filter(Boolean).join("\n"),
+        origin: "fixture-abandonment-notice",
+        originLabel: "Abandoned match notice",
+        metadata: {
+          fixtureId: fixture.id,
+          role: "team",
+          reason: reason.value,
+        },
+        createdByUserId: input.recordedByUserId,
+      });
+      dispatchIds.push(dispatch.dispatchId);
+    }
+  }
+
+  if (dispatchIds.length > 0) {
+    await processNotificationQueue(Math.max(20, dispatchIds.length + 10));
+  }
+
+  return {
+    fixtureId: fixture.id,
+    reason: reason.value,
+    responsibleTeamId: responsibleTeam?.id ?? null,
+    innocentTeamId: innocentTeam?.id ?? null,
+    responsibleFinalChargePence,
+    innocentPaidPence,
+    innocentCreditPence,
+    innocentFeeOutcome,
+    notificationsQueued: dispatchIds.length,
+  };
+}


### PR DESCRIPTION
## Summary
- add an explicit abandoned-match control to each referee-night fixture
- include a reason dropdown, including player/manager refusing to leave after a referee instruction
- require the referee to identify the responsible team for team-conduct abandonments
- apply the existing SIXFL rule automatically: responsible team pays both match fees
- waive the innocent team’s unpaid match fee and cancel its open player payment links
- if the innocent STANDARD team has already paid, add the amount actually received as team credit for a future match
- email both teams explaining the abandonment, fee outcome and that the match result remains for SIXFL to decide
- keep no-fault abandonments (medical/weather/venue/etc.) financially neutral pending admin review
- preserve the score at abandonment for audit, remove it as an official result, and mark the fixture cancelled so it does not enter the table automatically
- allow an abandoned fixture to count as an outcome for referee-night cashup submission
- add an auditable FixtureAbandonment record and a regression contract

The existing league rule already states that when one team’s conduct causes an abandonment, that team pays both match fees and SIXFL decides the result separately.