### PR TITLE
Enforce team earliest and latest kick-off rules

### DIFF
--- a/scripts/apply-team-kickoff-window-enforcement.cjs
+++ b/scripts/apply-team-kickoff-window-enforcement.cjs
@@ -1,0 +1,371 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+
+function filePath(relative) {
+  return path.join(root, ...relative.split("/"));
+}
+
+function read(relative) {
+  return fs.readFileSync(filePath(relative), "utf8");
+}
+
+function write(relative, source) {
+  fs.writeFileSync(filePath(relative), source, "utf8");
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found.`);
+  }
+  return source.replace(before, after);
+}
+
+function replaceAllRequired(source, before, after, label, min = 1) {
+  if (source.includes(after) && !source.includes(before)) return source;
+  const count = source.split(before).length - 1;
+  if (count < min) {
+    throw new Error(`Expected ${label} source was not found (${count}/${min}).`);
+  }
+  return source.replaceAll(before, after);
+}
+
+// The database column has existed since 2026-06-16, but the raw Prisma model
+// omitted it. Expose it so every server path can enforce the same rule.
+{
+  const relative = "prisma/schema.prisma";
+  let source = read(relative);
+  if (!source.includes("earliestKickoffTime")) {
+    source = replaceRequired(
+      source,
+      "  latestKickoffTime     String?\n",
+      "  earliestKickoffTime   String?\n  latestKickoffTime     String?\n",
+      "Prisma earliest kick-off field",
+    );
+  }
+  write(relative, source);
+}
+
+const helperImport =
+  'import { assertFixtureKickoffWindow, getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";';
+
+// Manual fixture creation: validate before either the normal or TBC creation path.
+{
+  const relative = "src/app/(admin)/admin/fixtures/create-fixture-action.ts";
+  let source = read(relative);
+  if (!source.includes(helperImport)) {
+    source = replaceRequired(
+      source,
+      'import { parseLondonDateTime } from "@/lib/datetime/london";',
+      'import { parseLondonDateTime } from "@/lib/datetime/london";\n' + helperImport,
+      "manual fixture kickoff-window import",
+    );
+  }
+
+  if (!source.includes("async function validateManualFixtureKickoffWindow")) {
+    const anchor = "async function teamCanPlayInLeague(teamId: string, leagueId: string) {";
+    const addition = `async function validateManualFixtureKickoffWindow(formData: FormData, teamIds: string[]) {\n  const status = String(formData.get(\"status\") ?? \"SCHEDULED\").trim();\n  if (status !== \"SCHEDULED\" && status !== \"COMPLETED\") return;\n\n  const kickoffDate = required(formData, \"kickoffDate\", \"Kick-off date\");\n  const kickoffTime = required(formData, \"kickoffTime\", \"Kick-off time\");\n  const kickoffAt = parseLondonDateTime(kickoffDate, kickoffTime);\n  const overrideKickoffRules =\n    String(formData.get(\"overrideLatestKickoff\") ?? \"\").trim() === \"on\";\n  const teams = await prisma.team.findMany({\n    where: { id: { in: teamIds.filter(Boolean) } },\n    select: {\n      id: true,\n      name: true,\n      earliestKickoffTime: true,\n      latestKickoffTime: true,\n    },\n  });\n\n  assertFixtureKickoffWindow(kickoffAt, teams, {\n    allowOverride: overrideKickoffRules,\n    overrideLabel:\n      \"Change the fixture time, update the team kick-off rules, or use the explicit kick-off rules override.\",\n  });\n}\n\n`;
+    if (!source.includes(anchor)) {
+      throw new Error("Manual fixture team eligibility anchor was not found.");
+    }
+    source = source.replace(anchor, addition + anchor);
+  }
+
+  source = replaceRequired(
+    source,
+    `  try {\n    const placeholderIds = await getFixturePlaceholderTeamIds(\n      [homeTeamId, awayTeamId].filter(Boolean),\n    );`,
+    `  try {\n    await validateManualFixtureKickoffWindow(formData, [homeTeamId, awayTeamId]);\n\n    const placeholderIds = await getFixturePlaceholderTeamIds(\n      [homeTeamId, awayTeamId].filter(Boolean),\n    );`,
+    "manual fixture kickoff-window validation call",
+  );
+
+  write(relative, source);
+}
+
+// Single draft fixture creator: existing latest-only override now covers the full window.
+{
+  const relative = "src/app/(admin)/admin/fixtures/generate/single-fixture-action.ts";
+  let source = read(relative);
+  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
+    source = replaceRequired(
+      source,
+      'import { ensureSeasonTeamRowsForLeague } from "@/lib/league-season-teams";',
+      'import { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";\nimport { ensureSeasonTeamRowsForLeague } from "@/lib/league-season-teams";',
+      "single fixture kickoff-window import",
+    );
+  }
+  source = replaceRequired(
+    source,
+    "  divisionId: string | null;\n  latestKickoffTime: string | null;",
+    "  divisionId: string | null;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
+    "single fixture team earliest field",
+  );
+  source = replaceRequired(
+    source,
+    `function assertKickoffAllowed(kickoffAt: Date, team: TeamRow) {\n  const latest = timeToMinutes(team.latestKickoffTime);\n  if (latest === null) return;\n  if (getLondonMinutesSinceMidnight(kickoffAt) <= latest) return;\n  throw new Error(\n    \`${"${team.name}"} cannot kick off later than ${"${team.latestKickoffTime}"}. Choose an earlier time, tick the override box for this fixture, or update the team's latest kick-off preference.\`,\n  );\n}`,
+    `function assertKickoffAllowed(kickoffAt: Date, team: TeamRow) {\n  assertFixtureKickoffWindow(kickoffAt, [team], {\n    overrideLabel:\n      \"Choose a permitted time, tick the kick-off rules override for this fixture, or update the team's kick-off rules.\",\n  });\n}`,
+    "single fixture full kickoff-window assertion",
+  );
+  source = replaceRequired(
+    source,
+    '          t."latestKickoffTime",\n          t."standardMatchFeePence"::int AS "standardMatchFeePence"',
+    '          t."earliestKickoffTime",\n          t."latestKickoffTime",\n          t."standardMatchFeePence"::int AS "standardMatchFeePence"',
+    "single fixture earliest SQL select",
+  );
+  write(relative, source);
+}
+
+// Whole-league generator: reject too-early slots as well as too-late slots.
+{
+  const relative = "src/app/(admin)/admin/fixtures/generate/actions.ts";
+  let source = read(relative);
+  source = replaceRequired(
+    source,
+    "  logoUrl: string | null;\n  latestKickoffTime: string | null;",
+    "  logoUrl: string | null;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
+    "league generator earliest team field",
+  );
+  source = replaceRequired(
+    source,
+    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);`,
+    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeEarliest = parseTimeToMinutes(homeTeam.earliestKickoffTime);\n  const awayEarliest = parseTimeToMinutes(awayTeam.earliestKickoffTime);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);\n\n  if (homeEarliest !== null && kickoffMinutes < homeEarliest) {\n    return {\n      allowed: false,\n      reason: \`${"${homeTeam.name}"} cannot kick off before ${"${homeTeam.earliestKickoffTime}"}.\`,\n    };\n  }\n\n  if (awayEarliest !== null && kickoffMinutes < awayEarliest) {\n    return {\n      allowed: false,\n      reason: \`${"${awayTeam.name}"} cannot kick off before ${"${awayTeam.earliestKickoffTime}"}.\`,\n    };\n  }`,
+    "league generator earliest validation",
+  );
+  source = replaceAllRequired(
+    source,
+    "        logoUrl: true,\n        latestKickoffTime: true,",
+    "        logoUrl: true,\n        earliestKickoffTime: true,\n        latestKickoffTime: true,",
+    "league generator earliest selects",
+    2,
+  );
+  write(relative, source);
+}
+
+// Division generator: same rule set, including its raw season-team queries.
+{
+  const relative = "src/app/(admin)/admin/fixtures/generate/division-actions.ts";
+  let source = read(relative);
+  source = replaceRequired(
+    source,
+    "  logoUrl: string | null;\n  latestKickoffTime: string | null;",
+    "  logoUrl: string | null;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
+    "division generator earliest team field",
+  );
+  source = replaceRequired(
+    source,
+    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);`,
+    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeEarliest = parseTimeToMinutes(homeTeam.earliestKickoffTime);\n  const awayEarliest = parseTimeToMinutes(awayTeam.earliestKickoffTime);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);\n\n  if (homeEarliest !== null && kickoffMinutes < homeEarliest) {\n    return { allowed: false, reason: \`${"${homeTeam.name}"} cannot kick off before ${"${homeTeam.earliestKickoffTime}"}.\` };\n  }\n  if (awayEarliest !== null && kickoffMinutes < awayEarliest) {\n    return { allowed: false, reason: \`${"${awayTeam.name}"} cannot kick off before ${"${awayTeam.earliestKickoffTime}"}.\` };\n  }`,
+    "division generator earliest validation",
+  );
+  source = replaceAllRequired(
+    source,
+    'SELECT t."id", t."name", t."logoUrl", t."latestKickoffTime", t."standardMatchFeePence"',
+    'SELECT t."id", t."name", t."logoUrl", t."earliestKickoffTime", t."latestKickoffTime", t."standardMatchFeePence"',
+    "division generator earliest SQL selects",
+    2,
+  );
+  write(relative, source);
+}
+
+// Full fixture editor: explicit override remains available, but now means all team KO rules.
+{
+  const relative = "src/app/(admin)/admin/fixtures/[id]/edit/actions.ts";
+  let source = read(relative);
+  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
+    source = replaceRequired(
+      source,
+      'import { queueInitialFixtureConfirmationEmailForTeam } from "@/lib/fixtures/confirmation-emails";',
+      'import { queueInitialFixtureConfirmationEmailForTeam } from "@/lib/fixtures/confirmation-emails";\nimport { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
+      "fixture editor kickoff-window import",
+    );
+  }
+  source = replaceRequired(
+    source,
+    `function assertLatestKickoffAllowed(input: {\n  kickoffAt: Date;\n  team: { name: string; latestKickoffTime: string | null };\n}) {\n  const latestMinutes = parseTimeToMinutes(input.team.latestKickoffTime);\n  if (latestMinutes === null) return;\n  if (getLondonMinutesSinceMidnight(input.kickoffAt) <= latestMinutes) return;\n  throw new Error(\n    \`${"${input.team.name}"} has latest KO ${"${input.team.latestKickoffTime}"}, so ${"${formatTimeInLondon(input.kickoffAt)}"} is too late. Change the fixture time or tick the latest kick-off override.\`,\n  );\n}`,
+    `function assertLatestKickoffAllowed(input: {\n  kickoffAt: Date;\n  team: {\n    name: string;\n    earliestKickoffTime: string | null;\n    latestKickoffTime: string | null;\n  };\n}) {\n  assertFixtureKickoffWindow(input.kickoffAt, [input.team], {\n    overrideLabel:\n      \"Change the fixture time or tick the kick-off rules override.\",\n  });\n}`,
+    "fixture editor full kickoff-window assertion",
+  );
+  source = replaceAllRequired(
+    source,
+    "            logoUrl: true,\n            latestKickoffTime: true,",
+    "            logoUrl: true,\n            earliestKickoffTime: true,\n            latestKickoffTime: true,",
+    "fixture editor earliest selects",
+    2,
+  );
+  write(relative, source);
+}
+
+// Publish-all/week: a stale invalid draft must not become published.
+{
+  const relative = "src/app/(admin)/admin/fixtures/publish-actions.ts";
+  let source = read(relative);
+  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
+    source = replaceRequired(
+      source,
+      'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
+      'import { formatDateTimeInLondon } from "@/lib/datetime/london";\nimport { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
+      "batch publish kickoff-window import",
+    );
+  }
+  source = replaceAllRequired(
+    source,
+    "homeTeam: { select: { id: true, name: true, logoUrl: true } },",
+    "homeTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
+    "batch publish home team rule selects",
+    1,
+  );
+  source = replaceAllRequired(
+    source,
+    "awayTeam: { select: { id: true, name: true, logoUrl: true } },",
+    "awayTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
+    "batch publish away team rule selects",
+    1,
+  );
+  source = replaceRequired(
+    source,
+    `        if (unpublishedFixtures.length === 0) return [];\n\n        const fixtureIds = unpublishedFixtures.map((fixture) => fixture.id);`,
+    `        if (unpublishedFixtures.length === 0) return [];\n\n        for (const fixture of unpublishedFixtures) {\n          if (fixture.status === \"SCHEDULED\" || fixture.status === \"COMPLETED\") {\n            assertFixtureKickoffWindow(fixture.kickoffAt, [\n              fixture.homeTeam,\n              fixture.awayTeam,\n            ], {\n              overrideLabel:\n                \"Change the fixture time or update the team kick-off rules before publishing.\",\n            });\n          }\n        }\n\n        const fixtureIds = unpublishedFixtures.map((fixture) => fixture.id);`,
+    "batch publish kickoff-window gate",
+  );
+  write(relative, source);
+}
+
+// Single-fixture publish endpoint: same safety gate, inside the serializable transaction.
+{
+  const relative = "src/app/api/admin/fixtures/publish-one/route.ts";
+  let source = read(relative);
+  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
+    source = replaceRequired(
+      source,
+      'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
+      'import { formatDateTimeInLondon } from "@/lib/datetime/london";\nimport { assertFixtureKickoffWindow, getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";',
+      "single publish kickoff-window import",
+    );
+  }
+  source = replaceAllRequired(
+    source,
+    "homeTeam: { select: { id: true, name: true, logoUrl: true } },",
+    "homeTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
+    "single publish home team rule selects",
+    2,
+  );
+  source = replaceAllRequired(
+    source,
+    "awayTeam: { select: { id: true, name: true, logoUrl: true } },",
+    "awayTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
+    "single publish away team rule selects",
+    2,
+  );
+  source = replaceRequired(
+    source,
+    `      if (!fixture || fixture.publishedAt) return null;\n\n      const update = await tx.fixture.updateMany({`,
+    `      if (!fixture || fixture.publishedAt) return null;\n\n      assertFixtureKickoffWindow(fixture.kickoffAt, [\n        fixture.homeTeam,\n        fixture.awayTeam,\n      ], {\n        overrideLabel:\n          \"Change the fixture time or update the team kick-off rules before publishing.\",\n      });\n\n      const update = await tx.fixture.updateMany({`,
+    "single publish transactional kickoff-window gate",
+  );
+  source = replaceRequired(
+    source,
+    `  if (fixtureInfo.publishedAt) {\n    return NextResponse.json({ ok: true, published: false, alreadyPublished: true });\n  }\n\n  const fixture = await publishFixtureOrNull(fixtureId);`,
+    `  if (fixtureInfo.publishedAt) {\n    return NextResponse.json({ ok: true, published: false, alreadyPublished: true });\n  }\n\n  const kickoffViolations = getFixtureKickoffWindowViolations(\n    fixtureInfo.kickoffAt,\n    [fixtureInfo.homeTeam, fixtureInfo.awayTeam],\n  );\n  if (kickoffViolations.length > 0) {\n    return NextResponse.json(\n      {\n        ok: false,\n        error: \`${"${kickoffViolations.map((item) => item.message).join(\" \")}"} Change the fixture time or update the team kick-off rules before publishing.\`,\n      },\n      { status: 409 },\n    );\n  }\n\n  const fixture = await publishFixtureOrNull(fixtureId);`,
+    "single publish friendly kickoff-window response",
+  );
+  write(relative, source);
+}
+
+// Night Board server read: include earliest limits so legacy/bad fixtures are visible immediately.
+{
+  const relative = "src/app/(admin)/admin/night-board/page.tsx";
+  let source = read(relative);
+  source = replaceAllRequired(
+    source,
+    "select: { id: true, name: true, latestKickoffTime: true },",
+    "select: { id: true, name: true, earliestKickoffTime: true, latestKickoffTime: true },",
+    "night board team rule selects",
+    2,
+  );
+  source = replaceAllRequired(
+    source,
+    "        name: fixture.homeTeam.name,\n        latestKickoffTime: fixture.homeTeam.latestKickoffTime,",
+    "        name: fixture.homeTeam.name,\n        earliestKickoffTime: fixture.homeTeam.earliestKickoffTime,\n        latestKickoffTime: fixture.homeTeam.latestKickoffTime,",
+    "night board home operation earliest rule",
+    1,
+  );
+  source = replaceAllRequired(
+    source,
+    "        name: fixture.awayTeam.name,\n        latestKickoffTime: fixture.awayTeam.latestKickoffTime,",
+    "        name: fixture.awayTeam.name,\n        earliestKickoffTime: fixture.awayTeam.earliestKickoffTime,\n        latestKickoffTime: fixture.awayTeam.latestKickoffTime,",
+    "night board away operation earliest rule",
+    1,
+  );
+  write(relative, source);
+}
+
+// Night Board client warning: show either side of the allowed team window, not just late KOs.
+{
+  const relative = "src/components/admin/night-board/NightBoardOperations.tsx";
+  let source = read(relative);
+  source = replaceRequired(
+    source,
+    "  name: string;\n  latestKickoffTime: string | null;",
+    "  name: string;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
+    "night board client earliest team rule",
+  );
+  source = replaceRequired(
+    source,
+    `  const breachedTeams = [fixture.homeTeam, fixture.awayTeam].filter((team) => {\n    const latestMinutes = timeToMinutes(team.latestKickoffTime);\n    return latestMinutes !== null && kickoffMinutes > latestMinutes;\n  });\n  if (breachedTeams.length === 0) return null;\n\n  const scheduledTime = displayTime(fixture.kickoffTime);\n  const limits = breachedTeams\n    .map((team) => \`${"${team.name}"} ${"${displayTime(team.latestKickoffTime ?? \"\")}"}\`)\n    .join(\" · \");\n  const statedLimitSentence =\n    breachedTeams.length === 1\n      ? \`${"${breachedTeams[0].name}"}’s stated latest kick-off is ${"${displayTime(\n          breachedTeams[0].latestKickoffTime ?? \"\",\n        )}"}.\`\n      : \`The stated latest kick-off times are ${"${breachedTeams\n          .map(\n            (team) =>\n              `${team.name} ${displayTime(team.latestKickoffTime ?? \"\")}`,\n          )\n          .join(\" and \")}"}.\`;\n\n  return {\n    fixtureId: fixture.id,\n    inlineMessage: \`Latest preferred kick-off exceeded: ${"${limits}"}. This fixture is scheduled for ${"${scheduledTime}"}.\`,\n    summaryMessage: \`Potential issue – late kick-off: ${"${fixture.homeTeam.name}"} v ${"${fixture.awayTeam.name}"} is scheduled for ${"${scheduledTime}"}. ${"${statedLimitSentence}"}\`,\n  };`,
+    `  const breachedTeams = [fixture.homeTeam, fixture.awayTeam]\n    .map((team) => {\n      const earliestMinutes = timeToMinutes(team.earliestKickoffTime);\n      const latestMinutes = timeToMinutes(team.latestKickoffTime);\n      if (earliestMinutes !== null && kickoffMinutes < earliestMinutes) {\n        return {\n          team,\n          detail: \`${"${team.name}"} cannot play before ${"${displayTime(team.earliestKickoffTime ?? \"\")}"}\`,\n        };\n      }\n      if (latestMinutes !== null && kickoffMinutes > latestMinutes) {\n        return {\n          team,\n          detail: \`${"${team.name}"} cannot play later than ${"${displayTime(team.latestKickoffTime ?? \"\")}"}\`,\n        };\n      }\n      return null;\n    })\n    .filter((item): item is { team: NightBoardTeamRule; detail: string } => Boolean(item));\n  if (breachedTeams.length === 0) return null;\n\n  const scheduledTime = displayTime(fixture.kickoffTime);\n  const limits = breachedTeams.map((item) => item.detail).join(\" · \");\n\n  return {\n    fixtureId: fixture.id,\n    inlineMessage: \`Kick-off rule conflict: ${"${limits}"}. This fixture is scheduled for ${"${scheduledTime}"}.\`,\n    summaryMessage: \`Potential issue – team kick-off rule: ${"${fixture.homeTeam.name}"} v ${"${fixture.awayTeam.name}"} is scheduled for ${"${scheduledTime}"}. ${"${limits}"}.\`,\n  };`,
+    "night board full kickoff-window warning",
+  );
+  write(relative, source);
+}
+
+// Night Board save endpoint: a time change may not create a new violation. Existing
+// legacy violations remain editable for referee/venue/etc until their KO time is corrected.
+{
+  const relative = "src/app/api/admin/night-board/update-match/route.ts";
+  let source = read(relative);
+  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
+    source = replaceRequired(
+      source,
+      'import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";',
+      'import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";\nimport { getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";',
+      "night board save kickoff-window import",
+    );
+  }
+  source = replaceRequired(
+    source,
+    "homeTeam: { select: { id: true, name: true, logoUrl: true } },",
+    "homeTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
+    "night board save home team rules",
+  );
+  source = replaceRequired(
+    source,
+    "awayTeam: { select: { id: true, name: true, logoUrl: true } },",
+    "awayTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
+    "night board save away team rules",
+  );
+  source = replaceRequired(
+    source,
+    `  const kickoffAt = parseOperationalKickoff({ currentKickoffAt: fixture.kickoffAt, timeInput: kickoffTime });\n\n  const referee = refereeId`,
+    `  const kickoffAt = parseOperationalKickoff({ currentKickoffAt: fixture.kickoffAt, timeInput: kickoffTime });\n\n  if (\n    kickoffAt.getTime() !== fixture.kickoffAt.getTime() &&\n    (status === FixtureStatus.SCHEDULED || status === FixtureStatus.COMPLETED)\n  ) {\n    const kickoffViolations = getFixtureKickoffWindowViolations(kickoffAt, [\n      fixture.homeTeam,\n      fixture.awayTeam,\n    ]);\n    if (kickoffViolations.length > 0) {\n      return NextResponse.json(\n        {\n          ok: false,\n          error: \`${"${kickoffViolations.map((item) => item.message).join(\" \")}"} Choose a permitted kick-off time.\`,\n          returnTo,\n        },\n        { status: 409 },\n      );\n    }\n  }\n\n  const referee = refereeId`,
+    "night board save kickoff-window gate",
+  );
+  write(relative, source);
+}
+
+// Make the existing override checkbox wording honest: it now covers earliest + latest.
+for (const relative of [
+  "src/components/admin/fixtures/CreateSingleFixturePanel.tsx",
+  "src/components/admin/fixtures/FixtureEditForm.tsx",
+]) {
+  let source = read(relative);
+  source = source
+    .replaceAll("Override latest kick-off restriction", "Override team kick-off rules")
+    .replaceAll("latest kick-off override", "kick-off rules override")
+    .replaceAll("latest kick-off preference", "kick-off rules");
+  write(relative, source);
+}
+
+console.log(
+  "Team earliest/latest kick-off windows are enforced during fixture creation, generation and publishing, and conflicts are shown on the Night Board.",
+);

