### PR TITLE
Keep division merge success visible

### DIFF
--- a/src/components/admin/leagues/MergeLeagueDivisionsButton.tsx
+++ b/src/components/admin/leagues/MergeLeagueDivisionsButton.tsx
@@ -60,7 +60,42 @@ export default function MergeLeagueDivisionsButton() {
     };
   }, [leagueId]);
 
-  if (!leagueId || checking || divisionNames.length === 0) return null;
+  if (!leagueId) return null;
+
+  if (divisionNames.length === 0) {
+    if (message || error) {
+      return (
+        <section
+          className={`mx-auto w-full max-w-7xl rounded-3xl border p-5 sm:p-6 ${
+            error
+              ? "border-red-400/25 bg-red-500/[0.08]"
+              : "border-emerald-400/25 bg-emerald-500/[0.08]"
+          }`}
+        >
+          <p
+            className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
+              error ? "text-red-200/75" : "text-emerald-200/75"
+            }`}
+          >
+            {error ? "League structure update failed" : "League structure updated"}
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            {error ? "The divisions were not changed" : "Divisions merged successfully"}
+          </h2>
+          <p
+            className={`mt-2 text-sm leading-6 ${
+              error ? "text-red-100" : "text-emerald-100"
+            }`}
+          >
+            {error || message}
+          </p>
+        </section>
+      );
+    }
+    return null;
+  }
+
+  if (checking) return null;
 
   async function mergeDivisions() {
     if (!leagueId || merging) return;
@@ -89,12 +124,12 @@ export default function MergeLeagueDivisionsButton() {
         throw new Error(payload?.error || "The divisions could not be merged.");
       }
 
+      const successMessage = payload.alreadyMerged
+        ? payload.message || "This league already uses one table."
+        : `${payload.message || "The divisions were merged."} ${payload.activeTeams ?? 0} active teams remain in the season; ${payload.savedResults ?? 0} saved results were preserved; ${payload.futureFixturesMerged ?? 0} unplayed fixture${payload.futureFixturesMerged === 1 ? " was" : "s were"} moved into the combined pool.`;
+
+      setMessage(successMessage);
       setDivisionNames([]);
-      setMessage(
-        payload.alreadyMerged
-          ? payload.message || "This league already uses one table."
-          : `${payload.message || "The divisions were merged."} ${payload.activeTeams ?? 0} active teams remain in the season; ${payload.savedResults ?? 0} saved results were preserved; ${payload.futureFixturesMerged ?? 0} unplayed fixture${payload.futureFixturesMerged === 1 ? " was" : "s were"} moved into the combined pool.`,
-      );
       router.refresh();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "The divisions could not be merged.");


### PR DESCRIPTION
Fresh current-main replacement for old PR #194. This only changes the client feedback around an already-successful division merge: when the active division list becomes empty, the component stays mounted long enough to show the success summary instead of disappearing. It does not change merge API logic, league membership, fixtures, results, payments or database writes. The old PR is not being merged because it is now conflict/stale against current main.