### PR TITLE
Add abandoned match email recovery

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Check abandonment runtime resilience
         run: node scripts/check-fixture-abandonment-runtime-resilience.mjs
 
+      - name: Check abandonment email recovery
+        run: node scripts/check-fixture-abandonment-email-recovery.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -106,6 +109,7 @@ jobs:
           node scripts/check-fixture-abandonment-workflow.mjs
           node scripts/check-abandoned-result-decision.mjs
           node scripts/check-fixture-abandonment-runtime-resilience.mjs
+          node scripts/check-fixture-abandonment-email-recovery.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/scripts/apply-fixture-abandonment-email-recovery.cjs
+++ b/scripts/apply-fixture-abandonment-email-recovery.cjs
@@ -1,0 +1,57 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const formPath = path.join(
+  process.cwd(),
+  "src",
+  "components",
+  "referee",
+  "AbandonedMatchForm.tsx",
+);
+let source = fs.readFileSync(formPath, "utf8");
+
+const importBefore =
+  'import { recordNightFixtureAbandonmentAction } from "@/app/(public)/referee/abandonment-actions";';
+const importAfter = `${importBefore}\nimport { resendNightFixtureAbandonmentEmailsAction } from "@/app/(public)/referee/abandonment-email-actions";`;
+if (!source.includes(importAfter)) {
+  if (!source.includes(importBefore)) {
+    throw new Error("Could not find the abandoned-match action import.");
+  }
+  source = source.replace(importBefore, importAfter);
+}
+
+const marker = `        <p className="mt-3 text-xs leading-5 text-white/45">
+          {officialResult
+            ? \`Official SIXFL result: \${homeTeam.name} \${officialResult.homeScore}-\${officialResult.awayScore} \${awayTeam.name}.\`
+            : "No official result has been awarded yet. The result and league outcome remain for SIXFL to decide."}
+        </p>`;
+
+const recovery = `${marker}
+        {canDecideResult ? (
+          <form
+            action={resendNightFixtureAbandonmentEmailsAction}
+            className="mt-4 rounded-xl border border-amber-300/20 bg-amber-500/10 p-3"
+          >
+            <input type="hidden" name="refereeNightId" value={refereeNightId} />
+            <input type="hidden" name="fixtureId" value={fixtureId} />
+            <p className="text-xs leading-5 text-amber-50/70">
+              If the original abandonment emails did not appear in the teams&apos; conversation timelines, use this to send the saved decision again. This does not change the abandonment, fees or official result.
+            </p>
+            <button
+              type="submit"
+              className="mt-3 inline-flex h-10 items-center justify-center rounded-lg border border-amber-300/30 bg-amber-400/15 px-4 text-xs font-bold text-amber-50 transition hover:bg-amber-400/25"
+            >
+              Send abandonment emails again
+            </button>
+          </form>
+        ) : null}`;
+
+if (!source.includes(recovery)) {
+  if (!source.includes(marker)) {
+    throw new Error("Could not find the recorded abandonment result block.");
+  }
+  source = source.replace(marker, recovery);
+}
+
+fs.writeFileSync(formPath, source, "utf8");
+console.log("Added an admin recovery control for abandoned-match emails.");

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -77,6 +77,7 @@ require("./fix-fixture-abandonment-build.cjs");
 require("./apply-fixture-abandonment-result-decision.cjs");
 require("./fix-fixture-abandonment-result-decision-build.cjs");
 require("./fix-fixture-abandonment-runtime-schema.cjs");
+require("./apply-fixture-abandonment-email-recovery.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");

