### PR TITLE
Fix admin lead exclude filter build typo

### DIFF
--- a/scripts/apply-rules-v2-hardening.cjs
+++ b/scripts/apply-rules-v2-hardening.cjs
@@ -10,6 +10,7 @@ require("./apply-participation-controls.cjs");
 require("./apply-kit-terms-v2-2.cjs");
 require("./apply-team-name-soft-review.cjs");
 require("./apply-admin-lead-exclude-filters.cjs");
+require("./fix-admin-lead-exclude-filter-typo.cjs");
 
 const root = process.cwd();
 

--- a/scripts/fix-admin-lead-exclude-filter-typo.cjs
+++ b/scripts/fix-admin-lead-exclude-filter-typo.cjs
@@ -1,0 +1,17 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const file = path.join(process.cwd(), "src", "app", "(admin)", "admin", "leads", "page.tsx");
+let source = fs.readFileSync(file, "utf8");
+
+source = source
+  .replaceAll(", excludeType, excludeStatus })", ", excludeType: excludedType, excludeStatus: excludedStatus })")
+  .replaceAll(", excludeType, excludeStatus:", ", excludeType: excludedType, excludeStatus:")
+  .replaceAll(", excludeStatus })", ", excludeStatus: excludedStatus })");
+
+if (source.includes(" excludeType,")) {
+  throw new Error("Admin lead exclude filter typo fix: unresolved excludeType variable reference remains.");
+}
+
+fs.writeFileSync(file, source, "utf8");
+console.log("Admin lead exclude filter variable names fixed.");


### PR DESCRIPTION
Fixes the deployment TypeScript error introduced by the Admin Leads exclude filter. The prebuild patch generated JSX references to `excludeType` / `excludeStatus`, while the resolved variables are named `excludedType` / `excludedStatus`.

Adds a small idempotent compatibility fix immediately after the exclude-filter patch so the generated Admin Leads page uses the correct variable names before TypeScript compilation.