### PR TITLE
Restore legacy waived fee adjustments in payment totals

### DIFF
--- a/scripts/fix-applied-late-fee-visibility.cjs
+++ b/scripts/fix-applied-late-fee-visibility.cjs
@@ -45,3 +45,5 @@ fs.writeFileSync(actionsPath, source, "utf8");
 console.log(
   "Applied late-payment fees now remain visible in the admin audit section, including after payment.",
 );
+
+require("./fix-legacy-waiver-reconciliation.cjs");

--- a/scripts/fix-applied-late-fee-visibility.cjs
+++ b/scripts/fix-applied-late-fee-visibility.cjs
@@ -12,28 +12,59 @@ let source = fs.readFileSync(actionsPath, "utf8");
 // admin page, which intentionally splits the returned rows into review rows and
 // an "Applied £10 late-payment fees" audit section. Keep APPLIED rows in the data
 // set, including paid ones, so the fee remains visible and reversible.
+//
+// Do not depend on one exact surrounding WHERE block here. Several later payment
+// patches legitimately reshape that block, so remove only the obsolete APPLIED
+// exclusion itself and leave every other candidate condition intact.
 source = source.replace(
-  `      WHERE charge.\"status\" <> 'VOID'\n        AND charge.\"latePaymentFeeStatus\" <> 'APPLIED'`,
-  `      WHERE charge.\"status\" <> 'VOID'`,
-);
-source = source.replace(
-  `      WHERE charge.\"status\" IN ('OPEN', 'PART_PAID')\n        AND charge.\"latePaymentFeeStatus\" <> 'APPLIED'`,
-  `      WHERE charge.\"status\" <> 'VOID'`,
+  /^\s*AND\s+charge\."latePaymentFeeStatus"\s*<>\s*'APPLIED'\s*$/gm,
+  "",
 );
 
-const oldFilter = `.filter((row) => row.outstandingPence > 0 && row.chargeStatus !== \"VOID\");`;
-const newFilter = `.filter(\n      (row) =>\n        row.chargeStatus !== \"VOID\" &&\n        (row.paymentLateFeeStatus === \"APPLIED\" || row.outstandingPence > 0),\n    );`;
-if (source.includes(oldFilter)) {
-  source = source.replace(oldFilter, newFilter);
-}
+// Very old generated variants can still carry the OPEN/PART_PAID pre-filter.
+// Canonical reconciliation must be allowed to inspect stale PAID rows too.
+source = source.replace(
+  `      WHERE charge."status" IN ('OPEN', 'PART_PAID')`,
+  `      WHERE charge."status" <> 'VOID'`,
+);
 
