### PR TITLE
Add team re-entry and player participation controls

### DIFF
--- a/prisma/migrations/20260822153000_participation_reentry_controls/migration.sql
+++ b/prisma/migrations/20260822153000_participation_reentry_controls/migration.sql
@@ -1,0 +1,184 @@
+ALTER TABLE "Team"
+  ADD COLUMN IF NOT EXISTS "registrationBlocked" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "registrationBlockedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "registrationBlockedReason" TEXT,
+  ADD COLUMN IF NOT EXISTS "registrationReviewRequired" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "registrationReviewReason" TEXT,
+  ADD COLUMN IF NOT EXISTS "registrationReviewSourceTeamId" TEXT,
+  ADD COLUMN IF NOT EXISTS "registrationReviewApprovedAt" TIMESTAMP(3);
+
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "teamManagementRestricted" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "teamManagementRestrictedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "teamManagementRestrictionReason" TEXT,
+  ADD COLUMN IF NOT EXISTS "playingRestricted" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "playingRestrictedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "playingRestrictedUntil" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "playingRestrictionReason" TEXT;
+
+CREATE INDEX IF NOT EXISTS "Team_registrationBlocked_idx"
+  ON "Team" ("registrationBlocked");
+
+CREATE INDEX IF NOT EXISTS "Team_registrationReviewRequired_idx"
+  ON "Team" ("registrationReviewRequired");
+
+CREATE INDEX IF NOT EXISTS "User_teamManagementRestricted_idx"
+  ON "User" ("teamManagementRestricted");
+
+CREATE INDEX IF NOT EXISTS "User_playingRestricted_idx"
+  ON "User" ("playingRestricted");
+
+CREATE TABLE IF NOT EXISTS "ParticipationRestrictionAudit" (
+  "id" TEXT PRIMARY KEY,
+  "subjectType" TEXT NOT NULL,
+  "subjectId" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "reason" TEXT,
+  "until" TIMESTAMP(3),
+  "createdByUserId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS "ParticipationRestrictionAudit_subject_idx"
+  ON "ParticipationRestrictionAudit" ("subjectType", "subjectId", "createdAt");
+
+CREATE INDEX IF NOT EXISTS "ParticipationRestrictionAudit_createdAt_idx"
+  ON "ParticipationRestrictionAudit" ("createdAt");
+
+CREATE OR REPLACE FUNCTION sixfl_normalise_contact_phone(value TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  digits TEXT;
+BEGIN
+  digits := REGEXP_REPLACE(COALESCE(value, ''), '[^0-9]', '', 'g');
+  IF digits = '' THEN
+    RETURN NULL;
+  END IF;
+
+  IF digits LIKE '0%' THEN
+    RETURN '44' || SUBSTRING(digits FROM 2);
+  END IF;
+
+  IF digits LIKE '44%' THEN
+    RETURN digits;
+  END IF;
+
+  RETURN '44' || digits;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sixfl_flag_blocked_team_contact_reuse()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  blocked_team_id TEXT;
+  blocked_team_name TEXT;
+BEGIN
+  IF COALESCE(NEW."registrationBlocked", false) = true
+     OR NEW."registrationReviewApprovedAt" IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT blocked."id", blocked."name"
+  INTO blocked_team_id, blocked_team_name
+  FROM "Team" blocked
+  WHERE blocked."id" <> NEW."id"
+    AND COALESCE(blocked."registrationBlocked", false) = true
+    AND (
+      (
+        NULLIF(LOWER(BTRIM(COALESCE(NEW."contactEmail", ''))), '') IS NOT NULL
+        AND LOWER(BTRIM(COALESCE(blocked."contactEmail", ''))) = LOWER(BTRIM(NEW."contactEmail"))
+      )
+      OR (
+        sixfl_normalise_contact_phone(NEW."contactPhone") IS NOT NULL
+        AND sixfl_normalise_contact_phone(blocked."contactPhone") = sixfl_normalise_contact_phone(NEW."contactPhone")
+      )
+    )
+  ORDER BY blocked."registrationBlockedAt" DESC NULLS LAST, blocked."createdAt" DESC
+  LIMIT 1;
+
+  IF blocked_team_id IS NOT NULL THEN
+    NEW."registrationReviewRequired" := true;
+    NEW."registrationReviewSourceTeamId" := blocked_team_id;
+    NEW."registrationReviewReason" :=
+      'Possible re-registration of blocked team ' || blocked_team_name ||
+      ': captain/contact details match. Admin approval required.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "Team_blocked_contact_reuse_guard" ON "Team";
+CREATE TRIGGER "Team_blocked_contact_reuse_guard"
+BEFORE INSERT OR UPDATE OF "contactEmail", "contactPhone", "registrationBlocked", "registrationReviewApprovedAt"
+ON "Team"
+FOR EACH ROW
+EXECUTE FUNCTION sixfl_flag_blocked_team_contact_reuse();
+
+CREATE OR REPLACE FUNCTION sixfl_flag_blocked_team_squad_overlap()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target_blocked BOOLEAN;
+  target_approved TIMESTAMP(3);
+  blocked_team_id TEXT;
+  blocked_team_name TEXT;
+  shared_players INTEGER;
+BEGIN
+  SELECT
+    COALESCE("registrationBlocked", false),
+    "registrationReviewApprovedAt"
+  INTO target_blocked, target_approved
+  FROM "Team"
+  WHERE "id" = NEW."teamId";
+
+  IF target_blocked = true OR target_approved IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT
+    blocked."id",
+    blocked."name",
+    COUNT(DISTINCT source_member."userId")::INTEGER
+  INTO blocked_team_id, blocked_team_name, shared_players
+  FROM "Team" blocked
+  INNER JOIN "TeamMember" source_member
+    ON source_member."teamId" = blocked."id"
+  INNER JOIN "TeamMember" target_member
+    ON target_member."teamId" = NEW."teamId"
+   AND target_member."userId" = source_member."userId"
+  WHERE blocked."id" <> NEW."teamId"
+    AND COALESCE(blocked."registrationBlocked", false) = true
+  GROUP BY blocked."id", blocked."name"
+  HAVING COUNT(DISTINCT source_member."userId") >= 4
+  ORDER BY COUNT(DISTINCT source_member."userId") DESC, blocked."name"
+  LIMIT 1;
+
+  IF blocked_team_id IS NOT NULL THEN
+    UPDATE "Team"
+    SET
+      "registrationReviewRequired" = true,
+      "registrationReviewSourceTeamId" = blocked_team_id,
+      "registrationReviewReason" =
+        'Possible re-formed blocked team: ' || shared_players ||
+        ' players overlap with ' || blocked_team_name ||
+        '. Admin approval required.'
+    WHERE "id" = NEW."teamId";
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "TeamMember_blocked_team_overlap_guard" ON "TeamMember";
+CREATE TRIGGER "TeamMember_blocked_team_overlap_guard"
+AFTER INSERT OR UPDATE OF "teamId", "userId"
+ON "TeamMember"
+FOR EACH ROW
+EXECUTE FUNCTION sixfl_flag_blocked_team_squad_overlap();

--- a/prisma/migrations/20260822153100_enforce_participation_restrictions/migration.sql
+++ b/prisma/migrations/20260822153100_enforce_participation_restrictions/migration.sql
@@ -1,0 +1,90 @@
+CREATE OR REPLACE FUNCTION sixfl_enforce_team_member_restrictions()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  management_restricted BOOLEAN;
+  playing_restricted BOOLEAN;
+  playing_until TIMESTAMP(3);
+BEGIN
+  SELECT
+    COALESCE("teamManagementRestricted", false),
+    COALESCE("playingRestricted", false),
+    "playingRestrictedUntil"
+  INTO management_restricted, playing_restricted, playing_until
+  FROM "User"
+  WHERE "id" = NEW."userId";
+
+  IF management_restricted = true
+     AND NEW."role"::text IN ('CAPTAIN', 'MANAGER', 'VICE_CAPTAIN') THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'SIXFL_TEAM_MANAGEMENT_RESTRICTED';
+  END IF;
+
+  IF playing_restricted = true
+     AND (playing_until IS NULL OR playing_until > NOW())
+     AND NEW."role"::text IN ('PLAYER', 'BACKUP_PLAYER') THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'SIXFL_PLAYER_PLAYING_RESTRICTED';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "TeamMember_participation_restriction_guard" ON "TeamMember";
+CREATE TRIGGER "TeamMember_participation_restriction_guard"
+BEFORE INSERT OR UPDATE OF "userId", "role"
+ON "TeamMember"
+FOR EACH ROW
+EXECUTE FUNCTION sixfl_enforce_team_member_restrictions();
+
+CREATE OR REPLACE FUNCTION sixfl_enforce_fixture_selection_restrictions()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  player_user_id TEXT;
+  playing_restricted BOOLEAN;
+  playing_until TIMESTAMP(3);
+BEGIN
+  IF NEW."selectionStatus" NOT IN ('SELECTED', 'BACKUP') THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT member."userId"
+  INTO player_user_id
+  FROM "TeamMember" member
+  WHERE member."id" = NEW."teamMemberId"
+  LIMIT 1;
+
+  IF player_user_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT
+    COALESCE("playingRestricted", false),
+    "playingRestrictedUntil"
+  INTO playing_restricted, playing_until
+  FROM "User"
+  WHERE "id" = player_user_id;
+
+  IF playing_restricted = true
+     AND (playing_until IS NULL OR playing_until > NOW()) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'SIXFL_PLAYER_PLAYING_RESTRICTED';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "FixtureSelection_participation_restriction_guard" ON "FixtureSelection";
+CREATE TRIGGER "FixtureSelection_participation_restriction_guard"
+BEFORE INSERT OR UPDATE OF "teamMemberId", "selectionStatus"
+ON "FixtureSelection"
+FOR EACH ROW
+EXECUTE FUNCTION sixfl_enforce_fixture_selection_restrictions();

--- a/scripts/apply-participation-controls.cjs
+++ b/scripts/apply-participation-controls.cjs
@@ -1,0 +1,124 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+
+function patchFile(relativePath, transform) {
+  const filePath = path.join(root, relativePath);
+  const before = fs.readFileSync(filePath, "utf8");
+  const after = transform(before);
+
+  if (after !== before) {
+    fs.writeFileSync(filePath, after, "utf8");
+    console.log(`Applied participation controls to ${relativePath}`);
+  }
+}
+
+function insertOnce(source, marker, anchor, insertion) {
+  if (source.includes(marker)) return source;
+  if (!source.includes(anchor)) {
+    throw new Error(`Participation control patch anchor not found: ${anchor}`);
+  }
+  return source.replace(anchor, `${insertion}${anchor}`);
+}
+
+patchFile("src/components/admin/AdminSidebar.tsx", (source) => {
+  const marker = 'href: "/admin/participation-controls"';
+  const anchor = `      {\n        name: "Backfill",\n        href: "/admin/fixtures/backfill",`;
+  const insertion = `      {\n        name: "Participation controls",\n        href: "/admin/participation-controls",\n        icon: ShieldCheckIcon,\n        description: "Blocks/suspensions",\n      },\n`;
+  return insertOnce(source, marker, anchor, insertion);
+});
+
+patchFile("src/app/(public)/claim/page.tsx", (source) => {
+  source = insertOnce(
+    source,
+    'from "@/lib/participation/controls"',
+    'import { prisma } from "@/lib/prisma";\n',
+    'import { getCaptainClaimRestriction } from "@/lib/participation/controls";\n',
+  );
+
+  source = insertOnce(
+    source,
+    "const claimRestriction = await getCaptainClaimRestriction",
+    "  const allowedEmails = getAllowedClaimEmails(team);\n",
+    `  const claimRestriction = await getCaptainClaimRestriction({\n    teamId: team.id,\n    userId: user.id,\n  });\n\n  if (claimRestriction.blocked) {\n    return {\n      ok: false as const,\n      error: claimRestriction.code,\n      code,\n    };\n  }\n\n`,
+  );
+
+  const errorAnchor = `          {error === "already_claimed" && (\n            <div className="text-red-300">`;
+  const errorInsertion = `          {error === "team_blocked" && (\n            <div className="text-red-300">\n              This team is not permitted to re-register or be reclaimed. Contact SIXFL if you believe this is an error.\n            </div>\n          )}\n          {error === "team_review" && (\n            <div className="text-amber-300">\n              This team registration is being held for SIXFL admin review before captain access can be activated.\n            </div>\n          )}\n          {error === "management_restricted" && (\n            <div className="text-red-300">\n              This account is not currently permitted to create, claim or manage a SIXFL team. Please contact SIXFL.\n            </div>\n          )}\n`;
+  source = insertOnce(source, 'error === "management_restricted"', errorAnchor, errorInsertion);
+
+  return source;
+});
+
+patchFile("src/lib/requireCaptain.ts", (source) => {
+  source = insertOnce(
+    source,
+    'from "@/lib/participation/controls"',
+    'import { prisma } from "@/lib/prisma";\n',
+    'import { getCaptainClaimRestriction } from "@/lib/participation/controls";\n',
+  );
+
+  const anchor = "  const isManagedTeam = team?.teamMode === \"MANAGED\";\n";
+  const insertion = `  if (user && !rawIsAdmin) {\n    const restriction = await getCaptainClaimRestriction({\n      teamId,\n      userId: user.id,\n    });\n\n    if (restriction.blocked) {\n      redirect(\`/dashboard?teamAccess=\${restriction.code}\`);\n    }\n  }\n\n`;
+  source = insertOnce(source, "teamAccess=${restriction.code}", anchor, insertion);
+
+  return source;
+});
+
+patchFile("src/lib/players/add-player-without-duplicates.ts", (source) => {
+  source = insertOnce(
+    source,
+    'getActivePlayingRestrictionForIdentity',
+    'import { prisma } from "@/lib/prisma";\n',
+    'import { getActivePlayingRestrictionForIdentity } from "@/lib/participation/controls";\n',
+  );
+
+  if (!source.includes('| "PLAYING_RESTRICTED";')) {
+    source = source.replace(
+      '    | "EMAIL_CONFLICT";',
+      '    | "EMAIL_CONFLICT"\n    | "PLAYING_RESTRICTED";',
+    );
+  }
+
+  const beforeTransaction = "  const normalisedPlayerName = normaliseName(displayName);\n\n  return prisma.$transaction";
+  if (!source.includes("const activePlayingRestriction = await getActivePlayingRestrictionForIdentity")) {
+    if (!source.includes(beforeTransaction)) {
+      throw new Error("Participation player guard transaction anchor not found");
+    }
+    source = source.replace(
+      beforeTransaction,
+      `  const normalisedPlayerName = normaliseName(displayName);\n  const activePlayingRestriction = await getActivePlayingRestrictionForIdentity({\n    email,\n    phone,\n  });\n\n  return prisma.$transaction`,
+    );
+  }
+
+  const guardAnchor = `    const sameTeamNameRows = (await tx.$queryRawUnsafe(`;
+  const guardInsertion = `    if (activePlayingRestriction) {\n      return block(tx, input, {\n        ok: false,\n        code: "PLAYING_RESTRICTED",\n        message: activePlayingRestriction.until\n          ? \`This player is suspended from SIXFL until \${activePlayingRestriction.until.toLocaleDateString("en-GB")}. Ask SIXFL admin to review the restriction.\`\n          : "This player is currently suspended from SIXFL. Ask SIXFL admin to review the restriction.",\n        matchedType: "PLAYING_RESTRICTION",\n        matchedRecordId: activePlayingRestriction.userId,\n      });\n    }\n\n`;
+  source = insertOnce(source, 'matchedType: "PLAYING_RESTRICTION"', guardAnchor, guardInsertion);
+
+  return source;
+});
+
+patchFile("src/app/teams/join/[joinSlug]/actions.ts", (source) => {
+  source = insertOnce(
+    source,
+    'from "@/lib/participation/controls"',
+    'import { prisma } from "@/lib/prisma";\n',
+    'import { getActivePlayingRestrictionForIdentity } from "@/lib/participation/controls";\n',
+  );
+
+  const anchor = `  const existing = await prisma.teamPlayerProspect.findFirst({`;
+  const insertion = `  const activePlayingRestriction = await getActivePlayingRestrictionForIdentity({\n    email,\n    phone,\n  });\n\n  if (activePlayingRestriction) {\n    redirect(\n      buildRedirect(\n        joinSlug,\n        "?error=This%20player%20registration%20requires%20SIXFL%20admin%20review.",\n      ),\n    );\n  }\n\n`;
+  source = insertOnce(source, "player%20registration%20requires%20SIXFL%20admin%20review", anchor, insertion);
+
+  return source;
+});
+
+patchFile("src/app/(admin)/admin/teams/[id]/page.tsx", (source) => {
+  const marker = "Participation controls";
+  const anchor = `          <Link\n            href="/admin/teams"`;
+  const insertion = `          <Link\n            href={\`/admin/participation-controls?q=\${encodeURIComponent(team.name)}\`}\n            className="inline-flex items-center justify-center rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-2.5 text-sm font-medium text-red-100 transition hover:bg-red-500/15"\n          >\n            Participation controls\n          </Link>\n\n`;
+  return insertOnce(source, marker, anchor, insertion);
+});
+
+console.log("Participation control compatibility patches checked.");

--- a/scripts/apply-rules-v2-hardening.cjs
+++ b/scripts/apply-rules-v2-hardening.cjs
@@ -1,8 +1,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
+const { execFileSync } = require("node:child_process");
 
 require("./apply-hidden-tbc-admin-ui.cjs");
 require("./apply-publish-tbc-fee-safety.cjs");
+require("./apply-participation-controls.cjs");
 
 const root = process.cwd();
 
@@ -59,5 +61,10 @@ if (failures.length > 0) {
   for (const [, message] of failures) console.error(`- ${message}`);
   process.exit(1);
 }
+
+execFileSync(process.execPath, [path.join(root, "scripts/check-participation-controls.mjs")], {
+  cwd: root,
+  stdio: "inherit",
+});
 
 console.log("Rules v2 hardening contract passed.");

--- a/scripts/apply-rules-v2-hardening.cjs
+++ b/scripts/apply-rules-v2-hardening.cjs
@@ -3,6 +3,7 @@ const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 
 require("./apply-hidden-tbc-admin-ui.cjs");
+require("./fix-publish-tbc-fee-safety-compat.cjs");
 require("./apply-publish-tbc-fee-safety.cjs");
 require("./apply-participation-controls.cjs");
 

--- a/scripts/check-participation-controls.mjs
+++ b/scripts/check-participation-controls.mjs
@@ -1,10 +1,16 @@
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+
+execFileSync(process.execPath, ["scripts/fix-participation-type-compat.cjs"], {
+  stdio: "inherit",
+});
 
 const checks = [
   ["src/components/admin/AdminSidebar.tsx", "/admin/participation-controls"],
   ["src/app/(public)/claim/page.tsx", "getCaptainClaimRestriction"],
   ["src/lib/requireCaptain.ts", "getCaptainClaimRestriction"],
-  ["src/lib/players/add-player-without-duplicates.ts", "PLAYING_RESTRICTED"],
+  ["src/lib/players/add-player-without-duplicates.ts", 'code: "PLAYING_RESTRICTED"'],
+  ["src/lib/players/add-player-without-duplicates.ts", '| "PLAYING_RESTRICTED";'],
   ["src/app/teams/join/[joinSlug]/actions.ts", "requires%20SIXFL%20admin%20review"],
   ["src/app/(admin)/admin/teams/[id]/page.tsx", "Participation controls"],
   ["src/app/(admin)/admin/participation-controls/page.tsx", "four shared registered players"],

--- a/scripts/check-participation-controls.mjs
+++ b/scripts/check-participation-controls.mjs
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+
+const checks = [
+  ["src/components/admin/AdminSidebar.tsx", "/admin/participation-controls"],
+  ["src/app/(public)/claim/page.tsx", "getCaptainClaimRestriction"],
+  ["src/lib/requireCaptain.ts", "getCaptainClaimRestriction"],
+  ["src/lib/players/add-player-without-duplicates.ts", "PLAYING_RESTRICTED"],
+  ["src/app/teams/join/[joinSlug]/actions.ts", "requires%20SIXFL%20admin%20review"],
+  ["src/app/(admin)/admin/teams/[id]/page.tsx", "Participation controls"],
+  ["src/app/(admin)/admin/participation-controls/page.tsx", "four shared registered players"],
+  ["src/app/(admin)/admin/participation-controls/actions.ts", "BLOCK_TEAM_REGISTRATION"],
+  ["src/lib/participation/controls.ts", "BLOCKED_TEAM_OVERLAP_THRESHOLD"],
+  ["prisma/migrations/20260822153000_participation_reentry_controls/migration.sql", "TeamMember_blocked_team_overlap_guard"],
+  ["prisma/migrations/20260822153100_enforce_participation_restrictions/migration.sql", "FixtureSelection_participation_restriction_guard"],
+];
+
+for (const [file, marker] of checks) {
+  const contents = fs.readFileSync(file, "utf8");
+  if (!contents.includes(marker)) {
+    throw new Error(`Participation control contract missing ${marker} in ${file}`);
+  }
+}
+
+console.log("Participation control contract passed.");

--- a/scripts/fix-participation-type-compat.cjs
+++ b/scripts/fix-participation-type-compat.cjs
@@ -1,0 +1,27 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const file = path.join(process.cwd(), "src/lib/players/add-player-without-duplicates.ts");
+let source = fs.readFileSync(file, "utf8");
+
+if (source.includes('code: "PLAYING_RESTRICTED"') && !source.includes('| "PLAYING_RESTRICTED";')) {
+  const preferred = '    | "SHARED_EMAIL_DIFFERENT_PLAYER";';
+  const fallback = '    | "EMAIL_CONFLICT";';
+
+  if (source.includes(preferred)) {
+    source = source.replace(
+      preferred,
+      '    | "SHARED_EMAIL_DIFFERENT_PLAYER"\n    | "PLAYING_RESTRICTED";',
+    );
+  } else if (source.includes(fallback)) {
+    source = source.replace(
+      fallback,
+      '    | "EMAIL_CONFLICT"\n    | "PLAYING_RESTRICTED";',
+    );
+  } else {
+    throw new Error("Could not extend AddPlayerWithoutDuplicatesResult for PLAYING_RESTRICTED.");
+  }
+
+  fs.writeFileSync(file, source, "utf8");
+  console.log("Extended duplicate-player result type for playing restrictions.");
+}

--- a/scripts/fix-publish-tbc-fee-safety-compat.cjs
+++ b/scripts/fix-publish-tbc-fee-safety-compat.cjs
@@ -21,6 +21,21 @@ function whitespaceFlexiblePattern(value) {
   return new RegExp(parts.join("\\\\s+"));
 }
 
+function replaceFeeDeclarationBlock(source, after, input) {
+  const scopeIndex = source.indexOf(input.scopeMarker);
+  if (scopeIndex < 0) return null;
+
+  const start = source.indexOf(input.startMarker, scopeIndex);
+  if (start < 0) return null;
+
+  const end = source.indexOf(input.endMarker, start);
+  if (end < 0) return null;
+
+  const afterLines = after.split("\\n");
+  const replacement = afterLines.slice(1).join("\\n") + "\\n";
+  return source.slice(0, start) + replacement + source.slice(end);
+}
+
 function replaceRequired(source, before, after, label) {
   if (source.includes(after)) return source;
   if (source.includes(before)) return source.replace(before, () => after);
@@ -32,14 +47,32 @@ function replaceRequired(source, before, after, label) {
   const match = source.match(flexibleBefore);
   if (match) return source.replace(match[0], () => after);
 
+  if (label === "week publish TBC fee resolution") {
+    const patched = replaceFeeDeclarationBlock(source, after, {
+      scopeMarker: "  for (const fixture of unpublishedFixtures) {",
+      startMarker: "    const homeMatchFeePence =",
+      endMarker: "    const chargeResult =",
+    });
+    if (patched) return patched;
+  }
+
+  if (label === "single publish TBC fee resolution") {
+    const patched = replaceFeeDeclarationBlock(source, after, {
+      scopeMarker: "  const { fixture, league } = input;",
+      startMarker: "  const homeMatchFeePence =",
+      endMarker: "  const chargeResult =",
+    });
+    if (patched) return patched;
+  }
+
   throw new Error(\`Expected \${label} source was not found.\`);
 }`;
 
-if (!source.includes("function whitespaceFlexiblePattern")) {
+if (!source.includes("function replaceFeeDeclarationBlock")) {
   if (!source.includes(before)) {
     throw new Error("TBC publish compatibility function anchor not found.");
   }
   source = source.replace(before, () => after);
   fs.writeFileSync(file, source, "utf8");
-  console.log("Made TBC publish safety patch whitespace tolerant.");
+  console.log("Made TBC publish safety patch compatible with evolved fixture-fee source.");
 }

--- a/scripts/fix-publish-tbc-fee-safety-compat.cjs
+++ b/scripts/fix-publish-tbc-fee-safety-compat.cjs
@@ -60,7 +60,7 @@ function replaceRequired(source, before, after, label) {
     const patched = replaceFeeDeclarationBlock(source, after, {
       scopeMarker: "  const { fixture, league } = input;",
       startMarker: "  const homeMatchFeePence =",
-      endMarker: "  const chargeResult =",
+      endMarker: "  const leagueDisplayName =",
     });
     if (patched) return patched;
   }

--- a/scripts/fix-publish-tbc-fee-safety-compat.cjs
+++ b/scripts/fix-publish-tbc-fee-safety-compat.cjs
@@ -23,14 +23,14 @@ function whitespaceFlexiblePattern(value) {
 
 function replaceRequired(source, before, after, label) {
   if (source.includes(after)) return source;
-  if (source.includes(before)) return source.replace(before, after);
+  if (source.includes(before)) return source.replace(before, () => after);
 
   const flexibleAfter = whitespaceFlexiblePattern(after);
   if (flexibleAfter.test(source)) return source;
 
   const flexibleBefore = whitespaceFlexiblePattern(before);
   const match = source.match(flexibleBefore);
-  if (match) return source.replace(match[0], after);
+  if (match) return source.replace(match[0], () => after);
 
   throw new Error(\`Expected \${label} source was not found.\`);
 }`;
@@ -39,7 +39,7 @@ if (!source.includes("function whitespaceFlexiblePattern")) {
   if (!source.includes(before)) {
     throw new Error("TBC publish compatibility function anchor not found.");
   }
-  source = source.replace(before, after);
+  source = source.replace(before, () => after);
   fs.writeFileSync(file, source, "utf8");
   console.log("Made TBC publish safety patch whitespace tolerant.");
 }

--- a/scripts/fix-publish-tbc-fee-safety-compat.cjs
+++ b/scripts/fix-publish-tbc-fee-safety-compat.cjs
@@ -1,0 +1,45 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const file = path.join(process.cwd(), "scripts/apply-publish-tbc-fee-safety.cjs");
+let source = fs.readFileSync(file, "utf8");
+
+const before = `function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(\`Expected \${label} source was not found.\`);
+  }
+  return source.replace(before, after);
+}`;
+
+const after = `function escapeRegExp(value) {
+  return value.replace(/[.*+?^\${}()|[\\]\\\\]/g, "\\\\$&");
+}
+
+function whitespaceFlexiblePattern(value) {
+  const parts = value.trim().split(/\\s+/).map(escapeRegExp);
+  return new RegExp(parts.join("\\\\s+"));
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (source.includes(before)) return source.replace(before, after);
+
+  const flexibleAfter = whitespaceFlexiblePattern(after);
+  if (flexibleAfter.test(source)) return source;
+
+  const flexibleBefore = whitespaceFlexiblePattern(before);
+  const match = source.match(flexibleBefore);
+  if (match) return source.replace(match[0], after);
+
+  throw new Error(\`Expected \${label} source was not found.\`);
+}`;
+
+if (!source.includes("function whitespaceFlexiblePattern")) {
+  if (!source.includes(before)) {
+    throw new Error("TBC publish compatibility function anchor not found.");
+  }
+  source = source.replace(before, after);
+  fs.writeFileSync(file, source, "utf8");
+  console.log("Made TBC publish safety patch whitespace tolerant.");
+}

--- a/src/app/(admin)/admin/participation-controls/actions.ts
+++ b/src/app/(admin)/admin/participation-controls/actions.ts
@@ -1,0 +1,337 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { recordParticipationAudit } from "@/lib/participation/controls";
+
+function text(formData: FormData, key: string) {
+  return String(formData.get(key) ?? "").trim();
+}
+
+function redirectWith(query: string) {
+  redirect(`/admin/participation-controls${query}`);
+}
+
+function parseUntil(value: string) {
+  if (!value) return null;
+  const parsed = new Date(`${value}T23:59:59.999Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+async function getActorUserId() {
+  const { user } = await requireAdmin();
+  return user?.id ?? null;
+}
+
+async function ensureNonAdminUser(userId: string) {
+  const rows = await prisma.$queryRawUnsafe<Array<{ role: string }>>(
+    `SELECT "role"::text AS "role" FROM "User" WHERE "id" = $1 LIMIT 1`,
+    userId,
+  );
+
+  if (!rows[0]) redirectWith("?error=user_not_found");
+  if (rows[0].role === "ADMIN") redirectWith("?error=admin_protected");
+}
+
+export async function blockTeamRegistrationAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const teamId = text(formData, "teamId");
+  const reason = text(formData, "reason");
+  const restrictCaptain = text(formData, "restrictCaptain") === "on";
+
+  if (!teamId || !reason) redirectWith("?error=team_reason_required");
+
+  const teamRows = await prisma.$queryRawUnsafe<
+    Array<{ id: string; name: string; captainUserId: string | null }>
+  >(
+    `
+      SELECT
+        team."id",
+        team."name",
+        COALESCE(
+          team."captainUserId",
+          (
+            SELECT member."userId"
+            FROM "TeamMember" member
+            WHERE member."teamId" = team."id"
+              AND member."role"::text = 'CAPTAIN'
+            ORDER BY member."createdAt" ASC
+            LIMIT 1
+          )
+        ) AS "captainUserId"
+      FROM "Team" team
+      WHERE team."id" = $1
+      LIMIT 1
+    `,
+    teamId,
+  );
+
+  const team = teamRows[0];
+  if (!team) redirectWith("?error=team_not_found");
+
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(
+      `
+        UPDATE "Team"
+        SET
+          "registrationBlocked" = true,
+          "registrationBlockedAt" = NOW(),
+          "registrationBlockedReason" = $2,
+          "registrationReviewRequired" = false,
+          "registrationReviewReason" = NULL,
+          "registrationReviewSourceTeamId" = NULL,
+          "registrationReviewApprovedAt" = NULL,
+          "isRecruiting" = false
+        WHERE "id" = $1
+      `,
+      teamId,
+      reason,
+    );
+
+    if (restrictCaptain && team.captainUserId) {
+      const protectedRows = await tx.$queryRawUnsafe<Array<{ role: string }>>(
+        `SELECT "role"::text AS "role" FROM "User" WHERE "id" = $1 LIMIT 1`,
+        team.captainUserId,
+      );
+
+      if (protectedRows[0]?.role !== "ADMIN") {
+        await tx.$executeRawUnsafe(
+          `
+            UPDATE "User"
+            SET
+              "teamManagementRestricted" = true,
+              "teamManagementRestrictedAt" = NOW(),
+              "teamManagementRestrictionReason" = $2
+            WHERE "id" = $1
+          `,
+          team.captainUserId,
+          `Linked to blocked team ${team.name}. ${reason}`,
+        );
+      }
+    }
+  });
+
+  await recordParticipationAudit({
+    subjectType: "TEAM",
+    subjectId: teamId,
+    action: "BLOCK_TEAM_REGISTRATION",
+    reason,
+    createdByUserId: actorUserId,
+  });
+
+  if (restrictCaptain && team.captainUserId) {
+    await recordParticipationAudit({
+      subjectType: "USER",
+      subjectId: team.captainUserId,
+      action: "RESTRICT_TEAM_MANAGEMENT_FROM_BLOCKED_TEAM",
+      reason: `Linked to blocked team ${team.name}. ${reason}`,
+      createdByUserId: actorUserId,
+    });
+  }
+
+  revalidatePath("/admin/participation-controls");
+  revalidatePath(`/admin/teams/${teamId}`);
+  revalidatePath("/admin/teams");
+  redirectWith("?saved=team_blocked");
+}
+
+export async function clearTeamRegistrationBlockAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const teamId = text(formData, "teamId");
+  const reason = text(formData, "reason") || "Block cleared by SIXFL admin.";
+
+  if (!teamId) redirectWith("?error=team_not_found");
+
+  await prisma.$executeRawUnsafe(
+    `
+      UPDATE "Team"
+      SET
+        "registrationBlocked" = false,
+        "registrationBlockedAt" = NULL,
+        "registrationBlockedReason" = NULL
+      WHERE "id" = $1
+    `,
+    teamId,
+  );
+
+  await recordParticipationAudit({
+    subjectType: "TEAM",
+    subjectId: teamId,
+    action: "CLEAR_TEAM_REGISTRATION_BLOCK",
+    reason,
+    createdByUserId: actorUserId,
+  });
+
+  revalidatePath("/admin/participation-controls");
+  revalidatePath(`/admin/teams/${teamId}`);
+  redirectWith("?saved=team_cleared");
+}
+
+export async function approveTeamRegistrationReviewAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const teamId = text(formData, "teamId");
+  const reason = text(formData, "reason") || "Registration overlap reviewed and approved by SIXFL admin.";
+
+  if (!teamId) redirectWith("?error=team_not_found");
+
+  await prisma.$executeRawUnsafe(
+    `
+      UPDATE "Team"
+      SET
+        "registrationReviewRequired" = false,
+        "registrationReviewApprovedAt" = NOW(),
+        "registrationReviewReason" = NULL,
+        "registrationReviewSourceTeamId" = NULL
+      WHERE "id" = $1
+    `,
+    teamId,
+  );
+
+  await recordParticipationAudit({
+    subjectType: "TEAM",
+    subjectId: teamId,
+    action: "APPROVE_REFORMED_TEAM_REVIEW",
+    reason,
+    createdByUserId: actorUserId,
+  });
+
+  revalidatePath("/admin/participation-controls");
+  revalidatePath(`/admin/teams/${teamId}`);
+  redirectWith("?saved=review_approved");
+}
+
+export async function restrictTeamManagementAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const userId = text(formData, "userId");
+  const reason = text(formData, "reason");
+
+  if (!userId || !reason) redirectWith("?error=user_reason_required");
+  await ensureNonAdminUser(userId);
+
+  await prisma.$executeRawUnsafe(
+    `
+      UPDATE "User"
+      SET
+        "teamManagementRestricted" = true,
+        "teamManagementRestrictedAt" = NOW(),
+        "teamManagementRestrictionReason" = $2
+      WHERE "id" = $1
+    `,
+    userId,
+    reason,
+  );
+
+  await recordParticipationAudit({
+    subjectType: "USER",
+    subjectId: userId,
+    action: "RESTRICT_TEAM_MANAGEMENT",
+    reason,
+    createdByUserId: actorUserId,
+  });
+
+  revalidatePath("/admin/participation-controls");
+  redirectWith("?saved=management_restricted");
+}
+
+export async function clearTeamManagementRestrictionAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const userId = text(formData, "userId");
+  const reason = text(formData, "reason") || "Team-management restriction cleared by SIXFL admin.";
+
+  if (!userId) redirectWith("?error=user_not_found");
+
+  await prisma.$executeRawUnsafe(
+    `
+      UPDATE "User"
+      SET
+        "teamManagementRestricted" = false,
+        "teamManagementRestrictedAt" = NULL,
+        "teamManagementRestrictionReason" = NULL
+      WHERE "id" = $1
+    `,
+    userId,
+  );
+
+  await recordParticipationAudit({
+    subjectType: "USER",
+    subjectId: userId,
+    action: "CLEAR_TEAM_MANAGEMENT_RESTRICTION",
+    reason,
+    createdByUserId: actorUserId,
+  });
+
+  revalidatePath("/admin/participation-controls");
+  redirectWith("?saved=management_cleared");
+}
+
+export async function suspendPlayerAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const userId = text(formData, "userId");
+  const reason = text(formData, "reason");
+  const until = parseUntil(text(formData, "until"));
+
+  if (!userId || !reason) redirectWith("?error=user_reason_required");
+  await ensureNonAdminUser(userId);
+
+  await prisma.$executeRawUnsafe(
+    `
+      UPDATE "User"
+      SET
+        "playingRestricted" = true,
+        "playingRestrictedAt" = NOW(),
+        "playingRestrictedUntil" = $2,
+        "playingRestrictionReason" = $3
+      WHERE "id" = $1
+    `,
+    userId,
+    until,
+    reason,
+  );
+
+  await recordParticipationAudit({
+    subjectType: "USER",
+    subjectId: userId,
+    action: "SUSPEND_PLAYER",
+    reason,
+    until,
+    createdByUserId: actorUserId,
+  });
+
+  revalidatePath("/admin/participation-controls");
+  redirectWith("?saved=player_suspended");
+}
+
+export async function clearPlayerSuspensionAction(formData: FormData) {
+  const actorUserId = await getActorUserId();
+  const userId = text(formData, "userId");
+  const reason = text(formData, "reason") || "Player suspension cleared by SIXFL admin.";
+
+  if (!userId) redirectWith("?error=user_not_found");
+
+  await prisma.$executeRawUnsafe(
+    `
+      UPDATE "User"
+      SET
+        "playingRestricted" = false,
+        "playingRestrictedAt" = NULL,
+        "playingRestrictedUntil" = NULL,
+        "playingRestrictionReason" = NULL
+      WHERE "id" = $1
+    `,
+    userId,
+  );
+
+  await recordParticipationAudit({
+    subjectType: "USER",
+    subjectId: userId,
+    action: "CLEAR_PLAYER_SUSPENSION",
+    reason,
+    createdByUserId: actorUserId,
+  });
+
+  revalidatePath("/admin/participation-controls");
+  redirectWith("?saved=player_cleared");
+}

--- a/src/app/(admin)/admin/participation-controls/page.tsx
+++ b/src/app/(admin)/admin/participation-controls/page.tsx
@@ -1,0 +1,503 @@
+import Link from "next/link";
+
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import {
+  approveTeamRegistrationReviewAction,
+  blockTeamRegistrationAction,
+  clearPlayerSuspensionAction,
+  clearTeamManagementRestrictionAction,
+  clearTeamRegistrationBlockAction,
+  restrictTeamManagementAction,
+  suspendPlayerAction,
+} from "./actions";
+
+type TeamControlRow = {
+  id: string;
+  name: string;
+  contactName: string | null;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  registrationBlocked: boolean;
+  registrationBlockedAt: Date | null;
+  registrationBlockedReason: string | null;
+  registrationReviewRequired: boolean;
+  registrationReviewReason: string | null;
+  registrationReviewSourceTeamId: string | null;
+  registrationReviewApprovedAt: Date | null;
+  sourceTeamName: string | null;
+  captainUserId: string | null;
+  captainName: string | null;
+  captainEmail: string | null;
+  memberCount: number;
+};
+
+type UserControlRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string;
+  teamManagementRestricted: boolean;
+  teamManagementRestrictedAt: Date | null;
+  teamManagementRestrictionReason: string | null;
+  playingRestricted: boolean;
+  playingRestrictedAt: Date | null;
+  playingRestrictedUntil: Date | null;
+  playingRestrictionReason: string | null;
+  teams: string | null;
+};
+
+type AuditRow = {
+  id: string;
+  subjectType: string;
+  subjectId: string;
+  action: string;
+  reason: string | null;
+  until: Date | null;
+  createdAt: Date;
+  subjectName: string | null;
+};
+
+function fmt(value: Date | null) {
+  if (!value) return "—";
+  return formatDateTimeInLondon(value, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function messageFor(saved?: string, error?: string) {
+  if (error === "team_reason_required") return "Add a reason before blocking the team.";
+  if (error === "user_reason_required") return "Add a reason before restricting this person.";
+  if (error === "team_not_found") return "Team not found.";
+  if (error === "user_not_found") return "User not found.";
+  if (error === "admin_protected") return "Admin accounts cannot be restricted from this screen.";
+  if (saved === "team_blocked") return "Team registration blocked.";
+  if (saved === "team_cleared") return "Team registration block cleared.";
+  if (saved === "review_approved") return "Team review approved.";
+  if (saved === "management_restricted") return "Team-management restriction applied.";
+  if (saved === "management_cleared") return "Team-management restriction cleared.";
+  if (saved === "player_suspended") return "Player suspension applied.";
+  if (saved === "player_cleared") return "Player suspension cleared.";
+  return null;
+}
+
+export default async function ParticipationControlsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ q?: string; saved?: string; error?: string }>;
+}) {
+  await requireAdmin();
+  const sp = (await searchParams) ?? {};
+  const q = (sp.q ?? "").trim();
+  const like = `%${q}%`;
+
+  const [activeTeams, activeUsers, audit, teamSearch, userSearch] = await Promise.all([
+    prisma.$queryRawUnsafe<TeamControlRow[]>(`
+      SELECT
+        team."id",
+        team."name",
+        team."contactName",
+        team."contactEmail",
+        team."contactPhone",
+        COALESCE(team."registrationBlocked", false) AS "registrationBlocked",
+        team."registrationBlockedAt",
+        team."registrationBlockedReason",
+        COALESCE(team."registrationReviewRequired", false) AS "registrationReviewRequired",
+        team."registrationReviewReason",
+        team."registrationReviewSourceTeamId",
+        team."registrationReviewApprovedAt",
+        source_team."name" AS "sourceTeamName",
+        COALESCE(
+          team."captainUserId",
+          (
+            SELECT member."userId"
+            FROM "TeamMember" member
+            WHERE member."teamId" = team."id"
+              AND member."role"::text = 'CAPTAIN'
+            ORDER BY member."createdAt" ASC
+            LIMIT 1
+          )
+        ) AS "captainUserId",
+        captain_user."name" AS "captainName",
+        captain_user."email" AS "captainEmail",
+        (SELECT COUNT(*)::int FROM "TeamMember" member_count WHERE member_count."teamId" = team."id") AS "memberCount"
+      FROM "Team" team
+      LEFT JOIN "Team" source_team ON source_team."id" = team."registrationReviewSourceTeamId"
+      LEFT JOIN "User" captain_user ON captain_user."id" = COALESCE(
+        team."captainUserId",
+        (
+          SELECT member."userId"
+          FROM "TeamMember" member
+          WHERE member."teamId" = team."id"
+            AND member."role"::text = 'CAPTAIN'
+          ORDER BY member."createdAt" ASC
+          LIMIT 1
+        )
+      )
+      WHERE COALESCE(team."registrationBlocked", false) = true
+         OR COALESCE(team."registrationReviewRequired", false) = true
+      ORDER BY team."registrationReviewRequired" DESC, team."registrationBlockedAt" DESC NULLS LAST, team."name" ASC
+    `),
+    prisma.$queryRawUnsafe<UserControlRow[]>(`
+      SELECT
+        player_user."id",
+        player_user."name",
+        player_user."email",
+        player_user."role"::text AS "role",
+        COALESCE(player_user."teamManagementRestricted", false) AS "teamManagementRestricted",
+        player_user."teamManagementRestrictedAt",
+        player_user."teamManagementRestrictionReason",
+        COALESCE(player_user."playingRestricted", false) AS "playingRestricted",
+        player_user."playingRestrictedAt",
+        player_user."playingRestrictedUntil",
+        player_user."playingRestrictionReason",
+        STRING_AGG(DISTINCT team."name", ', ' ORDER BY team."name") AS "teams"
+      FROM "User" player_user
+      LEFT JOIN "TeamMember" member ON member."userId" = player_user."id"
+      LEFT JOIN "Team" team ON team."id" = member."teamId"
+      WHERE COALESCE(player_user."teamManagementRestricted", false) = true
+         OR (
+           COALESCE(player_user."playingRestricted", false) = true
+           AND (player_user."playingRestrictedUntil" IS NULL OR player_user."playingRestrictedUntil" > NOW())
+         )
+      GROUP BY player_user."id"
+      ORDER BY player_user."name" ASC NULLS LAST, player_user."email" ASC NULLS LAST
+    `),
+    prisma.$queryRawUnsafe<AuditRow[]>(`
+      SELECT
+        audit."id",
+        audit."subjectType",
+        audit."subjectId",
+        audit."action",
+        audit."reason",
+        audit."until",
+        audit."createdAt",
+        CASE
+          WHEN audit."subjectType" = 'TEAM' THEN (SELECT team."name" FROM "Team" team WHERE team."id" = audit."subjectId")
+          WHEN audit."subjectType" = 'USER' THEN (SELECT COALESCE(player_user."name", player_user."email") FROM "User" player_user WHERE player_user."id" = audit."subjectId")
+          ELSE NULL
+        END AS "subjectName"
+      FROM "ParticipationRestrictionAudit" audit
+      ORDER BY audit."createdAt" DESC
+      LIMIT 100
+    `),
+    q.length >= 2
+      ? prisma.$queryRawUnsafe<TeamControlRow[]>(
+          `
+            SELECT
+              team."id",
+              team."name",
+              team."contactName",
+              team."contactEmail",
+              team."contactPhone",
+              COALESCE(team."registrationBlocked", false) AS "registrationBlocked",
+              team."registrationBlockedAt",
+              team."registrationBlockedReason",
+              COALESCE(team."registrationReviewRequired", false) AS "registrationReviewRequired",
+              team."registrationReviewReason",
+              team."registrationReviewSourceTeamId",
+              team."registrationReviewApprovedAt",
+              source_team."name" AS "sourceTeamName",
+              COALESCE(team."captainUserId", captain_member."userId") AS "captainUserId",
+              captain_user."name" AS "captainName",
+              captain_user."email" AS "captainEmail",
+              (SELECT COUNT(*)::int FROM "TeamMember" member_count WHERE member_count."teamId" = team."id") AS "memberCount"
+            FROM "Team" team
+            LEFT JOIN "Team" source_team ON source_team."id" = team."registrationReviewSourceTeamId"
+            LEFT JOIN LATERAL (
+              SELECT member."userId"
+              FROM "TeamMember" member
+              WHERE member."teamId" = team."id"
+                AND member."role"::text = 'CAPTAIN'
+              ORDER BY member."createdAt" ASC
+              LIMIT 1
+            ) captain_member ON true
+            LEFT JOIN "User" captain_user ON captain_user."id" = COALESCE(team."captainUserId", captain_member."userId")
+            WHERE team."name" ILIKE $1
+               OR COALESCE(team."contactName", '') ILIKE $1
+               OR COALESCE(team."contactEmail", '') ILIKE $1
+               OR COALESCE(team."contactPhone", '') ILIKE $1
+            ORDER BY team."name" ASC
+            LIMIT 30
+          `,
+          like,
+        )
+      : Promise.resolve([] as TeamControlRow[]),
+    q.length >= 2
+      ? prisma.$queryRawUnsafe<UserControlRow[]>(
+          `
+            SELECT
+              player_user."id",
+              player_user."name",
+              player_user."email",
+              player_user."role"::text AS "role",
+              COALESCE(player_user."teamManagementRestricted", false) AS "teamManagementRestricted",
+              player_user."teamManagementRestrictedAt",
+              player_user."teamManagementRestrictionReason",
+              COALESCE(player_user."playingRestricted", false) AS "playingRestricted",
+              player_user."playingRestrictedAt",
+              player_user."playingRestrictedUntil",
+              player_user."playingRestrictionReason",
+              STRING_AGG(DISTINCT team."name", ', ' ORDER BY team."name") AS "teams"
+            FROM "User" player_user
+            LEFT JOIN "TeamMember" member ON member."userId" = player_user."id"
+            LEFT JOIN "Team" team ON team."id" = member."teamId"
+            WHERE COALESCE(player_user."name", '') ILIKE $1
+               OR COALESCE(player_user."email", '') ILIKE $1
+            GROUP BY player_user."id"
+            ORDER BY player_user."name" ASC NULLS LAST, player_user."email" ASC NULLS LAST
+            LIMIT 40
+          `,
+          like,
+        )
+      : Promise.resolve([] as UserControlRow[]),
+  ]);
+
+  const notice = messageFor(sp.saved, sp.error);
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div className="space-y-2">
+        <Link href="/admin" className="text-sm text-emerald-300 hover:text-emerald-200">
+          ← Back to admin
+        </Link>
+        <h1 className="text-3xl font-semibold text-white">Participation controls</h1>
+        <p className="max-w-4xl text-sm leading-6 text-white/60">
+          Block removed teams from simply returning under another name, restrict a captain or organiser from creating or managing teams, and suspend an individual player without automatically penalising the rest of their squad.
+        </p>
+      </div>
+
+      {notice ? (
+        <div className={`rounded-2xl border p-4 text-sm ${sp.error ? "border-red-400/25 bg-red-500/10 text-red-100" : "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"}`}>
+          {notice}
+        </div>
+      ) : null}
+
+      <section className="rounded-2xl border border-amber-400/20 bg-amber-500/[0.06] p-5">
+        <h2 className="text-lg font-semibold text-amber-100">How the safeguard works</h2>
+        <p className="mt-2 text-sm leading-6 text-white/65">
+          Blocking a team does not automatically ban every player. A captain can be restricted separately, and individual players can be suspended separately. If a new team reuses blocked-team contact details, or reaches four shared registered players with a blocked team, it is automatically held for admin review. Admin can approve a legitimate re-formation.
+        </p>
+      </section>
+
+      <section className="rounded-2xl border border-white/10 bg-black/30 p-5">
+        <h2 className="text-lg font-semibold text-white">Find a team or person</h2>
+        <form className="mt-4 flex flex-col gap-3 sm:flex-row" action="/admin/participation-controls" method="get">
+          <input
+            name="q"
+            defaultValue={q}
+            placeholder="Team name, captain, email or phone"
+            className="min-w-0 flex-1 rounded-xl border border-white/10 bg-black/40 px-4 py-2.5 text-white outline-none placeholder:text-white/30 focus:border-emerald-400/50"
+          />
+          <button className="rounded-xl bg-emerald-500 px-4 py-2.5 font-medium text-black hover:bg-emerald-400">
+            Search
+          </button>
+        </form>
+      </section>
+
+      {q.length >= 2 ? (
+        <div className="grid gap-6 xl:grid-cols-2">
+          <section className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-5">
+            <h2 className="text-lg font-semibold text-white">Team results</h2>
+            {teamSearch.length === 0 ? <p className="text-sm text-white/50">No matching teams.</p> : null}
+            {teamSearch.map((team) => (
+              <div key={team.id} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <Link href={`/admin/teams/${team.id}`} className="font-semibold text-white hover:text-emerald-200">{team.name}</Link>
+                    <div className="mt-1 text-xs text-white/50">
+                      Captain: {team.captainName || team.contactName || "—"} · {team.captainEmail || team.contactEmail || "no email"} · {team.memberCount} registered
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    {team.registrationBlocked ? <span className="rounded-full bg-red-500/15 px-2 py-1 text-red-200">Blocked</span> : null}
+                    {team.registrationReviewRequired ? <span className="rounded-full bg-amber-500/15 px-2 py-1 text-amber-200">Review required</span> : null}
+                  </div>
+                </div>
+
+                {!team.registrationBlocked ? (
+                  <form action={blockTeamRegistrationAction} className="mt-4 space-y-3">
+                    <input type="hidden" name="teamId" value={team.id} />
+                    <textarea name="reason" required placeholder="Reason for blocking this team" className="min-h-20 w-full rounded-xl border border-white/10 bg-black/40 p-3 text-sm text-white outline-none placeholder:text-white/30" />
+                    <label className="flex items-center gap-2 text-sm text-white/70">
+                      <input type="checkbox" name="restrictCaptain" defaultChecked className="h-4 w-4" />
+                      Also restrict the current captain/organiser from creating or managing another team
+                    </label>
+                    <button className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-2 text-sm font-medium text-red-100 hover:bg-red-500/15">Block team registration</button>
+                  </form>
+                ) : (
+                  <form action={clearTeamRegistrationBlockAction} className="mt-4 flex flex-wrap gap-2">
+                    <input type="hidden" name="teamId" value={team.id} />
+                    <button className="rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-sm text-white hover:bg-white/10">Clear team block</button>
+                  </form>
+                )}
+
+                {team.registrationReviewRequired ? (
+                  <div className="mt-4 rounded-xl border border-amber-400/20 bg-amber-500/[0.06] p-3 text-sm text-amber-50">
+                    <div>{team.registrationReviewReason}</div>
+                    {team.sourceTeamName ? <div className="mt-1 text-xs text-amber-100/60">Matched blocked team: {team.sourceTeamName}</div> : null}
+                    <form action={approveTeamRegistrationReviewAction} className="mt-3">
+                      <input type="hidden" name="teamId" value={team.id} />
+                      <button className="rounded-xl bg-amber-300 px-3 py-2 text-sm font-medium text-black hover:bg-amber-200">Approve this re-formation</button>
+                    </form>
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </section>
+
+          <section className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-5">
+            <h2 className="text-lg font-semibold text-white">People results</h2>
+            {userSearch.length === 0 ? <p className="text-sm text-white/50">No matching people.</p> : null}
+            {userSearch.map((user) => {
+              const activePlayingRestriction = user.playingRestricted && (!user.playingRestrictedUntil || user.playingRestrictedUntil.getTime() > Date.now());
+              return (
+                <div key={user.id} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+                  <div className="font-semibold text-white">{user.name || user.email || "Unnamed account"}</div>
+                  <div className="mt-1 text-xs text-white/50">{user.email || "No email"}{user.teams ? ` · ${user.teams}` : ""}</div>
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                    {user.teamManagementRestricted ? <span className="rounded-full bg-red-500/15 px-2 py-1 text-red-200">Cannot manage teams</span> : null}
+                    {activePlayingRestriction ? <span className="rounded-full bg-amber-500/15 px-2 py-1 text-amber-200">Player suspended</span> : null}
+                  </div>
+
+                  <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                    {user.teamManagementRestricted ? (
+                      <form action={clearTeamManagementRestrictionAction}>
+                        <input type="hidden" name="userId" value={user.id} />
+                        <button className="rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-sm text-white hover:bg-white/10">Allow team management</button>
+                      </form>
+                    ) : (
+                      <form action={restrictTeamManagementAction} className="space-y-2">
+                        <input type="hidden" name="userId" value={user.id} />
+                        <textarea name="reason" required placeholder="Why can’t this person manage a team?" className="min-h-20 w-full rounded-xl border border-white/10 bg-black/40 p-3 text-sm text-white outline-none placeholder:text-white/30" />
+                        <button className="rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100 hover:bg-red-500/15">Restrict team management</button>
+                      </form>
+                    )}
+
+                    {activePlayingRestriction ? (
+                      <form action={clearPlayerSuspensionAction}>
+                        <input type="hidden" name="userId" value={user.id} />
+                        <button className="rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-sm text-white hover:bg-white/10">Clear player suspension</button>
+                      </form>
+                    ) : (
+                      <form action={suspendPlayerAction} className="space-y-2">
+                        <input type="hidden" name="userId" value={user.id} />
+                        <textarea name="reason" required placeholder="Reason for player suspension" className="min-h-20 w-full rounded-xl border border-white/10 bg-black/40 p-3 text-sm text-white outline-none placeholder:text-white/30" />
+                        <label className="block text-xs text-white/55">End date (leave blank for indefinite)</label>
+                        <input type="date" name="until" className="w-full rounded-xl border border-white/10 bg-black/40 px-3 py-2 text-sm text-white" />
+                        <button className="rounded-xl border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-100 hover:bg-amber-500/15">Suspend player</button>
+                      </form>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <section className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-5">
+          <h2 className="text-lg font-semibold text-white">Teams blocked or awaiting review</h2>
+          {activeTeams.length === 0 ? <p className="text-sm text-white/50">No active team blocks or reviews.</p> : null}
+          {activeTeams.map((team) => (
+            <div key={team.id} className="rounded-xl border border-white/10 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <Link href={`/admin/teams/${team.id}`} className="font-semibold text-white hover:text-emerald-200">{team.name}</Link>
+                  <div className="mt-1 text-xs text-white/45">{team.memberCount} registered players · captain {team.captainName || team.contactName || "—"}</div>
+                </div>
+                <div className="flex gap-2 text-xs">
+                  {team.registrationBlocked ? <span className="rounded-full bg-red-500/15 px-2 py-1 text-red-200">Blocked</span> : null}
+                  {team.registrationReviewRequired ? <span className="rounded-full bg-amber-500/15 px-2 py-1 text-amber-200">Review</span> : null}
+                </div>
+              </div>
+              {team.registrationBlockedReason ? <p className="mt-3 text-sm text-white/65">{team.registrationBlockedReason}</p> : null}
+              {team.registrationReviewReason ? <p className="mt-3 text-sm text-amber-100/80">{team.registrationReviewReason}</p> : null}
+              {team.registrationBlockedAt ? <div className="mt-2 text-xs text-white/40">Blocked {fmt(team.registrationBlockedAt)}</div> : null}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {team.registrationBlocked ? (
+                  <form action={clearTeamRegistrationBlockAction}>
+                    <input type="hidden" name="teamId" value={team.id} />
+                    <button className="rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-sm text-white hover:bg-white/10">Clear block</button>
+                  </form>
+                ) : null}
+                {team.registrationReviewRequired ? (
+                  <form action={approveTeamRegistrationReviewAction}>
+                    <input type="hidden" name="teamId" value={team.id} />
+                    <button className="rounded-xl bg-amber-300 px-3 py-2 text-sm font-medium text-black hover:bg-amber-200">Approve review</button>
+                  </form>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="space-y-3 rounded-2xl border border-white/10 bg-black/30 p-5">
+          <h2 className="text-lg font-semibold text-white">Restricted people</h2>
+          {activeUsers.length === 0 ? <p className="text-sm text-white/50">No active individual restrictions.</p> : null}
+          {activeUsers.map((user) => (
+            <div key={user.id} className="rounded-xl border border-white/10 p-4">
+              <div className="font-semibold text-white">{user.name || user.email || "Unnamed account"}</div>
+              <div className="mt-1 text-xs text-white/45">{user.email || "No email"}{user.teams ? ` · ${user.teams}` : ""}</div>
+              {user.teamManagementRestricted ? (
+                <div className="mt-3 rounded-xl bg-red-500/[0.08] p-3 text-sm text-red-100">
+                  <div className="font-medium">Cannot create/manage teams</div>
+                  <div className="mt-1 text-red-100/70">{user.teamManagementRestrictionReason || "No reason recorded"}</div>
+                  <form action={clearTeamManagementRestrictionAction} className="mt-2">
+                    <input type="hidden" name="userId" value={user.id} />
+                    <button className="rounded-lg border border-red-200/20 px-2.5 py-1.5 text-xs hover:bg-white/5">Clear management restriction</button>
+                  </form>
+                </div>
+              ) : null}
+              {user.playingRestricted && (!user.playingRestrictedUntil || user.playingRestrictedUntil.getTime() > Date.now()) ? (
+                <div className="mt-3 rounded-xl bg-amber-500/[0.08] p-3 text-sm text-amber-100">
+                  <div className="font-medium">Player suspended {user.playingRestrictedUntil ? `until ${fmt(user.playingRestrictedUntil)}` : "indefinitely"}</div>
+                  <div className="mt-1 text-amber-100/70">{user.playingRestrictionReason || "No reason recorded"}</div>
+                  <form action={clearPlayerSuspensionAction} className="mt-2">
+                    <input type="hidden" name="userId" value={user.id} />
+                    <button className="rounded-lg border border-amber-200/20 px-2.5 py-1.5 text-xs hover:bg-white/5">Clear player suspension</button>
+                  </form>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </section>
+      </div>
+
+      <section className="rounded-2xl border border-white/10 bg-black/30 p-5">
+        <h2 className="text-lg font-semibold text-white">Restriction audit trail</h2>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[760px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-white/40">
+              <tr>
+                <th className="pb-3 pr-4">When</th>
+                <th className="pb-3 pr-4">Subject</th>
+                <th className="pb-3 pr-4">Action</th>
+                <th className="pb-3 pr-4">Reason</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/8">
+              {audit.map((row) => (
+                <tr key={row.id}>
+                  <td className="py-3 pr-4 text-white/50">{fmt(row.createdAt)}</td>
+                  <td className="py-3 pr-4 text-white">{row.subjectName || row.subjectId}</td>
+                  <td className="py-3 pr-4 text-white/70">{row.action.replaceAll("_", " ")}</td>
+                  <td className="py-3 pr-4 text-white/60">{row.reason || "—"}{row.until ? ` · until ${fmt(row.until)}` : ""}</td>
+                </tr>
+              ))}
+              {audit.length === 0 ? (
+                <tr><td colSpan={4} className="py-4 text-white/40">No restriction actions recorded yet.</td></tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/participation/controls.ts
+++ b/src/lib/participation/controls.ts
@@ -1,0 +1,216 @@
+import { prisma } from "@/lib/prisma";
+
+export const BLOCKED_TEAM_OVERLAP_THRESHOLD = 4;
+
+type TeamGuardRow = {
+  registrationBlocked: boolean;
+  registrationBlockedReason: string | null;
+  registrationReviewRequired: boolean;
+  registrationReviewReason: string | null;
+};
+
+type UserRestrictionRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  teamManagementRestricted: boolean;
+  teamManagementRestrictionReason: string | null;
+  playingRestricted: boolean;
+  playingRestrictedUntil: Date | null;
+  playingRestrictionReason: string | null;
+};
+
+export type ParticipationIdentityRestriction = {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  reason: string | null;
+  until: Date | null;
+};
+
+function cleanEmail(value: string | null | undefined) {
+  return value?.trim().toLowerCase() || null;
+}
+
+function cleanPhoneDigits(value: string | null | undefined) {
+  const digits = value?.replace(/[^0-9]/g, "") || "";
+  if (!digits) return null;
+  if (digits.startsWith("0")) return `44${digits.slice(1)}`;
+  if (digits.startsWith("44")) return digits;
+  return `44${digits}`;
+}
+
+export async function getTeamRegistrationGuard(teamId: string) {
+  const rows = await prisma.$queryRawUnsafe<TeamGuardRow[]>(
+    `
+      SELECT
+        COALESCE("registrationBlocked", false) AS "registrationBlocked",
+        "registrationBlockedReason",
+        COALESCE("registrationReviewRequired", false) AS "registrationReviewRequired",
+        "registrationReviewReason"
+      FROM "Team"
+      WHERE "id" = $1
+      LIMIT 1
+    `,
+    teamId,
+  );
+
+  return rows[0] ?? null;
+}
+
+export async function getUserParticipationRestriction(userId: string) {
+  const rows = await prisma.$queryRawUnsafe<UserRestrictionRow[]>(
+    `
+      SELECT
+        "id",
+        "name",
+        "email",
+        COALESCE("teamManagementRestricted", false) AS "teamManagementRestricted",
+        "teamManagementRestrictionReason",
+        COALESCE("playingRestricted", false) AS "playingRestricted",
+        "playingRestrictedUntil",
+        "playingRestrictionReason"
+      FROM "User"
+      WHERE "id" = $1
+      LIMIT 1
+    `,
+    userId,
+  );
+
+  const row = rows[0] ?? null;
+  if (!row) return null;
+
+  const playingRestrictionActive =
+    row.playingRestricted &&
+    (!row.playingRestrictedUntil || row.playingRestrictedUntil.getTime() > Date.now());
+
+  return {
+    ...row,
+    playingRestrictionActive,
+  };
+}
+
+export async function getActivePlayingRestrictionForIdentity(input: {
+  email?: string | null;
+  phone?: string | null;
+}): Promise<ParticipationIdentityRestriction | null> {
+  const email = cleanEmail(input.email);
+  const phoneDigits = cleanPhoneDigits(input.phone);
+
+  if (!email && !phoneDigits) return null;
+
+  const rows = await prisma.$queryRawUnsafe<ParticipationIdentityRestriction[]>(
+    `
+      SELECT DISTINCT
+        player_user."id" AS "userId",
+        player_user."name" AS "name",
+        player_user."email" AS "email",
+        player_user."playingRestrictionReason" AS "reason",
+        player_user."playingRestrictedUntil" AS "until"
+      FROM "User" player_user
+      LEFT JOIN "TeamMember" member ON member."userId" = player_user."id"
+      LEFT JOIN "TeamMemberProfile" profile ON profile."teamMemberId" = member."id"
+      WHERE COALESCE(player_user."playingRestricted", false) = true
+        AND (
+          player_user."playingRestrictedUntil" IS NULL
+          OR player_user."playingRestrictedUntil" > NOW()
+        )
+        AND (
+          ($1::text IS NOT NULL AND LOWER(BTRIM(COALESCE(player_user."email", ''))) = $1)
+          OR
+          ($2::text IS NOT NULL AND (
+            CASE
+              WHEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') LIKE '0%'
+                THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') FROM 2)
+              WHEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') LIKE '44%'
+                THEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g')
+              ELSE CASE
+                WHEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') = '' THEN NULL
+                ELSE '44' || REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g')
+              END
+            END
+          ) = $2)
+        )
+      LIMIT 1
+    `,
+    email,
+    phoneDigits,
+  );
+
+  return rows[0] ?? null;
+}
+
+export async function getCaptainClaimRestriction(input: {
+  teamId: string;
+  userId: string;
+}) {
+  const [teamGuard, userRestriction] = await Promise.all([
+    getTeamRegistrationGuard(input.teamId),
+    getUserParticipationRestriction(input.userId),
+  ]);
+
+  if (teamGuard?.registrationBlocked) {
+    return {
+      blocked: true as const,
+      code: "team_blocked" as const,
+      reason: teamGuard.registrationBlockedReason,
+    };
+  }
+
+  if (teamGuard?.registrationReviewRequired) {
+    return {
+      blocked: true as const,
+      code: "team_review" as const,
+      reason: teamGuard.registrationReviewReason,
+    };
+  }
+
+  if (userRestriction?.teamManagementRestricted) {
+    return {
+      blocked: true as const,
+      code: "management_restricted" as const,
+      reason: userRestriction.teamManagementRestrictionReason,
+    };
+  }
+
+  return { blocked: false as const };
+}
+
+export async function recordParticipationAudit(input: {
+  subjectType: "TEAM" | "USER";
+  subjectId: string;
+  action: string;
+  reason?: string | null;
+  until?: Date | null;
+  createdByUserId?: string | null;
+}) {
+  await prisma.$executeRawUnsafe(
+    `
+      INSERT INTO "ParticipationRestrictionAudit" (
+        "id",
+        "subjectType",
+        "subjectId",
+        "action",
+        "reason",
+        "until",
+        "createdByUserId",
+        "createdAt"
+      ) VALUES (
+        gen_random_uuid()::text,
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        NOW()
+      )
+    `,
+    input.subjectType,
+    input.subjectId,
+    input.action,
+    input.reason ?? null,
+    input.until ?? null,
+    input.createdByUserId ?? null,
+  );
+}


### PR DESCRIPTION
Adds a participation-control layer so a removed/problem team cannot simply return under another name, without automatically banning every player in that squad.

Key changes:
- admin Participation controls page under Back end functions;
- team-level registration block with reason/date and audit trail;
- optional captain/organiser restriction when a team is blocked;
- separate individual player suspension with optional end date;
- captain claim and captain-dashboard access guards;
- player-add and public prospect guards for suspended identities;
- database enforcement for restricted team-management memberships and selected matchday squads;
- automatic admin-review hold when a new team reuses blocked-team contact details;
- automatic admin-review hold at 4 shared registered players with a blocked team;
- explicit admin approval path for legitimate re-formations;
- no automatic blanket ban on ordinary players from a blocked team;
- migration-backed audit history for restriction changes.

The overlap threshold is a review trigger rather than an automatic ban, so legitimate player movement can be approved by admin.

This replaces #310 and is based cleanly on the latest main, retaining the newer TBC fee-safety prebuild change.