### PR TITLE
Harden SIXFL rules and retain version history

### DIFF
--- a/docs/rules-versioning.md
+++ b/docs/rules-versioning.md
@@ -1,0 +1,29 @@
+# SIXFL rules versioning
+
+SIXFL keeps dated, versioned rule documents so an earlier incident can be checked against the wording that was in force at the time.
+
+## Active documents
+
+The public League Rules, Match Rules and League Participation Agreement each show an active version and effective date. The source-of-truth constants live in `src/lib/league-rules.ts`, `src/lib/match-rules.ts` and `src/lib/league-agreement.ts`.
+
+## Before publishing a new version
+
+1. Copy the complete outgoing rule text into `src/lib/rules-archive.ts`.
+2. Record the outgoing version, original effective date and superseded date.
+3. Increase the active document version and effective date.
+4. Update any captain-guide wording that summarises the changed rule.
+5. Update the rules hardening contract if a new critical protection needs to be retained.
+
+Do not overwrite or silently rewrite an archived version. If an archive entry is found to contain a transcription error, correct it with an explicit commit that explains the correction.
+
+## Which version applies
+
+Unless a change is required for safety or law, an incident should normally be assessed using the rules that were in force when the incident occurred. Publishing a stronger or clearer rule later must not be presented as though that wording existed earlier.
+
+## Captain acceptance
+
+New captain acceptances record `captainAgreementVersion`. Acceptances made before version tracking remain valid historical acceptances but are shown as `accepted before version tracking`; they must not be falsely attributed to a later rules version.
+
+## Internal archive
+
+Admins can view retained versions at `/admin/rules-archive` under **Back end functions**. Git history remains an additional audit trail, but the admin archive is the deliberate operational record of superseded versions.

--- a/prisma/migrations/20260822142300_add_captain_agreement_version/migration.sql
+++ b/prisma/migrations/20260822142300_add_captain_agreement_version/migration.sql
@@ -1,0 +1,6 @@
+-- Track which captain terms/rules version was accepted.
+-- Existing acceptances remain valid but may have a NULL version because the
+-- system did not previously record one. New acceptances record the active version.
+
+ALTER TABLE "Team"
+  ADD COLUMN IF NOT EXISTS "captainAgreementVersion" TEXT;

