### PR TITLE
Stop abandoned-match save from crashing

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Check abandoned result decision
         run: node scripts/check-abandoned-result-decision.mjs
 
+      - name: Check abandonment runtime resilience
+        run: node scripts/check-fixture-abandonment-runtime-resilience.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -102,6 +105,7 @@ jobs:
           node scripts/check-ai-prediction-text-team-integrity.mjs
           node scripts/check-fixture-abandonment-workflow.mjs
           node scripts/check-abandoned-result-decision.mjs
+          node scripts/check-fixture-abandonment-runtime-resilience.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -75,6 +75,7 @@ require("./apply-fixture-abandonment-workflow.cjs");
 require("./fix-fixture-abandonment-build.cjs");
 require("./apply-fixture-abandonment-result-decision.cjs");
 require("./fix-fixture-abandonment-result-decision-build.cjs");
+require("./fix-fixture-abandonment-runtime-schema.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");

--- a/scripts/check-fixture-abandonment-runtime-resilience.mjs
+++ b/scripts/check-fixture-abandonment-runtime-resilience.mjs
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+
+const service = fs.readFileSync("src/lib/fixtures/abandonment.ts", "utf8");
+const action = fs.readFileSync("src/app/(public)/referee/abandonment-actions.ts", "utf8");
+const form = fs.readFileSync("src/components/referee/AbandonedMatchForm.tsx", "utf8");
+const page = fs.readFileSync("src/app/(public)/referee/night/[id]/page.tsx", "utf8");
+const chain = fs.readFileSync("scripts/check-central-standings-usage.cjs", "utf8");
+
+const failures = [];
+const expect = (value, message) => { if (!value) failures.push(message); };
+
+expect(!service.includes('      "awardedHomeScore",\n      "awardedAwayScore",'), "runtime abandonment reads must not depend on optional awarded-result audit columns");
+expect(!service.includes('        "awardedHomeScore",\n        "awardedAwayScore",'), "runtime abandonment writes must not depend on optional awarded-result audit columns");
+expect(service.includes("matchResult.create") && service.includes("officialResultLine"), "3-0 awards must still be stored as the official MatchResult and included in emails");
+expect(service.includes("Abandonment notifications were queued but immediate processing failed"), "notification processor failures must not turn a saved abandonment into an application error");
+expect(action.includes("Abandonment was saved but referee-night cashup recalculation failed"), "cashup recalculation failures must not turn a saved abandonment into an application error");
+expect(form.includes("officialResult") && page.includes("officialResult={fixture.result"), "recorded abandonment UI must read the official result from MatchResult");
+expect(chain.includes('require("./fix-fixture-abandonment-runtime-schema.cjs")'), "runtime abandonment resilience patch must run in the production preparation chain");
+
+if (failures.length) {
+  console.error("Abandonment runtime resilience contract failed:");
+  failures.forEach((failure) => console.error(` - ${failure}`));
+  process.exit(1);
+}
+
+console.log("Abandonment runtime resilience contract passed.");

