### PR TITLE
Preserve late-payment admin fee on fixture sync

### DIFF
--- a/prisma/migrations/20260821140000_repair_applied_late_payment_fee_totals/migration.sql
+++ b/prisma/migrations/20260821140000_repair_applied_late_payment_fee_totals/migration.sql
@@ -1,0 +1,62 @@
+-- A fixture sync writes the base fixture fee back onto PaymentCharge.amountPence.
+-- Before the matching code safeguard, that could overwrite an already-applied
+-- late-payment admin fee while leaving latePaymentFeeStatus = APPLIED.
+--
+-- Example of the broken state:
+--   expected fixture fee £40
+--   late-payment admin fee £10
+--   stored PaymentCharge.amountPence £40
+-- The captain ledger then inferred an impossible £30 base + £10 fee.
+--
+-- Repair only the unmistakable reset case: an open/part-paid APPLIED charge whose
+-- stored total exactly equals the authoritative base fixture fee. Correct charges
+-- already stored as base + admin fee are left untouched.
+WITH applied_charge_bases AS (
+  SELECT
+    charge."id" AS "chargeId",
+    charge."amountPence" AS "currentAmountPence",
+    charge."latePaymentFeeAmountPence" AS "lateFeePence",
+    CASE
+      WHEN charge."teamId" = fixture."homeTeamId" THEN
+        COALESCE(
+          fixture."homeMatchFeePence",
+          charged_team."standardMatchFeePence",
+          fixture."matchFeePence"
+        )
+      WHEN charge."teamId" = fixture."awayTeamId" THEN
+        COALESCE(
+          fixture."awayMatchFeePence",
+          charged_team."standardMatchFeePence",
+          fixture."matchFeePence"
+        )
+      ELSE NULL
+    END AS "baseAmountPence"
+  FROM "PaymentCharge" charge
+  INNER JOIN "Fixture" fixture ON fixture."id" = charge."fixtureId"
+  INNER JOIN "Team" charged_team ON charged_team."id" = charge."teamId"
+  WHERE charge."latePaymentFeeStatus" = 'APPLIED'::"PaymentLateFeeStatus"
+    AND charge."latePaymentFeeAmountPence" > 0
+    AND charge."status" IN (
+      'OPEN'::"PaymentChargeStatus",
+      'PART_PAID'::"PaymentChargeStatus"
+    )
+),
+charges_to_repair AS (
+  SELECT
+    "chargeId",
+    "baseAmountPence" + "lateFeePence" AS "repairedAmountPence"
+  FROM applied_charge_bases
+  WHERE "baseAmountPence" IS NOT NULL
+    AND "baseAmountPence" > 0
+    AND "currentAmountPence" = "baseAmountPence"
+)
+UPDATE "PaymentCharge" charge
+SET
+  "amountPence" = charges_to_repair."repairedAmountPence",
+  "lastStripeCheckoutUrl" = NULL,
+  "lastStripeCheckoutSessionId" = NULL,
+  "lastStripeCheckoutCreatedAt" = NULL,
+  "lastStripeCheckoutAmountPence" = NULL,
+  "updatedAt" = NOW()
+FROM charges_to_repair
+WHERE charge."id" = charges_to_repair."chargeId";