-const olderFilter = `.filter(\n      (row) =>\n        row.outstandingPence > 0 &&\n        row.chargeStatus !== \"PAID\" &&\n        row.chargeStatus !== \"VOID\",\n    );`;
-if (source.includes(olderFilter)) {
-  source = source.replace(olderFilter, newFilter);
+const requiredFilter = [
+  '.filter(',
+  '      (row) =>',
+  '        row.chargeStatus !== "VOID" &&',
+  '        (row.paymentLateFeeStatus === "APPLIED" || row.outstandingPence > 0),',
+  '    );',
+].join("\n");
+
+if (!source.includes(requiredFilter)) {
+  const simpleFilter = `.filter((row) => row.outstandingPence > 0 && row.chargeStatus !== "VOID");`;
+  const legacyFilter = [
+    '.filter(',
+    '      (row) =>',
+    '        row.outstandingPence > 0 &&',
+    '        row.chargeStatus !== "PAID" &&',
+    '        row.chargeStatus !== "VOID",',
+    '    );',
+  ].join("\n");
+  const reversedOrderFilter = [
+    '.filter(',
+    '      (row) =>',
+    '        row.chargeStatus !== "VOID" &&',
+    '        (row.outstandingPence > 0 || row.paymentLateFeeStatus === "APPLIED"),',
+    '    );',
+  ].join("\n");
+
+  if (source.includes(simpleFilter)) {
+    source = source.replace(simpleFilter, requiredFilter);
+  } else if (source.includes(legacyFilter)) {
+    source = source.replace(legacyFilter, requiredFilter);
+  } else if (source.includes(reversedOrderFilter)) {
+    source = source.replace(reversedOrderFilter, requiredFilter);
+  }
 }
 
 if (
-  source.includes(`charge.\"latePaymentFeeStatus\" <> 'APPLIED'`) ||
+  /charge\."latePaymentFeeStatus"\s*<>\s*'APPLIED'/.test(source) ||
   !source.includes('row.paymentLateFeeStatus === "APPLIED" || row.outstandingPence > 0')
 ) {
   throw new Error(

--- a/scripts/fix-late-fee-adjustment-integrity-build.cjs
+++ b/scripts/fix-late-fee-adjustment-integrity-build.cjs
@@ -1,0 +1,42 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const filePath = path.join(
+  process.cwd(),
+  "scripts/apply-late-fee-adjustment-integrity.cjs",
+);
+
+let source = fs.readFileSync(filePath, "utf8");
+
+// This preparation file contains a generated TSX component inside a template
+// literal. Some inner template-literal backticks/interpolations were written with
+// two backslashes, which means Node closes/evaluates the outer template instead
+// of preserving the generated TSX. Normalise only those generated-template
+// escape prefixes before the preparation file is required.
+const overEscapedBacktick = "\\\\`";
+const correctBacktick = "\\`";
+const overEscapedInterpolation = "\\\\${";
+const correctInterpolation = "\\${";
+
+const backtickCount = source.split(overEscapedBacktick).length - 1;
+const interpolationCount = source.split(overEscapedInterpolation).length - 1;
+
+if (backtickCount > 0) {
+  source = source.replaceAll(overEscapedBacktick, correctBacktick);
+}
+if (interpolationCount > 0) {
+  source = source.replaceAll(overEscapedInterpolation, correctInterpolation);
+}
+
+fs.writeFileSync(filePath, source, "utf8");
+
+if (
+  source.includes(overEscapedBacktick) ||
+  source.includes(overEscapedInterpolation)
+) {
+  throw new Error("Late-fee adjustment generated-template escaping was not fully repaired.");
+}
+
+console.log(
+  `Repaired ${backtickCount} generated backtick escape(s) and ${interpolationCount} interpolation escape(s) in late-fee adjustment integrity.`,
+);

--- a/scripts/fix-late-fee-canonical-72h-review.cjs
+++ b/scripts/fix-late-fee-canonical-72h-review.cjs
@@ -57,3 +57,5 @@ fs.writeFileSync(actionsPath, source, "utf8");
 console.log(
   "Canonical late-fee reconciliation now preserves the 72-hour post-fixture review window and the separate seven-day £10 fee grace period.",
 );
+
+require("./fix-late-fee-adjustment-integrity-build.cjs");

--- a/scripts/fix-legacy-waiver-reconciliation.cjs
+++ b/scripts/fix-legacy-waiver-reconciliation.cjs
@@ -1,0 +1,94 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, ...relativePath.split("/")), "utf8");
+}
+
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, ...relativePath.split("/")), source, "utf8");
+}
+
+// Before explicit SIXFL waiver markers existed, the admin payment control recorded
+// a waiver by physically reducing PaymentCharge.amountPence and adding text such as:
+//   Admin fee adjustment: £5.00 waived/reduced. Charge changed from £40.00 to £35.00.
+// Later fixture synchronisation could restore the charge to £40 while leaving only
+// that audit text behind. The newer canonical ledger then sees £35 settled against
+// £40 and incorrectly resurrects £5 as debt. Preserve those historical decisions
+// without treating a reduction that is still reflected in the current amount as an
+// extra waiver.
+const waiverPath = "src/lib/payments/team-charge-waivers.ts";
+let waiverSource = read(waiverPath);
+
+if (!waiverSource.includes("getLegacyAdminAdjustmentWaivedPence")) {
+  const marker = "export function buildTeamChargeWaiverNote";
+  const markerIndex = waiverSource.indexOf(marker);
+  if (markerIndex < 0) {
+    throw new Error("Legacy waiver compatibility could not find waiver helper insertion point.");
+  }
+
+  const helper = `const LEGACY_ADMIN_WAIVER_PATTERN = /Admin fee adjustment:\\s*£([\\d,]+(?:\\.\\d{1,2})?)\\s+waived\\/reduced\\.\\s*Charge changed from £([\\d,]+(?:\\.\\d{1,2})?) to £([\\d,]+(?:\\.\\d{1,2})?)\\./g;\n\nfunction legacyMoneyToPence(value: string) {\n  const pounds = Number(value.replaceAll(\",\", \"\"));\n  return Number.isFinite(pounds) ? Math.round(pounds * 100) : 0;\n}\n\nexport function getLegacyAdminAdjustmentWaivedPence(\n  description: string | null | undefined,\n  currentChargeAmountPence: number,\n) {\n  if (!description || !Number.isFinite(currentChargeAmountPence)) return 0;\n\n  let total = 0;\n  for (const match of description.matchAll(LEGACY_ADMIN_WAIVER_PATTERN)) {\n    const recordedReductionPence = legacyMoneyToPence(match[1]);\n    const oldAmountPence = legacyMoneyToPence(match[2]);\n    const reducedAmountPence = legacyMoneyToPence(match[3]);\n    const recordedDifferencePence = Math.max(oldAmountPence - reducedAmountPence, 0);\n    const validReductionPence = Math.min(recordedReductionPence, recordedDifferencePence);\n    if (validReductionPence <= 0) continue;\n\n    // If the current charge is still at (or below) the reduced amount then the\n    // historical decision is already represented by amountPence and must not be\n    // counted again. If sync restored some/all of it, count only the lost part.\n    const lostReductionPence = Math.max(\n      Math.min(currentChargeAmountPence - reducedAmountPence, validReductionPence),\n      0,\n    );\n    total += lostReductionPence;\n  }\n\n  return total;\n}\n\n`;
+
+  waiverSource =
+    waiverSource.slice(0, markerIndex) + helper + waiverSource.slice(markerIndex);
+  write(waiverPath, waiverSource);
+}
+
+for (const relativePath of [
+  "src/lib/payments/charge-summary.ts",
+  "src/lib/payments/team-payment-ledger.ts",
+]) {
+  let source = read(relativePath);
+
+  if (!source.includes("getLegacyAdminAdjustmentWaivedPence")) {
+    if (source.includes('import { getTeamChargeWaivedPence } from "@/lib/payments/team-charge-waivers";')) {
+      source = source.replace(
+        'import { getTeamChargeWaivedPence } from "@/lib/payments/team-charge-waivers";',
+        'import {\n  getLegacyAdminAdjustmentWaivedPence,\n  getTeamChargeWaivedPence,\n} from "@/lib/payments/team-charge-waivers";',
+      );
+    } else if (source.includes("  getTeamChargeWaivedPence,\n  stripTeamChargeWaiverMarkers,")) {
+      source = source.replace(
+        "  getTeamChargeWaivedPence,\n  stripTeamChargeWaiverMarkers,",
+        "  getLegacyAdminAdjustmentWaivedPence,\n  getTeamChargeWaivedPence,\n  stripTeamChargeWaiverMarkers,",
+      );
+    } else {
+      throw new Error(`Legacy waiver compatibility could not patch imports in ${relativePath}.`);
+    }
+  }
+
+  const oldLine = "    const waivedPence = getTeamChargeWaivedPence(charge.description);";
+  const newLine = [
+    "    const waivedPence =",
+    "      getTeamChargeWaivedPence(charge.description) +",
+    "      getLegacyAdminAdjustmentWaivedPence(charge.description, charge.amountPence);",
+  ].join("\n");
+
+  if (!source.includes(newLine)) {
+    if (!source.includes(oldLine)) {
+      throw new Error(`Legacy waiver compatibility could not patch waiver calculation in ${relativePath}.`);
+    }
+    source = source.replace(oldLine, newLine);
+  }
+
+  write(relativePath, source);
+}
+
+const finalWaiverSource = read(waiverPath);
+const finalSummary = read("src/lib/payments/charge-summary.ts");
+const finalLedger = read("src/lib/payments/team-payment-ledger.ts");
+
+if (
+  !finalWaiverSource.includes("LEGACY_ADMIN_WAIVER_PATTERN") ||
+  !finalWaiverSource.includes("getLegacyAdminAdjustmentWaivedPence") ||
+  !finalWaiverSource.includes("currentChargeAmountPence - reducedAmountPence") ||
+  !finalSummary.includes("getLegacyAdminAdjustmentWaivedPence(charge.description, charge.amountPence)") ||
+  !finalLedger.includes("getLegacyAdminAdjustmentWaivedPence(charge.description, charge.amountPence)")
+) {
+  throw new Error("Legacy waived/reduced payment compatibility contract failed.");
+}
+
+console.log(
+  "Legacy waived/reduced admin adjustments now remain settled if a later fixture sync restored the original charge amount.",
+);


### PR DESCRIPTION
Fixes historical waived/reduced match-fee adjustments that were previously recorded by reducing PaymentCharge.amountPence and leaving an audit note such as `Admin fee adjustment: £5.00 waived/reduced. Charge changed from £40.00 to £35.00.`

Later fixture synchronisation could restore the charge to the original £40 while leaving that historical waiver only in the description. The newer canonical Late Fees calculation then saw £35 settled against £40 and resurrected £5 as debt, while Team Payments still displayed a PAID status with arithmetic that did not add up.

This compatibility fix:
- recognises only the old `Admin fee adjustment ... waived/reduced` audit format;
- treats the historical reduction as a waiver only when the current charge has actually been restored above the old reduced amount;
- does not double-count a reduction when the current amount is still £35;
- feeds that recovered waiver into the canonical charge summary and team payment ledger;
- therefore shows a £5 SIXFL waiver line, £40 total settled and £0 outstanding for the example shown;
- ensures Late Fees uses the same £40 settled position and does not chase the £5 again;
- makes no database changes and leaves the original audit text intact.

Future reductions/waivers continue to use the newer explicit controls; this is backwards compatibility for historical records.