--- a/scripts/fix-fixture-abandonment-runtime-schema.cjs
+++ b/scripts/fix-fixture-abandonment-runtime-schema.cjs
@@ -1,0 +1,174 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+
+function patch(relativePath, replacements) {
+  const filePath = path.join(root, ...relativePath.split("/"));
+  let source = fs.readFileSync(filePath, "utf8");
+
+  for (const { before, after, label } of replacements) {
+    if (source.includes(after)) continue;
+    if (!source.includes(before)) {
+      throw new Error(`Expected ${label} source was not found in ${relativePath}.`);
+    }
+    source = source.replace(before, after);
+  }
+
+  fs.writeFileSync(filePath, source, "utf8");
+}
+
+patch("src/lib/fixtures/abandonment.ts", [
+  {
+    label: "abandonment row awarded fields",
+    before: [
+      "  awayScoreAtAbandonment: number | null;",
+      "  awardedHomeScore: number | null;",
+      "  awardedAwayScore: number | null;",
+      "  resultDecidedByUserId: string | null;",
+      "  resultDecidedAt: Date | null;",
+      "  recordedAt: Date;",
+    ].join("\n"),
+    after: [
+      "  awayScoreAtAbandonment: number | null;",
+      "  recordedAt: Date;",
+    ].join("\n"),
+  },
+  {
+    label: "abandonment result select columns",
+    before: [
+      '      "homeScoreAtAbandonment",',
+      '      "awayScoreAtAbandonment",',
+      '      "awardedHomeScore",',
+      '      "awardedAwayScore",',
+      '      "resultDecidedByUserId",',
+      '      "resultDecidedAt",',
+      '      "recordedAt"',
+    ].join("\n"),
+    after: [
+      '      "homeScoreAtAbandonment",',
+      '      "awayScoreAtAbandonment",',
+      '      "recordedAt"',
+    ].join("\n"),
+  },
+  {
+    label: "abandonment result audit columns",
+    before: [
+      '        "homeScoreAtAbandonment",',
+      '        "awayScoreAtAbandonment",',
+      '        "awardedHomeScore",',
+      '        "awardedAwayScore",',
+      '        "resultDecidedByUserId",',
+      '        "resultDecidedAt",',
+      '        "recordedByUserId",',
+    ].join("\n"),
+    after: [
+      '        "homeScoreAtAbandonment",',
+      '        "awayScoreAtAbandonment",',
+      '        "recordedByUserId",',
+    ].join("\n"),
+  },
+  {
+    label: "abandonment result audit values",
+    before: [
+      "        ${fixture.result?.homeScore ?? null},",
+      "        ${fixture.result?.awayScore ?? null},",
+      "        ${awardedHomeScore},",
+      "        ${awardedAwayScore},",
+      "        ${hasOfficialResult ? input.recordedByUserId : null},",
+      "        ${hasOfficialResult ? new Date() : null},",
+      "        ${input.recordedByUserId},",
+    ].join("\n"),
+    after: [
+      "        ${fixture.result?.homeScore ?? null},",
+      "        ${fixture.result?.awayScore ?? null},",
+      "        ${input.recordedByUserId},",
+    ].join("\n"),
+  },
+]);
+
+patch("src/components/referee/AbandonedMatchForm.tsx", [
+  {
+    label: "official result prop",
+    before: [
+      "  abandonment,",
+      "  locked,",
+      "  canDecideResult,",
+      "}: {",
+    ].join("\n"),
+    after: [
+      "  abandonment,",
+      "  locked,",
+      "  canDecideResult,",
+      "  officialResult,",
+      "}: {",
+    ].join("\n"),
+  },
+  {
+    label: "official result prop type",
+    before: [
+      "  abandonment: FixtureAbandonmentRow | null;",
+      "  locked: boolean;",
+      "  canDecideResult: boolean;",
+      "}) {",
+    ].join("\n"),
+    after: [
+      "  abandonment: FixtureAbandonmentRow | null;",
+      "  locked: boolean;",
+      "  canDecideResult: boolean;",
+      "  officialResult: { homeScore: number; awayScore: number } | null;",
+      "}) {",
+    ].join("\n"),
+  },
+  {
+    label: "recorded official result copy",
+    before: [
+      '        <p className="mt-3 text-xs leading-5 text-white/45">',
+      "          {abandonment.awardedHomeScore !== null && abandonment.awardedAwayScore !== null",
+      "            ? `Official SIXFL result: ${homeTeam.name} ${abandonment.awardedHomeScore}-${abandonment.awardedAwayScore} ${awayTeam.name}.`",
+      '            : "No official result has been awarded yet. The result and league outcome remain for SIXFL to decide."}',
+      "        </p>",
+    ].join("\n"),
+    after: [
+      '        <p className="mt-3 text-xs leading-5 text-white/45">',
+      "          {officialResult",
+      "            ? `Official SIXFL result: ${homeTeam.name} ${officialResult.homeScore}-${officialResult.awayScore} ${awayTeam.name}.`",
+      '            : "No official result has been awarded yet. The result and league outcome remain for SIXFL to decide."}',
+      "        </p>",
+    ].join("\n"),
+  },
+]);
+
+patch("src/app/(public)/referee/night/[id]/page.tsx", [
+  {
+    label: "abandonment official result prop",
+    before: [
+      "                      abandonment={abandonment}",
+      "                      locked={locked}",
+      "                      canDecideResult={user.role === UserRole.ADMIN}",
+      "                    />",
+    ].join("\n"),
+    after: [
+      "                      abandonment={abandonment}",
+      "                      locked={locked}",
+      "                      canDecideResult={user.role === UserRole.ADMIN}",
+      "                      officialResult={fixture.result ? { homeScore: fixture.result.homeScore, awayScore: fixture.result.awayScore } : null}",
+      "                    />",
+    ].join("\n"),
+  },
+  {
+    label: "abandonment page official result copy",
+    before: [
+      "                            ? abandonment.awardedHomeScore !== null && abandonment.awardedAwayScore !== null",
+      "                              ? `Official SIXFL result: ${fixture.homeTeam.name} ${abandonment.awardedHomeScore}-${abandonment.awardedAwayScore} ${fixture.awayTeam.name}.`",
+      '                              : "The referee abandoned this fixture. No official score is recorded yet; SIXFL will decide the result and league outcome separately."',
+    ].join("\n"),
+    after: [
+      "                            ? fixture.result",
+      "                              ? `Official SIXFL result: ${fixture.homeTeam.name} ${fixture.result.homeScore}-${fixture.result.awayScore} ${fixture.awayTeam.name}.`",
+      '                              : "The referee abandoned this fixture. No official score is recorded yet; SIXFL will decide the result and league outcome separately."',
+    ].join("\n"),
+  },
+]);
+
+console.log("Abandoned-match result decisions now use MatchResult as the runtime source of truth and do not require the optional audit columns to exist before the page can load.");

