### PR TITLE
Restore normal captain payment ledger view

### DIFF
--- a/src/lib/payments/team-payment-ledger.ts
+++ b/src/lib/payments/team-payment-ledger.ts
@@ -199,6 +199,7 @@ export async function getTeamPaymentLedger(teamId: string): Promise<TeamPaymentL
     prisma.paymentCharge.findMany({
       where: {
         teamId: { in: relatedTeamIds },
+        status: { not: "VOID" },
       },
       orderBy: [{ dueDate: "asc" }, { createdAt: "asc" }],
       include: {


### PR DESCRIPTION
Reverts the captain-facing ledger visibility change from 31 July that deliberately exposed stored VOID payment-charge rows. The captain payment ledger will again exclude VOID charges, matching its previous normal behaviour. This does not delete or alter any payment data; it only stops cancelled/replaced/obsolete charge records appearing as if they are current fees.