### PR TITLE
Preserve 72-hour late-fee review after canonical reconciliation

### DIFF
--- a/scripts/check-visible-late-payment-fees.cjs
+++ b/scripts/check-visible-late-payment-fees.cjs
@@ -5,6 +5,7 @@ require("./apply-fixture-matchup-grid-screen-fit.cjs");
 require("./apply-meta-area-import-inference.cjs");
 require("./apply-late-fee-canonical-coverage.cjs");
 require("./fix-late-fee-stale-paid-candidates.cjs");
+require("./fix-late-fee-canonical-72h-review.cjs");
 
 const root = process.cwd();
 
@@ -70,6 +71,13 @@ const checks = [
       actions.includes("canonicalOutstandingPence") &&
       !actions.includes('charge.status === "PAID" ||'),
     message: "late-payment review must not hide genuinely unpaid charges just because their stored status is stale PAID",
+  },
+  {
+    ok:
+      actions.includes("INTERVAL '72 hours' <= NOW()") &&
+      actions.includes('COALESCE(fixture."kickoffAt", charge."dueDate")') &&
+      !actions.includes('WHERE "daysLate" >= 7'),
+    message: "canonical payment reconciliation must preserve the 72-hour post-fixture review window",
   },
 ];
 

--- a/scripts/fix-late-fee-canonical-72h-review.cjs
+++ b/scripts/fix-late-fee-canonical-72h-review.cjs
@@ -1,0 +1,59 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const actionsPath = path.join(
+  process.cwd(),
+  "src/app/(admin)/admin/fixtures/late-fees/actions.ts",
+);
+let source = fs.readFileSync(actionsPath, "utf8");
+
+function replaceRequired(before, after, label) {
+  if (source.includes(after)) return;
+  if (!source.includes(before)) {
+    throw new Error(`Expected ${label} source was not found.`);
+  }
+  source = source.replace(before, after);
+}
+
+// Canonical payment reconciliation is applied late in the production patch chain.
+// It must not undo the existing rule that unpaid fixture charges enter admin review
+// 72 hours after kick-off. The separate £10 admin-fee eligibility remains seven days.
+replaceRequired(
+  [
+    '        CASE',
+    '          WHEN charge."dueDate" IS NULL THEN NULL',
+    '          ELSE FLOOR(EXTRACT(EPOCH FROM (NOW() - charge."dueDate")) / 86400)::int',
+    '        END AS "daysLate",',
+  ].join("\n"),
+  [
+    '        CASE',
+    '          WHEN COALESCE(fixture."kickoffAt", charge."dueDate") IS NULL THEN NULL',
+    '          ELSE FLOOR(',
+    '            EXTRACT(EPOCH FROM (NOW() - COALESCE(fixture."kickoffAt", charge."dueDate"))) / 86400',
+    '          )::int',
+    '        END AS "daysLate",',
+  ].join("\n"),
+  "canonical late-fee 72-hour age calculation",
+);
+
+replaceRequired(
+  '    WHERE "daysLate" >= 7',
+  [
+    '    WHERE COALESCE("kickoffAt", "dueDate") IS NOT NULL',
+    '      AND COALESCE("kickoffAt", "dueDate") + INTERVAL \'72 hours\' <= NOW()',
+  ].join("\n"),
+  "canonical late-fee 72-hour review filter",
+);
+
+if (
+  source.includes('WHERE "daysLate" >= 7') ||
+  !source.includes("INTERVAL '72 hours' <= NOW()") ||
+  !source.includes('COALESCE(fixture."kickoffAt", charge."dueDate")')
+) {
+  throw new Error("Canonical late-fee review no longer preserves the 72-hour review window.");
+}
+
+fs.writeFileSync(actionsPath, source, "utf8");
+console.log(
+  "Canonical late-fee reconciliation now preserves the 72-hour post-fixture review window and the separate seven-day £10 fee grace period.",
+);


### PR DESCRIPTION
Fixes the remaining reason recent unpaid teams such as Eagles could still be absent from Admin > Late Fees even after stale PAID charges were restored.

Root cause: the earlier 72-hour review patch was applied first, but the later canonical payment reconciliation patch rebuilt getPaymentLateFeeRows() with the old `daysLate >= 7` filter. That silently changed the review window back to seven days. Eagles' Tue 18 Aug fixture is only about five days old, so it was correctly shown as £40 due on the fixture/night board but then filtered out of Late Fees until day seven.

This change reapplies and guards the intended rule after canonical reconciliation:
- fixture charges enter Late Fees 72 hours after kick-off;
- manual charges use due date + 72 hours when there is no fixture;
- the £10 admin fee still keeps its separate existing seven-day grace period;
- stale stored PAID charges are still reconciled using canonical settlement coverage before deciding whether they remain visible;
- regression checks fail if a later patch silently restores the seven-day review filter again.

No payment data or charge statuses are changed.