### PR TITLE
Add inactive status for historic squad players

### DIFF
--- a/scripts/apply-inactive-squad-player-surfaces.cjs
+++ b/scripts/apply-inactive-squad-player-surfaces.cjs
@@ -81,20 +81,24 @@ function replaceRequired(source, before, after, label) {
     source = replaceRequired(source, sectionAnchor, guidance, "Captain squad inactive guidance");
   }
 
+  // The role/badge row has legacy build-time variants. Add an inline badge when the
+  // native shape is available, but never make the whole prebuild depend on cosmetic markup.
   if (!source.includes("isInactiveCaptainSquadMember")) {
     const mapAnchor = `            {team.members.map((member) => {
               const profile = profileByMemberId.get(member.id);`;
-    const mapReplacement = `            {team.members.map((member) => {
-              const profile = profileByMemberId.get(member.id);
-              const isInactiveCaptainSquadMember =
-                squadStatusByMemberIdForCaptainSquad.get(member.id)?.squadStatus === "INACTIVE";`;
-    source = replaceRequired(source, mapAnchor, mapReplacement, "Captain squad inactive row state");
-
     const badgeAnchor = `                        <span className={\`rounded-full border px-2.5 py-1 text-[11px] font-medium \${getRoleBadgeClasses(member.role)}\`}>
                           {getRoleLabel(member.role)}
                         </span>
                         {whatsAppUrl ? <WhatsAppLink href={whatsAppUrl} playerName={playerName} /> : null}`;
-    const badgeReplacement = `                        <span className={\`rounded-full border px-2.5 py-1 text-[11px] font-medium \${getRoleBadgeClasses(member.role)}\`}>
+
+    if (source.includes(mapAnchor) && source.includes(badgeAnchor)) {
+      const mapReplacement = `            {team.members.map((member) => {
+              const profile = profileByMemberId.get(member.id);
+              const isInactiveCaptainSquadMember =
+                squadStatusByMemberIdForCaptainSquad.get(member.id)?.squadStatus === "INACTIVE";`;
+      source = source.replace(mapAnchor, mapReplacement);
+
+      const badgeReplacement = `                        <span className={\`rounded-full border px-2.5 py-1 text-[11px] font-medium \${getRoleBadgeClasses(member.role)}\`}>
                           {getRoleLabel(member.role)}
                         </span>
                         {isInactiveCaptainSquadMember ? (
@@ -103,7 +107,8 @@ function replaceRequired(source, before, after, label) {
                           </span>
                         ) : null}
                         {whatsAppUrl ? <WhatsAppLink href={whatsAppUrl} playerName={playerName} /> : null}`;
-    source = replaceRequired(source, badgeAnchor, badgeReplacement, "Captain squad inactive badge");
+      source = source.replace(badgeAnchor, badgeReplacement);
+    }
   }
 
   write(file, source);

--- a/scripts/apply-inactive-squad-player-surfaces.cjs
+++ b/scripts/apply-inactive-squad-player-surfaces.cjs
@@ -1,0 +1,217 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, ...relativePath.split("/")), "utf8");
+}
+
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, ...relativePath.split("/")), source, "utf8");
+}
+
+function ensureImport(source, importLine, anchor, label) {
+  if (source.includes(importLine)) return source;
+  if (!source.includes(anchor)) throw new Error(`${label} import anchor not found.`);
+  return source.replace(anchor, `${importLine}\n${anchor}`);
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) throw new Error(`${label} anchor not found.`);
+  return source.replace(before, after);
+}
+
+// Captain squad: keep historic players visible, but clearly distinguish them from
+// the current active squad and explain how the status affects Squad payments.
+{
+  const file = "src/app/captain/team/[teamid]/captain-squad/page.tsx";
+  let source = read(file);
+  const importLine = 'import { getTeamMemberSquadStatusMap } from "@/lib/managed-squad/squadStatus";';
+  source = ensureImport(
+    source,
+    importLine,
+    'import { prisma } from "@/lib/prisma";',
+    "Captain squad inactive status",
+  );
+
+  if (!source.includes("squadStatusByMemberIdForCaptainSquad")) {
+    const anchor = `  const usesWhatsappByUserId = new Map(
+    whatsappRows.map((row) => [row.id, Boolean(row.usesWhatsapp)]),
+  );`;
+    if (!source.includes(anchor)) throw new Error("Captain squad status-map anchor not found.");
+    source = source.replace(
+      anchor,
+      `  const squadStatusByMemberIdForCaptainSquad = await getTeamMemberSquadStatusMap(teamid);\n\n${anchor}`,
+    );
+  }
+
+  if (!source.includes("activeMembersForCaptainSquad")) {
+    const countAnchor = `  const organiserCount = team.members.filter((member) =>
+    ["CAPTAIN", "MANAGER", "VICE_CAPTAIN"].includes(member.role),
+  ).length;
+  const playerCount = team.members.filter((member) => member.role === "PLAYER").length;
+  const backupCount = team.members.filter((member) => member.role === "BACKUP_PLAYER").length;
+  const totalSquadCount = team.members.length;`;
+    const replacement = `  const activeMembersForCaptainSquad = team.members.filter(
+    (member) => squadStatusByMemberIdForCaptainSquad.get(member.id)?.squadStatus !== "INACTIVE",
+  );
+  const inactiveMemberCount = team.members.length - activeMembersForCaptainSquad.length;
+  const organiserCount = activeMembersForCaptainSquad.filter((member) =>
+    ["CAPTAIN", "MANAGER", "VICE_CAPTAIN"].includes(member.role),
+  ).length;
+  const playerCount = activeMembersForCaptainSquad.filter((member) => member.role === "PLAYER").length;
+  const backupCount = activeMembersForCaptainSquad.filter((member) => member.role === "BACKUP_PLAYER").length;
+  const totalSquadCount = activeMembersForCaptainSquad.length;`;
+    source = replaceRequired(source, countAnchor, replacement, "Captain squad active counts");
+  }
+
+  if (!source.includes("Historic players can stay on SIXFL without blocking Squad payments")) {
+    const sectionAnchor = `      <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">`;
+    const guidance = `      <section className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm leading-6 text-sky-50/80">
+        <span className="font-semibold text-white">Historic players can stay on SIXFL without blocking Squad payments.</span>{" "}
+        If someone no longer plays, choose <span className="font-semibold text-white">Edit player</span> and mark them <span className="font-semibold text-white">Inactive</span>. Their old matches, statistics and payments remain in the system, but they are removed from current availability, fixture selection and Squad payments.
+        {inactiveMemberCount > 0 ? (
+          <span className="mt-2 block text-sky-100/60">
+            {inactiveMemberCount} historic/inactive player{inactiveMemberCount === 1 ? " is" : "s are"} currently kept on this team.
+          </span>
+        ) : null}
+      </section>\n\n${sectionAnchor}`;
+    source = replaceRequired(source, sectionAnchor, guidance, "Captain squad inactive guidance");
+  }
+
+  if (!source.includes("isInactiveCaptainSquadMember")) {
+    const mapAnchor = `            {team.members.map((member) => {
+              const profile = profileByMemberId.get(member.id);`;
+    const mapReplacement = `            {team.members.map((member) => {
+              const profile = profileByMemberId.get(member.id);
+              const isInactiveCaptainSquadMember =
+                squadStatusByMemberIdForCaptainSquad.get(member.id)?.squadStatus === "INACTIVE";`;
+    source = replaceRequired(source, mapAnchor, mapReplacement, "Captain squad inactive row state");
+
+    const badgeAnchor = `                        <span className={\`rounded-full border px-2.5 py-1 text-[11px] font-medium \${getRoleBadgeClasses(member.role)}\`}>
+                          {getRoleLabel(member.role)}
+                        </span>
+                        {whatsAppUrl ? <WhatsAppLink href={whatsAppUrl} playerName={playerName} /> : null}`;
+    const badgeReplacement = `                        <span className={\`rounded-full border px-2.5 py-1 text-[11px] font-medium \${getRoleBadgeClasses(member.role)}\`}>
+                          {getRoleLabel(member.role)}
+                        </span>
+                        {isInactiveCaptainSquadMember ? (
+                          <span className="rounded-full border border-white/15 bg-white/[0.04] px-2.5 py-1 text-[11px] font-semibold text-white/50">
+                            Inactive · history kept
+                          </span>
+                        ) : null}
+                        {whatsAppUrl ? <WhatsAppLink href={whatsAppUrl} playerName={playerName} /> : null}`;
+    source = replaceRequired(source, badgeAnchor, badgeReplacement, "Captain squad inactive badge");
+  }
+
+  write(file, source);
+}
+
+// Availability: inactive historic players are not part of current fixture responses,
+// counts or chase controls. Historic availability records remain stored untouched.
+{
+  const file = "src/app/captain/team/[teamid]/availability/page.tsx";
+  let source = read(file);
+
+  if (!source.includes("activeMembersForAvailability")) {
+    const anchor = `  const smsDispatchBySourceId = new Map<string, (typeof smsDispatches)[number]>();`;
+    if (!source.includes(anchor)) throw new Error("Availability active-member anchor not found.");
+    source = source.replace(
+      anchor,
+      `  const activeMembersForAvailability = team.members.filter(
+    (member) => squadStatusByMemberId.get(member.id)?.squadStatus !== "INACTIVE",
+  );\n\n${anchor}`,
+    );
+  }
+
+  source = source
+    .replace("    return team.members.map((member) =>", "    return activeMembersForAvailability.map((member) =>")
+    .replace(
+      `{team.members.length} squad member\n                {team.members.length === 1 ? "" : "s"}`,
+      `{activeMembersForAvailability.length} active squad member\n                {activeMembersForAvailability.length === 1 ? "" : "s"}`,
+    )
+    .replace("          const fixtureResponses = team.members.map((member) =>", "          const fixtureResponses = activeMembersForAvailability.map((member) =>")
+    .replace("                {team.members.map((member) => {", "                {activeMembersForAvailability.map((member) => {");
+
+  if (!source.includes("activeMembersForAvailability.map((member) =>")) {
+    throw new Error("Availability inactive-player filters were not applied.");
+  }
+
+  write(file, source);
+}
+
+// Fixture selection: inactive historic players do not appear in current selection,
+// do not contribute to selection counts, and stale forms cannot re-select them.
+{
+  const pageFile = "src/app/captain/team/[teamid]/fixtures/[fixtureId]/selection/page.tsx";
+  let page = read(pageFile);
+
+  if (!page.includes("activeMembersForSelection")) {
+    const anchor = `  const availabilityByMemberId = new Map(
+    fixture.availabilities.map((item) => [item.teamMemberId, item]),
+  );`;
+    if (!page.includes(anchor)) throw new Error("Fixture selection active-member anchor not found.");
+    page = page.replace(
+      anchor,
+      `  const activeMembersForSelection = team.members.filter(
+    (member) => squadStatusByMemberId.get(member.id)?.squadStatus !== "INACTIVE",
+  );\n\n${anchor}`,
+    );
+  }
+
+  page = page
+    .replace(
+      `      squadStatusByMemberId.get(item.teamMemberId)?.squadStatus !== "INJURED",`,
+      `      squadStatusByMemberId.get(item.teamMemberId)?.squadStatus !== "INJURED" &&
+      squadStatusByMemberId.get(item.teamMemberId)?.squadStatus !== "INACTIVE",`,
+    )
+    .replace(
+      `      squadStatusByMemberId.get(item.teamMemberId)?.squadStatus !== "INJURED",`,
+      `      squadStatusByMemberId.get(item.teamMemberId)?.squadStatus !== "INJURED" &&
+      squadStatusByMemberId.get(item.teamMemberId)?.squadStatus !== "INACTIVE",`,
+    )
+    .replace("                {team.members.length}", "                {activeMembersForSelection.length}")
+    .replace("          {team.members.map((member) => {", "          {activeMembersForSelection.map((member) => {");
+
+  if (!page.includes("activeMembersForSelection.map((member) =>")) {
+    throw new Error("Fixture selection inactive-player filters were not applied.");
+  }
+
+  write(pageFile, page);
+
+  const actionFile = "src/app/captain/team/[teamid]/fixtures/[fixtureId]/selection/actions.ts";
+  let action = read(actionFile);
+  const importLine = 'import { getTeamMemberSquadStatusMap } from "@/lib/managed-squad/squadStatus";';
+  action = ensureImport(
+    action,
+    importLine,
+    'import { upsertNotificationRecipient } from "@/lib/notifications/recipients";',
+    "Fixture selection inactive status",
+  );
+
+  if (!action.includes("inactive players cannot be selected for current fixtures")) {
+    const anchor = `  if (!membership) {
+    redirect(buildSelectionRedirect(teamid, fixtureId, "?error=Team%20member%20not%20found."));
+  }`;
+    const replacement = `${anchor}
+
+  const squadStatusByMemberId = await getTeamMemberSquadStatusMap(teamid);
+  // Inactive historic players remain attached to old records, but inactive players cannot be selected for current fixtures.
+  if (squadStatusByMemberId.get(teamMemberId)?.squadStatus === "INACTIVE") {
+    redirect(
+      buildSelectionRedirect(
+        teamid,
+        fixtureId,
+        "?error=This%20historic%20player%20is%20inactive.%20Mark%20them%20active%20before%20selecting%20them.",
+      ),
+    );
+  }`;
+    action = replaceRequired(action, anchor, replacement, "Fixture selection stale inactive guard");
+  }
+
+  write(actionFile, action);
+}
+
+console.log("Inactive squad players are excluded from current payments, availability and fixture selection while remaining in team history.");