--- a/scripts/check-fixture-abandonment-email-recovery.mjs
+++ b/scripts/check-fixture-abandonment-email-recovery.mjs
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+
+const sender = fs.readFileSync("src/lib/fixtures/abandonment-email-recovery.ts", "utf8");
+const action = fs.readFileSync("src/app/(public)/referee/abandonment-email-actions.ts", "utf8");
+const form = fs.readFileSync("src/components/referee/AbandonedMatchForm.tsx", "utf8");
+const chain = fs.readFileSync("scripts/check-central-standings-usage.cjs", "utf8");
+
+const failures = [];
+const expect = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+expect(
+  sender.includes("resendFixtureAbandonmentEmails") &&
+    sender.includes('FROM "FixtureAbandonment"') &&
+    sender.includes("officialResultLine"),
+  "email recovery must rebuild the saved abandonment decision and current official result",
+);
+expect(
+  sender.includes('role: "responsible_team"') &&
+    sender.includes('role: "innocent_team"') &&
+    sender.includes("recoveryResend: true"),
+  "email recovery must queue separate responsible and innocent team messages",
+);
+expect(
+  sender.includes("getDirectChargePaidTotal") &&
+    sender.includes("getPlayerFeeCashReceivedPence") &&
+    sender.includes("buildChargePaymentUrl"),
+  "responsible-team recovery email must calculate current paid/outstanding money and preserve the payment link",
+);
+expect(
+  action.includes("Only SIXFL admin can resend abandoned-match decision emails") &&
+    action.includes("resendFixtureAbandonmentEmails"),
+  "only admin may explicitly resend a saved abandonment decision",
+);
+expect(
+  form.includes("Send abandonment emails again") &&
+    form.includes("resendNightFixtureAbandonmentEmailsAction") &&
+    form.includes("does not change the abandonment, fees or official result"),
+  "recorded abandoned fixtures must expose a clear admin recovery button",
+);
+expect(
+  chain.includes('require("./apply-fixture-abandonment-email-recovery.cjs")'),
+  "abandonment email recovery UI must be applied by the production preparation chain",
+);
+
+if (failures.length) {
+  console.error("Abandonment email recovery contract failed:");
+  failures.forEach((failure) => console.error(` - ${failure}`));
+  process.exit(1);
+}
+
+console.log("Abandonment email recovery contract passed.");

--- a/src/app/(public)/referee/abandonment-email-actions.ts
+++ b/src/app/(public)/referee/abandonment-email-actions.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { UserRole } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requireReferee } from "@/lib/admin";
+import { resendFixtureAbandonmentEmails } from "@/lib/fixtures/abandonment-email-recovery";
+import { getRefereeNightFixtureIds } from "@/lib/referee-nights";
+
+function required(formData: FormData, key: string, label: string) {
+  const value = String(formData.get(key) ?? "").trim();
+  if (!value) throw new Error(`${label} is required.`);
+  return value;
+}
+
+export async function resendNightFixtureAbandonmentEmailsAction(formData: FormData) {
+  const { user } = await requireReferee();
+  if (user.role !== UserRole.ADMIN) {
+    throw new Error("Only SIXFL admin can resend abandoned-match decision emails.");
+  }
+
+  const refereeNightId = required(formData, "refereeNightId", "Referee night");
+  const fixtureId = required(formData, "fixtureId", "Fixture");
+  const fixtureIds = await getRefereeNightFixtureIds(refereeNightId);
+  if (!fixtureIds.includes(fixtureId)) {
+    throw new Error("Fixture is not part of this referee night.");
+  }
+
+  const result = await resendFixtureAbandonmentEmails({
+    fixtureId,
+    createdByUserId: user.id,
+  });
+
+  revalidatePath(`/referee/night/${refereeNightId}`);
+  revalidatePath("/admin/teams");
+  revalidatePath("/admin/messages");
+
+  redirect(
+    `/referee/night/${refereeNightId}?saved=abandonment-emails-resent&queued=${result.queued}&failed=${result.failed}`,
+  );
+}

