### PR TITLE
Version kit terms and record captain acceptance

### DIFF
--- a/docs/kit-terms-v2-2.md
+++ b/docs/kit-terms-v2-2.md
@@ -1,0 +1,14 @@
+# Kit Offer Terms v2.2
+
+Effective: 22 August 2026
+
+This version clarifies that paid additional kits are a separate purchase from a team's right to participate in a SIXFL competition.
+
+- Unplaced free allocations may be withdrawn if a team withdraws, is suspended or is removed.
+- Paid additional kits that have not been placed with the supplier or entered production may be cancelled and refunded if participation ends.
+- Paid personalised kits already placed with the supplier or in production normally continue and are supplied.
+- Kit payments remain separate from match fees, disciplinary charges and other league balances unless expressly agreed otherwise.
+- New final kit submissions require the captain to accept the current terms and record the accepted version, timestamp and account.
+- Existing orders are not backfilled with v2.2 acceptance; null acceptance fields mean the order predates version tracking.
+
+Version 2.1 is retained in the admin Rules archive.

--- a/prisma/migrations/20260822194500_version_kit_terms_acceptance/migration.sql
+++ b/prisma/migrations/20260822194500_version_kit_terms_acceptance/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "TeamKitOrder"
+  ADD COLUMN IF NOT EXISTS "kitTermsVersion" TEXT,
+  ADD COLUMN IF NOT EXISTS "kitTermsAcceptedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "kitTermsAcceptedByUserId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "TeamKitOrder_kitTermsVersion_idx"
+  ON "TeamKitOrder" ("kitTermsVersion");
+
+COMMENT ON COLUMN "TeamKitOrder"."kitTermsVersion" IS
+  'Snapshot of the Founding Team Kit Offer Terms version accepted when the order was submitted. Null means the order predates version tracking.';
+
+COMMENT ON COLUMN "TeamKitOrder"."kitTermsAcceptedAt" IS
+  'Timestamp at which the submitting captain accepted the recorded kit terms version.';
+
+COMMENT ON COLUMN "TeamKitOrder"."kitTermsAcceptedByUserId" IS
+  'User account that accepted the recorded kit terms version. Stored as an audit snapshot rather than a foreign key so history survives account changes.';