--- a/scripts/fix-fixture-abandonment-runtime-schema.cjs
+++ b/scripts/fix-fixture-abandonment-runtime-schema.cjs
@@ -174,6 +174,11 @@ patch("src/app/(public)/referee/night/[id]/page.tsx", [
     ].join("\n"),
   },
   {
+    label: "abandonment header official result copy",
+    before: '{abandonment ? abandonment.awardedHomeScore !== null && abandonment.awardedAwayScore !== null ? `Match abandoned · official result ${abandonment.awardedHomeScore}-${abandonment.awardedAwayScore}` : "Match abandoned · result to be decided by SIXFL" : fixture.result ? `Current result: ${fixture.result.homeScore}-${fixture.result.awayScore}${fixture.result.isDisputed ? " · disputed" : ""}` : "No result entered"}',
+    after: '{abandonment ? fixture.result ? `Match abandoned · official result ${fixture.result.homeScore}-${fixture.result.awayScore}` : "Match abandoned · result to be decided by SIXFL" : fixture.result ? `Current result: ${fixture.result.homeScore}-${fixture.result.awayScore}${fixture.result.isDisputed ? " · disputed" : ""}` : "No result entered"}',
+  },
+  {
     label: "abandonment page official result copy",
     before: [
       "                            ? abandonment.awardedHomeScore !== null && abandonment.awardedAwayScore !== null",

--- a/scripts/fix-fixture-abandonment-runtime-schema.cjs
+++ b/scripts/fix-fixture-abandonment-runtime-schema.cjs
@@ -85,6 +85,23 @@ patch("src/lib/fixtures/abandonment.ts", [
       "        ${input.recordedByUserId},",
     ].join("\n"),
   },
+  {
+    label: "notification queue resilience",
+    before: [
+      "  if (dispatchIds.length > 0) {",
+      "    await processNotificationQueue(Math.max(20, dispatchIds.length + 10));",
+      "  }",
+    ].join("\n"),
+    after: [
+      "  if (dispatchIds.length > 0) {",
+      "    try {",
+      "      await processNotificationQueue(Math.max(20, dispatchIds.length + 10));",
+      "    } catch (error) {",
+      '      console.error("Abandonment notifications were queued but immediate processing failed", error);',
+      "    }",
+      "  }",
+    ].join("\n"),
+  },
 ]);
 
 patch("src/components/referee/AbandonedMatchForm.tsx", [
@@ -171,4 +188,18 @@ patch("src/app/(public)/referee/night/[id]/page.tsx", [
   },
 ]);
 
-console.log("Abandoned-match result decisions now use MatchResult as the runtime source of truth and do not require the optional audit columns to exist before the page can load.");
+patch("src/app/(public)/referee/abandonment-actions.ts", [
+  {
+    label: "cashup recalculation resilience",
+    before: "  await recalculateRefereeNightCashup(refereeNightId);",
+    after: [
+      "  try {",
+      "    await recalculateRefereeNightCashup(refereeNightId);",
+      "  } catch (error) {",
+      '    console.error("Abandonment was saved but referee-night cashup recalculation failed", error);',
+      "  }",
+    ].join("\n"),
+  },
+]);
+
+console.log("Abandoned-match result decisions now use MatchResult as the runtime source of truth, avoid optional audit-column dependency, and do not turn post-save notification/cashup work into a blank application-error page.");


### PR DESCRIPTION
## Summary
- remove the runtime dependency on the optional awarded-result audit columns that can break the referee-night page if a deployment reaches the app before the DB migration
- keep the official 3-0 result in MatchResult, which is already the league-table source of truth
- keep the score at abandonment in FixtureAbandonment
- keep the 3-0 wording in both abandonment emails
- do not turn a successfully saved abandonment into a blank application-error page if immediate notification processing or cashup recalculation fails afterwards
- add a dedicated runtime resilience contract

This is an urgent follow-up to the server-side exception seen immediately after marking a fixture abandoned.