### PR TITLE
Send formal conduct notices after abandoned matches

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Check abandonment email recovery
         run: node scripts/check-fixture-abandonment-email-recovery.mjs
 
+      - name: Check formal conduct notice
+        run: node scripts/check-fixture-formal-conduct-notice.mjs
+
       - name: Check native admin Kits navigation
         run: node scripts/check-native-admin-kits-navigation.mjs
 
@@ -110,6 +113,7 @@ jobs:
           node scripts/check-abandoned-result-decision.mjs
           node scripts/check-fixture-abandonment-runtime-resilience.mjs
           node scripts/check-fixture-abandonment-email-recovery.mjs
+          node scripts/check-fixture-formal-conduct-notice.mjs
 
       - name: Generate Prisma client
         run: npx prisma generate

--- a/prisma/migrations/20260820000000_add_formal_conduct_notice_template/migration.sql
+++ b/prisma/migrations/20260820000000_add_formal_conduct_notice_template/migration.sql
@@ -1,0 +1,35 @@
+-- Formal conduct notice for a team whose conduct caused a referee-abandoned match.
+-- Preserve any administrator-edited version if this template already exists.
+
+INSERT INTO "NotificationTemplate" (
+  "id",
+  "key",
+  "name",
+  "description",
+  "kind",
+  "channel",
+  "audience",
+  "subject",
+  "body",
+  "ctaLabel",
+  "ctaUrlKey",
+  "isActive",
+  "createdAt",
+  "updatedAt"
+) VALUES (
+  'fixture-abandonment-formal-conduct-email',
+  'fixture-abandonment-formal-conduct-email',
+  'Abandoned match — formal conduct notice',
+  'Formal transactional conduct notice sent to the responsible team after a referee-abandoned match caused by player, manager or team conduct.',
+  'TRANSACTIONAL',
+  'EMAIL',
+  'TEAM',
+  'Formal conduct notice — {{teamName}}',
+  E'Hi {{firstName}},\n\nFollowing the abandonment of {{fixtureLabel}}, SIXFL is issuing a formal conduct notice to {{teamName}}.\n\nReason recorded: {{reasonLabel}}.\n{{refereeNoteLine}}\nFor the safety and smooth running of the league, the referee’s decisions and instructions during a match must be respected by all players, substitutes, managers and other team members.\n\nIf a player or team official is sent from the playing area, they must comply with the referee’s instruction and leave when asked. Refusing or repeatedly ignoring a referee’s instruction is not acceptable and can prevent a match from continuing safely.\n\nThe referee’s decision on the night is final. If your team disagrees with a decision or wishes to raise a concern, the instruction must still be followed at the time and the matter can be raised with SIXFL afterwards through the proper process.\n\nTeam captains and managers are responsible for making sure everyone connected with their team understands and follows these expectations.\n\nBehaviour that undermines the referee’s authority, or affects the safety and smooth running of the league, will not be tolerated. Any further conduct issues may result in further action under the SIXFL league rules.\n\nThis formal conduct notice is separate from the result and match-fee decision for the abandoned fixture.\n\nWe expect the full cooperation of everyone connected with {{teamName}} going forward.\n\nSIXFL',
+  NULL,
+  NULL,
+  TRUE,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+)
+ON CONFLICT ("key") DO NOTHING;

--- a/scripts/apply-fixture-abandonment-email-recovery.cjs
+++ b/scripts/apply-fixture-abandonment-email-recovery.cjs
@@ -10,15 +10,26 @@ const formPath = path.join(
 );
 let source = fs.readFileSync(formPath, "utf8");
 