--- a/scripts/apply-kit-terms-v2-2.cjs
+++ b/scripts/apply-kit-terms-v2-2.cjs
@@ -1,0 +1,108 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+
+function read(file) {
+  return fs.readFileSync(path.join(root, ...file.split("/")), "utf8");
+}
+
+function write(file, source) {
+  fs.writeFileSync(path.join(root, ...file.split("/")), source, "utf8");
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found.`);
+  }
+  return source.replace(before, after);
+}
+
+// Captain-facing form: acceptance is required only for final submission, not Save draft.
+{
+  const file = "src/components/captain/TeamKitOrderForm.tsx";
+  let source = read(file);
+
+  if (!source.includes('name="acceptKitTerms"')) {
+    const anchor = `      {!locked ? (\n        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">`;
+    const block = `      {!locked ? (\n        <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/[0.06] p-5 sm:p-6">\n          <label className="flex items-start gap-3 text-sm leading-6 text-white/75">\n            <input\n              type="checkbox"\n              name="acceptKitTerms"\n              className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-black/30"\n            />\n            <span>\n              I have checked the order details and agree to the current{\" \"}\n              <a\n                href="/founding-team-kit-terms"\n                target="_blank"\n                rel="noreferrer"\n                className="font-semibold text-emerald-200 underline underline-offset-2 hover:text-emerald-100"\n              >\n                Founding Team Kit Offer Terms\n              </a>\n              . This box is required when submitting the order; it is not required to save a draft.\n            </span>\n          </label>\n        </section>\n      ) : null}\n\n${anchor}`;
+
+    if (!source.includes(anchor)) {
+      throw new Error("Kit terms acceptance form anchor not found.");
+    }
+    source = source.replace(anchor, block);
+  }
+
+  write(file, source);
+}
+
+// Captain page: give a precise message when final submission is attempted without acceptance.
+{
+  const file = "src/app/captain/team/[teamid]/kit/page.tsx";
+  let source = read(file);
+
+  if (!source.includes('error === "kit_terms_required"')) {
+    const anchor = `  if (error === "save_failed") {`;
+    const insertion = `  if (error === "kit_terms_required") {\n    return "Please accept the current Founding Team Kit Offer Terms before submitting the order. You can still save the order as a draft without accepting them.";\n  }\n`;
+    if (!source.includes(anchor)) {
+      throw new Error("Kit terms error-message anchor not found.");
+    }
+    source = source.replace(anchor, `${insertion}${anchor}`);
+  }
+
+  write(file, source);
+}
+
+// Server action: server-side enforcement and immutable acceptance snapshot.
+{
+  const file = "src/app/captain/team/[teamid]/kit/save-v2.ts";
+  let source = read(file);
+
+  if (!source.includes('from "@/lib/kits/terms"')) {
+    source = replaceRequired(
+      source,
+      'import { getTeamExtraKitPaymentSummary } from "@/lib/kits/extra-kit-quantity";\n',
+      'import { getTeamExtraKitPaymentSummary } from "@/lib/kits/extra-kit-quantity";\nimport { KIT_OFFER_TERMS_VERSION } from "@/lib/kits/terms";\n',
+      "kit terms version import",
+    );
+  }
+
+  if (!source.includes('error: "kit_terms_required"')) {
+    source = replaceRequired(
+      source,
+      `  const intent = readString(formData, "intent");\n  const status = intent === "submit" ? "SUBMITTED" : "DRAFT";\n  const orderId = existingOrder?.id ?? randomUUID();`,
+      `  const intent = readString(formData, "intent");\n  const status = intent === "submit" ? "SUBMITTED" : "DRAFT";\n  const acceptedKitTerms = readString(formData, "acceptKitTerms") === "on";\n\n  if (status === "SUBMITTED" && !acceptedKitTerms) {\n    redirect(buildRedirect(teamId, { error: "kit_terms_required" }));\n  }\n\n  const orderId = existingOrder?.id ?? randomUUID();`,
+      "kit terms submit guard",
+    );
+  }
+
+  if (!source.includes('"kitTermsVersion" = CASE')) {
+    source = replaceRequired(
+      source,
+      `            "submittedAt" = CASE\n              WHEN \${status} = 'SUBMITTED' THEN \${now}\n              ELSE NULL\n            END,\n            "approvedAt" = NULL,`,
+      `            "submittedAt" = CASE\n              WHEN \${status} = 'SUBMITTED' THEN \${now}\n              ELSE NULL\n            END,\n            "kitTermsVersion" = CASE\n              WHEN \${status} = 'SUBMITTED' THEN \${KIT_OFFER_TERMS_VERSION}\n              ELSE "kitTermsVersion"\n            END,\n            "kitTermsAcceptedAt" = CASE\n              WHEN \${status} = 'SUBMITTED' THEN \${now}\n              ELSE "kitTermsAcceptedAt"\n            END,\n            "kitTermsAcceptedByUserId" = CASE\n              WHEN \${status} = 'SUBMITTED' THEN \${access.user?.id ?? null}\n              ELSE "kitTermsAcceptedByUserId"\n            END,\n            "approvedAt" = NULL,`,
+      "existing order kit terms audit fields",
+    );
+  }
+
+  if (!source.includes('"kitTermsVersion", "kitTermsAcceptedAt", "kitTermsAcceptedByUserId"')) {
+    source = replaceRequired(
+      source,
+      `            "captainNotes", "submittedByUserId", "lastEditedByUserId",\n            "submittedAt", "createdAt", "updatedAt"\n          )`,
+      `            "captainNotes", "submittedByUserId", "lastEditedByUserId",\n            "submittedAt", "kitTermsVersion", "kitTermsAcceptedAt",\n            "kitTermsAcceptedByUserId", "createdAt", "updatedAt"\n          )`,
+      "new order kit terms columns",
+    );
+
+    source = replaceRequired(
+      source,
+      `            \${access.user?.id ?? null},\n            \${status === "SUBMITTED" ? now : null}, \${now}, \${now}\n          )`,
+      `            \${access.user?.id ?? null},\n            \${status === "SUBMITTED" ? now : null},\n            \${status === "SUBMITTED" ? KIT_OFFER_TERMS_VERSION : null},\n            \${status === "SUBMITTED" ? now : null},\n            \${status === "SUBMITTED" ? access.user?.id ?? null : null},\n            \${now}, \${now}\n          )`,
+      "new order kit terms values",
+    );
+  }
+
+  write(file, source);
+}
+
+console.log("Kit Terms v2.2 acceptance and audit snapshot are applied.");

--- a/scripts/apply-kit-terms-v2-2.cjs
+++ b/scripts/apply-kit-terms-v2-2.cjs
@@ -69,11 +69,13 @@ function replaceRequired(source, before, after, label) {
   }
 
   if (!source.includes('error: "kit_terms_required"')) {
+    const statusAnchor = `  const status = intent === "submit" ? "SUBMITTED" : "DRAFT";\n`;
+    const acceptanceGuard = `${statusAnchor}  const acceptedKitTerms = readString(formData, "acceptKitTerms") === "on";\n\n  if (status === "SUBMITTED" && !acceptedKitTerms) {\n    redirect(buildRedirect(teamId, { error: "kit_terms_required" }));\n  }\n`;
     source = replaceRequired(
       source,
-      `  const intent = readString(formData, "intent");\n  const status = intent === "submit" ? "SUBMITTED" : "DRAFT";\n  const orderId = existingOrder?.id ?? randomUUID();`,
-      `  const intent = readString(formData, "intent");\n  const status = intent === "submit" ? "SUBMITTED" : "DRAFT";\n  const acceptedKitTerms = readString(formData, "acceptKitTerms") === "on";\n\n  if (status === "SUBMITTED" && !acceptedKitTerms) {\n    redirect(buildRedirect(teamId, { error: "kit_terms_required" }));\n  }\n\n  const orderId = existingOrder?.id ?? randomUUID();`,
-      "kit terms submit guard",
+      statusAnchor,
+      acceptanceGuard,
+      "kit terms submit status anchor",
     );
   }
 

--- a/scripts/apply-rules-v2-hardening.cjs
+++ b/scripts/apply-rules-v2-hardening.cjs
@@ -7,6 +7,7 @@ require("./fix-publish-tbc-fee-safety-compat.cjs");
 require("./apply-publish-tbc-fee-safety.cjs");
 require("./apply-resilient-published-fee-repair.cjs");
 require("./apply-participation-controls.cjs");
+require("./apply-kit-terms-v2-2.cjs");
 
 const root = process.cwd();
 
@@ -41,6 +42,11 @@ const matchRules = read("src/lib/match-rules.ts");
 const agreement = read("src/lib/league-agreement.ts");
 const archive = read("src/lib/rules-archive.ts");
 const captainGuide = read("src/app/captain/team/[teamid]/guide/page.tsx");
+const kitTerms = read("src/lib/kits/terms.ts");
+const kitTermsPage = read("src/app/(public)/founding-team-kit-terms/page.tsx");
+const kitForm = read("src/components/captain/TeamKitOrderForm.tsx");
+const kitSave = read("src/app/captain/team/[teamid]/kit/save-v2.ts");
+const rulesArchivePage = read("src/app/(admin)/admin/rules-archive/page.tsx");
 
 const checks = [
   [leagueRules.includes('LEAGUE_RULES_VERSION = "2.0"'), "League Rules must remain on v2.0"],
@@ -55,6 +61,14 @@ const checks = [
   [archive.includes('id: "match-rules-1-4"'), "Match Rules v1.4 must remain archived"],
   [archive.includes('id: "league-agreement-1-2"'), "League Agreement v1.2 must remain archived"],
   [captainGuide.includes("accepted before version tracking"), "Captain guide must show legacy acceptance state"],
+  [kitTerms.includes('KIT_OFFER_TERMS_VERSION = "2.2"'), "Kit Offer Terms must remain on v2.2"],
+  [kitTerms.includes('id: "founding-team-kit-terms-2-1"'), "Kit Offer Terms v2.1 must remain archived"],
+  [kitTerms.includes("Paid additional kits are treated separately"), "Kit terms must separate paid kit purchases from league participation"],
+  [kitTermsPage.includes("kitOfferTermsSections"), "Public kit terms page must use the versioned terms source"],
+  [rulesArchivePage.includes("archivedKitOfferTermsDocuments"), "Admin rules archive must include previous kit terms"],
+  [kitForm.includes('name="acceptKitTerms"'), "Kit submission form must require an explicit terms acknowledgement"],
+  [kitSave.includes('error: "kit_terms_required"'), "Kit submission server action must enforce terms acceptance"],
+  [kitSave.includes('"kitTermsAcceptedAt" = CASE'), "Kit submission must snapshot terms acceptance details"],
 ];
 
 const failures = checks.filter(([ok]) => !ok);

--- a/src/app/(admin)/admin/rules-archive/page.tsx
+++ b/src/app/(admin)/admin/rules-archive/page.tsx
@@ -10,6 +10,11 @@ import {
   LEAGUE_RULES_EFFECTIVE_DATE,
   LEAGUE_RULES_VERSION,
 } from "@/lib/league-rules";
+import {
+  KIT_OFFER_TERMS_EFFECTIVE_DATE,
+  KIT_OFFER_TERMS_VERSION,
+  archivedKitOfferTermsDocuments,
+} from "@/lib/kits/terms";
 import { MATCH_RULES_VERSION } from "@/lib/match-rules";
 import { archivedRuleDocuments } from "@/lib/rules-archive";
 import { requireAdmin } from "@/lib/requireAdmin";
@@ -37,6 +42,16 @@ const currentDocuments = [
     version: LEAGUE_AGREEMENT_VERSION,
     effectiveDate: LEAGUE_AGREEMENT_EFFECTIVE_DATE,
   },
+  {
+    document: "Founding Team Kit Offer Terms",
+    version: KIT_OFFER_TERMS_VERSION,
+    effectiveDate: KIT_OFFER_TERMS_EFFECTIVE_DATE,
+  },
+];
+
+const supersededDocuments = [
+  ...archivedRuleDocuments,
+  ...archivedKitOfferTermsDocuments,
 ];
 
 export default async function RulesArchivePage() {
@@ -52,13 +67,13 @@ export default async function RulesArchivePage() {
           Rules archive
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-emerald-50/75">
-          Superseded rules are retained here so SIXFL can identify the wording
-          that applied at an earlier date. Before publishing a new rules version,
+          Superseded rules and terms are retained here so SIXFL can identify the wording
+          that applied at an earlier date. Before publishing a new version,
           the outgoing active version should be copied into this archive.
         </p>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {currentDocuments.map((document) => (
           <div
             key={document.document}
@@ -90,7 +105,7 @@ export default async function RulesArchivePage() {
           </h2>
         </div>
 
-        {archivedRuleDocuments.map((document) => (
+        {supersededDocuments.map((document) => (
           <article
             key={document.id}
             className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.04]"

--- a/src/app/(public)/founding-team-kit-terms/page.tsx
+++ b/src/app/(public)/founding-team-kit-terms/page.tsx
@@ -4,57 +4,16 @@
 
 import Link from "next/link";
 
-const terms = [
-  {
-    title: "1. Who can receive the offer",
-    body: "The Founding Team Kit Offer is available only to teams expressly selected by SIXFL for a participating launch league. Registering interest does not guarantee eligibility. The team must complete registration and secure its league place. The free kit entitlement becomes claimable only after the team has played three SIXFL league fixtures and the corresponding fixture charges for those three matches have been paid in full.",
-  },
-  {
-    title: "2. Claim deadline",
-    body: "Once the team becomes eligible after its third paid match, the free kit order must be claimed and submitted within 60 days. The 60-day period starts on the date the third qualifying fixture charge is paid in full. If the team does not submit its free kit order within that period, the unclaimed offer expires unless SIXFL agrees otherwise in writing.",
-  },
-  {
-    title: "3. What is included",
-    body: "The offer contains seven complete playing kits: seven shirts, seven pairs of shorts and seven pairs of socks. One design is selected for the whole team, subject to supplier availability.",
-  },
-  {
-    title: "4. Price",
-    body: "The seven included kits are supplied free of charge. Personalised names and shirt numbers are included and there is no compulsory printing contribution.",
-  },
-  {
-    title: "5. Personalisation",
-    body: "Every shirt must have a unique squad number from 1 to 99. A player name may also be added but is optional. The submitted personalisation is included in the free seven-kit allocation.",
-  },
-  {
-    title: "6. Captain approval",
-    body: "The captain is responsible for checking the selected design, all kit sizes, names and shirt numbers before submitting the order. Submitting confirms that the supplied details are correct and that the captain accepts these terms.",
-  },
-  {
-    title: "7. Changes and personalised items",
-    body: "Changes cannot normally be made once personalised production has started. SIXFL is not responsible for errors supplied or approved by the captain. This does not affect rights relating to items that are faulty, incorrectly produced or not as described.",
-  },
-  {
-    title: "8. Availability and alternatives",
-    body: "Designs, colours and sizes remain subject to supplier availability. If a selected design becomes unavailable, SIXFL will offer a reasonable alternative for the captain to approve before ordering.",
-  },
-  {
-    title: "9. Additional and replacement items",
-    body: "The free offer covers seven complete kits. Additional complete kits cost £20 each. Later replacements and changes requested after the original order may be charged separately at the price confirmed by SIXFL.",
-  },
-  {
-    title: "10. Withdrawal, expiry, transfer and cash value",
-    body: "The offer has no cash alternative and cannot be transferred to another team without SIXFL approval. SIXFL may withdraw an unplaced allocation where a team does not secure its league place, does not complete and pay for the three qualifying matches, misses the 60-day claim deadline, withdraws from the league or provides incomplete order details.",
-  },
-  {
-    title: "11. Production and delivery",
-    body: "Any production or delivery date is an estimate and may be affected by supplier availability, personalisation or shipping. SIXFL will update the captain if there is a material delay.",
-  },
-];
+import {
+  KIT_OFFER_TERMS_EFFECTIVE_DATE,
+  KIT_OFFER_TERMS_VERSION,
+  kitOfferTermsSections,
+} from "@/lib/kits/terms";
 
 export const metadata = {
   title: "Founding Team Kit Offer Terms | SIXFL",
   description:
-    "Terms for the SIXFL founding-team offer of seven complete personalised playing kits free of charge after three paid matches, with a 60-day claim period.",
+    "Terms for the SIXFL founding-team offer of seven complete personalised playing kits free of charge after three paid matches, including paid additional-kit orders.",
 };
 
 export default function FoundingTeamKitTermsPage() {
@@ -68,14 +27,14 @@ export default function FoundingTeamKitTermsPage() {
           Free Team Kit Offer Terms
         </h1>
         <p className="mt-5 max-w-3xl text-base leading-7 text-white/70 sm:text-lg">
-          Seven complete personalised playing kits free of charge after three paid matches. Once eligible, the offer must be claimed within 60 days.
+          Seven complete personalised playing kits free of charge after three paid matches. Paid additional kits are handled separately from league participation.
         </p>
 
         <div className="mt-7 grid gap-3 sm:grid-cols-4">
           {[
             ["Included", "7 complete kits"],
             ["Team price", "Free"],
-            ["Eligible after", "3 paid matches"],
+            ["Extra kits", "£20 each"],
             ["Claim within", "60 days"],
           ].map(([label, value]) => (
             <div key={label} className="rounded-2xl border border-white/10 bg-black/25 p-4">
@@ -89,10 +48,14 @@ export default function FoundingTeamKitTermsPage() {
       </section>
 
       <section className="space-y-4">
-        {terms.map((term) => (
+        {kitOfferTermsSections.map((term) => (
           <article key={term.title} className="rounded-2xl border border-white/10 bg-white/[0.04] p-5 sm:p-6">
             <h2 className="text-lg font-black text-white">{term.title}</h2>
-            <p className="mt-2 text-sm leading-7 text-white/70 sm:text-base">{term.body}</p>
+            <div className="mt-2 space-y-2 text-sm leading-7 text-white/70 sm:text-base">
+              {term.points.map((point) => (
+                <p key={point}>{point}</p>
+              ))}
+            </div>
           </article>
         ))}
       </section>
@@ -100,7 +63,7 @@ export default function FoundingTeamKitTermsPage() {
       <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-6 sm:p-8">
         <h2 className="text-2xl font-black text-white">Before submitting an order</h2>
         <p className="mt-3 max-w-3xl text-sm leading-7 text-white/75 sm:text-base">
-          Check that your team has completed three paid SIXFL matches and is still within its 60-day claim period. Then check every design, size, name and number carefully before submitting the order.
+          Check every design, size, name and number carefully. New kit submissions record the version of these terms accepted by the captain at the time of submission.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
@@ -119,7 +82,7 @@ export default function FoundingTeamKitTermsPage() {
       </section>
 
       <p className="text-xs leading-6 text-white/40">
-        Version 2.1 · Last updated 11 August 2026
+        Version {KIT_OFFER_TERMS_VERSION} · Effective {KIT_OFFER_TERMS_EFFECTIVE_DATE}
       </p>
     </div>
   );

--- a/src/lib/kits/terms.ts
+++ b/src/lib/kits/terms.ts
@@ -1,0 +1,118 @@
+export const KIT_OFFER_TERMS_VERSION = "2.2";
+export const KIT_OFFER_TERMS_EFFECTIVE_DATE = "22 August 2026";
+export const KIT_OFFER_TERMS_NEXT_REVIEW = "22 August 2027";
+
+export type KitOfferTermSection = {
+  title: string;
+  points: string[];
+};
+
+export const kitOfferTermsSections: KitOfferTermSection[] = [
+  {
+    title: "1. Who can receive the offer",
+    points: [
+      "The Founding Team Kit Offer is available only to teams expressly selected by SIXFL for a participating launch league. Registering interest does not guarantee eligibility.",
+      "The team must complete registration and secure its league place. The free kit entitlement becomes claimable only after the team has played three SIXFL league fixtures and the corresponding fixture charges for those three matches have been paid in full.",
+    ],
+  },
+  {
+    title: "2. Claim deadline",
+    points: [
+      "Once the team becomes eligible after its third paid match, the free kit order must be claimed and submitted within 60 days. The 60-day period starts on the date the third qualifying fixture charge is paid in full.",
+      "If the team does not submit its free kit order within that period, the unclaimed offer expires unless SIXFL agrees otherwise in writing.",
+    ],
+  },
+  {
+    title: "3. What is included",
+    points: [
+      "The offer contains seven complete playing kits: seven shirts, seven pairs of shorts and seven pairs of socks. One design is selected for the whole team, subject to supplier availability.",
+    ],
+  },
+  {
+    title: "4. Price",
+    points: [
+      "The seven included kits are supplied free of charge. Personalised names and shirt numbers are included and there is no compulsory printing contribution.",
+    ],
+  },
+  {
+    title: "5. Personalisation",
+    points: [
+      "Every shirt must have a unique squad number from 1 to 99. A player name may also be added but is optional. The submitted personalisation is included in the free seven-kit allocation.",
+    ],
+  },
+  {
+    title: "6. Captain approval and acceptance",
+    points: [
+      "The captain is responsible for checking the selected design, all kit sizes, names and shirt numbers before submitting the order.",
+      "Submitting the order confirms that the supplied details are correct and that the captain accepts the version of these terms displayed at the time of submission.",
+      "SIXFL records the accepted terms version, acceptance time and submitting account for new kit submissions made after version tracking was introduced.",
+    ],
+  },
+  {
+    title: "7. Changes and personalised items",
+    points: [
+      "Changes cannot normally be made once personalised production has started. SIXFL is not responsible for errors supplied or approved by the captain.",
+      "This does not affect rights relating to items that are faulty, incorrectly produced or not as described.",
+    ],
+  },
+  {
+    title: "8. Availability and alternatives",
+    points: [
+      "Designs, colours and sizes remain subject to supplier availability. If a selected design becomes unavailable, SIXFL will offer a reasonable alternative for the captain to approve before ordering.",
+    ],
+  },
+  {
+    title: "9. Additional and replacement items",
+    points: [
+      "The free offer covers seven complete kits. Additional complete kits cost £20 each unless SIXFL expressly confirms a different price before purchase.",
+      "Later replacements and changes requested after the original order may be charged separately at the price confirmed by SIXFL.",
+    ],
+  },
+  {
+    title: "10. Withdrawal, suspension, removal, transfer and cash value",
+    points: [
+      "The free offer has no cash alternative and cannot be transferred to another team without SIXFL approval.",
+      "SIXFL may withdraw an unplaced free kit allocation where a team does not secure its league place, does not complete and pay for the three qualifying matches, misses the 60-day claim deadline, withdraws from the league, is suspended or removed from the competition, or provides incomplete order details.",
+      "Withdrawal, suspension or removal does not entitle a team to the cash value of an unplaced free allocation.",
+    ],
+  },
+  {
+    title: "11. Paid additional kits if a team leaves or is removed",
+    points: [
+      "Paid additional kits are treated separately from the team's right to participate in the league.",
+      "If paid additional kits have not been placed with the supplier or entered personalised production when the team withdraws, is suspended or is removed, SIXFL may cancel those unplaced paid items and will refund the amount paid for the cancelled items.",
+      "Where paid personalised kits have already been placed with the supplier or entered production, the order will normally continue and the items will be supplied to the purchaser. A team's withdrawal, suspension or removal from a SIXFL competition does not by itself cancel an already-placed paid personalised kit order.",
+      "Kit payments are accounted for separately from match fees, disciplinary charges and other league balances unless SIXFL and the purchaser expressly agree otherwise.",
+    ],
+  },
+  {
+    title: "12. Production and delivery",
+    points: [
+      "Any production or delivery date is an estimate and may be affected by supplier availability, personalisation or shipping. SIXFL will update the captain if there is a material delay.",
+    ],
+  },
+];
+
+export const archivedKitOfferTermsDocuments = [
+  {
+    id: "founding-team-kit-terms-2-1",
+    document: "Founding Team Kit Offer Terms",
+    version: "2.1",
+    effectiveDate: "11 August 2026",
+    supersededDate: "22 August 2026",
+    status: "Superseded" as const,
+    sections: [
+      { title: "1. Who can receive the offer", points: ["The Founding Team Kit Offer is available only to teams expressly selected by SIXFL for a participating launch league. Registering interest does not guarantee eligibility. The team must complete registration and secure its league place. The free kit entitlement becomes claimable only after the team has played three SIXFL league fixtures and the corresponding fixture charges for those three matches have been paid in full."] },
+      { title: "2. Claim deadline", points: ["Once the team becomes eligible after its third paid match, the free kit order must be claimed and submitted within 60 days. The 60-day period starts on the date the third qualifying fixture charge is paid in full. If the team does not submit its free kit order within that period, the unclaimed offer expires unless SIXFL agrees otherwise in writing."] },
+      { title: "3. What is included", points: ["The offer contains seven complete playing kits: seven shirts, seven pairs of shorts and seven pairs of socks. One design is selected for the whole team, subject to supplier availability."] },
+      { title: "4. Price", points: ["The seven included kits are supplied free of charge. Personalised names and shirt numbers are included and there is no compulsory printing contribution."] },
+      { title: "5. Personalisation", points: ["Every shirt must have a unique squad number from 1 to 99. A player name may also be added but is optional. The submitted personalisation is included in the free seven-kit allocation."] },
+      { title: "6. Captain approval", points: ["The captain is responsible for checking the selected design, all kit sizes, names and shirt numbers before submitting the order. Submitting confirms that the supplied details are correct and that the captain accepts these terms."] },
+      { title: "7. Changes and personalised items", points: ["Changes cannot normally be made once personalised production has started. SIXFL is not responsible for errors supplied or approved by the captain. This does not affect rights relating to items that are faulty, incorrectly produced or not as described."] },
+      { title: "8. Availability and alternatives", points: ["Designs, colours and sizes remain subject to supplier availability. If a selected design becomes unavailable, SIXFL will offer a reasonable alternative for the captain to approve before ordering."] },
+      { title: "9. Additional and replacement items", points: ["The free offer covers seven complete kits. Additional complete kits cost £20 each. Later replacements and changes requested after the original order may be charged separately at the price confirmed by SIXFL."] },
+      { title: "10. Withdrawal, expiry, transfer and cash value", points: ["The offer has no cash alternative and cannot be transferred to another team without SIXFL approval. SIXFL may withdraw an unplaced allocation where a team does not secure its league place, does not complete and pay for the three qualifying matches, misses the 60-day claim deadline, withdraws from the league or provides incomplete order details."] },
+      { title: "11. Production and delivery", points: ["Any production or delivery date is an estimate and may be affected by supplier availability, personalisation or shipping. SIXFL will update the captain if there is a material delay."] },
+    ],
+  },
+];


### PR DESCRIPTION
Publishes Founding Team Kit Offer Terms v2.2 and records the accepted terms version for future kit submissions.

Key changes:
- clarifies that paid additional kits are separate from league participation;
- permits cancellation/refund of paid extras that have not been placed into production when a team leaves/is suspended/is removed;
- confirms paid personalised kits already placed with the supplier or in production normally continue and are supplied;
- clarifies that unplaced free allocations may be withdrawn if a team withdraws, is suspended or is removed;
- keeps kit payments separate from match fees and disciplinary balances;
- archives Kit Terms v2.1 in Back end functions > Rules archive;
- adds a captain acceptance checkbox for final kit submission (Save draft remains available without acceptance);
- server-side enforcement prevents final submission without acceptance;
- stores accepted kit terms version, timestamp and user account on TeamKitOrder;
- does not backfill existing orders, so pre-version-tracking orders remain clearly distinguishable.

Effective date: 22 August 2026.