--- a/src/lib/fixtures/abandonment-email-recovery.ts
+++ b/src/lib/fixtures/abandonment-email-recovery.ts
@@ -1,0 +1,297 @@
+import { NotificationChannel, Prisma } from "@prisma/client";
+
+import { sendTeamBroadcastMessage } from "@/lib/communications/send-team-broadcast";
+import { getFixtureAbandonmentReasonLabel } from "@/lib/fixtures/abandonment";
+import { processNotificationQueue } from "@/lib/notifications/processor";
+import { getDirectChargePaidTotal } from "@/lib/payments/charge-summary";
+import { buildChargePaymentUrl } from "@/lib/payments/fixture-match-fees";
+import { getPlayerFeeCashReceivedPence } from "@/lib/payments/player-fee-coverage";
+import { prisma } from "@/lib/prisma";
+
+type AbandonmentNoticeRow = {
+  fixtureId: string;
+  reason: string;
+  responsibleTeamId: string | null;
+  innocentTeamId: string | null;
+  details: string | null;
+  responsibleOriginalFeePence: number | null;
+  innocentOriginalFeePence: number | null;
+  responsibleFinalChargePence: number | null;
+  innocentPaidPence: number;
+  innocentCreditPence: number;
+};
+
+function formatMoney(pence: number) {
+  return `£${(Math.max(0, pence) / 100).toFixed(2)}`;
+}
+
+function getPaidPence(input: {
+  fixtureId: string;
+  teamId: string;
+  charge: {
+    transactions: Array<{ amountPence: number; notes: string | null }>;
+  } | null;
+  fees: Array<{
+    fixtureId: string;
+    teamId: string;
+    amountPence: number;
+    status: string;
+  }>;
+}) {
+  const directPaidPence = input.charge
+    ? getDirectChargePaidTotal(input.charge.transactions)
+    : 0;
+  const playerPaidPence = input.fees
+    .filter((fee) => fee.fixtureId === input.fixtureId && fee.teamId === input.teamId)
+    .reduce(
+      (sum, fee) =>
+        sum +
+        getPlayerFeeCashReceivedPence({
+          amountPence: fee.amountPence,
+          status: fee.status,
+        }),
+      0,
+    );
+
+  return directPaidPence + playerPaidPence;
+}
+
+export async function resendFixtureAbandonmentEmails(input: {
+  fixtureId: string;
+  createdByUserId: string;
+}) {
+  const rows = await prisma.$queryRaw<AbandonmentNoticeRow[]>(Prisma.sql`
+    SELECT
+      "fixtureId",
+      "reason",
+      "responsibleTeamId",
+      "innocentTeamId",
+      "details",
+      "responsibleOriginalFeePence",
+      "innocentOriginalFeePence",
+      "responsibleFinalChargePence",
+      "innocentPaidPence",
+      "innocentCreditPence"
+    FROM "FixtureAbandonment"
+    WHERE "fixtureId" = ${input.fixtureId}
+    LIMIT 1
+  `);
+  const abandonment = rows[0];
+  if (!abandonment) {
+    throw new Error("This fixture is not recorded as abandoned.");
+  }
+
+  const fixture = await prisma.fixture.findUnique({
+    where: { id: input.fixtureId },
+    include: {
+      homeTeam: { select: { id: true, name: true } },
+      awayTeam: { select: { id: true, name: true } },
+      result: { select: { homeScore: true, awayScore: true } },
+      paymentCharges: {
+        select: {
+          id: true,
+          teamId: true,
+          amountPence: true,
+          paymentToken: true,
+          transactions: {
+            select: { amountPence: true, notes: true },
+          },
+        },
+      },
+    },
+  });
+  if (!fixture) throw new Error("Fixture not found.");
+
+  const playerFees = await prisma.playerMatchFee.findMany({
+    where: {
+      fixtureId: fixture.id,
+      teamId: { in: [fixture.homeTeam.id, fixture.awayTeam.id] },
+    },
+    select: {
+      fixtureId: true,
+      teamId: true,
+      amountPence: true,
+      status: true,
+    },
+  });
+
+  const responsibleTeam = abandonment.responsibleTeamId
+    ? abandonment.responsibleTeamId === fixture.homeTeam.id
+      ? fixture.homeTeam
+      : abandonment.responsibleTeamId === fixture.awayTeam.id
+        ? fixture.awayTeam
+        : null
+    : null;
+  const innocentTeam = abandonment.innocentTeamId
+    ? abandonment.innocentTeamId === fixture.homeTeam.id
+      ? fixture.homeTeam
+      : abandonment.innocentTeamId === fixture.awayTeam.id
+        ? fixture.awayTeam
+        : null
+    : null;
+
+  const chargeByTeam = new Map(
+    fixture.paymentCharges.map((charge) => [charge.teamId, charge]),
+  );
+  const fixtureLabel = `${fixture.homeTeam.name} v ${fixture.awayTeam.name}`;
+  const reasonLabel = getFixtureAbandonmentReasonLabel(abandonment.reason);
+  const officialResultLine = fixture.result
+    ? `SIXFL has awarded the official result: ${fixture.homeTeam.name} ${fixture.result.homeScore}-${fixture.result.awayScore} ${fixture.awayTeam.name}.`
+    : "The league/result outcome remains for SIXFL to decide after reviewing the abandonment.";
+
+  const queuedDispatchIds: string[] = [];
+  const failures: string[] = [];
+
+  const queueTeamEmail = async (args: Parameters<typeof sendTeamBroadcastMessage>[0]) => {
+    try {
+      const dispatch = await sendTeamBroadcastMessage(args);
+      queuedDispatchIds.push(dispatch.dispatchId);
+    } catch (error) {
+      failures.push(
+        `${args.teamId}: ${error instanceof Error ? error.message : "Unable to queue email"}`,
+      );
+    }
+  };
+
+  if (responsibleTeam && innocentTeam) {
+    const responsibleCharge = chargeByTeam.get(responsibleTeam.id) ?? null;
+    const responsiblePaidPence = getPaidPence({
+      fixtureId: fixture.id,
+      teamId: responsibleTeam.id,
+      charge: responsibleCharge,
+      fees: playerFees,
+    });
+    const total =
+      abandonment.responsibleFinalChargePence ??
+      responsibleCharge?.amountPence ??
+      0;
+    const outstanding = Math.max(0, total - responsiblePaidPence);
+    const payUrl =
+      outstanding > 0 && responsibleCharge?.paymentToken
+        ? buildChargePaymentUrl(responsibleCharge.paymentToken)
+        : null;
+
+    await queueTeamEmail({
+      teamId: responsibleTeam.id,
+      channel: NotificationChannel.EMAIL,
+      subject: `Match abandoned: fee decision for ${fixtureLabel}`,
+      body: [
+        "Hi {{firstName}},",
+        "",
+        `The referee abandoned ${fixtureLabel}.`,
+        `Reason: ${reasonLabel}.`,
+        abandonment.details ? `Referee note: ${abandonment.details}` : null,
+        "",
+        `Under the SIXFL abandoned-match rule, ${responsibleTeam.name} is responsible for both its own match fee (${formatMoney(abandonment.responsibleOriginalFeePence ?? 0)}) and ${innocentTeam.name}'s match fee (${formatMoney(abandonment.innocentOriginalFeePence ?? 0)}).`,
+        `Total charge: ${formatMoney(total)}. Amount already covered: ${formatMoney(responsiblePaidPence)}. Outstanding: ${formatMoney(outstanding)}.`,
+        "",
+        officialResultLine,
+        "",
+        payUrl
+          ? "Use the button below to pay the outstanding balance."
+          : "No further payment is currently outstanding.",
+        "",
+        "SIXFL",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      ctaLabel: payUrl ? "Pay outstanding match fees" : null,
+      ctaUrl: payUrl,
+      origin: "fixture-abandonment-fee-decision-recovery",
+      originLabel: "Abandoned match fee decision resend",
+      metadata: {
+        fixtureId: fixture.id,
+        role: "responsible_team",
+        recoveryResend: true,
+      },
+      createdByUserId: input.createdByUserId,
+    });
+
+    await queueTeamEmail({
+      teamId: innocentTeam.id,
+      channel: NotificationChannel.EMAIL,
+      subject: `Match abandoned: your fee has been waived for ${fixtureLabel}`,
+      body: [
+        "Hi {{firstName}},",
+        "",
+        `The referee abandoned ${fixtureLabel}.`,
+        `Reason: ${reasonLabel}.`,
+        abandonment.details ? `Referee note: ${abandonment.details}` : null,
+        "",
+        `SIXFL has recorded ${responsibleTeam.name} as the team responsible for the abandonment. You will not be charged for this fixture.`,
+        abandonment.innocentPaidPence > 0
+          ? abandonment.innocentCreditPence > 0
+            ? `${formatMoney(abandonment.innocentCreditPence)} that had already been paid has been added to ${innocentTeam.name}'s SIXFL team credit for a future match.`
+            : `${formatMoney(abandonment.innocentPaidPence)} had already been paid. SIXFL will account for that payment separately.`
+          : "No payment is due from your team for this abandoned fixture.",
+        "",
+        officialResultLine,
+        "",
+        "SIXFL",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      origin: "fixture-abandonment-fee-decision-recovery",
+      originLabel: "Abandoned match fee decision resend",
+      metadata: {
+        fixtureId: fixture.id,
+        role: "innocent_team",
+        recoveryResend: true,
+      },
+      createdByUserId: input.createdByUserId,
+    });
+  } else {
+    for (const team of [fixture.homeTeam, fixture.awayTeam]) {
+      await queueTeamEmail({
+        teamId: team.id,
+        channel: NotificationChannel.EMAIL,
+        subject: `Match abandoned: ${fixtureLabel}`,
+        body: [
+          "Hi {{firstName}},",
+          "",
+          `The referee abandoned ${fixtureLabel}.`,
+          `Reason: ${reasonLabel}.`,
+          abandonment.details ? `Referee note: ${abandonment.details}` : null,
+          "",
+          "No automatic fee transfer was applied because this abandonment was not recorded as being caused by one team's conduct. SIXFL will review any fee adjustment separately.",
+          "",
+          officialResultLine,
+          "",
+          "SIXFL",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        origin: "fixture-abandonment-notice-recovery",
+        originLabel: "Abandoned match notice resend",
+        metadata: {
+          fixtureId: fixture.id,
+          role: "team",
+          recoveryResend: true,
+        },
+        createdByUserId: input.createdByUserId,
+      });
+    }
+  }
+
+  if (queuedDispatchIds.length > 0) {
+    try {
+      await processNotificationQueue(Math.max(20, queuedDispatchIds.length + 10));
+    } catch (error) {
+      console.error("Recovered abandonment emails were queued but immediate processing failed", error);
+    }
+  }
+
+  if (queuedDispatchIds.length === 0) {
+    throw new Error(
+      failures.length > 0
+        ? `No abandonment emails could be queued. ${failures.join(" | ")}`
+        : "No abandonment emails could be queued.",
+    );
+  }
+
+  return {
+    queued: queuedDispatchIds.length,
+    failed: failures.length,
+    failures,
+  };
+}


### PR DESCRIPTION
## Summary
- add an admin-only **Send abandonment emails again** recovery button to recorded abandoned fixtures
- rebuild the email from the saved abandonment decision, current official result and current payment position
- send the responsible-team and innocent-team emails independently so one delivery setup problem does not block the other team
- keep the responsible team's current outstanding payment link in the recovered email where required
- do not change the saved abandonment, fees, credit or official result when resending
- add a regression contract for the recovery path

This is the recovery path for the live abandonment attempt where the server errored before either team email appeared in the conversation timelines.