### PR TITLE
Stop stale PAID status hiding unpaid late fees

### DIFF
--- a/scripts/check-visible-late-payment-fees.cjs
+++ b/scripts/check-visible-late-payment-fees.cjs
@@ -4,6 +4,7 @@ const path = require("node:path");
 require("./apply-fixture-matchup-grid-screen-fit.cjs");
 require("./apply-meta-area-import-inference.cjs");
 require("./apply-late-fee-canonical-coverage.cjs");
+require("./fix-late-fee-stale-paid-candidates.cjs");
 
 const root = process.cwd();
 
@@ -60,6 +61,15 @@ const checks = [
   {
     ok: page.includes('Covered: {formatMoney(row.paidTotalPence)}'),
     message: "late-payment review must label canonical fixture coverage accurately",
+  },
+  {
+    ok:
+      actions.includes(`WHERE charge.\"status\" <> 'VOID'`) &&
+      !actions.includes(`charge.\"status\" IN ('OPEN', 'PART_PAID')`) &&
+      actions.includes("const settledPence = ledgerEntry?.settledPence ?? coveredPence;") &&
+      actions.includes("canonicalOutstandingPence") &&
+      !actions.includes('charge.status === "PAID" ||'),
+    message: "late-payment review must not hide genuinely unpaid charges just because their stored status is stale PAID",
   },
 ];
 

--- a/scripts/fix-late-fee-stale-paid-candidates.cjs
+++ b/scripts/fix-late-fee-stale-paid-candidates.cjs
@@ -1,0 +1,56 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const actionsPath = path.join(
+  process.cwd(),
+  "src/app/(admin)/admin/fixtures/late-fees/actions.ts",
+);
+
+let source = fs.readFileSync(actionsPath, "utf8");
+
+function replaceRequired(before, after, label) {
+  if (source.includes(after)) return;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found.`);
+  }
+  source = source.replace(before, after);
+}
+
+replaceRequired(
+  `      WHERE charge.\"status\" IN ('OPEN', 'PART_PAID')\n        AND charge.\"latePaymentFeeStatus\" <> 'APPLIED'`,
+  `      WHERE charge.\"status\" <> 'VOID'\n        AND charge.\"latePaymentFeeStatus\" <> 'APPLIED'`,
+  "late-fee candidate stored-status filter",
+);
+
+replaceRequired(
+  `    const coveredPence = ledgerEntry?.coveredPence ?? charge.paidTotalPence;\n    const outstandingBeforeDecision =\n      ledgerEntry?.outstandingPence ??\n      Math.max(charge.amountPence - coveredPence, 0);\n\n    if (\n      charge.status === \"PAID\" ||\n      ledgerEntry?.displayStatus === \"PAID\" ||\n      outstandingBeforeDecision <= 0\n    ) {\n      throw new Error(\"Charge is already fully covered and cannot receive a late payment fee.\");\n    }`,
+  `    const coveredPence = ledgerEntry?.coveredPence ?? charge.paidTotalPence;\n    const settledPence = ledgerEntry?.settledPence ?? coveredPence;\n    const outstandingBeforeDecision = Math.max(\n      charge.amountPence - settledPence,\n      0,\n    );\n\n    if (outstandingBeforeDecision <= 0) {\n      throw new Error(\"Charge is already fully covered and cannot receive a late payment fee.\");\n    }`,
+  "late-fee decision stale paid status guard",
+);
+
+replaceRequired(
+  `    const nextStatus = getChargeStatus({\n      amountPence: nextAmountPence,\n      paidTotalPence: coveredPence,\n    });`,
+  `    const nextStatus = getChargeStatus({\n      amountPence: nextAmountPence,\n      paidTotalPence: settledPence,\n    });`,
+  "late-fee decision settled status calculation",
+);
+
+replaceRequired(
+  `    .map((row) => {\n      const ledgerEntry = ledgerEntryByChargeId.get(row.chargeId);\n      if (!ledgerEntry) return row;\n\n      return {\n        ...row,\n        chargeStatus: ledgerEntry.displayStatus,\n        paidTotalPence: ledgerEntry.coveredPence,\n        outstandingPence: ledgerEntry.outstandingPence,\n      };\n    })\n    .filter(\n      (row) =>\n        row.outstandingPence > 0 &&\n        row.chargeStatus !== \"PAID\" &&\n        row.chargeStatus !== \"VOID\",\n    );`,
+  `    .map((row) => {\n      const ledgerEntry = ledgerEntryByChargeId.get(row.chargeId);\n      const coveredPence = ledgerEntry?.coveredPence ?? row.paidTotalPence;\n      const settledPence = ledgerEntry?.settledPence ?? coveredPence;\n      const canonicalOutstandingPence = Math.max(\n        row.amountPence - settledPence,\n        0,\n      );\n      const canonicalStatus =\n        canonicalOutstandingPence <= 0\n          ? \"PAID\"\n          : settledPence > 0\n            ? \"PART_PAID\"\n            : \"OPEN\";\n\n      return {\n        ...row,\n        chargeStatus: canonicalStatus,\n        paidTotalPence: coveredPence,\n        outstandingPence: canonicalOutstandingPence,\n      };\n    })\n    .filter((row) => row.outstandingPence > 0 && row.chargeStatus !== \"VOID\");`,
+  "late-fee candidate canonical status mapping",
+);
+
+if (
+  source.includes(`charge.\"status\" IN ('OPEN', 'PART_PAID')`) ||
+  source.includes('charge.status === "PAID" ||') ||
+  !source.includes("const settledPence = ledgerEntry?.settledPence ?? coveredPence;") ||
+  !source.includes("canonicalOutstandingPence") ||
+  !source.includes(`WHERE charge.\"status\" <> 'VOID'`)
+) {
+  throw new Error("Stale paid late-fee candidate repair did not apply correctly.");
+}
+
+fs.writeFileSync(actionsPath, source, "utf8");
+console.log(
+  "Late-fee review now evaluates stale stored PAID charges from real settlement coverage before deciding whether to hide them.",
+);


### PR DESCRIPTION
Fixes missing unpaid teams such as Eagles/Bayern disappearing from Admin > Late Fees after canonical payment reconciliation.

Root cause: the late-fee query still pre-filtered candidates to stored PaymentCharge status OPEN/PART_PAID before the canonical ledger reconciliation ran. Any historically stale PAID status therefore vanished before real settled/outstanding amounts could be checked.

This change:
- considers every non-VOID charge old enough for late-fee review, regardless of stored OPEN/PART_PAID/PAID state;
- derives true outstanding from canonical settledPence (real payments + player settlement/subsidy + valid SIXFL waiver), so genuine settled charges remain hidden;
- reclassifies stale PAID rows as OPEN/PART_PAID for this review when real settlement is short;
- removes the server-side stored-PAID block so a genuinely outstanding stale charge can still be warned/charged;
- keeps VOID charges excluded, including correctly waived innocent-team abandonment charges;
- adds a regression contract so stale stored PAID can no longer silently hide genuine debt.

No payment records or charge statuses are rewritten.