### PR TITLE
Require complete squad emails before Squad payments

### DIFF
--- a/scripts/apply-player-payment-email-required.cjs
+++ b/scripts/apply-player-payment-email-required.cjs
@@ -8,6 +8,50 @@ const pagePath = path.join(root, "src", "app", "captain", "team", "[teamid]", "p
 let actions = fs.readFileSync(actionsPath, "utf8");
 let page = fs.readFileSync(pagePath, "utf8");
 
+// Require the whole current squad to have email addresses before a captain can
+// create or update Squad payments. The page wrapper enforces the same rule in
+// the UI; this server-side check also protects stale/open forms.
+if (!actions.includes("squadMembersForEmailReadiness")) {
+  const readinessAnchor = `export async function createCaptainSquadPaymentCollectionAction(formData: FormData) {
+  const teamId = getString(formData, "teamId");
+  const fixtureId = getString(formData, "fixtureId");
+  const defaultAmountPence = parseAmountPence(getString(formData, "amount"));
+  const players = getSelectedPlayers(formData);
+
+  if (!teamId || !fixtureId) {
+    redirect(getPlayerPaymentsPath(teamId, fixtureId, "&error=missing_fixture"));
+  }
+
+  await requireCaptain(teamId);`;
+
+  if (!actions.includes(readinessAnchor)) {
+    throw new Error("Captain squad-payment action readiness anchor not found.");
+  }
+
+  actions = actions.replace(
+    readinessAnchor,
+    `${readinessAnchor}
+
+  const squadMembersForEmailReadiness = await prisma.teamMember.findMany({
+    where: { teamId },
+    select: { id: true, user: { select: { email: true } } },
+  });
+  const hasMissingSquadEmail = squadMembersForEmailReadiness.some(
+    (member) => !member.user.email?.trim(),
+  );
+
+  if (hasMissingSquadEmail) {
+    redirect(
+      getPlayerPaymentsPath(
+        teamId,
+        fixtureId,
+        "&error=squad_emails_incomplete",
+      ),
+    );
+  }`,
+  );
+}
+
 // Native source now owns this guard. Keep this compatibility patch safe for older
 // branches, but do not duplicate the native server-side check during prebuild.
 if (!actions.includes("selectedMemberIdsForEmailCheck")) {

--- a/src/app/captain/team/[teamid]/player-payments/page.tsx
+++ b/src/app/captain/team/[teamid]/player-payments/page.tsx
@@ -2,6 +2,11 @@
 // File: src/app/captain/team/[teamid]/player-payments/page.tsx
 // ========================================
 
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { requireCaptain } from "@/lib/requireCaptain";
 import PaymentPageServer from "./PaymentPageServer";
 
 export const dynamic = "force-dynamic";
@@ -11,4 +16,99 @@ export const metadata = {
   title: "Squad Payments | SIXFL",
 };
 
-export default PaymentPageServer;
+type Props = {
+  params: Promise<{ teamid: string }>;
+  searchParams?: Promise<{
+    fixtureId?: string;
+    saved?: string;
+    error?: string;
+    emailsQueued?: string;
+    emailsSkipped?: string;
+  }>;
+};
+
+export default async function SquadPaymentsPage(props: Props) {
+  const { teamid } = await props.params;
+  await requireCaptain(teamid);
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamid },
+    select: {
+      id: true,
+      name: true,
+      members: {
+        orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+        select: {
+          id: true,
+          role: true,
+          user: {
+            select: {
+              name: true,
+              email: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!team) notFound();
+
+  const missingEmailMembers = team.members.filter(
+    (member) => !member.user.email?.trim(),
+  );
+
+  if (missingEmailMembers.length > 0) {
+    return (
+      <div className="space-y-6">
+        <section className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.08] p-6 sm:p-8">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200/80">
+            Squad payments not ready
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">
+            Add every squad member&apos;s email before using Squad payments
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-amber-50/75 sm:text-base">
+            SIXFL sends individual payment links by email. To stop payment requests being
+            missed or set up against incomplete player records, every current squad member
+            must have an email address saved before {team.name} can set up or update Squad
+            payments.
+          </p>
+
+          <div className="mt-6 rounded-2xl border border-amber-300/20 bg-black/20 p-4">
+            <div className="text-sm font-semibold text-white">
+              {missingEmailMembers.length} squad member{missingEmailMembers.length === 1 ? " is" : "s are"} missing an email
+            </div>
+            <ul className="mt-3 space-y-2 text-sm text-amber-50/75">
+              {missingEmailMembers.map((member) => (
+                <li key={member.id} className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
+                  <span>{member.user.name?.trim() || "Unnamed squad member"}</span>
+                  <span className="text-xs uppercase tracking-wide text-amber-200/60">
+                    {member.role.replaceAll("_", " ")}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href={`/captain/team/${team.id}/captain-squad`}
+              className="inline-flex min-h-11 items-center justify-center rounded-full bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200"
+            >
+              Add missing emails
+            </Link>
+            <Link
+              href={`/captain/team/${team.id}`}
+              className="inline-flex min-h-11 items-center justify-center rounded-full border border-white/10 bg-black/20 px-5 text-sm font-semibold text-white/80 transition hover:bg-white/[0.06] hover:text-white"
+            >
+              Back to captain hub
+            </Link>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return <PaymentPageServer {...props} />;
+}


### PR DESCRIPTION
Requires a complete squad email set before captain Squad payments can be used.

- Squad payments does not open while any current TeamMember has no saved email
- blocker shows the number and names of squad members missing email addresses
- direct **Add missing emails** button takes the captain to Captain squad
- once all current squad emails are present, the existing Squad payments page opens normally
- strengthens the existing server-side payment-email safeguard so a stale/open form is also rejected if any current squad member is missing an email
- keeps the existing per-selected-player email delivery check as an additional safeguard
- page gate is native and sits outside the legacy player-payment rendering patch chain

No existing payment amounts, charges or settled payment records are altered.