-const importBefore =
-  'import { recordNightFixtureAbandonmentAction } from "@/app/(public)/referee/abandonment-actions";';
-const importAfter = `${importBefore}\nimport { resendNightFixtureAbandonmentEmailsAction } from "@/app/(public)/referee/abandonment-email-actions";`;
-if (!source.includes(importAfter)) {
-  if (!source.includes(importBefore)) {
-    throw new Error("Could not find the abandoned-match action import.");
+function ensureImport(importLine, anchor, label) {
+  if (source.includes(importLine)) return;
+  if (!source.includes(anchor)) {
+    throw new Error(`Could not find ${label} import anchor.`);
   }
-  source = source.replace(importBefore, importAfter);
+  source = source.replace(anchor, `${anchor}\n${importLine}`);
 }
+
+const abandonmentActionImport =
+  'import { recordNightFixtureAbandonmentAction } from "@/app/(public)/referee/abandonment-actions";';
+ensureImport(
+  'import { resendNightFixtureAbandonmentEmailsAction } from "@/app/(public)/referee/abandonment-email-actions";',
+  abandonmentActionImport,
+  "abandoned-match email recovery",
+);
+ensureImport(
+  'import { sendNightFixtureFormalConductNoticeAction } from "@/app/(public)/referee/abandonment-conduct-actions";',
+  'import { resendNightFixtureAbandonmentEmailsAction } from "@/app/(public)/referee/abandonment-email-actions";',
+  "formal conduct notice",
+);
 
 const marker = `        <p className="mt-3 text-xs leading-5 text-white/45">
           {officialResult
@@ -53,5 +64,71 @@ if (!source.includes(recovery)) {
   source = source.replace(marker, recovery);
 }
 
+const conductRecovery = `${recovery}
+        {canDecideResult &&
+        responsibleName &&
+        ["REFUSED_TO_LEAVE", "TEAM_CONDUCT", "VIOLENT_OR_THREATENING_CONDUCT", "SERIOUS_MISCONDUCT"].includes(abandonment.reason) ? (
+          <form
+            action={sendNightFixtureFormalConductNoticeAction}
+            className="mt-4 rounded-xl border border-red-300/25 bg-red-500/10 p-3"
+          >
+            <input type="hidden" name="refereeNightId" value={refereeNightId} />
+            <input type="hidden" name="fixtureId" value={fixtureId} />
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-red-100/80">
+              Formal conduct notice · {responsibleName}
+            </p>
+            <p className="mt-2 text-xs leading-5 text-red-50/70">
+              This is a separate conduct email covering referee authority, player and manager behaviour, and the safety and smooth running of the league. It is logged permanently in the team&apos;s conversation timeline. Use this button for an existing abandonment if the conduct notice has not already been sent.
+            </p>
+            <button
+              type="submit"
+              className="mt-3 inline-flex h-10 items-center justify-center rounded-lg border border-red-300/35 bg-red-400/15 px-4 text-xs font-bold text-red-50 transition hover:bg-red-400/25"
+            >
+              Send formal conduct notice now
+            </button>
+          </form>
+        ) : null}`;
+
+if (!source.includes("Send formal conduct notice now")) {
+  if (!source.includes(recovery)) {
+    throw new Error("Could not find the abandonment email recovery block.");
+  }
+  source = source.replace(recovery, conductRecovery);
+}
+
 fs.writeFileSync(formPath, source, "utf8");
-console.log("Added an admin recovery control for abandoned-match emails.");
+
+const pagePath = path.join(
+  process.cwd(),
+  "src",
+  "app",
+  "(public)",
+  "referee",
+  "night",
+  "[id]",
+  "page.tsx",
+);
+let page = fs.readFileSync(pagePath, "utf8");
+const savedAnchor = [
+  '    case "abandoned":',
+  '      return "Match marked as abandoned. Fee changes have been applied and both teams have been notified where applicable.";',
+].join("\n");
+const savedConduct = [
+  savedAnchor,
+  '    case "formal-conduct-sent":',
+  '      return "Formal conduct notice sent and logged in the responsible team’s conversation timeline.";',
+  '    case "formal-conduct-queued":',
+  '      return "Formal conduct notice queued. Check the responsible team’s conversation timeline for the final delivery status.";',
+  '    case "formal-conduct-failed":',
+  '      return "Formal conduct notice was not sent. Check the responsible team’s saved email address and Email audit before trying again.";',
+].join("\n");
+
+if (!page.includes('case "formal-conduct-sent":')) {
+  if (!page.includes(savedAnchor)) {
+    throw new Error("Could not find the abandonment saved-message block.");
+  }
+  page = page.replace(savedAnchor, savedConduct);
+}
+
+fs.writeFileSync(pagePath, page, "utf8");
+console.log("Added admin recovery controls for abandoned-match emails and formal conduct notices.");

--- a/scripts/check-fixture-formal-conduct-notice.mjs
+++ b/scripts/check-fixture-formal-conduct-notice.mjs
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+
+const migration = fs.readFileSync(
+  "prisma/migrations/20260820000000_add_formal_conduct_notice_template/migration.sql",
+  "utf8",
+);
+const sender = fs.readFileSync(
+  "src/lib/fixtures/formal-conduct-notice.ts",
+  "utf8",
+);
+const manualAction = fs.readFileSync(
+  "src/app/(public)/referee/abandonment-conduct-actions.ts",
+  "utf8",
+);
+const abandonmentAction = fs.readFileSync(
+  "src/app/(public)/referee/abandonment-actions.ts",
+  "utf8",
+);
+const recoveryUi = fs.readFileSync(
+  "scripts/apply-fixture-abandonment-email-recovery.cjs",
+  "utf8",
+);
+
+const failures = [];
+const expect = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+expect(
+  migration.includes("fixture-abandonment-formal-conduct-email") &&
+    migration.includes("The referee’s decision on the night is final") &&
+    migration.includes("will not be tolerated") &&
+    migration.includes('ON CONFLICT ("key") DO NOTHING'),
+  "formal conduct wording must live in an editable system template and preserve admin edits",
+);
+expect(
+  sender.includes("queueNotificationFromTemplate") &&
+    sender.includes("FORMAL_CONDUCT_NOTICE_TEMPLATE_KEY") &&
+    sender.includes("logNotificationDispatchToThread") &&
+    sender.includes("processNotificationQueue"),
+  "formal conduct notices must use the template notification pipeline, be logged to the conversation timeline and be processed immediately",
+);
+expect(
+  sender.includes("REFUSED_TO_LEAVE") &&
+    sender.includes("TEAM_CONDUCT") &&
+    sender.includes("VIOLENT_OR_THREATENING_CONDUCT") &&
+    sender.includes("SERIOUS_MISCONDUCT"),
+  "all team-conduct abandonment reasons must qualify for a formal notice",
+);
+expect(
+  abandonmentAction.includes("isFixtureConductAbandonmentReason") &&
+    abandonmentAction.includes("sendFixtureFormalConductNotice") &&
+    abandonmentAction.includes("separate formal conduct notice could not be sent"),
+  "new conduct-related abandonments must automatically attempt the separate formal conduct notice without undoing a saved abandonment if delivery fails",
+);
+expect(
+  manualAction.includes("Only SIXFL admin can send a formal conduct notice") &&
+    manualAction.includes("formal-conduct-sent") &&
+    manualAction.includes("formal-conduct-failed") &&
+    manualAction.includes("resend: true"),
+  "admin must have an explicit recovery action with visible sent/failed feedback",
+);
+expect(
+  recoveryUi.includes("Send formal conduct notice now") &&
+    recoveryUi.includes("Formal conduct notice · {responsibleName}") &&
+    recoveryUi.includes("formal-conduct-sent") &&
+    recoveryUi.includes("team&apos;s conversation timeline"),
+  "recorded conduct abandonments must expose the admin send button and clear delivery feedback",
+);
+expect(
+  !sender.includes("The referee’s decision on the night is final") &&
+    !sender.includes("will not be tolerated"),
+  "final customer-facing conduct wording must not be hard-coded in the sender",
+);
+
+if (failures.length) {
+  console.error("Formal conduct notice contract failed:");
+  failures.forEach((failure) => console.error(` - ${failure}`));
+  process.exit(1);
+}
+
+console.log("Formal conduct notice contract passed.");

--- a/src/app/(public)/referee/abandonment-actions.ts
+++ b/src/app/(public)/referee/abandonment-actions.ts
@@ -6,6 +6,10 @@ import { redirect } from "next/navigation";
 
 import { requireReferee } from "@/lib/admin";
 import { recordFixtureAbandonment } from "@/lib/fixtures/abandonment";
+import {
+  isFixtureConductAbandonmentReason,
+  sendFixtureFormalConductNotice,
+} from "@/lib/fixtures/formal-conduct-notice";
 import { getRefereeNightFixtureIds, recalculateRefereeNightCashup } from "@/lib/referee-nights";
 import { prisma } from "@/lib/prisma";
 
@@ -63,6 +67,20 @@ export async function recordNightFixtureAbandonmentAction(formData: FormData) {
     details,
     recordedByUserId: user.id,
   });
+
+  if (responsibleTeamId && isFixtureConductAbandonmentReason(reason)) {
+    try {
+      await sendFixtureFormalConductNotice({
+        fixtureId,
+        createdByUserId: user.id,
+      });
+    } catch (error) {
+      console.error(
+        "Abandonment was saved but the separate formal conduct notice could not be sent",
+        error,
+      );
+    }
+  }
 
   await recalculateRefereeNightCashup(refereeNightId);
 

--- a/src/app/(public)/referee/abandonment-conduct-actions.ts
+++ b/src/app/(public)/referee/abandonment-conduct-actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { UserRole } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requireReferee } from "@/lib/admin";
+import { sendFixtureFormalConductNotice } from "@/lib/fixtures/formal-conduct-notice";
+import { getRefereeNightFixtureIds } from "@/lib/referee-nights";
+
+function required(formData: FormData, key: string, label: string) {
+  const value = String(formData.get(key) ?? "").trim();
+  if (!value) throw new Error(`${label} is required.`);
+  return value;
+}
+
+export async function sendNightFixtureFormalConductNoticeAction(formData: FormData) {
+  const { user } = await requireReferee();
+  if (user.role !== UserRole.ADMIN) {
+    throw new Error("Only SIXFL admin can send a formal conduct notice.");
+  }
+
+  const refereeNightId = required(formData, "refereeNightId", "Referee night");
+  const fixtureId = required(formData, "fixtureId", "Fixture");
+  const fixtureIds = await getRefereeNightFixtureIds(refereeNightId);
+  if (!fixtureIds.includes(fixtureId)) {
+    throw new Error("Fixture is not part of this referee night.");
+  }
+
+  let saved = "formal-conduct-failed";
+
+  try {
+    const result = await sendFixtureFormalConductNotice({
+      fixtureId,
+      createdByUserId: user.id,
+      resend: true,
+    });
+
+    saved =
+      result.status === "SENT"
+        ? "formal-conduct-sent"
+        : result.status === "QUEUED" || result.status === "PROCESSING"
+          ? "formal-conduct-queued"
+          : "formal-conduct-failed";
+  } catch (error) {
+    console.error("Unable to send formal conduct notice", error);
+  }
+
+  revalidatePath(`/referee/night/${refereeNightId}`);
+  revalidatePath("/admin/messages");
+  revalidatePath("/admin/teams");
+
+  redirect(`/referee/night/${refereeNightId}?saved=${saved}`);
+}

--- a/src/lib/fixtures/formal-conduct-notice.ts
+++ b/src/lib/fixtures/formal-conduct-notice.ts
@@ -1,0 +1,169 @@
+import { Prisma } from "@prisma/client";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import { processNotificationQueue } from "@/lib/notifications/processor";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
+import { prisma } from "@/lib/prisma";
+
+export const FORMAL_CONDUCT_NOTICE_TEMPLATE_KEY =
+  "fixture-abandonment-formal-conduct-email";
+
+const CONDUCT_REASON_LABELS: Record<string, string> = {
+  REFUSED_TO_LEAVE: "Player / manager refused to leave after referee instruction",
+  TEAM_CONDUCT: "Conduct of one team made the match impossible to continue",
+  VIOLENT_OR_THREATENING_CONDUCT: "Violent, threatening or aggressive conduct",
+  SERIOUS_MISCONDUCT: "Other serious player / manager misconduct",
+};
+
+export function isFixtureConductAbandonmentReason(reason: string) {
+  return Boolean(CONDUCT_REASON_LABELS[reason]);
+}
+
+type AbandonmentConductRow = {
+  fixtureId: string;
+  reason: string;
+  responsibleTeamId: string | null;
+  details: string | null;
+};
+
+function firstName(value: string | null | undefined) {
+  return value?.trim().split(/\s+/)[0]?.trim() || "there";
+}
+
+export async function sendFixtureFormalConductNotice(input: {
+  fixtureId: string;
+  createdByUserId: string;
+  resend?: boolean;
+}) {
+  const rows = await prisma.$queryRaw<AbandonmentConductRow[]>(Prisma.sql`
+    SELECT
+      "fixtureId",
+      "reason",
+      "responsibleTeamId",
+      "details"
+    FROM "FixtureAbandonment"
+    WHERE "fixtureId" = ${input.fixtureId}
+    LIMIT 1
+  `);
+  const abandonment = rows[0];
+
+  if (!abandonment) {
+    throw new Error("This fixture is not recorded as abandoned.");
+  }
+  if (!isFixtureConductAbandonmentReason(abandonment.reason)) {
+    throw new Error("This abandonment is not a team-conduct incident.");
+  }
+  if (!abandonment.responsibleTeamId) {
+    throw new Error("No responsible team is recorded for this abandonment.");
+  }
+
+  const fixture = await prisma.fixture.findUnique({
+    where: { id: input.fixtureId },
+    select: {
+      id: true,
+      homeTeam: {
+        select: {
+          id: true,
+          name: true,
+          logoUrl: true,
+          league: { select: { name: true, season: true } },
+        },
+      },
+      awayTeam: {
+        select: {
+          id: true,
+          name: true,
+          logoUrl: true,
+          league: { select: { name: true, season: true } },
+        },
+      },
+    },
+  });
+
+  if (!fixture) throw new Error("Fixture not found.");
+
+  const responsibleTeam =
+    abandonment.responsibleTeamId === fixture.homeTeam.id
+      ? fixture.homeTeam
+      : abandonment.responsibleTeamId === fixture.awayTeam.id
+        ? fixture.awayTeam
+        : null;
+
+  if (!responsibleTeam) {
+    throw new Error("The recorded responsible team is not part of this fixture.");
+  }
+
+  const { recipient, snapshot } = await upsertTeamNotificationRecipient(
+    responsibleTeam.id,
+  );
+  const leagueName = responsibleTeam.league
+    ? `${responsibleTeam.league.name}${responsibleTeam.league.season ? ` — ${responsibleTeam.league.season}` : ""}`
+    : snapshot.leagueName;
+  const fixtureLabel = `${fixture.homeTeam.name} v ${fixture.awayTeam.name}`;
+  const reasonLabel = CONDUCT_REASON_LABELS[abandonment.reason];
+  const refereeNoteLine = abandonment.details?.trim()
+    ? `Referee note: ${abandonment.details.trim()}\n`
+    : "";
+
+  const dispatch = await queueNotificationFromTemplate({
+    templateKey: FORMAL_CONDUCT_NOTICE_TEMPLATE_KEY,
+    recipientId: recipient.id,
+    variables: {
+      firstName: firstName(snapshot.primaryContact.name ?? snapshot.teamName),
+      teamName: responsibleTeam.name,
+      fixtureLabel,
+      reasonLabel,
+      refereeNoteLine,
+    },
+    sourceType: "TEAM",
+    sourceId: responsibleTeam.id,
+    metadata: {
+      origin: "fixture-abandonment-formal-conduct",
+      originLabel: "Formal conduct notice",
+      teamId: responsibleTeam.id,
+      teamName: responsibleTeam.name,
+      leagueId: snapshot.leagueId,
+      fixtureId: fixture.id,
+      reason: abandonment.reason,
+      formalConductNotice: true,
+      resend: Boolean(input.resend),
+      contactName: snapshot.primaryContact.name,
+    },
+    emailBranding: {
+      teamName: responsibleTeam.name,
+      teamLogoUrl: responsibleTeam.logoUrl,
+      leagueName: leagueName || null,
+    },
+    createdByUserId: input.createdByUserId,
+  });
+
+  await logNotificationDispatchToThread({ dispatch, recipient });
+
+  if (dispatch.status === "QUEUED") {
+    try {
+      await processNotificationQueue(20);
+    } catch (error) {
+      console.error("Formal conduct notice was queued but immediate processing failed", error);
+    }
+  }
+
+  const finalDispatch = await prisma.notificationDispatch.findUnique({
+    where: { id: dispatch.id },
+    select: {
+      id: true,
+      status: true,
+      failureReason: true,
+      sentAt: true,
+    },
+  });
+
+  return {
+    dispatchId: dispatch.id,
+    teamId: responsibleTeam.id,
+    teamName: responsibleTeam.name,
+    status: finalDispatch?.status ?? dispatch.status,
+    failureReason: finalDispatch?.failureReason ?? dispatch.failureReason ?? null,
+    sentAt: finalDispatch?.sentAt ?? dispatch.sentAt ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- add a separate formal conduct email for the responsible team when a match is abandoned for player, manager or team conduct
- keep the customer-facing wording in a new editable System Template, preserving any later admin edits
- make clear that referee decisions and instructions must be respected by all players, substitutes, managers and team members; the referee's decision on the night is final and concerns should be raised with SIXFL afterwards
- state that behaviour undermining referee authority or the safety/smooth running of the league will not be tolerated
- automatically attempt the conduct notice after future conduct-related abandonments without undoing the abandonment if email delivery fails
- add an admin-only **Send formal conduct notice now** recovery control for an already-recorded abandonment
- process the email immediately, log it permanently in the team's conversation timeline, and show clear sent/queued/failed feedback
- add a permanent formal-conduct regression contract

This is deliberately separate from the existing result/fee email so the financial decision and the formal behaviour warning remain clear.