### PR TITLE
Give team badges more space inside the review box

### DIFF
--- a/src/components/captain/TeamBadgeReviewPanel.tsx
+++ b/src/components/captain/TeamBadgeReviewPanel.tsx
@@ -186,7 +186,7 @@ export default function TeamBadgeReviewPanel({
                 src={logoUrl ?? ""}
                 alt={`${teamName} team badge`}
                 onError={() => setImageFailed(true)}
-                className="max-h-full max-w-full object-contain object-center"
+                className="max-h-[88%] max-w-[88%] object-contain object-center"
               />
             ) : (
               <div className="text-center">


### PR DESCRIPTION
Fresh current-main replacement for old PR #207. This is deliberately one UI-only line: the team badge preview uses 88% of the available review box instead of filling the full box. No badge data, kit-order logic, API behaviour or other team displays are changed. Old PR #207 is not being merged because it is now conflict/stale against current main.