--- a/scripts/apply-rules-v2-hardening.cjs
+++ b/scripts/apply-rules-v2-hardening.cjs
@@ -1,0 +1,60 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, ...relativePath.split("/")), "utf8");
+}
+
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, ...relativePath.split("/")), source, "utf8");
+}
+
+// Keep the rules archive visible inside the existing Back end functions admin group.
+{
+  const file = "src/components/admin/AdminSidebar.tsx";
+  let source = read(file);
+
+  if (!source.includes('href: "/admin/rules-archive"')) {
+    const anchor = `      {\n        name: "Email audit",\n        href: "/admin/email-audit",\n        icon: MagnifyingGlassIcon,\n        description: "Address counts",\n      },`;
+    const replacement = `${anchor}\n      {\n        name: "Rules archive",\n        href: "/admin/rules-archive",\n        icon: DocumentTextIcon,\n        description: "Versions",\n      },`;
+
+    if (!source.includes(anchor)) {
+      throw new Error("Rules archive admin navigation anchor not found.");
+    }
+
+    source = source.replace(anchor, replacement);
+    write(file, source);
+  }
+}
+
+const leagueRules = read("src/lib/league-rules.ts");
+const matchRules = read("src/lib/match-rules.ts");
+const agreement = read("src/lib/league-agreement.ts");
+const archive = read("src/lib/rules-archive.ts");
+const captainGuide = read("src/app/captain/team/[teamid]/guide/page.tsx");
+
+const checks = [
+  [leagueRules.includes('LEAGUE_RULES_VERSION = "2.0"'), "League Rules must remain on v2.0"],
+  [leagueRules.includes("administrative forfeit result will be 3–0"), "League Rules must define the default 3–0 forfeit result"],
+  [leagueRules.includes("less than 24 hours before kick-off"), "League Rules must retain the late-cancellation rule"],
+  [leagueRules.includes("There is no automatic right to an independent appeal"), "League Rules must retain the review/appeal wording"],
+  [matchRules.includes("Shin pads are mandatory"), "Match Rules must retain mandatory shin pads"],
+  [matchRules.includes("A dismissed player must promptly leave"), "Match Rules must retain the red-card leave requirement"],
+  [matchRules.includes("does not by itself establish that it did not happen"), "Match Rules must retain limited-camera evidence wording"],
+  [agreement.includes('LEAGUE_AGREEMENT_VERSION = "2.0"'), "League agreement must remain on v2.0"],
+  [archive.includes('id: "league-rules-1-4"'), "League Rules v1.4 must remain archived"],
+  [archive.includes('id: "match-rules-1-4"'), "Match Rules v1.4 must remain archived"],
+  [archive.includes('id: "league-agreement-1-2"'), "League Agreement v1.2 must remain archived"],
+  [captainGuide.includes("accepted before version tracking"), "Captain guide must show legacy acceptance state"],
+];
+
+const failures = checks.filter(([ok]) => !ok);
+if (failures.length > 0) {
+  console.error("Rules v2 hardening contract failed:");
+  for (const [, message] of failures) console.error(`- ${message}`);
+  process.exit(1);
+}
+
+console.log("Rules v2 hardening contract passed.");

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -83,6 +83,7 @@ require("./fix-fixture-abandonment-result-decision-build.cjs");
 require("./fix-fixture-abandonment-runtime-schema.cjs");
 require("./apply-fixture-abandonment-email-recovery.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
+require("./apply-rules-v2-hardening.cjs");
 require("./check-visible-late-payment-fees.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");

--- a/src/app/(admin)/admin/rules-archive/page.tsx
+++ b/src/app/(admin)/admin/rules-archive/page.tsx
@@ -1,0 +1,137 @@
+// ========================================
+// File: src/app/(admin)/admin/rules-archive/page.tsx
+// ========================================
+
+import {
+  LEAGUE_AGREEMENT_EFFECTIVE_DATE,
+  LEAGUE_AGREEMENT_VERSION,
+} from "@/lib/league-agreement";
+import {
+  LEAGUE_RULES_EFFECTIVE_DATE,
+  LEAGUE_RULES_VERSION,
+} from "@/lib/league-rules";
+import { MATCH_RULES_VERSION } from "@/lib/match-rules";
+import { archivedRuleDocuments } from "@/lib/rules-archive";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Rules Archive | SIXFL Admin",
+};
+
+const currentDocuments = [
+  {
+    document: "League Rules",
+    version: LEAGUE_RULES_VERSION,
+    effectiveDate: LEAGUE_RULES_EFFECTIVE_DATE,
+  },
+  {
+    document: "Match Rules",
+    version: MATCH_RULES_VERSION.replace("Version ", ""),
+    effectiveDate: "22 August 2026",
+  },
+  {
+    document: "League Participation Agreement",
+    version: LEAGUE_AGREEMENT_VERSION,
+    effectiveDate: LEAGUE_AGREEMENT_EFFECTIVE_DATE,
+  },
+];
+
+export default async function RulesArchivePage() {
+  await requireAdmin();
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-100/70">
+          Back end functions
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          Rules archive
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-emerald-50/75">
+          Superseded rules are retained here so SIXFL can identify the wording
+          that applied at an earlier date. Before publishing a new rules version,
+          the outgoing active version should be copied into this archive.
+        </p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {currentDocuments.map((document) => (
+          <div
+            key={document.document}
+            className="rounded-3xl border border-white/10 bg-white/[0.04] p-5"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+              Current
+            </p>
+            <h2 className="mt-2 text-lg font-semibold text-white">
+              {document.document}
+            </h2>
+            <p className="mt-3 text-2xl font-semibold text-emerald-200">
+              v{document.version}
+            </p>
+            <p className="mt-2 text-sm text-white/55">
+              Effective {document.effectiveDate}
+            </p>
+          </div>
+        ))}
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+            Superseded
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Previous versions
+          </h2>
+        </div>
+
+        {archivedRuleDocuments.map((document) => (
+          <article
+            key={document.id}
+            className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04]"
+          >
+            <div className="flex flex-col gap-4 border-b border-white/10 px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-xl font-semibold text-white">
+                    {document.document}
+                  </h3>
+                  <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-amber-100">
+                    v{document.version}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-white/55">
+                  Effective {document.effectiveDate} · superseded{" "}
+                  {document.supersededDate}
+                </p>
+              </div>
+              <span className="text-sm font-semibold text-white/45">
+                {document.sections.length} sections
+              </span>
+            </div>
+
+            <div className="divide-y divide-white/10">
+              {document.sections.map((section) => (
+                <details key={section.title} className="group px-6 py-4">
+                  <summary className="cursor-pointer list-none font-semibold text-white/80">
+                    {section.title}
+                  </summary>
+                  <div className="mt-3 space-y-2 text-sm leading-6 text-white/60">
+                    {section.points.map((point) => (
+                      <p key={point}>{point}</p>
+                    ))}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(public)/league-agreement/page.tsx
+++ b/src/app/(public)/league-agreement/page.tsx
@@ -4,12 +4,19 @@
 
 import Link from "next/link";
 
+import {
+  LEAGUE_AGREEMENT_EFFECTIVE_DATE,
+  LEAGUE_AGREEMENT_NEXT_REVIEW,
+  LEAGUE_AGREEMENT_VERSION,
+  leagueAgreementSections,
+} from "@/lib/league-agreement";
+
 const documentDetails = [
   { label: "Document", value: "League Participation Agreement" },
-  { label: "Version", value: "1.2" },
+  { label: "Version", value: LEAGUE_AGREEMENT_VERSION },
   { label: "Status", value: "Active" },
-  { label: "Last updated", value: "3 August 2026" },
-  { label: "Next review", value: "3 August 2027" },
+  { label: "Effective", value: LEAGUE_AGREEMENT_EFFECTIVE_DATE },
+  { label: "Next review", value: LEAGUE_AGREEMENT_NEXT_REVIEW },
   { label: "Owner", value: "SIXFL League Operations" },
   { label: "Applies to", value: "Registered teams, captains and players" },
 ];
@@ -29,9 +36,8 @@ export default function LeagueAgreementPage() {
             </h1>
 
             <p className="mt-4 text-white/70 md:text-lg">
-              This agreement outlines the responsibilities of teams and players
-              participating in SIXFL leagues. By registering a team or
-              participating in a SIXFL competition, you agree to the terms below.
+              This agreement sets out the responsibilities accepted by teams,
+              captains and players participating in SIXFL leagues.
             </p>
 
             <div className="mt-6 rounded-2xl border border-emerald-400/25 bg-emerald-400/10 p-5">
@@ -39,8 +45,8 @@ export default function LeagueAgreementPage() {
                 Agreement statement
               </p>
               <p className="mt-3 text-sm leading-6 text-white/75">
-                This agreement supports fair league management, clear team
-                responsibilities and respectful participation in SIXFL fixtures.
+                The active agreement is versioned and dated. Superseded versions
+                are retained internally alongside earlier League and Match Rules.
               </p>
             </div>
           </div>
@@ -63,63 +69,13 @@ export default function LeagueAgreementPage() {
       </section>
 
       <div className="space-y-6">
-        <AgreementSection
-          title="1. Team Registration"
-          text="Teams register for a SIXFL league through a designated team captain or organiser. The captain confirms they are authorised to enter the team into the league and communicate with SIXFL on behalf of the team."
-        />
-
-        <AgreementSection
-          title="2. Captain Responsibilities"
-          text="The team captain acts as the primary contact for the league. The captain is responsible for ensuring team members are aware of fixtures, league rules and conduct expectations."
-        />
-
-        <AgreementSection
-          title="3. Match Attendance"
-          text="Teams are expected to attend scheduled fixtures. If a team cannot attend a match, they should notify the league as early as possible. Failure to attend may result in the match being recorded as a forfeit."
-        />
-
-        <AgreementSection
-          title="4. Player Conduct"
-          text="Players are expected to behave respectfully toward opponents, referees and league organisers. Unsporting or abusive behaviour may result in disciplinary action or removal from the league."
-        />
-
-        <AgreementSection
-          title="5. Referee Authority"
-          text="All matches are officiated by referees appointed by the league. Decisions made by the referee during the match are final."
-        />
-
-        <AgreementSection
-          title="6. Fixtures and Scheduling"
-          text="Fixtures are organised and communicated by SIXFL. Match schedules may occasionally change due to weather, venue availability or other operational factors."
-        />
-
-        <AgreementSection
-          title="7. League Management"
-          text="SIXFL reserves the right to make reasonable decisions in the interest of fair play, safety and the smooth running of the league."
-        />
-
-        <AgreementSection
-          title="8. Participation Risk"
-          text="Football is a physical sport and participation carries a risk of injury. Players take part at their own risk and are responsible for ensuring they are fit to play."
-        />
-
-        <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.07] p-6">
-          <h2 className="text-lg font-bold text-white">9. Founding Team Kit Offer</h2>
-          <p className="mt-2 leading-7 text-white/75">
-            Where SIXFL expressly allocates the Founding Team Kit Offer, the team receives seven complete personalised playing kits free of charge. There is no printing contribution. Additional complete kits cost £20 each. The captain is responsible for checking all designs, sizes, names and numbers before submission.
-          </p>
-          <Link
-            href="/founding-team-kit-terms"
-            className="mt-4 inline-flex min-h-10 items-center rounded-full border border-emerald-300/25 bg-emerald-500/10 px-4 text-sm font-bold text-emerald-100 transition hover:bg-emerald-500/15"
-          >
-            Read the full Kit Offer Terms
-          </Link>
-        </div>
-
-        <AgreementSection
-          title="10. Agreement Acceptance"
-          text="By registering a team, joining a team or participating in a SIXFL match, players acknowledge and agree to these participation terms. A captain who submits a Founding Team Kit Offer order also confirms acceptance of the separate Kit Offer Terms."
-        />
+        {leagueAgreementSections.map((section) => (
+          <AgreementSection
+            key={section.title}
+            title={section.title}
+            points={section.points}
+          />
+        ))}
       </div>
 
       <section className="rounded-3xl border border-emerald-500/20 bg-emerald-500/10 px-6 py-8">
@@ -128,7 +84,8 @@ export default function LeagueAgreementPage() {
         </h2>
 
         <p className="mt-3 text-white/70">
-          If you have any questions about league participation, team registration or the Founding Team Kit Offer, please contact SIXFL.
+          If you have a genuine question about league participation or a rule
+          which applies to your team, please contact SIXFL.
         </p>
 
         <div className="mt-6 flex flex-wrap gap-4">
@@ -183,15 +140,19 @@ export default function LeagueAgreementPage() {
 
 function AgreementSection({
   title,
-  text,
+  points,
 }: {
   title: string;
-  text: string;
+  points: string[];
 }) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
       <h2 className="text-lg font-bold text-white">{title}</h2>
-      <p className="mt-2 leading-7 text-white/75">{text}</p>
-    </div>
+      <div className="mt-3 space-y-2 leading-7 text-white/75">
+        {points.map((point) => (
+          <p key={point}>{point}</p>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/src/app/(public)/league-rules/page.tsx
+++ b/src/app/(public)/league-rules/page.tsx
@@ -4,12 +4,19 @@
 
 import Link from "next/link";
 
+import {
+  LEAGUE_RULES_EFFECTIVE_DATE,
+  LEAGUE_RULES_NEXT_REVIEW,
+  LEAGUE_RULES_VERSION,
+  leagueRuleSections,
+} from "@/lib/league-rules";
+
 const documentDetails = [
   { label: "Document", value: "League Rules" },
-  { label: "Version", value: "1.4" },
+  { label: "Version", value: LEAGUE_RULES_VERSION },
   { label: "Status", value: "Active" },
-  { label: "Last updated", value: "12 August 2026" },
-  { label: "Next review", value: "12 August 2027" },
+  { label: "Effective", value: LEAGUE_RULES_EFFECTIVE_DATE },
+  { label: "Next review", value: LEAGUE_RULES_NEXT_REVIEW },
   { label: "Owner", value: "SIXFL League Operations" },
   { label: "Applies to", value: "All SIXFL teams, players and league fixtures" },
 ];
@@ -29,9 +36,9 @@ export default function LeagueRulesPage() {
             </h1>
 
             <p className="mt-4 text-white/70 md:text-lg">
-              These rules outline the basic structure and expectations for teams
-              participating in SIXFL competitions. Our aim is to provide a fair,
-              well-organised and enjoyable football experience for all players.
+              These rules set out the competition, payment, conduct and fixture
+              requirements for SIXFL teams. The Match Rules cover the laws and
+              procedures used on the pitch.
             </p>
 
             <div className="mt-6 rounded-2xl border border-emerald-400/25 bg-emerald-400/10 p-5">
@@ -39,8 +46,9 @@ export default function LeagueRulesPage() {
                 Rules statement
               </p>
               <p className="mt-3 text-sm leading-6 text-white/75">
-                These rules apply to all SIXFL leagues unless a league, venue or
-                competition format confirms a specific local rule.
+                Active rules are versioned and dated. SIXFL retains superseded
+                versions internally so the wording in force at an earlier date
+                can be identified.
               </p>
             </div>
           </div>
@@ -63,64 +71,18 @@ export default function LeagueRulesPage() {
       </section>
 
       <div className="space-y-6">
-        <RulesSection
-          title="1. Team Registration"
-          text="All teams must complete the SIXFL registration process and provide accurate captain and player details before participating in league matches."
-        />
-
-        <RulesSection
-          title="2. Match Format"
-          text="Matches are played as 6-a-side fixtures in accordance with SIXFL competition regulations. Specific venue rules, kick-off times and fixture details will be communicated by the league."
-        />
-
-        <RulesSection
-          title="3. Player Eligibility"
-          text="Only properly registered players may represent a team in league fixtures. Teams may not field ineligible players or deliberately misrepresent player identity."
-        />
-
-        <RulesSection
-          title="4. Squad Size and Matchday Player Limit"
-          text="There is no maximum squad size. Teams may register as many players to their squad as they wish. However, a maximum of nine players may take part in any single fixture: six players on the pitch and up to three rolling substitutes. All players who participate in the fixture, including guest players, count towards this nine-player limit. Exceptions require prior approval from SIXFL."
-        />
-
-        <RulesSection
-          title="5. Respect and Conduct"
-          text="Players, captains and spectators must behave respectfully towards referees, opponents and league staff. Abuse, threatening behaviour and serious misconduct may result in suspension or removal from the league."
-        />
-
-        <RulesSection
-          title="6. Results and League Table"
-          text="Match results are recorded by the referee or league administrator and used to update the standings. SIXFL may correct administrative recording errors or amend results where an ineligible player, serious misconduct, cheating or another significant rule breach is established. Ordinary refereeing decisions made during play will not normally be reconsidered retrospectively."
-        />
-
-        <RulesSection
-          title="7. Discipline"
-          text="SIXFL may take disciplinary action in response to misconduct, dangerous play, abusive language, repeated non-attendance or any behaviour that brings the league into disrepute."
-        />
-
-        <RulesSection
-          title="8. Abandoned Matches"
-          text="Where a referee abandons a match because of the conduct of one team, the referee's decision to abandon the match is final. The team whose conduct caused the abandonment will be responsible for payment of both its own match fee and the opposing team's match fee. The result and league outcome of any abandoned fixture will be determined by SIXFL at its sole discretion, taking into account the circumstances of the abandonment. This may include allowing the score at the time of abandonment to stand, awarding the match to either team, recording a forfeit or taking any other action SIXFL considers appropriate."
-        />
-
-        <RulesSection
-          title="9. Fixtures and Cancellations"
-          text="Fixtures are scheduled by SIXFL and may be changed where necessary due to venue issues, weather, operational requirements or exceptional circumstances."
-        />
-
-        <RulesSection
-          title="10. Video Footage and Post-Match Review"
-          text="Referee decisions regarding facts connected with play are final. Video footage may be reviewed for disciplinary, safeguarding, administrative and referee-development purposes, including serious misconduct, violence, abuse, mistaken identity, suspected cheating, use of an ineligible player or an incorrectly entered score. Unless SIXFL has announced a formal competition-specific video-review process in advance, footage will not normally be used to re-referee a match, overturn an on-field decision or change a result arising from that decision. There is no automatic right to a video review, and footage may not be available or of equal quality for every match."
-        />
-
-        <RulesSection
-          title="11. League Decisions"
-          text="SIXFL reserves the right to interpret and apply league rules in the interests of fairness, safety and good league management. League decisions are final unless otherwise stated."
-        />
+        {leagueRuleSections.map((section) => (
+          <RulesSection
+            key={section.title}
+            title={section.title}
+            points={section.points}
+          />
+        ))}
       </div>
 
       <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-6 text-sm text-white/70">
-        These rules apply to all SIXFL leagues unless otherwise stated.
+        These rules apply to all SIXFL leagues unless SIXFL has expressly
+        notified a more specific competition or venue rule.
       </div>
 
       <div className="flex flex-wrap gap-4 text-sm">
@@ -151,15 +113,19 @@ export default function LeagueRulesPage() {
 
 function RulesSection({
   title,
-  text,
+  points,
 }: {
   title: string;
-  text: string;
+  points: string[];
 }) {
   return (
     <section className="rounded-2xl border border-white/10 bg-white/5 px-6 py-6">
       <h2 className="text-lg font-semibold text-white">{title}</h2>
-      <p className="mt-2 text-white/70">{text}</p>
+      <div className="mt-3 space-y-2 leading-7 text-white/70">
+        {points.map((point) => (
+          <p key={point}>{point}</p>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/app/(public)/match-rules/page.tsx
+++ b/src/app/(public)/match-rules/page.tsx
@@ -10,8 +10,8 @@ const documentDetails = [
   { label: "Document", value: "Match Rules" },
   { label: "Version", value: MATCH_RULES_VERSION.replace("Version ", "") },
   { label: "Status", value: "Active" },
-  { label: "Last updated", value: "12 August 2026" },
-  { label: "Next review", value: "12 August 2027" },
+  { label: "Effective", value: "22 August 2026" },
+  { label: "Next review", value: "22 August 2027" },
   { label: "Owner", value: "SIXFL League Operations" },
   { label: "Applies to", value: "All SIXFL matches and competitions" },
 ];
@@ -41,7 +41,8 @@ export default function MatchRulesPage() {
               </p>
               <p className="mt-3 text-sm leading-6 text-white/75">
                 These match rules support fair play, safe match management and a
-                consistent experience across SIXFL fixtures.
+                consistent experience across SIXFL fixtures. League administration,
+                payments and competition outcomes are governed by the League Rules.
               </p>
             </div>
           </div>

--- a/src/app/captain/team/[teamid]/guide/page.tsx
+++ b/src/app/captain/team/[teamid]/guide/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from "next/navigation";
 
 import {
   CAPTAIN_AGREEMENT_TEXT,
+  CAPTAIN_AGREEMENT_VERSION,
   getCaptainOnboardingStatus,
 } from "@/lib/captain/onboarding";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
@@ -28,7 +29,7 @@ const guideSections = [
       "Add your squad and make sure player names are clear.",
       "Add player email addresses if you want to use squad payment links.",
       "Check your first fixture, venue and kick-off time.",
-      "Read the captain responsibilities and terms below.",
+      "Read the captain responsibilities, League Rules and Match Rules.",
     ],
   },
   {
@@ -36,9 +37,8 @@ const guideSections = [
     items: [
       "The captain is responsible for team communication, squad management, fixture confirmation and making sure team fees are covered.",
       "The captain should raise fixture, payment or player issues early using the captain area or official SIXFL contact routes.",
-      "Late cancellations can affect the opposition, referee, venue and league schedule, so SIXFL should be told as early as possible.",
       "Repeated late payment, late confirmation, poor conduct or avoidable fixture issues may lead to admin fees, fixture action or review of the team's place in the league.",
-      "The captain agreement below records that the captain understands and accepts these responsibilities.",
+      "The captain agreement below records acceptance of these responsibilities. Active rules are versioned and previous versions are retained by SIXFL.",
     ],
   },
   {
@@ -56,7 +56,7 @@ const guideSections = [
     items: [
       "Availability should be confirmed at least 72 hours before kick-off.",
       "If there is a problem, raise it early through the fixture tools rather than waiting until matchday.",
-      "We do not want to charge admin fees, but a £10 late confirmation admin fee may be added if avoidable late confirmation creates extra admin, fixture chasing or rearranging work.",
+      "A £10 late confirmation admin fee may be added if avoidable late confirmation creates extra admin, fixture chasing or rearranging work.",
       "SIXFL may send reminders or warnings first where practical, but captains should not rely on a warning before acting.",
     ],
   },
@@ -75,7 +75,8 @@ const guideSections = [
     items: [
       "The standard team fee is £40 per fixture unless SIXFL has agreed otherwise.",
       "The captain remains responsible for the team fee even when squad payments are used.",
-      "We do not want to charge late payment admin fees, but a £10 late payment admin fee may be added if a team fee is more than 7 days overdue and SIXFL has to spend extra time chasing it.",
+      "Match fees are due on match day unless SIXFL has agreed otherwise.",
+      "A £10 late payment admin fee may be added if a team fee is more than 7 days overdue and SIXFL has to spend extra time chasing it.",
       "Payment reminders or warnings may be sent first where practical, but payment issues should still be raised early so they can be sorted before they become a problem.",
     ],
   },
@@ -89,19 +90,30 @@ const guideSections = [
     ],
   },
   {
-    title: "Referees and results",
+    title: "Safety, referees and results",
     items: [
-      "Referees manage the game on the night and their decisions should be respected.",
-      "Results should be checked promptly after each fixture.",
-      "If something is wrong with a result, raise a dispute through the results area rather than informal messages.",
+      "Shin pads are mandatory for every player. A referee may prevent a player taking part until required safety equipment is being worn.",
+      "Referees manage the game on the night and decisions regarding facts connected with play are final.",
+      "A player shown a red card must promptly leave the playing area and any nearby area the referee reasonably directs them to leave.",
+      "Refusal or unreasonable delay in leaving may be treated as further misconduct and can lead to abandonment if the match cannot safely or properly continue.",
+      "If something is wrong with a recorded result, raise a dispute through the results area rather than informal messages.",
     ],
   },
   {
     title: "What happens if a team cancels",
     items: [
-      "Tell SIXFL as early as possible if you cannot fulfil a fixture.",
-      "Late cancellations can affect the opposition, referee, venue and league schedule.",
-      "Repeated late cancellations may lead to charges, fixture action or review of the team's place in the league.",
+      "Tell SIXFL directly as early as possible if you cannot fulfil a fixture. An agreement only with the opposition does not cancel or rearrange the fixture.",
+      "A team cancelling less than 24 hours before kick-off remains liable for its own match fee unless SIXFL expressly agrees otherwise.",
+      "A no-show or repeated avoidable late cancellation may lead to a forfeit, disciplinary action or review of the team's place in the league.",
+    ],
+  },
+  {
+    title: "Reviews and evidence",
+    items: [
+      "SIXFL may consider referee reports, available footage, messages, system records and relevant witness or player accounts.",
+      "Video can be incomplete or limited to one angle; something not visible on a recording does not by itself establish that it did not happen.",
+      "There is no automatic right to an independent appeal or to a frame-by-frame re-refereeing process.",
+      "SIXFL may reconsider a decision if genuinely new and material evidence is provided or an obvious administrative error is identified.",
     ],
   },
   {
@@ -117,8 +129,8 @@ const guideSections = [
 const quickLinks = [
   "Captain terms and conditions",
   "Availability confirmation",
-  "Earliest and latest kick-off times",
   "Payments and late fees",
+  "What happens if a team cancels",
 ];
 
 function getSectionId(title: string) {
@@ -183,7 +195,9 @@ export default async function CaptainGuidePage({
             Captain guide and terms
           </h1>
           <p className="mt-3 max-w-3xl text-sm leading-6 text-white/68 sm:text-base">
-            A short reference for {team.name}. This keeps payment responsibilities, captain terms and key SIXFL processes in one place. Playing rules are kept on the separate Match Rules page.
+            A short reference for {team.name}. This keeps payment responsibilities,
+            captain terms and key SIXFL processes in one place. The League Rules
+            and Match Rules remain the authoritative rule documents.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
@@ -197,6 +211,12 @@ export default async function CaptainGuidePage({
               className="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/15 px-5 py-3 text-sm font-medium text-emerald-50 transition hover:bg-emerald-500/20"
             >
               Open match rules
+            </Link>
+            <Link
+              href="/league-rules"
+              className="inline-flex items-center rounded-full border border-white/10 bg-black/20 px-5 py-3 text-sm font-medium text-white/80 transition hover:border-white/20 hover:bg-white/5 hover:text-white"
+            >
+              Open league rules
             </Link>
           </div>
         </div>
@@ -250,7 +270,10 @@ export default async function CaptainGuidePage({
         <div className="px-6 py-6">
           {onboardingStatus.isAgreementAccepted ? (
             <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100/85">
-              Captain agreement accepted{acceptedAt ? ` on ${acceptedAt}` : ""}.
+              Captain agreement accepted{acceptedAt ? ` on ${acceptedAt}` : ""}
+              {onboardingStatus.captainAgreementVersion
+                ? ` · version ${onboardingStatus.captainAgreementVersion}`
+                : " · accepted before version tracking"}.
             </div>
           ) : (
             <form action={acceptCaptainAgreementAction} className="space-y-4">
@@ -262,7 +285,10 @@ export default async function CaptainGuidePage({
                   required
                   className="mt-1 h-5 w-5 shrink-0 rounded border-white/20 bg-black text-emerald-400"
                 />
-                <span className="text-sm leading-6 text-white/76">{CAPTAIN_AGREEMENT_TEXT}</span>
+                <span className="text-sm leading-6 text-white/76">
+                  {CAPTAIN_AGREEMENT_TEXT} (Captain terms version{" "}
+                  {CAPTAIN_AGREEMENT_VERSION}.)
+                </span>
               </label>
               <button
                 type="submit"

--- a/src/app/captain/team/[teamid]/onboarding/actions.ts
+++ b/src/app/captain/team/[teamid]/onboarding/actions.ts
@@ -7,6 +7,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
+import { CAPTAIN_AGREEMENT_VERSION } from "@/lib/captain/onboarding";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
 
@@ -38,6 +39,7 @@ export async function acceptCaptainAgreementAction(formData: FormData) {
     SET
       "captainAgreementAcceptedAt" = COALESCE("captainAgreementAcceptedAt", NOW()),
       "captainAgreementAcceptedById" = COALESCE("captainAgreementAcceptedById", ${userId}),
+      "captainAgreementVersion" = COALESCE("captainAgreementVersion", ${CAPTAIN_AGREEMENT_VERSION}),
       "onboardingCompletedAt" = COALESCE("onboardingCompletedAt", NOW())
     WHERE "id" = ${teamid}
   `;

--- a/src/lib/captain/onboarding.ts
+++ b/src/lib/captain/onboarding.ts
@@ -10,13 +10,15 @@ import {
 
 import { prisma } from "@/lib/prisma";
 
+export const CAPTAIN_AGREEMENT_VERSION = "2.0";
 export const CAPTAIN_AGREEMENT_TEXT =
-  "I understand that as team captain I am responsible for keeping squad details up to date, confirming fixture availability, arranging payment of match fees, and making sure my team follows SIXFL matchday rules.";
+  "I understand that as team captain I am responsible for keeping squad details up to date, confirming fixture availability, arranging payment of match fees, making sure my team follows SIXFL matchday rules, and complying with the current SIXFL League Rules and Match Rules.";
 
 export type CaptainOnboardingSummary = {
   teamId: string;
   captainAgreementAcceptedAt: Date | null;
   captainAgreementAcceptedById: string | null;
+  captainAgreementVersion: string | null;
   onboardingCompletedAt: Date | null;
   onboardingWelcomeEmailSentAt: Date | null;
   onboardingFirstFixtureEmailSentAt: Date | null;
@@ -40,6 +42,7 @@ type RawCaptainOnboardingSummary = {
   id: string;
   captainAgreementAcceptedAt: Date | null;
   captainAgreementAcceptedById: string | null;
+  captainAgreementVersion: string | null;
   onboardingCompletedAt: Date | null;
   onboardingWelcomeEmailSentAt: Date | null;
   onboardingFirstFixtureEmailSentAt: Date | null;
@@ -54,6 +57,7 @@ async function ensureCaptainOnboardingColumns() {
       ALTER TABLE "Team"
         ADD COLUMN IF NOT EXISTS "captainAgreementAcceptedAt" TIMESTAMP(3),
         ADD COLUMN IF NOT EXISTS "captainAgreementAcceptedById" TEXT,
+        ADD COLUMN IF NOT EXISTS "captainAgreementVersion" TEXT,
         ADD COLUMN IF NOT EXISTS "onboardingCompletedAt" TIMESTAMP(3),
         ADD COLUMN IF NOT EXISTS "onboardingWelcomeEmailSentAt" TIMESTAMP(3),
         ADD COLUMN IF NOT EXISTS "onboardingFirstFixtureEmailSentAt" TIMESTAMP(3),
@@ -82,6 +86,7 @@ function emptySummary(teamId: string): CaptainOnboardingSummary {
     teamId,
     captainAgreementAcceptedAt: null,
     captainAgreementAcceptedById: null,
+    captainAgreementVersion: null,
     onboardingCompletedAt: null,
     onboardingWelcomeEmailSentAt: null,
     onboardingFirstFixtureEmailSentAt: null,
@@ -94,6 +99,7 @@ function normaliseSummary(row: RawCaptainOnboardingSummary): CaptainOnboardingSu
     teamId: row.id,
     captainAgreementAcceptedAt: row.captainAgreementAcceptedAt,
     captainAgreementAcceptedById: row.captainAgreementAcceptedById,
+    captainAgreementVersion: row.captainAgreementVersion,
     onboardingCompletedAt: row.onboardingCompletedAt,
     onboardingWelcomeEmailSentAt: row.onboardingWelcomeEmailSentAt,
     onboardingFirstFixtureEmailSentAt: row.onboardingFirstFixtureEmailSentAt,
@@ -117,6 +123,7 @@ export async function getTeamOnboardingSummaries(teamIds: string[]) {
         "id",
         "captainAgreementAcceptedAt",
         "captainAgreementAcceptedById",
+        "captainAgreementVersion",
         "onboardingCompletedAt",
         "onboardingWelcomeEmailSentAt",
         "onboardingFirstFixtureEmailSentAt",
@@ -179,7 +186,10 @@ export async function getCaptainOnboardingStatus(teamId: string): Promise<Captai
   const squadEmailCount = squadMembers.filter((member) => Boolean(member.user.email?.trim())).length;
   const nextFixtureConfirmationStatus = nextFixture?.captainConfirmations[0]?.status ?? null;
   const isAgreementAccepted = Boolean(summary.captainAgreementAcceptedAt);
-  const availabilityComplete = !nextFixture || nextFixtureConfirmationStatus === "CONFIRMED" || nextFixtureConfirmationStatus === "ISSUE_RAISED";
+  const availabilityComplete =
+    !nextFixture ||
+    nextFixtureConfirmationStatus === "CONFIRMED" ||
+    nextFixtureConfirmationStatus === "ISSUE_RAISED";
   const squadComplete = squadMembers.length >= 6;
   const emailsComplete = squadMembers.length === 0 || squadEmailCount === squadMembers.length;
   const paymentsComplete = openTeamChargeCount === 0;
@@ -195,6 +205,11 @@ export async function getCaptainOnboardingStatus(teamId: string): Promise<Captai
     nextFixtureConfirmationStatus,
     openTeamChargeCount,
     isAgreementAccepted,
-    isChecklistComplete: isAgreementAccepted && squadComplete && emailsComplete && availabilityComplete && paymentsComplete,
+    isChecklistComplete:
+      isAgreementAccepted &&
+      squadComplete &&
+      emailsComplete &&
+      availabilityComplete &&
+      paymentsComplete,
   };
 }

--- a/src/lib/league-agreement.ts
+++ b/src/lib/league-agreement.ts
@@ -1,0 +1,119 @@
+// ========================================
+// File: src/lib/league-agreement.ts
+// ========================================
+
+export const LEAGUE_AGREEMENT_VERSION = "2.0";
+export const LEAGUE_AGREEMENT_EFFECTIVE_DATE = "22 August 2026";
+export const LEAGUE_AGREEMENT_NEXT_REVIEW = "22 August 2027";
+
+export type LeagueAgreementSection = {
+  title: string;
+  points: string[];
+};
+
+export const leagueAgreementSections: LeagueAgreementSection[] = [
+  {
+    title: "1. Agreement Scope and Acceptance",
+    points: [
+      "This agreement applies to registered teams, captains and players participating in SIXFL leagues.",
+      "By registering a team, joining a team or taking part in a SIXFL fixture, participants acknowledge the current League Rules, Match Rules and relevant competition requirements.",
+      "The League Rules govern league administration, eligibility, discipline, payments, fixtures and competition outcomes. The Match Rules govern on-pitch play.",
+    ],
+  },
+  {
+    title: "2. Captain Authority and Responsibilities",
+    points: [
+      "The registered captain or organiser confirms that they are authorised to enter and communicate on behalf of the team.",
+      "The captain is responsible for team communication, keeping squad details reasonably up to date, confirming fixtures, arranging payment of team fees and making sure players are aware of SIXFL rules and safety requirements.",
+      "The captain remains responsible for the team's overall match fee even where individual player payment links or squad-payment tools are used.",
+    ],
+  },
+  {
+    title: "3. Player Eligibility and Safety",
+    points: [
+      "Players must be properly registered or used as permitted guest players in accordance with the Match Rules.",
+      "Teams must not knowingly field an ineligible player or deliberately misrepresent player identity.",
+      "Shin pads are mandatory. A referee may prevent a player from taking part until required safety equipment is being worn.",
+    ],
+  },
+  {
+    title: "4. Fixture Attendance, Confirmation and Cancellations",
+    points: [
+      "Teams are expected to attend scheduled fixtures and should confirm availability no later than 72 hours before kick-off or raise a genuine fixture issue with SIXFL before that deadline.",
+      "A team that cannot fulfil a fixture must notify SIXFL directly as early as possible. An agreement only with the opposition does not cancel or rearrange the SIXFL fixture.",
+      "A team cancelling less than 24 hours before kick-off remains liable for its own match fee unless SIXFL expressly agrees otherwise.",
+      "A no-show or repeated avoidable late cancellation may result in a forfeit, disciplinary action or review of the team's place in the league.",
+    ],
+  },
+  {
+    title: "5. Match Fees and Admin Fees",
+    points: [
+      "The standard team match fee is £40 per fixture unless SIXFL has agreed a different fee for the team, fixture or competition.",
+      "Match fees are due on match day unless SIXFL has agreed otherwise.",
+      "A £10 late-confirmation admin fee may be applied where an avoidable missed 72-hour confirmation creates additional chasing, rearranging or administrative work.",
+      "A £10 late-payment admin fee may be applied where a match fee remains unpaid more than seven days after the due date and SIXFL has to carry out additional payment-chasing or administration.",
+      "SIXFL may send reminders or warnings where practical, but a warning is not a prerequisite to enforcement of a published payment or confirmation requirement.",
+    ],
+  },
+  {
+    title: "6. Conduct and Team Responsibility",
+    points: [
+      "Players, captains and spectators must behave respectfully towards referees, opponents, venue staff and SIXFL staff.",
+      "Unsporting behaviour, abuse, threats, intimidation, violence, repeated dissent or serious disruption may result in warnings, conduct notices, suspension, fixture sanctions or removal from the league.",
+      "SIXFL may review the team's continued participation where there is repeated non-payment, repeated late cancellation, persistent misconduct or another serious operational problem.",
+    ],
+  },
+  {
+    title: "7. Referee Authority and Abandoned Matches",
+    points: [
+      "Referee decisions regarding facts connected with play are final.",
+      "A player shown a red card is dismissed and must promptly leave the playing area and any nearby area the referee reasonably directs them to leave.",
+      "Where a referee abandons a match because of the conduct of one team, the referee's decision to abandon the fixture is final.",
+      "The team whose conduct caused the abandonment is responsible for both teams' match fees. SIXFL determines the result and league outcome at its sole discretion in accordance with the League Rules.",
+      "Where SIXFL records a forfeit and does not expressly determine a different score, the administrative forfeit result will be 3–0.",
+    ],
+  },
+  {
+    title: "8. Video Footage and Evidence",
+    points: [
+      "SIXFL may review footage for disciplinary, safeguarding, administrative and referee-development purposes.",
+      "Footage may be incomplete, silent, obstructed or limited to a particular camera angle. The fact that an event or conversation is not visible on one recording does not by itself establish that it did not occur.",
+      "SIXFL may take account of referee reports, footage, system records, contemporaneous communications, witness information and player or captain accounts.",
+      "There is no automatic right to a video review or to have an ordinary on-field decision re-refereed retrospectively.",
+    ],
+  },
+  {
+    title: "9. League Decisions, Reviews and Appeals",
+    points: [
+      "SIXFL reserves the right to interpret and apply its rules and to make reasonable decisions in the interests of fairness, safety and the effective running of the league.",
+      "There is no automatic right to an independent appeal, independent hearing or external review unless SIXFL has expressly created such a process for the competition concerned.",
+      "SIXFL may reconsider an administrative or disciplinary decision where genuinely new and material evidence is provided or an obvious administrative error is identified.",
+      "Any reconsideration is an internal SIXFL process unless SIXFL expressly states otherwise.",
+      "Once a final decision has been communicated, SIXFL may close the matter and is not required to continue responding to repeated arguments which contain no genuinely new material evidence.",
+    ],
+  },
+  {
+    title: "10. Participation Risk",
+    points: [
+      "Football is a physical sport and participation carries a risk of injury.",
+      "Players are responsible for making sure they are fit to participate and for following reasonable safety instructions from the referee, venue and SIXFL.",
+      "Nothing in this agreement excludes any liability which cannot lawfully be excluded.",
+    ],
+  },
+  {
+    title: "11. Founding Team Kit Offer",
+    points: [
+      "Where SIXFL expressly allocates the Founding Team Kit Offer, the team receives seven complete personalised playing kits free of charge. There is no printing contribution.",
+      "Additional complete kits cost £20 each unless SIXFL expressly confirms a different price.",
+      "The captain is responsible for checking designs, sizes, names and numbers before submitting the order and is also bound by the separate Kit Offer Terms.",
+    ],
+  },
+  {
+    title: "12. Rule Changes and Version History",
+    points: [
+      "SIXFL may update its rules and agreements from time to time. Active documents will show a version number and effective date.",
+      "Superseded versions are retained internally so that SIXFL can identify the wording which applied at an earlier date.",
+      "Unless a change is required for safety or law, an incident will normally be considered under the version that was in force when it occurred.",
+    ],
+  },
+];

--- a/src/lib/league-rules.ts
+++ b/src/lib/league-rules.ts
@@ -1,0 +1,158 @@
+// ========================================
+// File: src/lib/league-rules.ts
+// ========================================
+
+export const LEAGUE_RULES_VERSION = "2.0";
+export const LEAGUE_RULES_EFFECTIVE_DATE = "22 August 2026";
+export const LEAGUE_RULES_NEXT_REVIEW = "22 August 2027";
+
+export type LeagueRuleSection = {
+  title: string;
+  points: string[];
+};
+
+export const leagueRuleSections: LeagueRuleSection[] = [
+  {
+    title: "1. Scope, Acceptance and Rule Hierarchy",
+    points: [
+      "These League Rules apply to all SIXFL teams, captains, players and league fixtures unless SIXFL has expressly notified a competition-specific or venue-specific rule.",
+      "By registering a team, joining a team or taking part in a SIXFL fixture, participants agree to comply with the rules in force for that competition.",
+      "The League Rules govern league administration, eligibility, discipline, payments, fixtures and competition outcomes. The Match Rules govern on-pitch play. A notified venue safety rule or competition-specific rule applies where it is more specific.",
+      "Where documents appear to conflict on an administrative or competition matter, these League Rules take priority. Mandatory venue safety requirements always apply.",
+      "SIXFL keeps an internal archive of superseded rule versions. Unless a change is required for safety or law, an incident will normally be considered under the rules that were in force when it occurred.",
+    ],
+  },
+  {
+    title: "2. Team Registration and Captain Responsibility",
+    points: [
+      "Teams must complete the SIXFL registration process and provide accurate captain and player details.",
+      "The registered captain or organiser acts as the primary team contact and is responsible for making sure players are aware of fixtures, payment responsibilities, safety requirements and league rules.",
+      "Teams must keep contact and squad information reasonably up to date. Where a SIXFL feature requires an email address or other contact detail, the team is responsible for providing accurate information.",
+    ],
+  },
+  {
+    title: "3. Player Eligibility and Guest Players",
+    points: [
+      "A player may take part if they are properly registered to the team or are being used as a permitted guest player in accordance with the Match Rules.",
+      "Teams must not field an ineligible player, deliberately misrepresent a player's identity or use another person's registration.",
+      "SIXFL may amend a result, remove a player from a fixture, impose disciplinary action or take another reasonable competition measure where an eligibility breach is established.",
+    ],
+  },
+  {
+    title: "4. Squad Size and Matchday Player Limit",
+    points: [
+      "There is no maximum registered squad size.",
+      "A maximum of nine players may take part for a team in any single fixture: six players on the pitch and up to three rolling substitutes.",
+      "Every player who participates in the fixture, including any permitted guest player, counts towards the nine-player limit.",
+      "A team may only exceed the nine-player matchday limit with prior approval from SIXFL.",
+    ],
+  },
+  {
+    title: "5. Safety Equipment",
+    points: [
+      "Shin pads are mandatory for every player taking part in a SIXFL fixture.",
+      "The referee may prevent a player from taking part, or require a player to leave the pitch until the issue is corrected, if required safety equipment is not being worn.",
+      "Repeated failure to comply with safety requirements may result in a conduct warning, disciplinary action or review of the team's participation in the league.",
+    ],
+  },
+  {
+    title: "6. Respect and Conduct",
+    points: [
+      "Players, captains and spectators must behave respectfully towards referees, opponents, venue staff and SIXFL staff.",
+      "Abuse, threats, intimidation, violence, serious misconduct, repeated dissent or conduct which materially disrupts a fixture may lead to warnings, formal conduct notices, suspension, removal from a fixture or removal from the league.",
+      "A captain is expected to assist with the behaviour of their team and spectators where reasonably possible.",
+    ],
+  },
+  {
+    title: "7. Referee Authority, Cards and Dismissals",
+    points: [
+      "Decisions of the referee regarding facts connected with play are final.",
+      "A player shown a red card is dismissed from the match and must promptly leave the playing area and any nearby area the referee reasonably directs them to leave.",
+      "A dismissed player who refuses or unreasonably delays complying with an instruction to leave may commit a further disciplinary offence. If that conduct prevents the match from continuing safely or properly, the referee may abandon the fixture.",
+      "Ordinary on-field decisions will not normally be retrospectively re-refereed because later footage or a different account suggests another decision could have been made.",
+    ],
+  },
+  {
+    title: "8. Results and League Table",
+    points: [
+      "Match results are recorded by the referee or league administrator and used to update the standings.",
+      "SIXFL may correct an administrative recording error or amend a result where serious misconduct, cheating, an eligibility breach or another significant competition breach is established.",
+      "A disagreement with an ordinary refereeing decision made during play does not, by itself, provide grounds to change a result.",
+    ],
+  },
+  {
+    title: "9. Abandoned Matches",
+    points: [
+      "Where a referee abandons a match because of the conduct of one team, the referee's decision to abandon the match is final.",
+      "The team whose conduct caused the abandonment is responsible for payment of both its own match fee and the opposing team's match fee, irrespective of how much of the fixture had been played.",
+      "The result and league outcome of any abandoned fixture will be determined by SIXFL at its sole discretion after taking into account the circumstances available to it.",
+      "SIXFL may allow the score at the time of abandonment to stand, award the match to either team, record a forfeit, leave the result pending while an administrative decision is made, or take any other competition action it considers appropriate.",
+      "Where SIXFL records a forfeit and does not expressly determine a different score, the administrative forfeit result will be 3–0.",
+      "A result decision, fee decision and disciplinary decision are separate administrative decisions and may all apply to the same incident.",
+    ],
+  },
+  {
+    title: "10. Fixture Confirmation",
+    points: [
+      "Teams should confirm fixture availability no later than 72 hours before kick-off or raise a genuine fixture issue through the SIXFL system before that deadline.",
+      "A £10 late-confirmation admin fee may be applied where an avoidable missed confirmation creates additional chasing, rearranging or administrative work.",
+      "SIXFL may send reminders or warnings where practical, but a warning is not a prerequisite to enforcement of a published confirmation requirement.",
+    ],
+  },
+  {
+    title: "11. Cancellations, No-Shows and Fixture Changes",
+    points: [
+      "A team that cannot fulfil a fixture must notify SIXFL directly as early as possible. Telling or agreeing something only with the opposition does not cancel or rearrange a SIXFL fixture.",
+      "A team cancelling less than 24 hours before kick-off remains liable for its own match fee unless SIXFL expressly agrees otherwise.",
+      "A no-show or repeated avoidable late cancellation may also result in a forfeit, disciplinary action or review of the team's place in the league.",
+      "SIXFL may postpone, cancel or rearrange fixtures because of venue availability, weather, safety, operational requirements or exceptional circumstances.",
+    ],
+  },
+  {
+    title: "12. Match Fees, Payment and Admin Fees",
+    points: [
+      "The standard team match fee is £40 per fixture unless SIXFL has agreed a different fee for that team, fixture or competition.",
+      "The captain remains responsible for making sure the overall team fee is covered even where individual player payment links or squad-payment tools are used.",
+      "Match fees are due on match day unless SIXFL has agreed otherwise.",
+      "A £10 late-payment admin fee may be applied where a match fee remains unpaid more than seven days after the due date and SIXFL has to carry out additional payment-chasing or administration.",
+      "SIXFL may send payment reminders or warnings where practical, but teams should not rely on receiving a warning before paying an amount that is already due.",
+      "An admin fee is additional to the underlying match fee. Applying, waiving or removing an admin fee does not alter the original match fee unless SIXFL expressly changes that charge.",
+    ],
+  },
+  {
+    title: "13. Video Footage and Other Evidence",
+    points: [
+      "Video footage may be reviewed for disciplinary, safeguarding, administrative and referee-development purposes.",
+      "Footage may be incomplete, obstructed, silent, recorded from a limited angle or fail to capture a conversation or event outside the camera view. The absence of an event from a particular recording does not by itself establish that the event did not occur.",
+      "When considering an administrative or disciplinary issue, SIXFL may take account of referee reports, available footage, contemporaneous messages, system records, player or captain accounts, witness information and any other material it considers relevant.",
+      "There is no automatic right to a video review, to a frame-by-frame re-refereeing process or to have an ordinary on-field decision overturned because footage is available.",
+      "Where footage clearly establishes an administrative recording error or other matter which SIXFL considers material, SIXFL may take it into account.",
+    ],
+  },
+  {
+    title: "14. Discipline and Formal Conduct Notices",
+    points: [
+      "SIXFL may issue informal warnings, formal conduct notices, fixture sanctions, player suspensions, team sanctions or removal from the league where conduct warrants it.",
+      "Serious incidents may be reported to the relevant County FA, venue, safeguarding authority or other appropriate body.",
+      "A disciplinary outcome may apply in addition to any match result or financial consequence arising from the same incident.",
+    ],
+  },
+  {
+    title: "15. Reviews, Appeals and Final Decisions",
+    points: [
+      "There is no automatic right to an independent appeal, independent hearing or external review of a SIXFL league decision unless SIXFL has expressly created such a process for the competition concerned.",
+      "SIXFL may reconsider an administrative or disciplinary decision where genuinely new and material evidence is provided, or where an obvious administrative error is identified.",
+      "Any reconsideration is an internal SIXFL process unless SIXFL expressly states otherwise. SIXFL decides what evidence is relevant and what weight to give it.",
+      "Once SIXFL has considered the material available and communicated a final decision, it may close the matter and is not required to continue responding to repeated arguments which do not contain genuinely new material evidence.",
+      "League decisions are final unless these rules, a competition-specific rule or SIXFL expressly states otherwise.",
+    ],
+  },
+  {
+    title: "16. League Management and Rule Changes",
+    points: [
+      "SIXFL reserves the right to make reasonable operational and competition decisions in the interests of fairness, safety and the effective running of the league.",
+      "SIXFL may review a team's continued participation where there is repeated non-payment, repeated late cancellation, persistent misconduct or another serious operational problem.",
+      "Updated rule versions will be dated and versioned. Superseded versions will be retained internally so that SIXFL can identify the wording that applied at an earlier date.",
+    ],
+  },
+];

--- a/src/lib/match-rules.ts
+++ b/src/lib/match-rules.ts
@@ -2,7 +2,7 @@
 // File: src/lib/match-rules.ts
 // ========================================
 
-export const MATCH_RULES_VERSION = "Version 1.4 — August 2026";
+export const MATCH_RULES_VERSION = "Version 2.0 — August 2026";
 
 export type MatchRuleSection = {
   title: string;
@@ -11,22 +11,30 @@ export type MatchRuleSection = {
 
 export const matchRuleSections: MatchRuleSection[] = [
   {
+    title: "Rule Scope and Hierarchy",
+    points: [
+      "These Match Rules govern on-pitch play in SIXFL fixtures. The League Rules govern competition administration, eligibility, payments, discipline and league outcomes.",
+      "A competition-specific rule or mandatory venue safety rule notified by SIXFL applies where it is more specific.",
+      "Where the Match Rules and League Rules appear to conflict on an administrative matter, the League Rules take priority.",
+    ],
+  },
+  {
     title: "Referee Decisions",
     points: [
       "Decisions of the referee regarding facts connected with play are final.",
       "An ordinary on-field decision will not be overturned merely because later video footage suggests that a different decision may have been made.",
       "Goals and match results will not normally be changed because of a retrospective disagreement with a refereeing decision made during play.",
-      "There is no automatic right to a video review, and the availability or quality of footage may differ between matches.",
+      "There is no automatic right to a video review.",
     ],
   },
   {
-    title: "Use of Video Footage",
+    title: "Use of Video Footage and Other Evidence",
     points: [
       "Video footage may be reviewed for disciplinary, safeguarding, administrative and referee-development purposes.",
       "SIXFL may use footage to investigate serious misconduct, violence, abuse, mistaken identity, suspected cheating, the use of an ineligible player or another significant rule breach.",
-      "Footage may also be used to correct an administrative error, such as an incorrectly entered score, where the referee's actual decision or the agreed final score is clear.",
-      "Unless SIXFL has announced a formal competition-specific video-review process in advance, footage will not normally be used to re-referee a match, overturn an on-field decision or amend a result arising from that decision.",
-      "SIXFL may still use footage privately to support referee feedback, training and performance review without changing the match result.",
+      "Footage may be incomplete, obstructed, silent, recorded from a limited angle or fail to capture an incident or conversation outside the camera view. Something not appearing on a particular recording does not by itself establish that it did not happen.",
+      "SIXFL may consider referee reports, available footage, contemporaneous messages, system records, witness information and player or captain accounts when making an administrative or disciplinary decision.",
+      "Unless SIXFL has announced a formal competition-specific video-review process in advance, footage will not normally be used to re-referee a match, overturn an ordinary on-field decision or amend a result arising solely from that decision.",
     ],
   },
   {
@@ -34,8 +42,16 @@ export const matchRuleSections: MatchRuleSection[] = [
     points: [
       "There is no maximum registered squad size.",
       "A maximum of nine players may take part for a team in any single fixture: six players on the pitch and up to three rolling substitutes.",
-      "Every player who participates in the fixture, including any guest player, counts towards the nine-player limit.",
+      "Every player who participates in the fixture, including any permitted guest player, counts towards the nine-player limit.",
       "A team may only exceed the nine-player fixture limit with prior approval from SIXFL.",
+    ],
+  },
+  {
+    title: "Required Safety Equipment",
+    points: [
+      "Shin pads are mandatory for every player taking part in a SIXFL fixture.",
+      "A referee may prevent a player from taking part, or require them to leave the pitch until the issue is corrected, if required safety equipment is not being worn.",
+      "Repeated failure to comply with safety-equipment requirements may be reported to SIXFL for disciplinary action.",
     ],
   },
   {
@@ -126,12 +142,14 @@ export const matchRuleSections: MatchRuleSection[] = [
     ],
   },
   {
-    title: "Discipline and Sin Bin Rule",
+    title: "Discipline, Cards and Dismissals",
     points: [
       "Referees may use temporary suspensions, known as sin bins, for cautionable offences.",
       "A player shown a blue card is temporarily suspended from play.",
       "A second blue card in the same match results in permanent exclusion from the match.",
       "A red card results in immediate dismissal from the match.",
+      "A dismissed player must promptly leave the playing area and any nearby area the referee reasonably directs them to leave.",
+      "Refusal or unreasonable delay in complying with an instruction to leave may be treated as further misconduct and may result in the fixture being abandoned if the referee considers that the match cannot safely or properly continue.",
       "Serious disciplinary incidents may be reported to the relevant County FA.",
     ],
   },
@@ -140,8 +158,10 @@ export const matchRuleSections: MatchRuleSection[] = [
     points: [
       "Where a referee abandons a match because of the conduct of one team, the referee's decision to abandon the match is final.",
       "The team whose conduct caused the abandonment is responsible for payment of both its own match fee and the opposing team's match fee.",
-      "The result and league outcome of any abandoned fixture will be determined by SIXFL at its sole discretion, taking into account the circumstances of the abandonment.",
-      "SIXFL may allow the score at the time of abandonment to stand, award the match to either team, record a forfeit or take any other action it considers appropriate.",
+      "The result and league outcome of any abandoned fixture will be determined by SIXFL at its sole discretion, taking into account the circumstances available to it.",
+      "SIXFL may allow the score at the time of abandonment to stand, award the match to either team, record a forfeit, leave the result pending while an administrative decision is made or take any other competition action it considers appropriate.",
+      "Where SIXFL records a forfeit and does not expressly determine a different score, the administrative forfeit result will be 3–0.",
+      "A result decision, fee decision and disciplinary decision are separate and may all apply to the same incident.",
     ],
   },
 ];

--- a/src/lib/rules-archive.ts
+++ b/src/lib/rules-archive.ts
@@ -1,0 +1,309 @@
+// ========================================
+// File: src/lib/rules-archive.ts
+// ========================================
+
+export type ArchivedRuleDocument = {
+  id: string;
+  document: string;
+  version: string;
+  effectiveDate: string;
+  supersededDate: string;
+  status: "Superseded";
+  sections: Array<{
+    title: string;
+    points: string[];
+  }>;
+};
+
+export const archivedRuleDocuments: ArchivedRuleDocument[] = [
+  {
+    id: "league-rules-1-4",
+    document: "League Rules",
+    version: "1.4",
+    effectiveDate: "12 August 2026",
+    supersededDate: "22 August 2026",
+    status: "Superseded",
+    sections: [
+      {
+        title: "1. Team Registration",
+        points: [
+          "All teams must complete the SIXFL registration process and provide accurate captain and player details before participating in league matches.",
+        ],
+      },
+      {
+        title: "2. Match Format",
+        points: [
+          "Matches are played as 6-a-side fixtures in accordance with SIXFL competition regulations. Specific venue rules, kick-off times and fixture details will be communicated by the league.",
+        ],
+      },
+      {
+        title: "3. Player Eligibility",
+        points: [
+          "Only properly registered players may represent a team in league fixtures. Teams may not field ineligible players or deliberately misrepresent player identity.",
+        ],
+      },
+      {
+        title: "4. Squad Size and Matchday Player Limit",
+        points: [
+          "There is no maximum squad size. Teams may register as many players to their squad as they wish. However, a maximum of nine players may take part in any single fixture: six players on the pitch and up to three rolling substitutes. All players who participate in the fixture, including guest players, count towards this nine-player limit. Exceptions require prior approval from SIXFL.",
+        ],
+      },
+      {
+        title: "5. Respect and Conduct",
+        points: [
+          "Players, captains and spectators must behave respectfully towards referees, opponents and league staff. Abuse, threatening behaviour and serious misconduct may result in suspension or removal from the league.",
+        ],
+      },
+      {
+        title: "6. Results and League Table",
+        points: [
+          "Match results are recorded by the referee or league administrator and used to update the standings. SIXFL may correct administrative recording errors or amend results where an ineligible player, serious misconduct, cheating or another significant rule breach is established. Ordinary refereeing decisions made during play will not normally be reconsidered retrospectively.",
+        ],
+      },
+      {
+        title: "7. Discipline",
+        points: [
+          "SIXFL may take disciplinary action in response to misconduct, dangerous play, abusive language, repeated non-attendance or any behaviour that brings the league into disrepute.",
+        ],
+      },
+      {
+        title: "8. Abandoned Matches",
+        points: [
+          "Where a referee abandons a match because of the conduct of one team, the referee's decision to abandon the match is final. The team whose conduct caused the abandonment will be responsible for payment of both its own match fee and the opposing team's match fee. The result and league outcome of any abandoned fixture will be determined by SIXFL at its sole discretion, taking into account the circumstances of the abandonment. This may include allowing the score at the time of abandonment to stand, awarding the match to either team, recording a forfeit or taking any other action SIXFL considers appropriate.",
+        ],
+      },
+      {
+        title: "9. Fixtures and Cancellations",
+        points: [
+          "Fixtures are scheduled by SIXFL and may be changed where necessary due to venue issues, weather, operational requirements or exceptional circumstances.",
+        ],
+      },
+      {
+        title: "10. Video Footage and Post-Match Review",
+        points: [
+          "Referee decisions regarding facts connected with play are final. Video footage may be reviewed for disciplinary, safeguarding, administrative and referee-development purposes, including serious misconduct, violence, abuse, mistaken identity, suspected cheating, use of an ineligible player or an incorrectly entered score. Unless SIXFL has announced a formal competition-specific video-review process in advance, footage will not normally be used to re-referee a match, overturn an on-field decision or change a result arising from that decision. There is no automatic right to a video review, and footage may not be available or of equal quality for every match.",
+        ],
+      },
+      {
+        title: "11. League Decisions",
+        points: [
+          "SIXFL reserves the right to interpret and apply league rules in the interests of fairness, safety and good league management. League decisions are final unless otherwise stated.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "match-rules-1-4",
+    document: "Match Rules",
+    version: "1.4",
+    effectiveDate: "12 August 2026",
+    supersededDate: "22 August 2026",
+    status: "Superseded",
+    sections: [
+      {
+        title: "Referee Decisions",
+        points: [
+          "Decisions of the referee regarding facts connected with play are final.",
+          "An ordinary on-field decision will not be overturned merely because later video footage suggests that a different decision may have been made.",
+          "Goals and match results will not normally be changed because of a retrospective disagreement with a refereeing decision made during play.",
+          "There is no automatic right to a video review, and the availability or quality of footage may differ between matches.",
+        ],
+      },
+      {
+        title: "Use of Video Footage",
+        points: [
+          "Video footage may be reviewed for disciplinary, safeguarding, administrative and referee-development purposes.",
+          "SIXFL may use footage to investigate serious misconduct, violence, abuse, mistaken identity, suspected cheating, the use of an ineligible player or another significant rule breach.",
+          "Footage may also be used to correct an administrative error, such as an incorrectly entered score, where the referee's actual decision or the agreed final score is clear.",
+          "Unless SIXFL has announced a formal competition-specific video-review process in advance, footage will not normally be used to re-referee a match, overturn an on-field decision or amend a result arising from that decision.",
+          "SIXFL may still use footage privately to support referee feedback, training and performance review without changing the match result.",
+        ],
+      },
+      {
+        title: "Players and Substitutes",
+        points: [
+          "There is no maximum registered squad size.",
+          "A maximum of nine players may take part for a team in any single fixture: six players on the pitch and up to three rolling substitutes.",
+          "Every player who participates in the fixture, including any guest player, counts towards the nine-player limit.",
+          "A team may only exceed the nine-player fixture limit with prior approval from SIXFL.",
+        ],
+      },
+      {
+        title: "Match Duration",
+        points: [
+          "Matches are typically played between 30–40 minutes in duration.",
+          "Competition formats may allow games to be played without a half-time interval or requirement to change ends.",
+          "Keep the night moving and follow the fixture schedule unless SIXFL or the venue confirms otherwise.",
+        ],
+      },
+      {
+        title: "Start of Play",
+        points: [
+          "The referee decides which team takes the kick-off, using a coin toss where time allows.",
+          "The other team chooses which end to attack, unless the referee gives different instructions to keep the night on schedule.",
+        ],
+      },
+      {
+        title: "Kick-Off",
+        points: [
+          "A kick-off is used to start the match, restart play after a goal and start the second half where a second half is used.",
+          "A goal may be scored directly from a kick-off.",
+        ],
+      },
+      {
+        title: "Ball In and Out of Play",
+        points: [
+          "The ball is out of play when it has wholly crossed the goal line or touchline, or when play has been stopped by the referee.",
+          "The ball is in play at all other times, including rebounds from the goalpost, crossbar, boards or referee unless the referee stops play.",
+        ],
+      },
+      {
+        title: "Scoring",
+        points: [
+          "A goal is scored when the whole of the ball passes over the goal line, between the goalposts and under the crossbar, unless the rules say the restart cannot score directly.",
+          "The team scoring the greater number of goals wins the match.",
+        ],
+      },
+      {
+        title: "Offside and Height Rules",
+        points: [
+          "There is no offside rule.",
+          "There is no overhead height restriction unless the venue has a specific local safety rule.",
+        ],
+      },
+      {
+        title: "Free Kicks",
+        points: [
+          "All free kicks are direct and are awarded to the opposing team for offences in accordance with the rules of play.",
+          "Opponents must stand at least five yards from the ball until it is in play.",
+          "Where the rules require a free kick outside the goalkeeper area, place the ball five yards outside the area in line with the offence or the point where the ball entered the area.",
+        ],
+      },
+      {
+        title: "Penalty Area",
+        points: [
+          "A penalty kick may be awarded if a defender commits a direct-free-kick offence inside the penalty or goalkeeper area.",
+          "If an attacking player enters the goalkeeper area and gains an advantage, the referee may award possession to the goalkeeper.",
+          "If the goalkeeper handles the ball outside the goalkeeper area, award a free kick from where the offence happened.",
+        ],
+      },
+      {
+        title: "Kick-Ins",
+        points: [
+          "Kick-ins replace throw-ins when the ball leaves the pitch over the touchline.",
+          "A goal cannot be scored directly from a kick-in.",
+          "The ball should be stationary on or behind the line and opponents should give at least five yards where possible.",
+        ],
+      },
+      {
+        title: "Goalkeeper and Back-Pass Rules",
+        points: [
+          "Goalkeepers may restart play by throwing the ball underarm or overarm.",
+          "Backpasses to the goalkeeper are allowed.",
+          "However, if a player receives the ball from their own goalkeeper, that player may not pass it straight back to the goalkeeper until another player has touched the ball.",
+          "If this keeper-return offence happens, award a free kick to the opposing team five yards outside the goalkeeper area, in line with the point where the ball entered the area.",
+          "Goalkeepers may save or stop the ball with their feet, but may not kick the ball out from their hands.",
+        ],
+      },
+      {
+        title: "Guest Players",
+        points: [
+          "Teams may use a maximum of two guest players per match unless SIXFL has approved otherwise.",
+          "Guest players may play a maximum of three matches for the same team during a season. After this point, the player must be registered as a permanent player for that team.",
+          "Guest players must be agreed with the opposing captain and referee before kick-off.",
+          "Guest players may not participate in playoff or final matches unless registered with the team.",
+          "Teams may not use guest players as substitutes during a match.",
+        ],
+      },
+      {
+        title: "Discipline and Sin Bin Rule",
+        points: [
+          "Referees may use temporary suspensions, known as sin bins, for cautionable offences.",
+          "A player shown a blue card is temporarily suspended from play.",
+          "A second blue card in the same match results in permanent exclusion from the match.",
+          "A red card results in immediate dismissal from the match.",
+          "Serious disciplinary incidents may be reported to the relevant County FA.",
+        ],
+      },
+      {
+        title: "Abandoned Matches",
+        points: [
+          "Where a referee abandons a match because of the conduct of one team, the referee's decision to abandon the match is final.",
+          "The team whose conduct caused the abandonment is responsible for payment of both its own match fee and the opposing team's match fee.",
+          "The result and league outcome of any abandoned fixture will be determined by SIXFL at its sole discretion, taking into account the circumstances of the abandonment.",
+          "SIXFL may allow the score at the time of abandonment to stand, award the match to either team, record a forfeit or take any other action it considers appropriate.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "league-agreement-1-2",
+    document: "League Participation Agreement",
+    version: "1.2",
+    effectiveDate: "3 August 2026",
+    supersededDate: "22 August 2026",
+    status: "Superseded",
+    sections: [
+      {
+        title: "1. Team Registration",
+        points: [
+          "Teams register for a SIXFL league through a designated team captain or organiser. The captain confirms they are authorised to enter the team into the league and communicate with SIXFL on behalf of the team.",
+        ],
+      },
+      {
+        title: "2. Captain Responsibilities",
+        points: [
+          "The team captain acts as the primary contact for the league. The captain is responsible for ensuring team members are aware of fixtures, league rules and conduct expectations.",
+        ],
+      },
+      {
+        title: "3. Match Attendance",
+        points: [
+          "Teams are expected to attend scheduled fixtures. If a team cannot attend a match, they should notify the league as early as possible. Failure to attend may result in the match being recorded as a forfeit.",
+        ],
+      },
+      {
+        title: "4. Player Conduct",
+        points: [
+          "Players are expected to behave respectfully toward opponents, referees and league organisers. Unsporting or abusive behaviour may result in disciplinary action or removal from the league.",
+        ],
+      },
+      {
+        title: "5. Referee Authority",
+        points: [
+          "All matches are officiated by referees appointed by the league. Decisions made by the referee during the match are final.",
+        ],
+      },
+      {
+        title: "6. Fixtures and Scheduling",
+        points: [
+          "Fixtures are organised and communicated by SIXFL. Match schedules may occasionally change due to weather, venue availability or other operational factors.",
+        ],
+      },
+      {
+        title: "7. League Management",
+        points: [
+          "SIXFL reserves the right to make reasonable decisions in the interest of fair play, safety and the smooth running of the league.",
+        ],
+      },
+      {
+        title: "8. Participation Risk",
+        points: [
+          "Football is a physical sport and participation carries a risk of injury. Players take part at their own risk and are responsible for ensuring they are fit to play.",
+        ],
+      },
+      {
+        title: "9. Founding Team Kit Offer",
+        points: [
+          "Where SIXFL expressly allocates the Founding Team Kit Offer, the team receives seven complete personalised playing kits free of charge. There is no printing contribution. Additional complete kits cost £20 each. The captain is responsible for checking all designs, sizes, names and numbers before submission.",
+        ],
+      },
+      {
+        title: "10. Agreement Acceptance",
+        points: [
+          "By registering a team, joining a team or participating in a SIXFL match, players acknowledge and agree to these participation terms. A captain who submits a Founding Team Kit Offer order also confirms acceptance of the separate Kit Offer Terms.",
+        ],
+      },
+    ],
+  },
+];


### PR DESCRIPTION
Introduces SIXFL Rules v2 hardening across the public League Rules, Match Rules, League Participation Agreement and Captain Guide.

Key changes:
- defines a clear document hierarchy and version/effective-date model;
- closes the registered-player/guest-player inconsistency;
- makes shin pads explicitly mandatory;
- requires a red-carded player to leave the playing area when directed and makes refusal capable of leading to abandonment;
- defines abandoned-match consequences and a default 3–0 administrative forfeit result where no different score is specified;
- consolidates 72-hour confirmation, <24-hour cancellation, £40 standard match fee, £10 late-confirmation fee and £10 late-payment fee rules;
- makes clear cancellations must be notified directly to SIXFL, not agreed only with an opponent;
- strengthens video/evidence wording so a limited camera angle is not treated as a complete record;
- states there is no automatic independent appeal or frame-by-frame re-refereeing process, while allowing genuinely new material evidence or administrative errors to be reconsidered;
- adds an internal admin Rules Archive containing the superseded League Rules v1.4, Match Rules v1.4 and League Participation Agreement v1.2;
- adds captain agreement version storage so future acceptances can be tied to a version;
- adds a prebuild hardening contract and injects a Rules archive link into the existing Back end functions navigation.

Existing captain acceptances remain valid; older ones display as accepted before version tracking rather than being falsely attributed to v2.0.