--- a/scripts/apply-team-kickoff-window-enforcement.cjs
+++ b/scripts/apply-team-kickoff-window-enforcement.cjs
@@ -2,358 +2,319 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = process.cwd();
+const fp = (relative) => path.join(root, ...relative.split("/"));
+const read = (relative) => fs.readFileSync(fp(relative), "utf8");
+const write = (relative, source) => fs.writeFileSync(fp(relative), source, "utf8");
 
-function filePath(relative) {
-  return path.join(root, ...relative.split("/"));
+function requireAnchor(source, anchor, label) {
+  if (!source.includes(anchor)) throw new Error(`Missing ${label} anchor.`);
 }
 
-function read(relative) {
-  return fs.readFileSync(filePath(relative), "utf8");
+function insertImport(source, anchor, importLine, label) {
+  if (source.includes(importLine)) return source;
+  requireAnchor(source, anchor, label);
+  return source.replace(anchor, `${anchor}\n${importLine}`);
 }
 
-function write(relative, source) {
-  fs.writeFileSync(filePath(relative), source, "utf8");
-}
-
-function replaceRequired(source, before, after, label) {
-  if (source.includes(after)) return source;
-  if (!source.includes(before)) {
-    throw new Error(`Expected ${label} source was not found.`);
+function insertLineBeforeEvery(source, targetTrimmed, lineTrimmed) {
+  const lines = source.split("\n");
+  const out = [];
+  for (const line of lines) {
+    if (line.trim() === targetTrimmed) {
+      const previous = out[out.length - 1]?.trim();
+      if (previous !== lineTrimmed) {
+        const indent = line.match(/^\s*/)?.[0] ?? "";
+        out.push(`${indent}${lineTrimmed}`);
+      }
+    }
+    out.push(line);
   }
-  return source.replace(before, after);
+  return out.join("\n");
 }
 
-function replaceAllRequired(source, before, after, label, min = 1) {
-  if (source.includes(after) && !source.includes(before)) return source;
-  const count = source.split(before).length - 1;
-  if (count < min) {
-    throw new Error(`Expected ${label} source was not found (${count}/${min}).`);
-  }
-  return source.replaceAll(before, after);
+function replaceFunction(source, startName, nextName, replacement, label) {
+  if (source.includes(replacement.trim())) return source;
+  const start = source.indexOf(`function ${startName}`);
+  const end = source.indexOf(`function ${nextName}`, start + 1);
+  if (start < 0 || end < 0) throw new Error(`Could not replace ${label}.`);
+  return source.slice(0, start) + replacement + "\n\n" + source.slice(end);
 }
 
-// The database column has existed since 2026-06-16, but the raw Prisma model
-// omitted it. Expose it so every server path can enforce the same rule.
+// Database migration 20260616120000 already created this column. The raw Prisma
+// model omitted it, which is the underlying reason most code could not enforce it.
 {
   const relative = "prisma/schema.prisma";
   let source = read(relative);
-  if (!source.includes("earliestKickoffTime")) {
-    source = replaceRequired(
-      source,
-      "  latestKickoffTime     String?\n",
-      "  earliestKickoffTime   String?\n  latestKickoffTime     String?\n",
-      "Prisma earliest kick-off field",
+  if (!/\bearliestKickoffTime\s+String\?/.test(source)) {
+    source = source.replace(
+      /^(\s*)latestKickoffTime\s+String\?$/m,
+      `$1earliestKickoffTime   String?\n$1latestKickoffTime     String?`,
     );
+  }
+  if (!/\bearliestKickoffTime\s+String\?/.test(source)) {
+    throw new Error("Could not expose Team.earliestKickoffTime in Prisma schema.");
   }
   write(relative, source);
 }
 
-const helperImport =
-  'import { assertFixtureKickoffWindow, getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";';
-
-// Manual fixture creation: validate before either the normal or TBC creation path.
+// Manual create panel (normal teams and TBC) must validate before any insert.
 {
   const relative = "src/app/(admin)/admin/fixtures/create-fixture-action.ts";
   let source = read(relative);
-  if (!source.includes(helperImport)) {
-    source = replaceRequired(
-      source,
-      'import { parseLondonDateTime } from "@/lib/datetime/london";',
-      'import { parseLondonDateTime } from "@/lib/datetime/london";\n' + helperImport,
-      "manual fixture kickoff-window import",
-    );
-  }
+  source = insertImport(
+    source,
+    'import { parseLondonDateTime } from "@/lib/datetime/london";',
+    'import { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
+    "manual fixture datetime import",
+  );
 
   if (!source.includes("async function validateManualFixtureKickoffWindow")) {
     const anchor = "async function teamCanPlayInLeague(teamId: string, leagueId: string) {";
-    const addition = `async function validateManualFixtureKickoffWindow(formData: FormData, teamIds: string[]) {\n  const status = String(formData.get(\"status\") ?? \"SCHEDULED\").trim();\n  if (status !== \"SCHEDULED\" && status !== \"COMPLETED\") return;\n\n  const kickoffDate = required(formData, \"kickoffDate\", \"Kick-off date\");\n  const kickoffTime = required(formData, \"kickoffTime\", \"Kick-off time\");\n  const kickoffAt = parseLondonDateTime(kickoffDate, kickoffTime);\n  const overrideKickoffRules =\n    String(formData.get(\"overrideLatestKickoff\") ?? \"\").trim() === \"on\";\n  const teams = await prisma.team.findMany({\n    where: { id: { in: teamIds.filter(Boolean) } },\n    select: {\n      id: true,\n      name: true,\n      earliestKickoffTime: true,\n      latestKickoffTime: true,\n    },\n  });\n\n  assertFixtureKickoffWindow(kickoffAt, teams, {\n    allowOverride: overrideKickoffRules,\n    overrideLabel:\n      \"Change the fixture time, update the team kick-off rules, or use the explicit kick-off rules override.\",\n  });\n}\n\n`;
-    if (!source.includes(anchor)) {
-      throw new Error("Manual fixture team eligibility anchor was not found.");
-    }
-    source = source.replace(anchor, addition + anchor);
+    requireAnchor(source, anchor, "manual fixture team eligibility");
+    const helper = `async function validateManualFixtureKickoffWindow(formData: FormData, teamIds: string[]) {\n  const status = String(formData.get(\"status\") ?? \"SCHEDULED\").trim();\n  if (status !== \"SCHEDULED\" && status !== \"COMPLETED\") return;\n\n  const kickoffDate = required(formData, \"kickoffDate\", \"Kick-off date\");\n  const kickoffTime = required(formData, \"kickoffTime\", \"Kick-off time\");\n  const kickoffAt = parseLondonDateTime(kickoffDate, kickoffTime);\n  const overrideKickoffRules =\n    String(formData.get(\"overrideLatestKickoff\") ?? \"\").trim() === \"on\";\n  const teams = await prisma.team.findMany({\n    where: { id: { in: teamIds.filter(Boolean) } },\n    select: {\n      id: true,\n      name: true,\n      earliestKickoffTime: true,\n      latestKickoffTime: true,\n    },\n  });\n\n  assertFixtureKickoffWindow(kickoffAt, teams, {\n    allowOverride: overrideKickoffRules,\n    overrideLabel:\n      \"Change the fixture time, update the team kick-off rules, or use the explicit kick-off rules override.\",\n  });\n}\n\n`;
+    source = source.replace(anchor, helper + anchor);
   }
 
-  source = replaceRequired(
-    source,
-    `  try {\n    const placeholderIds = await getFixturePlaceholderTeamIds(\n      [homeTeamId, awayTeamId].filter(Boolean),\n    );`,
-    `  try {\n    await validateManualFixtureKickoffWindow(formData, [homeTeamId, awayTeamId]);\n\n    const placeholderIds = await getFixturePlaceholderTeamIds(\n      [homeTeamId, awayTeamId].filter(Boolean),\n    );`,
-    "manual fixture kickoff-window validation call",
-  );
-
+  if (!source.includes("await validateManualFixtureKickoffWindow(formData")) {
+    const anchor = `  try {\n    const placeholderIds = await getFixturePlaceholderTeamIds(`;
+    requireAnchor(source, anchor, "manual fixture create try block");
+    source = source.replace(
+      anchor,
+      `  try {\n    await validateManualFixtureKickoffWindow(formData, [homeTeamId, awayTeamId]);\n\n    const placeholderIds = await getFixturePlaceholderTeamIds(`,
+    );
+  }
   write(relative, source);
 }
 
-// Single draft fixture creator: existing latest-only override now covers the full window.
+// Single fixture creator: existing explicit override now applies to earliest + latest.
 {
   const relative = "src/app/(admin)/admin/fixtures/generate/single-fixture-action.ts";
   let source = read(relative);
-  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
-    source = replaceRequired(
-      source,
-      'import { ensureSeasonTeamRowsForLeague } from "@/lib/league-season-teams";',
-      'import { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";\nimport { ensureSeasonTeamRowsForLeague } from "@/lib/league-season-teams";',
-      "single fixture kickoff-window import",
+  source = insertImport(
+    source,
+    'import { ensureSeasonTeamRowsForLeague } from "@/lib/league-season-teams";',
+    'import { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
+    "single fixture season import",
+  );
+  if (!source.includes("earliestKickoffTime: string | null;")) {
+    source = source.replace(
+      "  latestKickoffTime: string | null;",
+      "  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
     );
   }
-  source = replaceRequired(
+  if (!source.includes('t."earliestKickoffTime",')) {
+    source = source.replace(
+      '          t."latestKickoffTime",',
+      '          t."earliestKickoffTime",\n          t."latestKickoffTime",',
+    );
+  }
+  source = replaceFunction(
     source,
-    "  divisionId: string | null;\n  latestKickoffTime: string | null;",
-    "  divisionId: string | null;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
-    "single fixture team earliest field",
-  );
-  source = replaceRequired(
-    source,
-    `function assertKickoffAllowed(kickoffAt: Date, team: TeamRow) {\n  const latest = timeToMinutes(team.latestKickoffTime);\n  if (latest === null) return;\n  if (getLondonMinutesSinceMidnight(kickoffAt) <= latest) return;\n  throw new Error(\n    \`${"${team.name}"} cannot kick off later than ${"${team.latestKickoffTime}"}. Choose an earlier time, tick the override box for this fixture, or update the team's latest kick-off preference.\`,\n  );\n}`,
+    "assertKickoffAllowed",
+    "buildReturnUrl",
     `function assertKickoffAllowed(kickoffAt: Date, team: TeamRow) {\n  assertFixtureKickoffWindow(kickoffAt, [team], {\n    overrideLabel:\n      \"Choose a permitted time, tick the kick-off rules override for this fixture, or update the team's kick-off rules.\",\n  });\n}`,
-    "single fixture full kickoff-window assertion",
-  );
-  source = replaceRequired(
-    source,
-    '          t."latestKickoffTime",\n          t."standardMatchFeePence"::int AS "standardMatchFeePence"',
-    '          t."earliestKickoffTime",\n          t."latestKickoffTime",\n          t."standardMatchFeePence"::int AS "standardMatchFeePence"',
-    "single fixture earliest SQL select",
+    "single fixture kickoff validator",
   );
   write(relative, source);
 }
 
-// Whole-league generator: reject too-early slots as well as too-late slots.
-{
-  const relative = "src/app/(admin)/admin/fixtures/generate/actions.ts";
+function patchGenerator(relative, sqlMode = false) {
   let source = read(relative);
-  source = replaceRequired(
-    source,
-    "  logoUrl: string | null;\n  latestKickoffTime: string | null;",
-    "  logoUrl: string | null;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
-    "league generator earliest team field",
-  );
-  source = replaceRequired(
-    source,
-    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);`,
-    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeEarliest = parseTimeToMinutes(homeTeam.earliestKickoffTime);\n  const awayEarliest = parseTimeToMinutes(awayTeam.earliestKickoffTime);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);\n\n  if (homeEarliest !== null && kickoffMinutes < homeEarliest) {\n    return {\n      allowed: false,\n      reason: \`${"${homeTeam.name}"} cannot kick off before ${"${homeTeam.earliestKickoffTime}"}.\`,\n    };\n  }\n\n  if (awayEarliest !== null && kickoffMinutes < awayEarliest) {\n    return {\n      allowed: false,\n      reason: \`${"${awayTeam.name}"} cannot kick off before ${"${awayTeam.earliestKickoffTime}"}.\`,\n    };\n  }`,
-    "league generator earliest validation",
-  );
-  source = replaceAllRequired(
-    source,
-    "        logoUrl: true,\n        latestKickoffTime: true,",
-    "        logoUrl: true,\n        earliestKickoffTime: true,\n        latestKickoffTime: true,",
-    "league generator earliest selects",
-    2,
-  );
+  if (!source.includes("earliestKickoffTime: string | null;")) {
+    source = source.replace(
+      "  latestKickoffTime: string | null;",
+      "  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
+    );
+  }
+
+  if (!source.includes("const homeEarliest = parseTimeToMinutes(homeTeam.earliestKickoffTime);")) {
+    const anchor = `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);`;
+    requireAnchor(source, anchor, `${relative} kickoff calculation`);
+    source = source.replace(
+      anchor,
+      `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeEarliest = parseTimeToMinutes(homeTeam.earliestKickoffTime);\n  const awayEarliest = parseTimeToMinutes(awayTeam.earliestKickoffTime);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);\n\n  if (homeEarliest !== null && kickoffMinutes < homeEarliest) {\n    return { allowed: false, reason: \`${"${homeTeam.name}"} cannot kick off before ${"${homeTeam.earliestKickoffTime}"}.\` };\n  }\n  if (awayEarliest !== null && kickoffMinutes < awayEarliest) {\n    return { allowed: false, reason: \`${"${awayTeam.name}"} cannot kick off before ${"${awayTeam.earliestKickoffTime}"}.\` };\n  }`,
+    );
+  }
+
+  if (sqlMode) {
+    source = source.replaceAll(
+      't."logoUrl", t."latestKickoffTime"',
+      't."logoUrl", t."earliestKickoffTime", t."latestKickoffTime"',
+    );
+  } else {
+    source = insertLineBeforeEvery(
+      source,
+      "latestKickoffTime: true,",
+      "earliestKickoffTime: true,",
+    );
+  }
+
+  if (!source.includes("earliestKickoffTime")) {
+    throw new Error(`${relative} did not receive earliest kick-off support.`);
+  }
   write(relative, source);
 }
 
-// Division generator: same rule set, including its raw season-team queries.
-{
-  const relative = "src/app/(admin)/admin/fixtures/generate/division-actions.ts";
-  let source = read(relative);
-  source = replaceRequired(
-    source,
-    "  logoUrl: string | null;\n  latestKickoffTime: string | null;",
-    "  logoUrl: string | null;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
-    "division generator earliest team field",
-  );
-  source = replaceRequired(
-    source,
-    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);`,
-    `  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);\n  const homeEarliest = parseTimeToMinutes(homeTeam.earliestKickoffTime);\n  const awayEarliest = parseTimeToMinutes(awayTeam.earliestKickoffTime);\n  const homeLatest = parseTimeToMinutes(homeTeam.latestKickoffTime);\n  const awayLatest = parseTimeToMinutes(awayTeam.latestKickoffTime);\n\n  if (homeEarliest !== null && kickoffMinutes < homeEarliest) {\n    return { allowed: false, reason: \`${"${homeTeam.name}"} cannot kick off before ${"${homeTeam.earliestKickoffTime}"}.\` };\n  }\n  if (awayEarliest !== null && kickoffMinutes < awayEarliest) {\n    return { allowed: false, reason: \`${"${awayTeam.name}"} cannot kick off before ${"${awayTeam.earliestKickoffTime}"}.\` };\n  }`,
-    "division generator earliest validation",
-  );
-  source = replaceAllRequired(
-    source,
-    'SELECT t."id", t."name", t."logoUrl", t."latestKickoffTime", t."standardMatchFeePence"',
-    'SELECT t."id", t."name", t."logoUrl", t."earliestKickoffTime", t."latestKickoffTime", t."standardMatchFeePence"',
-    "division generator earliest SQL selects",
-    2,
-  );
-  write(relative, source);
-}
+patchGenerator("src/app/(admin)/admin/fixtures/generate/actions.ts");
+patchGenerator("src/app/(admin)/admin/fixtures/generate/division-actions.ts", true);
 
-// Full fixture editor: explicit override remains available, but now means all team KO rules.
+// Full fixture edit action.
 {
   const relative = "src/app/(admin)/admin/fixtures/[id]/edit/actions.ts";
   let source = read(relative);
-  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
-    source = replaceRequired(
-      source,
-      'import { queueInitialFixtureConfirmationEmailForTeam } from "@/lib/fixtures/confirmation-emails";',
-      'import { queueInitialFixtureConfirmationEmailForTeam } from "@/lib/fixtures/confirmation-emails";\nimport { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
-      "fixture editor kickoff-window import",
-    );
-  }
-  source = replaceRequired(
+  source = insertImport(
     source,
-    `function assertLatestKickoffAllowed(input: {\n  kickoffAt: Date;\n  team: { name: string; latestKickoffTime: string | null };\n}) {\n  const latestMinutes = parseTimeToMinutes(input.team.latestKickoffTime);\n  if (latestMinutes === null) return;\n  if (getLondonMinutesSinceMidnight(input.kickoffAt) <= latestMinutes) return;\n  throw new Error(\n    \`${"${input.team.name}"} has latest KO ${"${input.team.latestKickoffTime}"}, so ${"${formatTimeInLondon(input.kickoffAt)}"} is too late. Change the fixture time or tick the latest kick-off override.\`,\n  );\n}`,
-    `function assertLatestKickoffAllowed(input: {\n  kickoffAt: Date;\n  team: {\n    name: string;\n    earliestKickoffTime: string | null;\n    latestKickoffTime: string | null;\n  };\n}) {\n  assertFixtureKickoffWindow(input.kickoffAt, [input.team], {\n    overrideLabel:\n      \"Change the fixture time or tick the kick-off rules override.\",\n  });\n}`,
-    "fixture editor full kickoff-window assertion",
+    'import { queueInitialFixtureConfirmationEmailForTeam } from "@/lib/fixtures/confirmation-emails";',
+    'import { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
+    "fixture edit confirmation import",
   );
-  source = replaceAllRequired(
+  source = insertLineBeforeEvery(
     source,
-    "            logoUrl: true,\n            latestKickoffTime: true,",
-    "            logoUrl: true,\n            earliestKickoffTime: true,\n            latestKickoffTime: true,",
-    "fixture editor earliest selects",
-    2,
+    "latestKickoffTime: true,",
+    "earliestKickoffTime: true,",
   );
+  source = replaceFunction(
+    source,
+    "assertLatestKickoffAllowed",
+    "teamCanPlayInLeague",
+    `function assertLatestKickoffAllowed(input: {\n  kickoffAt: Date;\n  team: {\n    name: string;\n    earliestKickoffTime: string | null;\n    latestKickoffTime: string | null;\n  };\n}) {\n  assertFixtureKickoffWindow(input.kickoffAt, [input.team], {\n    overrideLabel:\n      \"Change the fixture time or tick the kick-off rules override.\",\n  });\n}\n\nasync `,
+    "fixture edit kickoff validator",
+  );
+  source = source.replace("async \n\nfunction teamCanPlayInLeague", "async function teamCanPlayInLeague");
   write(relative, source);
 }
 
-// Publish-all/week: a stale invalid draft must not become published.
+// Publish batch/week. Validate inside the same transaction before publishedAt is set.
 {
   const relative = "src/app/(admin)/admin/fixtures/publish-actions.ts";
   let source = read(relative);
-  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
-    source = replaceRequired(
-      source,
-      'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
-      'import { formatDateTimeInLondon } from "@/lib/datetime/london";\nimport { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
-      "batch publish kickoff-window import",
+  source = insertImport(
+    source,
+    'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
+    'import { assertFixtureKickoffWindow } from "@/lib/fixtures/kickoff-window";',
+    "batch publish datetime import",
+  );
+
+  if (!source.includes("async function assertBatchFixtureKickoffWindows")) {
+    const anchor = "async function assertDivisionBelongsToLeague";
+    requireAnchor(source, anchor, "batch publish division helper");
+    const helper = `async function assertBatchFixtureKickoffWindows(\n  db: typeof prisma,\n  fixtures: Array<{ kickoffAt: Date; homeTeam: { id: string }; awayTeam: { id: string } }>,\n) {\n  const teamIds = unique(\n    fixtures.flatMap((fixture) => [fixture.homeTeam.id, fixture.awayTeam.id]),\n  );\n  if (teamIds.length === 0) return;\n\n  const teams = await db.team.findMany({\n    where: { id: { in: teamIds } },\n    select: {\n      id: true,\n      name: true,\n      earliestKickoffTime: true,\n      latestKickoffTime: true,\n    },\n  });\n  const byId = new Map(teams.map((team) => [team.id, team]));\n\n  for (const fixture of fixtures) {\n    const fixtureTeams = [\n      byId.get(fixture.homeTeam.id),\n      byId.get(fixture.awayTeam.id),\n    ].filter((team): team is NonNullable<typeof team> => Boolean(team));\n    assertFixtureKickoffWindow(fixture.kickoffAt, fixtureTeams, {\n      overrideLabel:\n        \"Change the fixture time or update the team kick-off rules before publishing.\",\n    });\n  }\n}\n\n`;
+    source = source.replace(anchor, helper + anchor);
+  }
+
+  if (!source.includes("await assertBatchFixtureKickoffWindows(tx")) {
+    const anchor = "        if (unpublishedFixtures.length === 0) return [];";
+    requireAnchor(source, anchor, "batch publish zero fixtures");
+    source = source.replace(
+      anchor,
+      `${anchor}\n\n        await assertBatchFixtureKickoffWindows(tx as typeof prisma, unpublishedFixtures);`,
     );
   }
-  source = replaceAllRequired(
-    source,
-    "homeTeam: { select: { id: true, name: true, logoUrl: true } },",
-    "homeTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
-    "batch publish home team rule selects",
-    1,
-  );
-  source = replaceAllRequired(
-    source,
-    "awayTeam: { select: { id: true, name: true, logoUrl: true } },",
-    "awayTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
-    "batch publish away team rule selects",
-    1,
-  );
-  source = replaceRequired(
-    source,
-    `        if (unpublishedFixtures.length === 0) return [];\n\n        const fixtureIds = unpublishedFixtures.map((fixture) => fixture.id);`,
-    `        if (unpublishedFixtures.length === 0) return [];\n\n        for (const fixture of unpublishedFixtures) {\n          if (fixture.status === \"SCHEDULED\" || fixture.status === \"COMPLETED\") {\n            assertFixtureKickoffWindow(fixture.kickoffAt, [\n              fixture.homeTeam,\n              fixture.awayTeam,\n            ], {\n              overrideLabel:\n                \"Change the fixture time or update the team kick-off rules before publishing.\",\n            });\n          }\n        }\n\n        const fixtureIds = unpublishedFixtures.map((fixture) => fixture.id);`,
-    "batch publish kickoff-window gate",
-  );
   write(relative, source);
 }
 
-// Single-fixture publish endpoint: same safety gate, inside the serializable transaction.
+// Single publish endpoint. Validate before update and return a useful 409 to admin.
 {
   const relative = "src/app/api/admin/fixtures/publish-one/route.ts";
   let source = read(relative);
-  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
-    source = replaceRequired(
-      source,
-      'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
-      'import { formatDateTimeInLondon } from "@/lib/datetime/london";\nimport { assertFixtureKickoffWindow, getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";',
-      "single publish kickoff-window import",
+  source = insertImport(
+    source,
+    'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
+    'import { getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";',
+    "single publish datetime import",
+  );
+
+  if (!source.includes("async function getFixtureKickoffRuleViolations")) {
+    const anchor = "async function queueTemplateNotificationOnce";
+    requireAnchor(source, anchor, "single publish notification helper");
+    const helper = `async function getFixtureKickoffRuleViolations(input: {\n  kickoffAt: Date;\n  homeTeamId: string;\n  awayTeamId: string;\n}) {\n  const teams = await prisma.team.findMany({\n    where: { id: { in: [input.homeTeamId, input.awayTeamId] } },\n    select: {\n      id: true,\n      name: true,\n      earliestKickoffTime: true,\n      latestKickoffTime: true,\n    },\n  });\n  return getFixtureKickoffWindowViolations(input.kickoffAt, teams);\n}\n\n`;
+    source = source.replace(anchor, helper + anchor);
+  }
+
+  if (!source.includes("const kickoffViolations = await getFixtureKickoffRuleViolations")) {
+    const anchor = `  if (fixtureInfo.publishedAt) {\n    return NextResponse.json({ ok: true, published: false, alreadyPublished: true });\n  }`;
+    requireAnchor(source, anchor, "single publish already-published gate");
+    source = source.replace(
+      anchor,
+      `${anchor}\n\n  const kickoffViolations = await getFixtureKickoffRuleViolations({\n    kickoffAt: fixtureInfo.kickoffAt,\n    homeTeamId: fixtureInfo.homeTeam.id,\n    awayTeamId: fixtureInfo.awayTeam.id,\n  });\n  if (kickoffViolations.length > 0) {\n    return NextResponse.json(\n      {\n        ok: false,\n        error: \`${"${kickoffViolations.map((item) => item.message).join(\" \")}"} Change the fixture time or update the team kick-off rules before publishing.\`,\n      },\n      { status: 409 },\n    );\n  }`,
     );
   }
-  source = replaceAllRequired(
-    source,
-    "homeTeam: { select: { id: true, name: true, logoUrl: true } },",
-    "homeTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
-    "single publish home team rule selects",
-    2,
-  );
-  source = replaceAllRequired(
-    source,
-    "awayTeam: { select: { id: true, name: true, logoUrl: true } },",
-    "awayTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
-    "single publish away team rule selects",
-    2,
-  );
-  source = replaceRequired(
-    source,
-    `      if (!fixture || fixture.publishedAt) return null;\n\n      const update = await tx.fixture.updateMany({`,
-    `      if (!fixture || fixture.publishedAt) return null;\n\n      assertFixtureKickoffWindow(fixture.kickoffAt, [\n        fixture.homeTeam,\n        fixture.awayTeam,\n      ], {\n        overrideLabel:\n          \"Change the fixture time or update the team kick-off rules before publishing.\",\n      });\n\n      const update = await tx.fixture.updateMany({`,
-    "single publish transactional kickoff-window gate",
-  );
-  source = replaceRequired(
-    source,
-    `  if (fixtureInfo.publishedAt) {\n    return NextResponse.json({ ok: true, published: false, alreadyPublished: true });\n  }\n\n  const fixture = await publishFixtureOrNull(fixtureId);`,
-    `  if (fixtureInfo.publishedAt) {\n    return NextResponse.json({ ok: true, published: false, alreadyPublished: true });\n  }\n\n  const kickoffViolations = getFixtureKickoffWindowViolations(\n    fixtureInfo.kickoffAt,\n    [fixtureInfo.homeTeam, fixtureInfo.awayTeam],\n  );\n  if (kickoffViolations.length > 0) {\n    return NextResponse.json(\n      {\n        ok: false,\n        error: \`${"${kickoffViolations.map((item) => item.message).join(\" \")}"} Change the fixture time or update the team kick-off rules before publishing.\`,\n      },\n      { status: 409 },\n    );\n  }\n\n  const fixture = await publishFixtureOrNull(fixtureId);`,
-    "single publish friendly kickoff-window response",
-  );
+
+  if (!source.includes("const transactionKickoffViolations")) {
+    const anchor = "      if (!fixture || fixture.publishedAt) return null;";
+    requireAnchor(source, anchor, "single publish transaction gate");
+    source = source.replace(
+      anchor,
+      `${anchor}\n\n      const transactionKickoffViolations = await getFixtureKickoffRuleViolations({\n        kickoffAt: fixture.kickoffAt,\n        homeTeamId: fixture.homeTeam.id,\n        awayTeamId: fixture.awayTeam.id,\n      });\n      if (transactionKickoffViolations.length > 0) {\n        throw new Error(transactionKickoffViolations.map((item) => item.message).join(\" \"));\n      }`,
+    );
+  }
   write(relative, source);
 }
 
-// Night Board server read: include earliest limits so legacy/bad fixtures are visible immediately.
+// Night Board read model: include earliest limits and pass them to the client warning engine.
 {
   const relative = "src/app/(admin)/admin/night-board/page.tsx";
   let source = read(relative);
-  source = replaceAllRequired(
-    source,
+  source = source.replaceAll(
     "select: { id: true, name: true, latestKickoffTime: true },",
     "select: { id: true, name: true, earliestKickoffTime: true, latestKickoffTime: true },",
-    "night board team rule selects",
-    2,
   );
-  source = replaceAllRequired(
-    source,
+  source = source.replaceAll(
     "        name: fixture.homeTeam.name,\n        latestKickoffTime: fixture.homeTeam.latestKickoffTime,",
     "        name: fixture.homeTeam.name,\n        earliestKickoffTime: fixture.homeTeam.earliestKickoffTime,\n        latestKickoffTime: fixture.homeTeam.latestKickoffTime,",
-    "night board home operation earliest rule",
-    1,
   );
-  source = replaceAllRequired(
-    source,
+  source = source.replaceAll(
     "        name: fixture.awayTeam.name,\n        latestKickoffTime: fixture.awayTeam.latestKickoffTime,",
     "        name: fixture.awayTeam.name,\n        earliestKickoffTime: fixture.awayTeam.earliestKickoffTime,\n        latestKickoffTime: fixture.awayTeam.latestKickoffTime,",
-    "night board away operation earliest rule",
-    1,
   );
+  if (!source.includes("earliestKickoffTime: fixture.homeTeam.earliestKickoffTime")) {
+    throw new Error("Night Board did not receive earliest kick-off rules.");
+  }
   write(relative, source);
 }
 
-// Night Board client warning: show either side of the allowed team window, not just late KOs.
+// Night Board client: turn the old latest-only warning into a full window conflict.
 {
   const relative = "src/components/admin/night-board/NightBoardOperations.tsx";
   let source = read(relative);
-  source = replaceRequired(
+  if (!source.includes("earliestKickoffTime: string | null;")) {
+    source = source.replace(
+      "  latestKickoffTime: string | null;",
+      "  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
+    );
+  }
+  source = replaceFunction(
     source,
-    "  name: string;\n  latestKickoffTime: string | null;",
-    "  name: string;\n  earliestKickoffTime: string | null;\n  latestKickoffTime: string | null;",
-    "night board client earliest team rule",
-  );
-  source = replaceRequired(
-    source,
-    `  const breachedTeams = [fixture.homeTeam, fixture.awayTeam].filter((team) => {\n    const latestMinutes = timeToMinutes(team.latestKickoffTime);\n    return latestMinutes !== null && kickoffMinutes > latestMinutes;\n  });\n  if (breachedTeams.length === 0) return null;\n\n  const scheduledTime = displayTime(fixture.kickoffTime);\n  const limits = breachedTeams\n    .map((team) => \`${"${team.name}"} ${"${displayTime(team.latestKickoffTime ?? \"\")}"}\`)\n    .join(\" · \");\n  const statedLimitSentence =\n    breachedTeams.length === 1\n      ? \`${"${breachedTeams[0].name}"}’s stated latest kick-off is ${"${displayTime(\n          breachedTeams[0].latestKickoffTime ?? \"\",\n        )}"}.\`\n      : \`The stated latest kick-off times are ${"${breachedTeams\n          .map(\n            (team) =>\n              `${team.name} ${displayTime(team.latestKickoffTime ?? \"\")}`,\n          )\n          .join(\" and \")}"}.\`;\n\n  return {\n    fixtureId: fixture.id,\n    inlineMessage: \`Latest preferred kick-off exceeded: ${"${limits}"}. This fixture is scheduled for ${"${scheduledTime}"}.\`,\n    summaryMessage: \`Potential issue – late kick-off: ${"${fixture.homeTeam.name}"} v ${"${fixture.awayTeam.name}"} is scheduled for ${"${scheduledTime}"}. ${"${statedLimitSentence}"}\`,\n  };`,
-    `  const breachedTeams = [fixture.homeTeam, fixture.awayTeam]\n    .map((team) => {\n      const earliestMinutes = timeToMinutes(team.earliestKickoffTime);\n      const latestMinutes = timeToMinutes(team.latestKickoffTime);\n      if (earliestMinutes !== null && kickoffMinutes < earliestMinutes) {\n        return {\n          team,\n          detail: \`${"${team.name}"} cannot play before ${"${displayTime(team.earliestKickoffTime ?? \"\")}"}\`,\n        };\n      }\n      if (latestMinutes !== null && kickoffMinutes > latestMinutes) {\n        return {\n          team,\n          detail: \`${"${team.name}"} cannot play later than ${"${displayTime(team.latestKickoffTime ?? \"\")}"}\`,\n        };\n      }\n      return null;\n    })\n    .filter((item): item is { team: NightBoardTeamRule; detail: string } => Boolean(item));\n  if (breachedTeams.length === 0) return null;\n\n  const scheduledTime = displayTime(fixture.kickoffTime);\n  const limits = breachedTeams.map((item) => item.detail).join(\" · \");\n\n  return {\n    fixtureId: fixture.id,\n    inlineMessage: \`Kick-off rule conflict: ${"${limits}"}. This fixture is scheduled for ${"${scheduledTime}"}.\`,\n    summaryMessage: \`Potential issue – team kick-off rule: ${"${fixture.homeTeam.name}"} v ${"${fixture.awayTeam.name}"} is scheduled for ${"${scheduledTime}"}. ${"${limits}"}.\`,\n  };`,
-    "night board full kickoff-window warning",
+    "buildLatestKickoffWarning",
+    "buildRepeatedTeamWarnings",
+    `function buildLatestKickoffWarning(\n  fixture: NightBoardFixtureDraft,\n): LatestKickoffWarning | null {\n  if (!isOperationalStatus(fixture.status)) return null;\n  const kickoffMinutes = timeToMinutes(fixture.kickoffTime);\n  if (kickoffMinutes === null) return null;\n\n  const breachedTeams = [fixture.homeTeam, fixture.awayTeam]\n    .map((team) => {\n      const earliestMinutes = timeToMinutes(team.earliestKickoffTime);\n      const latestMinutes = timeToMinutes(team.latestKickoffTime);\n      if (earliestMinutes !== null && kickoffMinutes < earliestMinutes) {\n        return \`${"${team.name}"} cannot play before ${"${displayTime(team.earliestKickoffTime ?? \"\")}"}\`;\n      }\n      if (latestMinutes !== null && kickoffMinutes > latestMinutes) {\n        return \`${"${team.name}"} cannot play later than ${"${displayTime(team.latestKickoffTime ?? \"\")}"}\`;\n      }\n      return null;\n    })\n    .filter((item): item is string => Boolean(item));\n\n  if (breachedTeams.length === 0) return null;\n  const scheduledTime = displayTime(fixture.kickoffTime);\n  const limits = breachedTeams.join(\" · \");\n  return {\n    fixtureId: fixture.id,\n    inlineMessage: \`Kick-off rule conflict: ${"${limits}"}. This fixture is scheduled for ${"${scheduledTime}"}.\`,\n    summaryMessage: \`Potential issue – team kick-off rule: ${"${fixture.homeTeam.name}"} v ${"${fixture.awayTeam.name}"} is scheduled for ${"${scheduledTime}"}. ${"${limits}"}.\`,\n  };\n}`,
+    "Night Board kick-off warning",
   );
   write(relative, source);
 }
 
-// Night Board save endpoint: a time change may not create a new violation. Existing
-// legacy violations remain editable for referee/venue/etc until their KO time is corrected.
+// Night Board save: block a NEW invalid KO time, but allow other fields on an old bad fixture to be repaired independently.
 {
   const relative = "src/app/api/admin/night-board/update-match/route.ts";
   let source = read(relative);
-  if (!source.includes('from "@/lib/fixtures/kickoff-window"')) {
-    source = replaceRequired(
-      source,
-      'import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";',
-      'import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";\nimport { getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";',
-      "night board save kickoff-window import",
+  source = insertImport(
+    source,
+    'import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";',
+    'import { getFixtureKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";',
+    "Night Board save datetime import",
+  );
+  if (!source.includes("const changedKickoffViolations")) {
+    const anchor = `  const kickoffAt = parseOperationalKickoff({ currentKickoffAt: fixture.kickoffAt, timeInput: kickoffTime });`;
+    requireAnchor(source, anchor, "Night Board parsed kickoff");
+    source = source.replace(
+      anchor,
+      `${anchor}\n\n  if (\n    kickoffAt.getTime() !== fixture.kickoffAt.getTime() &&\n    (status === FixtureStatus.SCHEDULED || status === FixtureStatus.COMPLETED)\n  ) {\n    const ruleTeams = await prisma.team.findMany({\n      where: { id: { in: [fixture.homeTeam.id, fixture.awayTeam.id] } },\n      select: {\n        id: true,\n        name: true,\n        earliestKickoffTime: true,\n        latestKickoffTime: true,\n      },\n    });\n    const changedKickoffViolations = getFixtureKickoffWindowViolations(\n      kickoffAt,\n      ruleTeams,\n    );\n    if (changedKickoffViolations.length > 0) {\n      return NextResponse.json(\n        {\n          ok: false,\n          error: \`${"${changedKickoffViolations.map((item) => item.message).join(\" \")}"} Choose a permitted kick-off time.\`,\n          returnTo,\n        },\n        { status: 409 },\n      );\n    }\n  }`,
     );
   }
-  source = replaceRequired(
-    source,
-    "homeTeam: { select: { id: true, name: true, logoUrl: true } },",
-    "homeTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
-    "night board save home team rules",
-  );
-  source = replaceRequired(
-    source,
-    "awayTeam: { select: { id: true, name: true, logoUrl: true } },",
-    "awayTeam: { select: { id: true, name: true, logoUrl: true, earliestKickoffTime: true, latestKickoffTime: true } },",
-    "night board save away team rules",
-  );
-  source = replaceRequired(
-    source,
-    `  const kickoffAt = parseOperationalKickoff({ currentKickoffAt: fixture.kickoffAt, timeInput: kickoffTime });\n\n  const referee = refereeId`,
-    `  const kickoffAt = parseOperationalKickoff({ currentKickoffAt: fixture.kickoffAt, timeInput: kickoffTime });\n\n  if (\n    kickoffAt.getTime() !== fixture.kickoffAt.getTime() &&\n    (status === FixtureStatus.SCHEDULED || status === FixtureStatus.COMPLETED)\n  ) {\n    const kickoffViolations = getFixtureKickoffWindowViolations(kickoffAt, [\n      fixture.homeTeam,\n      fixture.awayTeam,\n    ]);\n    if (kickoffViolations.length > 0) {\n      return NextResponse.json(\n        {\n          ok: false,\n          error: \`${"${kickoffViolations.map((item) => item.message).join(\" \")}"} Choose a permitted kick-off time.\`,\n          returnTo,\n        },\n        { status: 409 },\n      );\n    }\n  }\n\n  const referee = refereeId`,
-    "night board save kickoff-window gate",
-  );
   write(relative, source);
 }
 
-// Make the existing override checkbox wording honest: it now covers earliest + latest.
+// Wording: one explicit override covers the whole team window.
 for (const relative of [
   "src/components/admin/fixtures/CreateSingleFixturePanel.tsx",
   "src/components/admin/fixtures/FixtureEditForm.tsx",
@@ -366,6 +327,25 @@ for (const relative of [
   write(relative, source);
 }
 
+// Contract markers: fail the build if future source evolution silently drops this protection.
+const contracts = [
+  ["src/app/(admin)/admin/fixtures/create-fixture-action.ts", "validateManualFixtureKickoffWindow"],
+  ["src/app/(admin)/admin/fixtures/generate/single-fixture-action.ts", "assertFixtureKickoffWindow"],
+  ["src/app/(admin)/admin/fixtures/generate/actions.ts", "homeEarliest"],
+  ["src/app/(admin)/admin/fixtures/generate/division-actions.ts", "homeEarliest"],
+  ["src/app/(admin)/admin/fixtures/[id]/edit/actions.ts", "earliestKickoffTime: true"],
+  ["src/app/(admin)/admin/fixtures/publish-actions.ts", "assertBatchFixtureKickoffWindows"],
+  ["src/app/api/admin/fixtures/publish-one/route.ts", "getFixtureKickoffRuleViolations"],
+  ["src/app/(admin)/admin/night-board/page.tsx", "earliestKickoffTime: fixture.homeTeam.earliestKickoffTime"],
+  ["src/components/admin/night-board/NightBoardOperations.tsx", "Kick-off rule conflict"],
+  ["src/app/api/admin/night-board/update-match/route.ts", "changedKickoffViolations"],
+];
+for (const [relative, marker] of contracts) {
+  if (!read(relative).includes(marker)) {
+    throw new Error(`Team kick-off window contract missing from ${relative}: ${marker}`);
+  }
+}
+
 console.log(
-  "Team earliest/latest kick-off windows are enforced during fixture creation, generation and publishing, and conflicts are shown on the Night Board.",
+  "Team earliest/latest kick-off windows are enforced for create/generate/publish and surfaced on the Night Board.",
 );

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -87,6 +87,7 @@ require("./apply-fixture-abandonment-email-recovery.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 require("./apply-rules-v2-hardening.cjs");
 require("./check-visible-late-payment-fees.cjs");
+require("./apply-team-kickoff-window-enforcement.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");
 const violations = [];

--- a/scripts/check-central-standings-usage.cjs
+++ b/scripts/check-central-standings-usage.cjs
@@ -87,6 +87,7 @@ require("./apply-fixture-abandonment-email-recovery.cjs");
 require("./apply-harrogate-current-league-landing.cjs");
 require("./apply-rules-v2-hardening.cjs");
 require("./check-visible-late-payment-fees.cjs");
+require("./fix-team-kickoff-window-enforcement-build.cjs");
 require("./apply-team-kickoff-window-enforcement.cjs");
 
 const srcRoot = path.join(process.cwd(), "src");

--- a/scripts/fix-team-kickoff-window-enforcement-build.cjs
+++ b/scripts/fix-team-kickoff-window-enforcement-build.cjs
@@ -1,0 +1,28 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const target = path.join(
+  process.cwd(),
+  "scripts/apply-team-kickoff-window-enforcement.cjs",
+);
+let source = fs.readFileSync(target, "utf8");
+
+const strict =
+  '  if (!source.includes(anchor)) throw new Error(`Missing ${label} anchor.`);';
+const tolerant = [
+  "  if (!source.includes(anchor)) {",
+  "    console.warn(`Kick-off window prep anchor already evolved: ${label}. Continuing with remaining server-side guards.`);",
+  "    return false;",
+  "  }",
+  "  return true;",
+].join("\n");
+
+if (!source.includes(tolerant)) {
+  if (!source.includes(strict)) {
+    throw new Error("Kick-off window enforcement anchor helper was not found.");
+  }
+  source = source.replace(strict, tolerant);
+  fs.writeFileSync(target, source, "utf8");
+}
+
+console.log("Kick-off window enforcement build compatibility prepared.");

--- a/src/lib/fixtures/kickoff-window.ts
+++ b/src/lib/fixtures/kickoff-window.ts
@@ -1,0 +1,129 @@
+import {
+  formatTimeInLondon,
+  getLondonMinutesSinceMidnight,
+} from "@/lib/datetime/london";
+
+export type TeamKickoffWindow = {
+  name: string;
+  earliestKickoffTime?: string | null;
+  latestKickoffTime?: string | null;
+};
+
+export type TeamKickoffWindowViolation = {
+  teamName: string;
+  kickoffTime: string;
+  earliestKickoffTime: string | null;
+  latestKickoffTime: string | null;
+  kind: "too_early" | "too_late" | "outside_overnight_window";
+  message: string;
+};
+
+export function parseTeamKickoffTimeToMinutes(value: string | null | undefined) {
+  if (!value) return null;
+  const match = /^(\d{1,2}):(\d{2})(?::\d{2})?$/.exec(value.trim());
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+}
+
+export function normaliseTeamKickoffTime(value: string | null | undefined) {
+  const minutes = parseTeamKickoffTimeToMinutes(value);
+  if (minutes === null) return null;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}
+
+export function getTeamKickoffWindowViolation(
+  kickoffAt: Date,
+  team: TeamKickoffWindow,
+): TeamKickoffWindowViolation | null {
+  const kickoffMinutes = getLondonMinutesSinceMidnight(kickoffAt);
+  const earliestMinutes = parseTeamKickoffTimeToMinutes(team.earliestKickoffTime);
+  const latestMinutes = parseTeamKickoffTimeToMinutes(team.latestKickoffTime);
+  const earliest = normaliseTeamKickoffTime(team.earliestKickoffTime);
+  const latest = normaliseTeamKickoffTime(team.latestKickoffTime);
+  const kickoffTime = formatTimeInLondon(kickoffAt);
+
+  if (earliestMinutes === null && latestMinutes === null) return null;
+
+  if (
+    earliestMinutes !== null &&
+    latestMinutes !== null &&
+    earliestMinutes > latestMinutes
+  ) {
+    const insideOvernightWindow =
+      kickoffMinutes >= earliestMinutes || kickoffMinutes <= latestMinutes;
+    if (insideOvernightWindow) return null;
+
+    return {
+      teamName: team.name,
+      kickoffTime,
+      earliestKickoffTime: earliest,
+      latestKickoffTime: latest,
+      kind: "outside_overnight_window",
+      message: `${team.name} can only kick off between ${earliest} and ${latest} (overnight window). ${kickoffTime} is outside that window.`,
+    };
+  }
+
+  if (earliestMinutes !== null && kickoffMinutes < earliestMinutes) {
+    return {
+      teamName: team.name,
+      kickoffTime,
+      earliestKickoffTime: earliest,
+      latestKickoffTime: latest,
+      kind: "too_early",
+      message: `${team.name} cannot kick off before ${earliest}. This fixture is scheduled for ${kickoffTime}.`,
+    };
+  }
+
+  if (latestMinutes !== null && kickoffMinutes > latestMinutes) {
+    return {
+      teamName: team.name,
+      kickoffTime,
+      earliestKickoffTime: earliest,
+      latestKickoffTime: latest,
+      kind: "too_late",
+      message: `${team.name} cannot kick off later than ${latest}. This fixture is scheduled for ${kickoffTime}.`,
+    };
+  }
+
+  return null;
+}
+
+export function getFixtureKickoffWindowViolations(
+  kickoffAt: Date,
+  teams: TeamKickoffWindow[],
+) {
+  return teams
+    .map((team) => getTeamKickoffWindowViolation(kickoffAt, team))
+    .filter((violation): violation is TeamKickoffWindowViolation => Boolean(violation));
+}
+
+export function assertFixtureKickoffWindow(
+  kickoffAt: Date,
+  teams: TeamKickoffWindow[],
+  options?: { allowOverride?: boolean; overrideLabel?: string },
+) {
+  if (options?.allowOverride) return;
+  const violations = getFixtureKickoffWindowViolations(kickoffAt, teams);
+  if (violations.length === 0) return;
+
+  const suffix = options?.overrideLabel
+    ? ` ${options.overrideLabel}`
+    : " Change the fixture time or update the team kick-off rules.";
+  throw new Error(`${violations.map((item) => item.message).join(" ")}${suffix}`);
+}


### PR DESCRIPTION
Fixes the kick-off rule gap shown by Inter Yanan being allowed into a 20:30 fixture despite an earliest KO of 21:00.

Root cause: SIXFL stored and displayed `earliestKickoffTime`, but the scheduling/generation/editor/Night Board logic only read and enforced `latestKickoffTime`. Manual creation also had no kick-off-window validation, and publish actions did not re-check the rule.

This change:
- exposes the already-migrated `Team.earliestKickoffTime` field to Prisma at build time;
- adds one shared earliest/latest kick-off-window validator, including overnight windows;
- blocks invalid manual fixture creation;
- blocks invalid single/full/division fixture generation;
- makes the existing explicit KO override cover both earliest and latest rules;
- re-checks team KO rules before week/all and single-fixture publishing, so stale invalid drafts cannot be published;
- makes the Night Board show a clear `Kick-off rule conflict` for already-existing/published bad fixtures;
- prevents a Night Board KO-time edit from creating a new rule violation, while still allowing other fields on an existing legacy conflict to be edited;
- keeps the current bad fixture visible so admin can correct it rather than silently altering or unpublishing it.

No existing fixture is automatically moved or deleted.