--- a/scripts/apply-player-payment-email-required.cjs
+++ b/scripts/apply-player-payment-email-required.cjs
@@ -8,9 +8,23 @@ const pagePath = path.join(root, "src", "app", "captain", "team", "[teamid]", "p
 let actions = fs.readFileSync(actionsPath, "utf8");
 let page = fs.readFileSync(pagePath, "utf8");
 
-// Require the whole current squad to have email addresses before a captain can
-// create or update Squad payments. The page wrapper enforces the same rule in
-// the UI; this server-side check also protects stale/open forms.
+const statusImport = 'import { getTeamMemberSquadStatusMap } from "@/lib/managed-squad/squadStatus";';
+if (!actions.includes(statusImport)) {
+  const importAnchor = 'import { prisma } from "@/lib/prisma";';
+  if (!actions.includes(importAnchor)) throw new Error("Player payment action Prisma import not found.");
+  actions = actions.replace(importAnchor, `${statusImport}\n${importAnchor}`);
+}
+
+if (!page.includes(statusImport)) {
+  const importAnchor = 'import { prisma } from "@/lib/prisma";';
+  if (!page.includes(importAnchor)) throw new Error("Player payment page Prisma import not found.");
+  page = page.replace(importAnchor, `${statusImport}\n${importAnchor}`);
+}
+
+// Require every ACTIVE current squad member to have an email before a captain can
+// create or update Squad payments. INACTIVE historic players deliberately do not
+// count. The page wrapper enforces the same rule in the UI; this server-side check
+// also protects stale/open forms.
 if (!actions.includes("squadMembersForEmailReadiness")) {
   const readinessAnchor = `export async function createCaptainSquadPaymentCollectionAction(formData: FormData) {
   const teamId = getString(formData, "teamId");
@@ -32,12 +46,17 @@ if (!actions.includes("squadMembersForEmailReadiness")) {
     readinessAnchor,
     `${readinessAnchor}
 
-  const squadMembersForEmailReadiness = await prisma.teamMember.findMany({
-    where: { teamId },
-    select: { id: true, user: { select: { email: true } } },
-  });
+  const [squadMembersForEmailReadiness, squadStatusByMemberIdForEmailReadiness] = await Promise.all([
+    prisma.teamMember.findMany({
+      where: { teamId },
+      select: { id: true, user: { select: { email: true } } },
+    }),
+    getTeamMemberSquadStatusMap(teamId),
+  ]);
   const hasMissingSquadEmail = squadMembersForEmailReadiness.some(
-    (member) => !member.user.email?.trim(),
+    (member) =>
+      squadStatusByMemberIdForEmailReadiness.get(member.id)?.squadStatus !== "INACTIVE" &&
+      !member.user.email?.trim(),
   );
 
   if (hasMissingSquadEmail) {
@@ -58,6 +77,30 @@ if (!actions.includes("selectedMemberIdsForEmailCheck")) {
   const actionGuardAnchor = '  if (players.length === 0) {\n    redirect(getPlayerPaymentsPath(teamId, fixtureId, "&error=no_players"));\n  }';
   if (!actions.includes(actionGuardAnchor)) throw new Error("Player payment no-players guard not found.");
   actions = actions.replace(actionGuardAnchor, `${actionGuardAnchor}\n\n  const selectedMemberIdsForEmailCheck = players.filter((player) => player.type === "member").map((player) => player.id);\n  const selectedProspectIdsForEmailCheck = players.filter((player) => player.type === "prospect").map((player) => player.id);\n  const [membersForEmailCheck, prospectsForEmailCheck] = await Promise.all([\n    prisma.teamMember.findMany({\n      where: { id: { in: selectedMemberIdsForEmailCheck }, teamId },\n      select: { id: true, user: { select: { email: true } } },\n    }),\n    prisma.teamPlayerProspect.findMany({\n      where: { id: { in: selectedProspectIdsForEmailCheck }, teamId },\n      select: { id: true, email: true },\n    }),\n  ]);\n  const memberEmailById = new Map(membersForEmailCheck.map((member) => [member.id, member.user.email?.trim() || null]));\n  const prospectEmailById = new Map(prospectsForEmailCheck.map((prospect) => [prospect.id, prospect.email?.trim() || null]));\n  for (const player of players) {\n    const enteredAmountPence = getPlayerAmountPence({ formData, type: player.type, id: player.id, defaultAmountPence });\n    if (enteredAmountPence === null) continue;\n    const method = getCollectionMethod({ formData, type: player.type, id: player.id, amountPence: enteredAmountPence });\n    const email = player.type === "member" ? memberEmailById.get(player.id) : prospectEmailById.get(player.id);\n    if (method === "link" && !email) {\n      redirect(getPlayerPaymentsPath(teamId, fixtureId, "&error=missing_player_email"));\n    }\n  }`);
+}
+
+// Keep inactive historic players out of the current player-collection picker. Existing
+// historic PlayerMatchFee rows are still loaded separately and remain visible in history.
+if (!page.includes("activeMembersForPayments")) {
+  const activeAnchor = '  const fixtureById = new Map(fixtures.map((fixture) => [fixture.id, fixture]));';
+  if (!page.includes(activeAnchor)) throw new Error("Player payment active-member anchor not found.");
+  page = page.replace(
+    activeAnchor,
+    `  const squadStatusByMemberIdForPayments = await getTeamMemberSquadStatusMap(teamid);
+  const activeMembersForPayments = members.filter(
+    (member) => squadStatusByMemberIdForPayments.get(member.id)?.squadStatus !== "INACTIVE",
+  );
+
+${activeAnchor}`,
+  );
+
+  const linkedMemberAnchor = '    members.flatMap(';
+  if (!page.includes(linkedMemberAnchor)) throw new Error("Player payment linked-member anchor not found.");
+  page = page.replace(linkedMemberAnchor, '    activeMembersForPayments.flatMap(');
+
+  const playerFormAnchor = '    ...members.map((member) => ({';
+  if (!page.includes(playerFormAnchor)) throw new Error("Player payment member-form anchor not found.");
+  page = page.replace(playerFormAnchor, '    ...activeMembersForPayments.map((member) => ({');
 }
 
 if (!page.includes('if (error === "missing_player_email")')) {
@@ -105,4 +148,4 @@ if (!page.includes('Email required')) {
 
 fs.writeFileSync(actionsPath, actions, "utf8");
 fs.writeFileSync(pagePath, page, "utf8");
-console.log("Player payment email requirement is present and the legacy compatibility patch is idempotent.");
+console.log("Player payment email requirement is present, inactive players are excluded, and the compatibility patch is idempotent.");

--- a/scripts/apply-player-payment-email-required.cjs
+++ b/scripts/apply-player-payment-email-required.cjs
@@ -148,4 +148,5 @@ if (!page.includes('Email required')) {
 
 fs.writeFileSync(actionsPath, actions, "utf8");
 fs.writeFileSync(pagePath, page, "utf8");
+require("./apply-inactive-squad-player-surfaces.cjs");
 console.log("Player payment email requirement is present, inactive players are excluded, and the compatibility patch is idempotent.");

--- a/src/app/captain/team/[teamid]/captain-squad/[membershipId]/edit/page.tsx
+++ b/src/app/captain/team/[teamid]/captain-squad/[membershipId]/edit/page.tsx
@@ -5,10 +5,12 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { getTeamMemberSquadStatusMap } from "@/lib/managed-squad/squadStatus";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
 import { getTeamMemberProfilesByTeamMemberIds } from "@/lib/teamMemberProfiles";
 import { updateManagedSquadMemberDetailsAction } from "../../../squad/edit-actions";
+import { updateCaptainSquadMemberActivityAction } from "../../../squad/status-actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -136,11 +138,14 @@ function WhatsAppToggle({ defaultChecked }: { defaultChecked: boolean }) {
 
 export default async function EditCaptainSquadPlayerPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ teamid: string; membershipId: string }>;
+  searchParams?: Promise<{ saved?: string; error?: string }>;
 }) {
   const { teamid, membershipId } = await params;
-  await requireCaptain(teamid);
+  const filters = (await searchParams) ?? {};
+  const access = await requireCaptain(teamid);
 
   const team = await prisma.team.findUnique({
     where: { id: teamid },
@@ -189,9 +194,21 @@ export default async function EditCaptainSquadPlayerPage({
 
   const usesWhatsapp = Boolean(whatsappRows[0]?.usesWhatsapp);
 
-  const profiles = await getTeamMemberProfilesByTeamMemberIds([membership.id]);
+  const [profiles, squadStatusMap] = await Promise.all([
+    getTeamMemberProfilesByTeamMemberIds([membership.id]),
+    getTeamMemberSquadStatusMap(teamid),
+  ]);
   const profile = profiles.get(membership.id) ?? null;
+  const squadStatus = squadStatusMap.get(membership.id)?.squadStatus ?? "ACTIVE";
+  const squadStatusNote = squadStatusMap.get(membership.id)?.squadStatusNote ?? null;
   const preferredNights = formatPreferredNights(profile?.preferredNights);
+  const savedMessage =
+    filters.saved === "player-marked-inactive"
+      ? "Player marked inactive. They remain in the team history but no longer count as a current player for Squad payments."
+      : filters.saved === "player-marked-active"
+        ? "Player marked active again."
+        : null;
+  const errorMessage = filters.error ? decodeURIComponent(filters.error) : null;
 
   return (
     <div className="space-y-8">
@@ -223,6 +240,17 @@ export default async function EditCaptainSquadPlayerPage({
                 <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-100">
                   {team.teamMode === "MANAGED" ? "SIXFL-managed" : "Team-managed"}
                 </span>
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                    squadStatus === "INACTIVE"
+                      ? "border-white/15 bg-white/[0.04] text-white/55"
+                      : squadStatus === "INJURED"
+                        ? "border-red-400/25 bg-red-500/10 text-red-100"
+                        : "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"
+                  }`}
+                >
+                  {squadStatus === "INACTIVE" ? "Inactive" : squadStatus === "INJURED" ? "Injured" : "Active"}
+                </span>
               </div>
             </div>
           </div>
@@ -236,6 +264,78 @@ export default async function EditCaptainSquadPlayerPage({
             </Link>
           </div>
         </div>
+      </section>
+
+      {savedMessage ? (
+        <section className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+          {savedMessage}
+        </section>
+      ) : null}
+
+      {errorMessage ? (
+        <section className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm text-amber-100">
+          {errorMessage}
+        </section>
+      ) : null}
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.28)] lg:p-8">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+          Player status
+        </p>
+        <h2 className="mt-2 text-xl font-semibold text-white">Active or historic player?</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
+          Historic players who no longer play can be made inactive. They stay attached to their historic matches, statistics and payments, but they are ignored for current Squad payments and do not need an email address to unlock Squad payments.
+        </p>
+
+        {squadStatus === "INJURED" && !access.isAdmin ? (
+          <div className="mt-5 rounded-2xl border border-red-400/20 bg-red-500/10 p-4 text-sm text-red-100/80">
+            This player is currently marked injured by SIXFL. Contact SIXFL before changing their squad status.
+            {squadStatusNote ? <span className="mt-2 block text-red-100/60">{squadStatusNote}</span> : null}
+          </div>
+        ) : (
+          <form action={updateCaptainSquadMemberActivityAction} className="mt-5 space-y-4">
+            <input type="hidden" name="teamid" value={teamid} />
+            <input type="hidden" name="membershipId" value={membership.id} />
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="flex cursor-pointer gap-3 rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.05] p-4">
+                <input
+                  type="radio"
+                  name="squadStatus"
+                  value="ACTIVE"
+                  defaultChecked={squadStatus !== "INACTIVE"}
+                  className="mt-1"
+                />
+                <span>
+                  <span className="block text-sm font-semibold text-white">Active player</span>
+                  <span className="mt-1 block text-xs leading-5 text-white/50">
+                    Current squad member. Included in Squad payments and future squad planning.
+                  </span>
+                </span>
+              </label>
+              <label className="flex cursor-pointer gap-3 rounded-2xl border border-white/10 bg-black/20 p-4">
+                <input
+                  type="radio"
+                  name="squadStatus"
+                  value="INACTIVE"
+                  defaultChecked={squadStatus === "INACTIVE"}
+                  className="mt-1"
+                />
+                <span>
+                  <span className="block text-sm font-semibold text-white">Inactive / historic player</span>
+                  <span className="mt-1 block text-xs leading-5 text-white/50">
+                    Keep their history, but do not include them in current Squad payments or future squad planning.
+                  </span>
+                </span>
+              </label>
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-xl border border-white/10 bg-white/[0.06] px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/[0.1]"
+            >
+              Save player status
+            </button>
+          </form>
+        )}
       </section>
 
       <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.28)] lg:p-8">

--- a/src/app/captain/team/[teamid]/player-payments/page.tsx
+++ b/src/app/captain/team/[teamid]/player-payments/page.tsx
@@ -5,6 +5,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { getTeamMemberSquadStatusMap } from "@/lib/managed-squad/squadStatus";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
 import PaymentPageServer from "./PaymentPageServer";
@@ -54,7 +55,14 @@ export default async function SquadPaymentsPage(props: Props) {
 
   if (!team) notFound();
 
-  const missingEmailMembers = team.members.filter(
+  const squadStatusByMemberId = await getTeamMemberSquadStatusMap(teamid);
+  const activeMembers = team.members.filter(
+    (member) => squadStatusByMemberId.get(member.id)?.squadStatus !== "INACTIVE",
+  );
+  const inactiveMembers = team.members.filter(
+    (member) => squadStatusByMemberId.get(member.id)?.squadStatus === "INACTIVE",
+  );
+  const missingEmailMembers = activeMembers.filter(
     (member) => !member.user.email?.trim(),
   );
 
@@ -66,37 +74,57 @@ export default async function SquadPaymentsPage(props: Props) {
             Squad payments not ready
           </p>
           <h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">
-            Add every squad member&apos;s email before using Squad payments
+            Add an email for every active squad member before using Squad payments
           </h1>
           <p className="mt-3 max-w-3xl text-sm leading-6 text-amber-50/75 sm:text-base">
-            SIXFL sends individual payment links by email. To stop payment requests being
-            missed or set up against incomplete player records, every current squad member
-            must have an email address saved before {team.name} can set up or update Squad
-            payments.
+            SIXFL sends individual payment links by email. Every player who is still part of
+            the current squad must therefore have an email address saved before {team.name}
+            can set up or update Squad payments.
           </p>
+
+          <div className="mt-5 rounded-2xl border border-sky-300/20 bg-sky-500/10 p-4 text-sm leading-6 text-sky-50/80">
+            <span className="font-semibold text-white">Historic player who no longer plays?</span>{" "}
+            Do not add a made-up email address. Open that player and mark them
+            <span className="font-semibold text-white"> Inactive</span>. Their historic matches,
+            statistics and payments stay on SIXFL, but they will no longer block Squad payments.
+          </div>
 
           <div className="mt-6 rounded-2xl border border-amber-300/20 bg-black/20 p-4">
             <div className="text-sm font-semibold text-white">
-              {missingEmailMembers.length} squad member{missingEmailMembers.length === 1 ? " is" : "s are"} missing an email
+              {missingEmailMembers.length} active squad member{missingEmailMembers.length === 1 ? " is" : "s are"} missing an email
             </div>
             <ul className="mt-3 space-y-2 text-sm text-amber-50/75">
               {missingEmailMembers.map((member) => (
-                <li key={member.id} className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
-                  <span>{member.user.name?.trim() || "Unnamed squad member"}</span>
-                  <span className="text-xs uppercase tracking-wide text-amber-200/60">
-                    {member.role.replaceAll("_", " ")}
-                  </span>
+                <li key={member.id} className="flex flex-col gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <span>{member.user.name?.trim() || "Unnamed squad member"}</span>
+                    <span className="ml-2 text-xs uppercase tracking-wide text-amber-200/60">
+                      {member.role.replaceAll("_", " ")}
+                    </span>
+                  </div>
+                  <Link
+                    href={`/captain/team/${team.id}/captain-squad/${member.id}/edit`}
+                    className="inline-flex min-h-9 items-center justify-center rounded-full border border-white/10 bg-black/20 px-4 text-xs font-semibold text-white/80 transition hover:bg-white/[0.06] hover:text-white"
+                  >
+                    Add email or mark inactive
+                  </Link>
                 </li>
               ))}
             </ul>
           </div>
+
+          {inactiveMembers.length > 0 ? (
+            <p className="mt-4 text-xs leading-5 text-white/45">
+              {inactiveMembers.length} historic/inactive player{inactiveMembers.length === 1 ? " is" : "s are"} already excluded from the current Squad payments email check.
+            </p>
+          ) : null}
 
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
               href={`/captain/team/${team.id}/captain-squad`}
               className="inline-flex min-h-11 items-center justify-center rounded-full bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200"
             >
-              Add missing emails
+              Check squad details
             </Link>
             <Link
               href={`/captain/team/${team.id}`}

--- a/src/app/captain/team/[teamid]/squad/status-actions.ts
+++ b/src/app/captain/team/[teamid]/squad/status-actions.ts
@@ -7,7 +7,11 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-import { setTeamMemberSquadStatus, type TeamMemberSquadStatus } from "@/lib/managed-squad/squadStatus";
+import {
+  getTeamMemberSquadStatusMap,
+  setTeamMemberSquadStatus,
+  type TeamMemberSquadStatus,
+} from "@/lib/managed-squad/squadStatus";
 import { requireCaptain } from "@/lib/requireCaptain";
 
 function cleanText(value: FormDataEntryValue | null) {
@@ -15,15 +19,41 @@ function cleanText(value: FormDataEntryValue | null) {
 }
 
 function getStatusValue(value: FormDataEntryValue | null): TeamMemberSquadStatus {
-  return cleanText(value).toUpperCase() === "INJURED" ? "INJURED" : "ACTIVE";
+  const parsed = cleanText(value).toUpperCase();
+  if (parsed === "INJURED") return "INJURED";
+  if (parsed === "INACTIVE") return "INACTIVE";
+  return "ACTIVE";
+}
+
+function getCaptainActivityStatus(value: FormDataEntryValue | null): TeamMemberSquadStatus {
+  return cleanText(value).toUpperCase() === "INACTIVE" ? "INACTIVE" : "ACTIVE";
 }
 
 function getRedirect(teamId: string, saved: string) {
   return `/captain/team/${teamId}/squad?saved=${encodeURIComponent(saved)}`;
 }
 
+function getCaptainEditRedirect(teamId: string, membershipId: string, saved: string) {
+  return `/captain/team/${teamId}/captain-squad/${membershipId}/edit?saved=${encodeURIComponent(saved)}`;
+}
+
 function getErrorRedirect(teamId: string, message: string) {
   return `/captain/team/${teamId}/squad?error=${encodeURIComponent(message)}`;
+}
+
+function getCaptainEditErrorRedirect(teamId: string, membershipId: string, message: string) {
+  return `/captain/team/${teamId}/captain-squad/${membershipId}/edit?error=${encodeURIComponent(message)}`;
+}
+
+function revalidateSquadStatusPaths(teamId: string) {
+  revalidatePath(`/captain/team/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}/squad`);
+  revalidatePath(`/captain/team/${teamId}/captain-squad`);
+  revalidatePath(`/captain/team/${teamId}/availability`);
+  revalidatePath(`/captain/team/${teamId}/fixtures`);
+  revalidatePath(`/captain/team/${teamId}/player-payments`);
+  revalidatePath(`/admin/teams/${teamId}`);
+  revalidatePath(`/admin/teams/${teamId}/squad`);
 }
 
 export async function updateManagedSquadMemberStatusAction(formData: FormData) {
@@ -36,7 +66,7 @@ export async function updateManagedSquadMemberStatusAction(formData: FormData) {
 
   const access = await requireCaptain(teamid);
   if (!access.isAdmin) {
-    redirect(getErrorRedirect(teamid, "Only SIXFL admins can change injury status."));
+    redirect(getErrorRedirect(teamid, "Only SIXFL admins can change managed squad injury status."));
   }
 
   const updated = await setTeamMemberSquadStatus({
@@ -50,11 +80,65 @@ export async function updateManagedSquadMemberStatusAction(formData: FormData) {
     redirect(getErrorRedirect(teamid, "Squad member not found."));
   }
 
-  revalidatePath(`/captain/team/${teamid}`);
-  revalidatePath(`/captain/team/${teamid}/squad`);
-  revalidatePath(`/captain/team/${teamid}/captain-squad`);
-  revalidatePath(`/admin/teams/${teamid}`);
-  revalidatePath(`/admin/teams/${teamid}/squad`);
+  revalidateSquadStatusPaths(teamid);
 
-  redirect(getRedirect(teamid, status === "INJURED" ? "member-marked-injured" : "member-marked-active"));
+  const saved =
+    status === "INJURED"
+      ? "member-marked-injured"
+      : status === "INACTIVE"
+        ? "member-marked-inactive"
+        : "member-marked-active";
+  redirect(getRedirect(teamid, saved));
+}
+
+export async function updateCaptainSquadMemberActivityAction(formData: FormData) {
+  const teamid = cleanText(formData.get("teamid"));
+  const membershipId = cleanText(formData.get("membershipId"));
+  const status = getCaptainActivityStatus(formData.get("squadStatus"));
+
+  if (!teamid || !membershipId) redirect("/captain");
+
+  const access = await requireCaptain(teamid);
+  const statusMap = await getTeamMemberSquadStatusMap(teamid);
+  const currentStatus = statusMap.get(membershipId)?.squadStatus;
+
+  if (!currentStatus) {
+    redirect(getCaptainEditErrorRedirect(teamid, membershipId, "Squad member not found."));
+  }
+
+  if (currentStatus === "INJURED" && !access.isAdmin) {
+    redirect(
+      getCaptainEditErrorRedirect(
+        teamid,
+        membershipId,
+        "This player is currently marked injured by SIXFL. Contact SIXFL before changing their squad status.",
+      ),
+    );
+  }
+
+  const note =
+    status === "INACTIVE"
+      ? "Historic/former player marked inactive by team captain."
+      : null;
+
+  const updated = await setTeamMemberSquadStatus({
+    teamId: teamid,
+    membershipId,
+    status,
+    note,
+  });
+
+  if (!updated) {
+    redirect(getCaptainEditErrorRedirect(teamid, membershipId, "Squad member not found."));
+  }
+
+  revalidateSquadStatusPaths(teamid);
+
+  redirect(
+    getCaptainEditRedirect(
+      teamid,
+      membershipId,
+      status === "INACTIVE" ? "player-marked-inactive" : "player-marked-active",
+    ),
+  );
 }

--- a/src/lib/managed-squad/squadStatus.ts
+++ b/src/lib/managed-squad/squadStatus.ts
@@ -2,7 +2,11 @@
 // File: src/lib/managed-squad/squadStatus.ts
 // ========================================
 
-import { NotificationDispatchStatus, Prisma } from "@prisma/client";
+import {
+  FixtureStatus,
+  NotificationDispatchStatus,
+  Prisma,
+} from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 
@@ -21,6 +25,22 @@ const MANAGED_SQUAD_AVAILABILITY_SOURCE_TYPES = [
   "MANAGED_SQUAD_AVAILABILITY_REQUEST",
   "MANAGED_SQUAD_AVAILABILITY_CHASE_24H",
   "MANAGED_SQUAD_AVAILABILITY_CHASE_72H",
+];
+
+const PLAYER_MATCH_FEE_NOTIFICATION_SOURCE_TYPES = [
+  "PLAYER_MATCH_FEE_REQUEST",
+  "PLAYER_MATCH_FEE_CHASE_24H",
+  "PLAYER_MATCH_FEE_CHASE_72H",
+];
+
+const FIXTURE_SELECTION_NOTIFICATION_SOURCE_TYPES = [
+  "FIXTURE_SELECTION_SELECTED",
+  "FIXTURE_SELECTION_MATCHDAY_REMINDER",
+];
+
+const FUTURE_FIXTURE_STATUSES = [
+  FixtureStatus.SCHEDULED,
+  FixtureStatus.POSTPONED,
 ];
 
 export async function ensureTeamMemberSquadStatusColumns(db: DbClient = prisma) {
@@ -68,6 +88,115 @@ async function cancelQueuedAvailabilityChasesForUnavailablePlayer(input: {
       failureReason: input.reason,
     },
   });
+}
+
+async function clearFutureActivityForInactivePlayer(input: {
+  membershipId: string;
+  teamId: string;
+  db: DbClient;
+}) {
+  const [futureFees, futureSelections] = await Promise.all([
+    input.db.playerMatchFee.findMany({
+      where: {
+        teamMemberId: input.membershipId,
+        teamId: input.teamId,
+        status: "OPEN",
+        fixture: {
+          status: { in: FUTURE_FIXTURE_STATUSES },
+        },
+      },
+      select: {
+        id: true,
+        note: true,
+      },
+    }),
+    input.db.fixtureSelection.findMany({
+      where: {
+        teamMemberId: input.membershipId,
+        fixture: {
+          status: { in: FUTURE_FIXTURE_STATUSES },
+        },
+      },
+      select: {
+        fixtureId: true,
+      },
+    }),
+  ]);
+
+  for (const fee of futureFees) {
+    await input.db.playerMatchFee.update({
+      where: { id: fee.id },
+      data: {
+        status: "CANCELLED",
+        cancelledAt: new Date(),
+        paymentUrl: null,
+        paymentToken: null,
+        note: [
+          fee.note,
+          "Cancelled automatically because this historic/former player was marked inactive before the fixture.",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      },
+    });
+  }
+
+  if (futureSelections.length > 0) {
+    await input.db.fixtureSelection.updateMany({
+      where: {
+        teamMemberId: input.membershipId,
+        fixture: {
+          status: { in: FUTURE_FIXTURE_STATUSES },
+        },
+      },
+      data: {
+        selectionStatus: "NOT_SELECTED",
+        isCaptain: false,
+        isGoalkeeper: false,
+        note: "Removed from future selection because player was marked inactive.",
+      },
+    });
+  }
+
+  const feeIds = futureFees.map((fee) => fee.id);
+  if (feeIds.length > 0) {
+    await input.db.notificationDispatch.updateMany({
+      where: {
+        sourceType: { in: PLAYER_MATCH_FEE_NOTIFICATION_SOURCE_TYPES },
+        sourceId: { in: feeIds },
+        status: {
+          in: [NotificationDispatchStatus.QUEUED, NotificationDispatchStatus.PROCESSING],
+        },
+      },
+      data: {
+        status: NotificationDispatchStatus.CANCELLED,
+        cancelledAt: new Date(),
+        failureReason: "Player was marked inactive before the fixture; future player-fee request cancelled.",
+      },
+    });
+  }
+
+  const selectionSourceIds = futureSelections.flatMap((selection) => [
+    `${selection.fixtureId}:${input.membershipId}:selected`,
+    `${selection.fixtureId}:${input.membershipId}:matchday-reminder`,
+  ]);
+
+  if (selectionSourceIds.length > 0) {
+    await input.db.notificationDispatch.updateMany({
+      where: {
+        sourceType: { in: FIXTURE_SELECTION_NOTIFICATION_SOURCE_TYPES },
+        sourceId: { in: selectionSourceIds },
+        status: {
+          in: [NotificationDispatchStatus.QUEUED, NotificationDispatchStatus.PROCESSING],
+        },
+      },
+      data: {
+        status: NotificationDispatchStatus.CANCELLED,
+        cancelledAt: new Date(),
+        failureReason: "Player was marked inactive; future fixture-selection message cancelled.",
+      },
+    });
+  }
 }
 
 export async function getTeamMemberSquadStatusMap(teamId: string, db: DbClient = prisma) {
@@ -123,11 +252,18 @@ export async function setTeamMemberSquadStatus(input: {
   }
 
   if (didUpdate && input.status === "INACTIVE") {
-    await cancelQueuedAvailabilityChasesForUnavailablePlayer({
-      membershipId: input.membershipId,
-      db,
-      reason: "Player marked inactive; future availability chase cancelled.",
-    });
+    await Promise.all([
+      cancelQueuedAvailabilityChasesForUnavailablePlayer({
+        membershipId: input.membershipId,
+        db,
+        reason: "Player marked inactive; future availability chase cancelled.",
+      }),
+      clearFutureActivityForInactivePlayer({
+        membershipId: input.membershipId,
+        teamId: input.teamId,
+        db,
+      }),
+    ]);
   }
 
   return didUpdate;

--- a/src/lib/managed-squad/squadStatus.ts
+++ b/src/lib/managed-squad/squadStatus.ts
@@ -8,7 +8,7 @@ import { prisma } from "@/lib/prisma";
 
 type DbClient = typeof prisma | Prisma.TransactionClient;
 
-export type TeamMemberSquadStatus = "ACTIVE" | "INJURED";
+export type TeamMemberSquadStatus = "ACTIVE" | "INJURED" | "INACTIVE";
 
 export type TeamMemberSquadStatusRow = {
   id: string;
@@ -45,9 +45,10 @@ export async function ensureTeamMemberSquadStatusColumns(db: DbClient = prisma) 
   `);
 }
 
-async function cancelQueuedAvailabilityChasesForInjuredPlayer(input: {
+async function cancelQueuedAvailabilityChasesForUnavailablePlayer(input: {
   membershipId: string;
   db: DbClient;
+  reason: string;
 }) {
   await input.db.notificationDispatch.updateMany({
     where: {
@@ -64,7 +65,7 @@ async function cancelQueuedAvailabilityChasesForInjuredPlayer(input: {
     data: {
       status: NotificationDispatchStatus.CANCELLED,
       cancelledAt: new Date(),
-      failureReason: "Player marked injured; future availability chase cancelled.",
+      failureReason: input.reason,
     },
   });
 }
@@ -75,7 +76,11 @@ export async function getTeamMemberSquadStatusMap(teamId: string, db: DbClient =
   const rows = await db.$queryRaw<TeamMemberSquadStatusRow[]>(Prisma.sql`
     SELECT
       "id",
-      CASE WHEN "squadStatus" = 'INJURED' THEN 'INJURED' ELSE 'ACTIVE' END AS "squadStatus",
+      CASE
+        WHEN "squadStatus" = 'INJURED' THEN 'INJURED'
+        WHEN "squadStatus" = 'INACTIVE' THEN 'INACTIVE'
+        ELSE 'ACTIVE'
+      END AS "squadStatus",
       "squadStatusUpdatedAt",
       "squadStatusNote"
     FROM "TeamMember"
@@ -110,9 +115,18 @@ export async function setTeamMemberSquadStatus(input: {
   const didUpdate = Number(updated) > 0;
 
   if (didUpdate && input.status === "INJURED") {
-    await cancelQueuedAvailabilityChasesForInjuredPlayer({
+    await cancelQueuedAvailabilityChasesForUnavailablePlayer({
       membershipId: input.membershipId,
       db,
+      reason: "Player marked injured; future availability chase cancelled.",
+    });
+  }
+
+  if (didUpdate && input.status === "INACTIVE") {
+    await cancelQueuedAvailabilityChasesForUnavailablePlayer({
+      membershipId: input.membershipId,
+      db,
+      reason: "Player marked inactive; future availability chase cancelled.",
     });
   }
 


### PR DESCRIPTION
Adds a proper inactive/historic player status without deleting the TeamMember record.

- captains can open Squad → Edit player and mark a former/historic player **Inactive**
- inactive players keep historic matches, statistics and completed/paid payment history
- inactive players no longer need an email to satisfy Squad payments readiness
- inactive players are excluded from the current Squad payments picker, availability and fixture selection
- marking a player inactive clears only open fees/selections for scheduled or postponed fixtures and cancels queued future reminders; historic/completed obligations are not erased
- stale fixture-selection and Squad-payment forms are protected server-side
- captains cannot use the toggle to override a SIXFL injury status; injured players remain protected
- captain-facing copy explicitly tells teams that historic players can be made inactive to allow Squad payments to be used

The existing raw TeamMember squadStatus infrastructure is extended from ACTIVE/INJURED to ACTIVE/INJURED/INACTIVE, so no player identity or historic links are deleted.