### PR TITLE
Use one consistent footer link colour

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -153,10 +153,7 @@ export default function SiteFooter() {
                   <Link
                     key={`${link.href}-${link.label}`}
                     href={link.href}
-                    className={[
-                      "inline-flex min-h-9 items-center leading-5 transition hover:text-emerald-400",
-                      link.featured ? "font-semibold text-emerald-200" : "",
-                    ].join(" ")}
+                    className="inline-flex min-h-9 items-center leading-5 text-white/80 transition hover:text-emerald-400"
                   >
                     {link.label}
                   </Link>


### PR DESCRIPTION
Makes every standard footer navigation link use the same light text colour by default, with green reserved for hover. Removes the visual inconsistency where selected links appeared permanently green while others were white. Footer CTA button, social icons and section headings are unchanged.