--- a/scripts/apply-late-payment-fee-sync-safeguard.cjs
+++ b/scripts/apply-late-payment-fee-sync-safeguard.cjs
@@ -1,0 +1,38 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const file = "src/lib/payments/fixture-match-fees.ts";
+const absolutePath = path.join(root, ...file.split("/"));
+let source = fs.readFileSync(absolutePath, "utf8");
+
+function replaceRequired(before, after, label) {
+  if (source.includes(after)) return;
+  if (!source.includes(before)) {
+    throw new Error(`${label} anchor not found.`);
+  }
+  source = source.replace(before, after);
+}
+
+// Fixture sync receives the base fixture fee. PaymentCharge.amountPence, however,
+// includes an already-applied late-payment admin fee. Never let a later fixture
+// sync overwrite the total back to the base amount and effectively erase the fee.
+if (!source.includes("const appliedLatePaymentFeePence =")) {
+  replaceRequired(
+    `    const paidTotalPence = getChargePaidTotal(existingCharge.transactions);\n\n    if (paidTotalPence > 0 && existingCharge.amountPence !== entry.amountPence) {`,
+    `    const appliedLatePaymentFeePence =\n      existingCharge.latePaymentFeeStatus === "APPLIED"\n        ? Math.max(existingCharge.latePaymentFeeAmountPence, 0)\n        : 0;\n    const effectiveAmountPence =\n      entry.amountPence + appliedLatePaymentFeePence;\n    const paidTotalPence = getChargePaidTotal(existingCharge.transactions);\n\n    if (paidTotalPence > 0 && existingCharge.amountPence !== effectiveAmountPence) {`,
+    "late-payment fee effective fixture amount",
+  );
+
+  replaceRequired(
+    `        amountPence: entry.amountPence,\n        dueDate: input.kickoffAt,\n        status: getChargeStatusFromAmounts(entry.amountPence, paidTotalPence),`,
+    `        amountPence: effectiveAmountPence,\n        dueDate: input.kickoffAt,\n        status: getChargeStatusFromAmounts(effectiveAmountPence, paidTotalPence),`,
+    "late-payment fee fixture charge preservation",
+  );
+}
+
+fs.writeFileSync(absolutePath, source, "utf8");
+
+console.log(
+  "Fixture match-fee sync now preserves any already-applied late-payment admin fee on top of the base fixture charge.",
+);

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -62,6 +62,7 @@ require("./fix-goal-of-week-dashboard-promo-payload-narrowing.cjs");
 require("./apply-critical-player-dashboard-features.cjs");
 require("./apply-late-payment-72h-review.cjs");
 require("./apply-visible-late-payment-fees.cjs");
+require("./apply-late-payment-fee-sync-safeguard.cjs");
 require("./apply-admin-outstanding-balance-copy.cjs");
 require("./apply-reopen-failed-stripe-player-payment.cjs");
 require("./apply-team-credit-cap-policy.cjs");

--- a/scripts/check-visible-late-payment-fees.cjs
+++ b/scripts/check-visible-late-payment-fees.cjs
@@ -11,10 +11,11 @@ const actions = read("src/app/(admin)/admin/fixtures/late-fees/actions.ts");
 const page = read("src/app/(admin)/admin/fixtures/late-fees/page.tsx");
 const ledger = read("src/lib/payments/team-payment-ledger.ts");
 const captainPayments = read("src/app/captain/team/[teamid]/payments/page.tsx");
+const fixtureMatchFees = read("src/lib/payments/fixture-match-fees.ts");
 
 // apply-visible-late-payment-fees.cjs itself uses an exact required replacement for
 // the old SQL filter, so prebuild already fails if that filter cannot be removed.
-// These contracts verify the durable user-visible behaviour after the full patch chain.
+// These contracts verify the durable user-visible and financial behaviour after the full patch chain.
 const checks = [
   {
     ok: actions.includes("queueLatePaymentAppliedEmail") && actions.includes("PAYMENT_LATE_FEE_APPLIED"),
@@ -35,6 +36,14 @@ const checks = [
   {
     ok: captainPayments.includes("Late-payment admin fee applied") && captainPayments.includes("base charge"),
     message: "captain payment screen must explain the £10 addition instead of only showing a larger total",
+  },
+  {
+    ok:
+      fixtureMatchFees.includes("const appliedLatePaymentFeePence =") &&
+      fixtureMatchFees.includes("const effectiveAmountPence =") &&
+      fixtureMatchFees.includes("amountPence: effectiveAmountPence") &&
+      fixtureMatchFees.includes("getChargeStatusFromAmounts(effectiveAmountPence, paidTotalPence)"),
+    message: "fixture match-fee sync must preserve an applied late-payment admin fee on top of the base fixture charge",
   },
 ];
 


### PR DESCRIPTION
Fixes the bug where a £10 late-payment admin fee could be applied correctly and then effectively disappear when fixture charge synchronisation rewrote `PaymentCharge.amountPence` back to the base fixture fee.

What changes:
- fixture charge sync now calculates `effectiveAmountPence = base fixture fee + applied late-payment fee`;
- existing correctly-applied fees remain on top if a fixture is re-synchronised;
- a migration repairs already-corrupted APPLIED charges where the stored total exactly equals the authoritative base fixture fee (for example £40 stored instead of £50);
- stale Stripe checkout cache fields are cleared on repaired charges;
- the late-fee contract now checks that fixture sync preserves the applied fee.

This directly addresses the captain-ledger state that displayed £30 base + £10 admin fee = £40 when the real fixture fee was £40 and the total should have been £50.