### PR TITLE
Add secure referral reward payout workflow

### DIFF
--- a/prisma/migrations/20260825162500_team_referral_payout_details/migration.sql
+++ b/prisma/migrations/20260825162500_team_referral_payout_details/migration.sql
@@ -1,0 +1,10 @@
+-- Secure player bank details for earned team-referral rewards.
+-- The bank details themselves are encrypted in application code before storage.
+ALTER TABLE "TeamReferral"
+  ADD COLUMN IF NOT EXISTS "payoutDetailsCiphertext" TEXT,
+  ADD COLUMN IF NOT EXISTS "payoutDetailsIv" TEXT,
+  ADD COLUMN IF NOT EXISTS "payoutDetailsAuthTag" TEXT,
+  ADD COLUMN IF NOT EXISTS "payoutDetailsSubmittedAt" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "TeamReferral_payoutDetailsSubmittedAt_idx"
+  ON "TeamReferral"("payoutDetailsSubmittedAt");

--- a/src/app/(admin)/admin/referrals/actions.ts
+++ b/src/app/(admin)/admin/referrals/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
+import { clearTeamReferralPayoutSecrets } from "@/lib/team-referral-payout";
 import { queueReferralRecordedEmail } from "@/lib/team-referral-notifications";
 import {
   attachReferralToLead,
@@ -141,7 +142,12 @@ export async function markReferralPaidAction(formData: FormData) {
   const referrals = await getTeamReferrals();
   const referral = referrals.find((item) => item.id === referralId);
 
-  if (!referral || referral.paidAt || referral.completedMatches < referral.requiredMatches) {
+  if (
+    !referral ||
+    referral.paidAt ||
+    referral.completedMatches < referral.requiredMatches ||
+    !referral.payoutDetailsSubmittedAt
+  ) {
     return;
   }
 
@@ -153,8 +159,15 @@ export async function markReferralPaidAction(formData: FormData) {
       "updatedAt" = CURRENT_TIMESTAMP
     WHERE "id" = ${referralId}
       AND "paidAt" IS NULL
+      AND "payoutDetailsSubmittedAt" IS NOT NULL
   `;
 
+  // Keep the audit timestamps, but remove the bank account number, sort code and
+  // encryption material once SIXFL records the reward as paid.
+  await clearTeamReferralPayoutSecrets(referralId);
+
   revalidatePath("/admin/referrals");
+  revalidatePath(`/admin/referrals/payout/${encodeURIComponent(referralId)}`);
   revalidatePath("/player/referrals");
+  revalidatePath(`/player/referrals/payout/${encodeURIComponent(referralId)}`);
 }

--- a/src/app/(admin)/admin/referrals/page.tsx
+++ b/src/app/(admin)/admin/referrals/page.tsx
@@ -4,7 +4,6 @@ import { requireAdmin } from "@/lib/requireAdmin";
 import { getTeamReferrals, referralStatus } from "@/lib/team-referrals";
 import {
   attachExistingLeadReferralAction,
-  markReferralPaidAction,
   retryReferralRecordedEmailAction,
 } from "./actions";
 
@@ -46,6 +45,7 @@ type ReferralEmailDeliveryRow = {
 };
 
 const RECOVERABLE_MISSING_EMAIL_REASON = "Recipient has no email address.";
+const RECOVERABLE_CHANNEL_DISABLED_REASON = "Recipient email notifications are disabled.";
 
 function money(pence: number) {
   return new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(pence / 100);
@@ -99,7 +99,7 @@ function emailNotice(value?: string) {
     case "blocked":
       return {
         tone: "warning" as const,
-        message: "SIXFL did not retry that email because the player is currently blocked, suppressed, or has email notifications disabled.",
+        message: "SIXFL did not retry that email because the recipient is suppressed or has explicitly disabled transactional email.",
       };
     case "no_email":
       return {
@@ -168,7 +168,11 @@ function emailStatusClass(status: string | null) {
 function canRetryReferralEmail(delivery?: ReferralEmailDeliveryRow) {
   if (!delivery?.dispatchId) return true;
   if (delivery.status === "FAILED") return true;
-  return delivery.status === "SKIPPED" && delivery.failureReason === RECOVERABLE_MISSING_EMAIL_REASON;
+  return (
+    delivery.status === "SKIPPED" &&
+    (delivery.failureReason === RECOVERABLE_MISSING_EMAIL_REASON ||
+      delivery.failureReason === RECOVERABLE_CHANNEL_DISABLED_REASON)
+  );
 }
 
 export default async function AdminReferralsPage({ searchParams }: { searchParams?: SearchParams }) {
@@ -408,17 +412,22 @@ export default async function AdminReferralsPage({ searchParams }: { searchParam
                   <div>
                     <p className="text-sm font-black text-slate-900">{Math.min(row.completedMatches, row.requiredMatches)} of {row.requiredMatches} matches</p>
                     <p className="mt-1 text-xs text-slate-500">Reward: {money(row.rewardPence)}</p>
+                    {status === "READY" ? (
+                      <p className={`mt-1 text-xs font-bold ${row.payoutDetailsSubmittedAt ? "text-emerald-700" : "text-amber-700"}`}>
+                        {row.payoutDetailsSubmittedAt ? "Payment details received" : "Awaiting payment details"}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="min-w-36 text-left lg:text-right">
                     {status === "PAID" ? (
                       <span className="inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-black text-emerald-800">Paid</span>
                     ) : status === "READY" ? (
-                      <form action={markReferralPaidAction}>
-                        <input type="hidden" name="referralId" value={row.id} />
-                        <button className="rounded-xl bg-emerald-600 px-4 py-2 text-sm font-black text-white hover:bg-emerald-500">
-                          Mark £75 paid
-                        </button>
-                      </form>
+                      <Link
+                        href={`/admin/referrals/payout/${encodeURIComponent(row.id)}`}
+                        className={`inline-flex rounded-xl px-4 py-2 text-sm font-black ${row.payoutDetailsSubmittedAt ? "bg-emerald-600 text-white hover:bg-emerald-500" : "bg-amber-100 text-amber-900 hover:bg-amber-200"}`}
+                      >
+                        {row.payoutDetailsSubmittedAt ? "View bank details" : "Awaiting bank details"}
+                      </Link>
                     ) : (
                       <span className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-black text-amber-800">In progress</span>
                     )}

--- a/src/app/(admin)/admin/referrals/payout/[id]/page.tsx
+++ b/src/app/(admin)/admin/referrals/payout/[id]/page.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { getTeamReferralPayoutDetails, formatSortCode } from "@/lib/team-referral-payout";
+import { getTeamReferrals, referralStatus } from "@/lib/team-referrals";
+import { markReferralPaidAction } from "../../actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata = { title: "Referral payout | SIXFL Admin" };
+
+type Params = Promise<{ id: string }>;
+
+function money(pence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 0,
+  }).format(pence / 100);
+}
+
+function dateTime(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(value);
+}
+
+export default async function AdminReferralPayoutPage({ params }: { params: Params }) {
+  await requireAdmin();
+  const { id } = await params;
+  const referrals = await getTeamReferrals();
+  const referral = referrals.find((item) => item.id === id);
+  if (!referral) notFound();
+
+  const status = referralStatus(referral);
+  const payout = await getTeamReferralPayoutDetails(referral.id);
+  const teamLabel = referral.teamName ?? referral.leadTeamName ?? "Referred team";
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-600">Referral payout</p>
+          <h1 className="mt-2 text-3xl font-black tracking-tight text-slate-950">{referral.referrerName ?? referral.referrerEmail ?? "Player"}</h1>
+          <p className="mt-2 text-sm text-slate-600">{teamLabel} · {money(referral.rewardPence)}</p>
+        </div>
+        <Link href="/admin/referrals" className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 shadow-sm hover:bg-slate-50">
+          Back to referrals
+        </Link>
+      </div>
+
+      {status === "PAID" ? (
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6">
+          <h2 className="text-xl font-black text-emerald-950">Paid</h2>
+          <p className="mt-2 text-sm leading-6 text-emerald-800">
+            This referral reward has been marked as paid. The stored account number and sort code were removed when payment was recorded.
+          </p>
+        </section>
+      ) : status !== "READY" ? (
+        <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6">
+          <h2 className="text-xl font-black text-amber-950">Not yet payable</h2>
+          <p className="mt-2 text-sm text-amber-800">The referred team has completed {referral.completedMatches} of {referral.requiredMatches} qualifying matches.</p>
+        </section>
+      ) : !payout?.details ? (
+        <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6">
+          <h2 className="text-xl font-black text-amber-950">Awaiting payment details</h2>
+          <p className="mt-2 text-sm leading-6 text-amber-800">
+            The reward is ready, but the player has not yet submitted bank details through the secure SIXFL payout page.
+          </p>
+        </section>
+      ) : (
+        <>
+          <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-black uppercase tracking-[0.14em] text-slate-500">Payment details received</p>
+                <h2 className="mt-2 text-xl font-black text-slate-950">UK bank transfer</h2>
+              </div>
+              {payout.submittedAt ? <span className="text-xs font-bold text-slate-500">Submitted {dateTime(payout.submittedAt)}</span> : null}
+            </div>
+
+            <dl className="mt-6 grid gap-4 sm:grid-cols-3">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <dt className="text-xs font-black uppercase tracking-[0.12em] text-slate-500">Account holder</dt>
+                <dd className="mt-2 font-black text-slate-950">{payout.details.accountHolderName}</dd>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <dt className="text-xs font-black uppercase tracking-[0.12em] text-slate-500">Sort code</dt>
+                <dd className="mt-2 font-mono text-lg font-black text-slate-950">{formatSortCode(payout.details.sortCode)}</dd>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <dt className="text-xs font-black uppercase tracking-[0.12em] text-slate-500">Account number</dt>
+                <dd className="mt-2 font-mono text-lg font-black text-slate-950">{payout.details.accountNumber}</dd>
+              </div>
+            </dl>
+
+            <div className="mt-6 rounded-xl border border-sky-200 bg-sky-50 px-4 py-3 text-sm leading-6 text-sky-900">
+              Pay {money(referral.rewardPence)} to the account above, then mark the reward paid. Marking it paid removes the stored sort code and account number from SIXFL.
+            </div>
+
+            <form action={markReferralPaidAction} className="mt-5">
+              <input type="hidden" name="referralId" value={referral.id} />
+              <button className="rounded-xl bg-emerald-600 px-5 py-3 text-sm font-black text-white hover:bg-emerald-500">
+                Mark {money(referral.rewardPence)} paid
+              </button>
+            </form>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -15,7 +15,10 @@ import { queueDueRefereeNightConfirmationChasers } from "@/lib/referee-night-con
 import { queueDueRefereeNightReminderEmails } from "@/lib/referee-night-emails";
 import { syncPublishedFixtureRefereeNightAssignmentsAndRecalculate } from "@/lib/referee-night-assignment-sync";
 import { prisma } from "@/lib/prisma";
-import { queueMissingReferralRecordedEmails } from "@/lib/team-referral-notifications";
+import {
+  queueMissingReferralRecordedEmails,
+  queueReadyReferralPayoutEmails,
+} from "@/lib/team-referral-notifications";
 
 export const dynamic = "force-dynamic";
 
@@ -76,6 +79,7 @@ export async function GET(request: NextRequest) {
     const refereeNights = await queueDueRefereeNightReminderEmails();
     const refereeConfirmations = await queueDueRefereeNightConfirmationChasers();
     const referralEmails = await queueMissingReferralRecordedEmails();
+    const referralPayoutEmails = await queueReadyReferralPayoutEmails();
     const queuedDispatches =
       onboarding.queuedDispatches +
       fixtureConfirmations.queued +
@@ -83,7 +87,8 @@ export async function GET(request: NextRequest) {
       fixtureConfirmationWarnings.queued +
       refereeNights.queued +
       refereeConfirmations.queued +
-      referralEmails.queued;
+      referralEmails.queued +
+      referralPayoutEmails.queued;
     const result = await processNotificationQueue(
       Math.max(25, queuedDispatches + 25),
     );
@@ -114,6 +119,7 @@ export async function GET(request: NextRequest) {
       refereeNights,
       refereeConfirmations,
       referralEmails,
+      referralPayoutEmails,
       matchdayAutoPay,
       ...result,
     });

--- a/src/app/player/referrals/page.tsx
+++ b/src/app/player/referrals/page.tsx
@@ -97,9 +97,19 @@ export default async function PlayerReferralsPage() {
                       {status === "PAID"
                         ? `Your ${money(row.rewardPence)} reward has been marked as paid.`
                         : status === "READY"
-                          ? `The team has completed three matches. Your ${money(row.rewardPence)} reward is now due.`
+                          ? row.payoutDetailsSubmittedAt
+                            ? `Your payment details have been received. SIXFL can now arrange your ${money(row.rewardPence)} reward.`
+                            : `The team has completed three matches. Your ${money(row.rewardPence)} reward is now due.`
                           : `${row.requiredMatches - progress} more completed ${row.requiredMatches - progress === 1 ? "match" : "matches"} until your ${money(row.rewardPence)} reward.`}
                     </p>
+                    {status === "READY" ? (
+                      <Link
+                        href={`/player/referrals/payout/${encodeURIComponent(row.id)}`}
+                        className="mt-4 inline-flex rounded-xl bg-emerald-400 px-4 py-2.5 text-sm font-black text-slate-950 hover:bg-emerald-300"
+                      >
+                        {row.payoutDetailsSubmittedAt ? "Review payment details" : "Provide payment details"}
+                      </Link>
+                    ) : null}
                   </div>
                 );
               })}

--- a/src/app/player/referrals/payout/[id]/actions.ts
+++ b/src/app/player/referrals/payout/[id]/actions.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { getServerSession } from "next-auth";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { saveTeamReferralPayoutDetails } from "@/lib/team-referral-payout";
+
+export async function saveReferralPayoutDetailsAction(formData: FormData) {
+  const referralId = String(formData.get("referralId") ?? "").trim();
+  const callback = referralId
+    ? `/player/referrals/payout/${encodeURIComponent(referralId)}`
+    : "/player/referrals";
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    redirect(`/login?callbackUrl=${encodeURIComponent(callback)}`);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email.trim().toLowerCase() },
+    select: { id: true },
+  });
+  if (!user || !referralId) redirect("/player/referrals");
+
+  const accountHolderName = String(formData.get("accountHolderName") ?? "");
+  const sortCode = String(formData.get("sortCode") ?? "");
+  const accountNumber = String(formData.get("accountNumber") ?? "");
+
+  try {
+    await saveTeamReferralPayoutDetails({
+      referralId,
+      referrerUserId: user.id,
+      details: { accountHolderName, sortCode, accountNumber },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not save payment details.";
+    redirect(`${callback}?error=${encodeURIComponent(message)}`);
+  }
+
+  revalidatePath("/player/referrals");
+  revalidatePath(callback);
+  revalidatePath("/admin/referrals");
+  revalidatePath(`/admin/referrals/payout/${encodeURIComponent(referralId)}`);
+  redirect(`${callback}?saved=1`);
+}

--- a/src/app/player/referrals/payout/[id]/page.tsx
+++ b/src/app/player/referrals/payout/[id]/page.tsx
@@ -1,0 +1,167 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { notFound, redirect } from "next/navigation";
+import { authOptions } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { getTeamReferralPayoutDetails, maskAccountNumber, formatSortCode } from "@/lib/team-referral-payout";
+import { getTeamReferrals, referralStatus } from "@/lib/team-referrals";
+import { saveReferralPayoutDetailsAction } from "./actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata = { title: "Referral payment details | SIXFL" };
+
+type Params = Promise<{ id: string }>;
+type SearchParams = Promise<{ saved?: string; error?: string }>;
+
+function money(pence: number) {
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 0,
+  }).format(pence / 100);
+}
+
+export default async function ReferralPayoutPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams?: SearchParams;
+}) {
+  const { id } = await params;
+  const sp = (await searchParams) ?? {};
+  const callback = `/player/referrals/payout/${encodeURIComponent(id)}`;
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    redirect(`/login?callbackUrl=${encodeURIComponent(callback)}`);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email.trim().toLowerCase() },
+    select: { id: true },
+  });
+  if (!user) redirect("/login");
+
+  const referrals = await getTeamReferrals(user.id);
+  const referral = referrals.find((item) => item.id === id);
+  if (!referral) notFound();
+
+  const status = referralStatus(referral);
+  const payout = await getTeamReferralPayoutDetails(referral.id);
+  const teamLabel = referral.teamName ?? referral.leadTeamName ?? "your referred team";
+  const hasStoredDetails = Boolean(payout?.details);
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-10 text-white">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-400">SIXFL reward</p>
+            <h1 className="mt-2 text-3xl font-black tracking-tight">Payment details</h1>
+            <p className="mt-3 text-sm leading-6 text-white/65">
+              {teamLabel} · {money(referral.rewardPence)} referral reward
+            </p>
+          </div>
+          <Link href="/player/referrals" className="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white hover:bg-white/10">
+            Back to referrals
+          </Link>
+        </div>
+
+        {sp.saved === "1" ? (
+          <div className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-5 py-4 text-sm font-bold text-emerald-100">
+            Payment details saved securely. SIXFL can now arrange your reward payment.
+          </div>
+        ) : null}
+
+        {sp.error ? (
+          <div className="rounded-2xl border border-red-400/30 bg-red-500/10 px-5 py-4 text-sm font-bold text-red-100">
+            {sp.error}
+          </div>
+        ) : null}
+
+        {status === "PAID" ? (
+          <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-6 sm:p-8">
+            <h2 className="text-xl font-black">Reward paid</h2>
+            <p className="mt-3 text-sm leading-7 text-emerald-50/90">
+              Your {money(referral.rewardPence)} referral reward has been marked as paid. Stored bank account numbers and sort codes are removed once the reward is marked paid.
+            </p>
+          </section>
+        ) : status !== "READY" ? (
+          <section className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 sm:p-8">
+            <h2 className="text-xl font-black">Not ready yet</h2>
+            <p className="mt-3 text-sm leading-7 text-white/65">
+              This reward becomes payable after the referred team completes {referral.requiredMatches} qualifying league matches.
+            </p>
+          </section>
+        ) : (
+          <section className="rounded-3xl border border-white/10 bg-white/[0.05] p-6 sm:p-8">
+            <h2 className="text-xl font-black">Bank transfer details</h2>
+            <p className="mt-3 text-sm leading-7 text-white/65">
+              Enter the UK bank account you would like SIXFL to use for your {money(referral.rewardPence)} reward. These details are encrypted before they are stored. Please do not send bank details by email, SMS or WhatsApp.
+            </p>
+
+            {payout?.details ? (
+              <div className="mt-5 rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-50">
+                <p className="font-black">Payment details already received</p>
+                <p className="mt-2 text-emerald-50/75">
+                  {payout.details.accountHolderName} · {formatSortCode(payout.details.sortCode)} · {maskAccountNumber(payout.details.accountNumber)}
+                </p>
+                <p className="mt-2 text-xs text-emerald-50/55">
+                  Full sort code and account number are not sent back to your browser after they have been saved. Only complete the form again if you want to replace them.
+                </p>
+              </div>
+            ) : null}
+
+            <form action={saveReferralPayoutDetailsAction} className="mt-6 space-y-5">
+              <input type="hidden" name="referralId" value={referral.id} />
+              <label className="block">
+                <span className="text-xs font-black uppercase tracking-[0.14em] text-white/60">Account holder name</span>
+                <input
+                  name="accountHolderName"
+                  required
+                  maxLength={120}
+                  autoComplete="name"
+                  defaultValue={payout?.details?.accountHolderName ?? ""}
+                  className="mt-2 h-12 w-full rounded-xl border border-white/15 bg-black/25 px-4 text-white outline-none focus:border-emerald-400"
+                />
+              </label>
+
+              <div className="grid gap-5 sm:grid-cols-2">
+                <label className="block">
+                  <span className="text-xs font-black uppercase tracking-[0.14em] text-white/60">Sort code</span>
+                  <input
+                    name="sortCode"
+                    required
+                    inputMode="numeric"
+                    autoComplete="off"
+                    placeholder={hasStoredDetails ? "Enter new sort code to replace" : "12-34-56"}
+                    defaultValue=""
+                    className="mt-2 h-12 w-full rounded-xl border border-white/15 bg-black/25 px-4 text-white outline-none focus:border-emerald-400"
+                  />
+                </label>
+                <label className="block">
+                  <span className="text-xs font-black uppercase tracking-[0.14em] text-white/60">Account number</span>
+                  <input
+                    name="accountNumber"
+                    required
+                    inputMode="numeric"
+                    autoComplete="off"
+                    placeholder={hasStoredDetails ? "Enter new account number" : "12345678"}
+                    defaultValue=""
+                    className="mt-2 h-12 w-full rounded-xl border border-white/15 bg-black/25 px-4 text-white outline-none focus:border-emerald-400"
+                  />
+                </label>
+              </div>
+
+              <button className="inline-flex h-12 items-center justify-center rounded-xl bg-emerald-400 px-6 text-sm font-black text-slate-950 hover:bg-emerald-300">
+                {hasStoredDetails ? "Replace payment details securely" : "Save payment details securely"}
+              </button>
+            </form>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/lib/team-referral-notifications.ts
+++ b/src/lib/team-referral-notifications.ts
@@ -3,15 +3,21 @@ import {
   NotificationChannel,
   NotificationRecipientSourceType,
 } from "@prisma/client";
-import { prisma } from "@/lib/prisma";
+import {
+  appendSIXFLTextSignature,
+  buildSIXFLEmailHtml,
+} from "@/lib/email/buildEmail";
 import {
   getNotificationRecipientBySource,
   upsertNotificationRecipient,
 } from "@/lib/notifications/recipients";
-import { queueDirectNotification } from "@/lib/notifications/service";
+import { prisma } from "@/lib/prisma";
+import { getEmailReplyDomain } from "@/lib/resend/client";
 
 const REFERRAL_RECORDED_SOURCE = "team-referral-recorded";
+const REFERRAL_PAYOUT_READY_SOURCE = "team-referral-payout-ready";
 const RECOVERABLE_MISSING_EMAIL_REASON = "Recipient has no email address.";
+const RECOVERABLE_CHANNEL_DISABLED_REASON = "Recipient email notifications are disabled.";
 
 type ReferralNotificationRow = {
   id: string;
@@ -22,6 +28,12 @@ type ReferralNotificationRow = {
   leadTeamName: string | null;
   rewardPence: number;
   requiredMatches: number;
+};
+
+type ReferralPayoutReadyRow = ReferralNotificationRow & {
+  completedMatches: number;
+  payoutDetailsSubmittedAt: Date | null;
+  paidAt: Date | null;
 };
 
 function firstName(value?: string | null) {
@@ -36,6 +48,13 @@ function money(pence: number) {
   }).format(pence / 100);
 }
 
+function isRecoverableRecordedSkip(reason?: string | null) {
+  return (
+    reason === RECOVERABLE_MISSING_EMAIL_REASON ||
+    reason === RECOVERABLE_CHANNEL_DISABLED_REASON
+  );
+}
+
 async function getReferralNotificationRecipient(referral: ReferralNotificationRow) {
   const currentEmail = referral.referrerEmail?.trim() || null;
   if (!currentEmail) return null;
@@ -46,7 +65,7 @@ async function getReferralNotificationRecipient(referral: ReferralNotificationRo
   });
 
   if (!existingRecipient) {
-    return upsertNotificationRecipient({
+    await upsertNotificationRecipient({
       sourceType: NotificationRecipientSourceType.USER,
       sourceId: referral.referrerUserId,
       audience: NotificationAudience.USER,
@@ -56,6 +75,11 @@ async function getReferralNotificationRecipient(referral: ReferralNotificationRo
       metadata: {
         referralId: referral.id,
       },
+    });
+
+    return getNotificationRecipientBySource({
+      sourceType: NotificationRecipientSourceType.USER,
+      sourceId: referral.referrerUserId,
     });
   }
 
@@ -67,9 +91,9 @@ async function getReferralNotificationRecipient(referral: ReferralNotificationRo
 
   if (!emailChanged && !nameChanged) return existingRecipient;
 
-  // Keep suppression and notification preferences exactly as they are. Only
-  // refresh identity fields from the current User record so transactional
-  // messages are not sent to a stale or missing recipient email address.
+  // Keep suppression and explicit transactional opt-in exactly as they are.
+  // Referral reward emails are essential account/payment messages, so the
+  // generic emailEnabled preference is deliberately not used as a blocker.
   return prisma.notificationRecipient.update({
     where: { id: existingRecipient.id },
     data: {
@@ -84,17 +108,18 @@ async function getReferralNotificationRecipient(referral: ReferralNotificationRo
   });
 }
 
-export async function queueReferralRecordedEmail(referralId: string) {
-  const id = referralId.trim();
-  if (!id) return { queued: false, reason: "missing_referral_id" as const };
-
-  // Only a live/successful dispatch should make this referral permanently
-  // idempotent. A FAILED dispatch or a recoverable SKIPPED dispatch must be
-  // allowed to try again after the underlying problem has been corrected.
+async function queueEssentialReferralEmail(input: {
+  referral: ReferralNotificationRow;
+  sourceType: string;
+  subject: string;
+  body: string;
+  cta: { label: string; url: string };
+  metadata: Record<string, string>;
+}) {
   const activeOrSentDispatch = await prisma.notificationDispatch.findFirst({
     where: {
-      sourceType: REFERRAL_RECORDED_SOURCE,
-      sourceId: id,
+      sourceType: input.sourceType,
+      sourceId: input.referral.id,
       status: { in: ["QUEUED", "PROCESSING", "SENT"] },
     },
     select: { id: true },
@@ -104,23 +129,72 @@ export async function queueReferralRecordedEmail(referralId: string) {
     return { queued: false, reason: "already_queued" as const };
   }
 
-  const latestSkippedDispatch = await prisma.notificationDispatch.findFirst({
-    where: {
-      sourceType: REFERRAL_RECORDED_SOURCE,
-      sourceId: id,
-      status: "SKIPPED",
-    },
-    orderBy: { createdAt: "desc" },
-    select: { failureReason: true },
-  });
+  const recipient = await getReferralNotificationRecipient(input.referral);
+  if (!recipient?.email?.trim()) {
+    return { queued: false, reason: "missing_email" as const };
+  }
 
-  if (
-    latestSkippedDispatch &&
-    latestSkippedDispatch.failureReason !== RECOVERABLE_MISSING_EMAIL_REASON
-  ) {
+  let blockedReason: string | null = null;
+  if (recipient.isSuppressed) blockedReason = "Recipient is suppressed.";
+  else if (!recipient.transactionalEmailOptIn) {
+    blockedReason = "Transactional email is disabled for recipient.";
+  }
+
+  const ctaText = `${input.cta.label}: ${input.cta.url}`;
+  const plainBody = input.body.includes("{{cta}}")
+    ? input.body.replace(/\{\{\s*cta\s*\}\}/gi, ctaText)
+    : `${input.body}\n\n${ctaText}`;
+  const bodyText = appendSIXFLTextSignature(
+    plainBody.replace(/\n{3,}/g, "\n\n").trim(),
+  );
+  const bodyHtml = buildSIXFLEmailHtml({ body: input.body, cta: input.cta });
+
+  if (blockedReason) {
+    await prisma.notificationDispatch.create({
+      data: {
+        recipientId: recipient.id,
+        channel: NotificationChannel.EMAIL,
+        audience: NotificationAudience.USER,
+        status: "SKIPPED",
+        isTransactional: true,
+        subject: input.subject,
+        bodyText,
+        bodyHtml,
+        sourceType: input.sourceType,
+        sourceId: input.referral.id,
+        metadata: input.metadata,
+        scheduledFor: new Date(),
+        failureReason: blockedReason,
+      },
+    });
     return { queued: false, reason: "recipient_blocked" as const };
   }
 
+  // Match the normal notification service's configuration check while allowing
+  // this essential transactional email to bypass only the generic channel toggle.
+  getEmailReplyDomain();
+
+  await prisma.notificationDispatch.create({
+    data: {
+      recipientId: recipient.id,
+      channel: NotificationChannel.EMAIL,
+      audience: NotificationAudience.USER,
+      status: "QUEUED",
+      isTransactional: true,
+      subject: input.subject,
+      bodyText,
+      bodyHtml,
+      sourceType: input.sourceType,
+      sourceId: input.referral.id,
+      metadata: input.metadata,
+      scheduledFor: new Date(),
+    },
+  });
+
+  return { queued: true, reason: null };
+}
+
+async function getReferralNotificationRow(referralId: string) {
   const rows = await prisma.$queryRaw<ReferralNotificationRow[]>`
     SELECT
       r."id",
@@ -134,11 +208,34 @@ export async function queueReferralRecordedEmail(referralId: string) {
     FROM "TeamReferral" r
     INNER JOIN "User" u ON u."id" = r."referrerUserId"
     INNER JOIN "InterestLead" l ON l."id" = r."interestLeadId"
-    WHERE r."id" = ${id}
+    WHERE r."id" = ${referralId}
     LIMIT 1
   `;
+  return rows[0] ?? null;
+}
 
-  const referral = rows[0];
+export async function queueReferralRecordedEmail(referralId: string) {
+  const id = referralId.trim();
+  if (!id) return { queued: false, reason: "missing_referral_id" as const };
+
+  const latestSkippedDispatch = await prisma.notificationDispatch.findFirst({
+    where: {
+      sourceType: REFERRAL_RECORDED_SOURCE,
+      sourceId: id,
+      status: "SKIPPED",
+    },
+    orderBy: { createdAt: "desc" },
+    select: { failureReason: true },
+  });
+
+  if (
+    latestSkippedDispatch &&
+    !isRecoverableRecordedSkip(latestSkippedDispatch.failureReason)
+  ) {
+    return { queued: false, reason: "recipient_blocked" as const };
+  }
+
+  const referral = await getReferralNotificationRow(id);
   if (!referral) return { queued: false, reason: "not_found" as const };
   if (!referral.referrerEmail?.trim()) {
     return { queued: false, reason: "missing_email" as const };
@@ -149,16 +246,10 @@ export async function queueReferralRecordedEmail(referralId: string) {
     referral.leadName?.trim() ||
     "the team you referred";
   const reward = money(referral.rewardPence);
-  const recipient = await getReferralNotificationRecipient(referral);
 
-  if (!recipient) {
-    return { queued: false, reason: "missing_email" as const };
-  }
-
-  const dispatch = await queueDirectNotification({
-    recipientId: recipient.id,
-    channel: NotificationChannel.EMAIL,
-    audience: NotificationAudience.USER,
+  return queueEssentialReferralEmail({
+    referral,
+    sourceType: REFERRAL_RECORDED_SOURCE,
     subject: "Your SIXFL team referral has been recorded",
     body: [
       `Hi ${firstName(referral.referrerName)},`,
@@ -176,28 +267,99 @@ export async function queueReferralRecordedEmail(referralId: string) {
       "",
       "Referral terms and conditions apply.",
     ].join("\n"),
-    isTransactional: true,
-    sourceType: REFERRAL_RECORDED_SOURCE,
-    sourceId: referral.id,
+    cta: {
+      label: "Track my referral",
+      url: "https://www.sixfl.co.uk/player/referrals",
+    },
     metadata: {
       event: "team_referral.recorded.email",
       referralId: referral.id,
       referredTeam: teamLabel,
     },
-    emailCta: {
-      label: "Track my referral",
-      url: "https://www.sixfl.co.uk/player/referrals",
-    },
   });
+}
 
-  if (dispatch.status !== "QUEUED") {
-    return {
-      queued: false,
-      reason: dispatch.status === "SKIPPED" ? "recipient_blocked" : "not_queued",
-    } as const;
+export async function queueReferralPayoutReadyEmail(referralId: string) {
+  const id = referralId.trim();
+  if (!id) return { queued: false, reason: "missing_referral_id" as const };
+
+  const rows = await prisma.$queryRaw<ReferralPayoutReadyRow[]>`
+    SELECT
+      r."id",
+      r."referrerUserId",
+      u."name" AS "referrerName",
+      u."email" AS "referrerEmail",
+      l."contactName" AS "leadName",
+      l."teamName" AS "leadTeamName",
+      r."rewardPence",
+      r."requiredMatches",
+      COUNT(DISTINCT f."id")::int AS "completedMatches",
+      r."payoutDetailsSubmittedAt",
+      r."paidAt"
+    FROM "TeamReferral" r
+    INNER JOIN "User" u ON u."id" = r."referrerUserId"
+    INNER JOIN "InterestLead" l ON l."id" = r."interestLeadId"
+    LEFT JOIN "Team" t ON t."id" = l."convertedTeamId"
+    LEFT JOIN "Fixture" f
+      ON (f."homeTeamId" = t."id" OR f."awayTeamId" = t."id")
+      AND f."status" = 'COMPLETED'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "FixtureAbandonment" abandonment
+        WHERE abandonment."fixtureId" = f."id"
+      )
+    WHERE r."id" = ${id}
+    GROUP BY
+      r."id", r."referrerUserId", u."name", u."email", l."contactName",
+      l."teamName", r."rewardPence", r."requiredMatches",
+      r."payoutDetailsSubmittedAt", r."paidAt"
+    LIMIT 1
+  `;
+
+  const referral = rows[0];
+  if (!referral) return { queued: false, reason: "not_found" as const };
+  if (referral.paidAt) return { queued: false, reason: "already_paid" as const };
+  if (referral.payoutDetailsSubmittedAt) {
+    return { queued: false, reason: "details_already_received" as const };
+  }
+  if (referral.completedMatches < referral.requiredMatches) {
+    return { queued: false, reason: "not_ready" as const };
   }
 
-  return { queued: true, reason: null };
+  const teamLabel =
+    referral.leadTeamName?.trim() ||
+    referral.leadName?.trim() ||
+    "the team you referred";
+  const reward = money(referral.rewardPence);
+
+  return queueEssentialReferralEmail({
+    referral,
+    sourceType: REFERRAL_PAYOUT_READY_SOURCE,
+    subject: `Your ${reward} SIXFL referral reward is ready`,
+    body: [
+      `Hi ${firstName(referral.referrerName)},`,
+      "",
+      `Great news — ${teamLabel} have now completed ${referral.requiredMatches} qualifying SIXFL league matches, so your ${reward} referral reward is ready to be paid.`,
+      "",
+      "Please use the secure SIXFL page below to provide the UK bank details you would like us to pay.",
+      "",
+      "For security, please do not send bank details by email or text message.",
+      "",
+      "{{cta}}",
+      "",
+      "Once your payment details are received, SIXFL can arrange the reward payment.",
+    ].join("\n"),
+    cta: {
+      label: "Provide payment details",
+      url: `https://www.sixfl.co.uk/player/referrals/payout/${encodeURIComponent(referral.id)}`,
+    },
+    metadata: {
+      event: "team_referral.payout_ready.email",
+      referralId: referral.id,
+      referredTeam: teamLabel,
+      reward,
+    },
+  });
 }
 
 export async function queueMissingReferralRecordedEmails(limit = 100) {
@@ -222,7 +384,10 @@ export async function queueMissingReferralRecordedEmails(limit = 100) {
         WHERE dispatch."sourceType" = ${REFERRAL_RECORDED_SOURCE}
           AND dispatch."sourceId" = r."id"
           AND dispatch."status" = 'SKIPPED'
-          AND COALESCE(dispatch."failureReason", '') <> ${RECOVERABLE_MISSING_EMAIL_REASON}
+          AND COALESCE(dispatch."failureReason", '') NOT IN (
+            ${RECOVERABLE_MISSING_EMAIL_REASON},
+            ${RECOVERABLE_CHANNEL_DISABLED_REASON}
+          )
       )
     ORDER BY r."createdAt" ASC
     LIMIT ${safeLimit}
@@ -239,6 +404,68 @@ export async function queueMissingReferralRecordedEmails(limit = 100) {
     } catch (error) {
       skipped += 1;
       console.error(`Referral recorded email queue failed for ${row.id}:`, error);
+    }
+  }
+
+  return {
+    checked: rows.length,
+    queued,
+    skipped,
+  };
+}
+
+export async function queueReadyReferralPayoutEmails(limit = 100) {
+  const safeLimit = Math.max(1, Math.min(Math.trunc(limit), 500));
+  const rows = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT r."id"
+    FROM "TeamReferral" r
+    INNER JOIN "User" u ON u."id" = r."referrerUserId"
+    INNER JOIN "InterestLead" l ON l."id" = r."interestLeadId"
+    LEFT JOIN "Team" t ON t."id" = l."convertedTeamId"
+    WHERE r."paidAt" IS NULL
+      AND r."payoutDetailsSubmittedAt" IS NULL
+      AND u."email" IS NOT NULL
+      AND BTRIM(u."email") <> ''
+      AND (
+        SELECT COUNT(DISTINCT f."id")
+        FROM "Fixture" f
+        WHERE (f."homeTeamId" = t."id" OR f."awayTeamId" = t."id")
+          AND f."status" = 'COMPLETED'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "FixtureAbandonment" abandonment
+            WHERE abandonment."fixtureId" = f."id"
+          )
+      ) >= r."requiredMatches"
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${REFERRAL_PAYOUT_READY_SOURCE}
+          AND dispatch."sourceId" = r."id"
+          AND dispatch."status" IN ('QUEUED', 'PROCESSING', 'SENT')
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${REFERRAL_PAYOUT_READY_SOURCE}
+          AND dispatch."sourceId" = r."id"
+          AND dispatch."status" = 'SKIPPED'
+      )
+    ORDER BY r."createdAt" ASC
+    LIMIT ${safeLimit}
+  `;
+
+  let queued = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    try {
+      const result = await queueReferralPayoutReadyEmail(row.id);
+      if (result.queued) queued += 1;
+      else skipped += 1;
+    } catch (error) {
+      skipped += 1;
+      console.error(`Referral payout-ready email queue failed for ${row.id}:`, error);
     }
   }
 

--- a/src/lib/team-referral-payout.ts
+++ b/src/lib/team-referral-payout.ts
@@ -1,0 +1,204 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { prisma } from "@/lib/prisma";
+
+export type TeamReferralPayoutDetails = {
+  accountHolderName: string;
+  sortCode: string;
+  accountNumber: string;
+};
+
+type StoredPayoutRow = {
+  payoutDetailsCiphertext: string | null;
+  payoutDetailsIv: string | null;
+  payoutDetailsAuthTag: string | null;
+  payoutDetailsSubmittedAt: Date | null;
+};
+
+function getEncryptionKey() {
+  const secret =
+    process.env.REFERRAL_PAYOUT_ENCRYPTION_KEY?.trim() ||
+    process.env.NEXTAUTH_SECRET?.trim() ||
+    process.env.AUTH_SECRET?.trim();
+
+  if (!secret) {
+    throw new Error(
+      "Referral payout encryption is not configured. Set REFERRAL_PAYOUT_ENCRYPTION_KEY or NEXTAUTH_SECRET.",
+    );
+  }
+
+  return createHash("sha256").update(secret, "utf8").digest();
+}
+
+function normaliseAccountHolderName(value: string) {
+  const name = value.trim().replace(/\s+/g, " ");
+  if (name.length < 2 || name.length > 120) {
+    throw new Error("Enter the account holder name exactly as it appears on the bank account.");
+  }
+  return name;
+}
+
+function normaliseSortCode(value: string) {
+  const digits = value.replace(/\D/g, "");
+  if (!/^\d{6}$/.test(digits)) {
+    throw new Error("Enter a valid 6-digit UK sort code.");
+  }
+  return digits;
+}
+
+function normaliseAccountNumber(value: string) {
+  const digits = value.replace(/\D/g, "");
+  if (!/^\d{8}$/.test(digits)) {
+    throw new Error("Enter a valid 8-digit UK account number.");
+  }
+  return digits;
+}
+
+export function validateTeamReferralPayoutDetails(input: TeamReferralPayoutDetails) {
+  return {
+    accountHolderName: normaliseAccountHolderName(input.accountHolderName),
+    sortCode: normaliseSortCode(input.sortCode),
+    accountNumber: normaliseAccountNumber(input.accountNumber),
+  } satisfies TeamReferralPayoutDetails;
+}
+
+function encryptDetails(details: TeamReferralPayoutDetails) {
+  const key = getEncryptionKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const plaintext = Buffer.from(JSON.stringify(details), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    ciphertext: ciphertext.toString("base64"),
+    iv: iv.toString("base64"),
+    authTag: authTag.toString("base64"),
+  };
+}
+
+function decryptDetails(row: StoredPayoutRow): TeamReferralPayoutDetails | null {
+  if (
+    !row.payoutDetailsCiphertext ||
+    !row.payoutDetailsIv ||
+    !row.payoutDetailsAuthTag
+  ) {
+    return null;
+  }
+
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    getEncryptionKey(),
+    Buffer.from(row.payoutDetailsIv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(row.payoutDetailsAuthTag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(row.payoutDetailsCiphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+
+  const parsed = JSON.parse(plaintext) as TeamReferralPayoutDetails;
+  return validateTeamReferralPayoutDetails(parsed);
+}
+
+export async function saveTeamReferralPayoutDetails(input: {
+  referralId: string;
+  referrerUserId: string;
+  details: TeamReferralPayoutDetails;
+}) {
+  const details = validateTeamReferralPayoutDetails(input.details);
+
+  const rows = await prisma.$queryRaw<Array<{
+    id: string;
+    requiredMatches: number;
+    completedMatches: number;
+    paidAt: Date | null;
+  }>>`
+    SELECT
+      referral."id",
+      referral."requiredMatches",
+      referral."paidAt",
+      COUNT(DISTINCT fixture."id")::int AS "completedMatches"
+    FROM "TeamReferral" referral
+    INNER JOIN "InterestLead" lead ON lead."id" = referral."interestLeadId"
+    LEFT JOIN "Team" team ON team."id" = lead."convertedTeamId"
+    LEFT JOIN "Fixture" fixture
+      ON (fixture."homeTeamId" = team."id" OR fixture."awayTeamId" = team."id")
+      AND fixture."status" = 'COMPLETED'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "FixtureAbandonment" abandonment
+        WHERE abandonment."fixtureId" = fixture."id"
+      )
+    WHERE referral."id" = ${input.referralId}
+      AND referral."referrerUserId" = ${input.referrerUserId}
+    GROUP BY referral."id", referral."requiredMatches", referral."paidAt"
+    LIMIT 1
+  `;
+
+  const referral = rows[0];
+  if (!referral) throw new Error("Referral reward not found.");
+  if (referral.paidAt) throw new Error("This referral reward has already been paid.");
+  if (referral.completedMatches < referral.requiredMatches) {
+    throw new Error("This referral reward is not ready for payment yet.");
+  }
+
+  const encrypted = encryptDetails(details);
+  await prisma.$executeRaw`
+    UPDATE "TeamReferral"
+    SET
+      "payoutDetailsCiphertext" = ${encrypted.ciphertext},
+      "payoutDetailsIv" = ${encrypted.iv},
+      "payoutDetailsAuthTag" = ${encrypted.authTag},
+      "payoutDetailsSubmittedAt" = CURRENT_TIMESTAMP,
+      "updatedAt" = CURRENT_TIMESTAMP
+    WHERE "id" = ${input.referralId}
+      AND "referrerUserId" = ${input.referrerUserId}
+      AND "paidAt" IS NULL
+  `;
+
+  return details;
+}
+
+export async function getTeamReferralPayoutDetails(referralId: string) {
+  const rows = await prisma.$queryRaw<StoredPayoutRow[]>`
+    SELECT
+      "payoutDetailsCiphertext",
+      "payoutDetailsIv",
+      "payoutDetailsAuthTag",
+      "payoutDetailsSubmittedAt"
+    FROM "TeamReferral"
+    WHERE "id" = ${referralId}
+    LIMIT 1
+  `;
+
+  const row = rows[0];
+  if (!row) return null;
+
+  return {
+    details: decryptDetails(row),
+    submittedAt: row.payoutDetailsSubmittedAt,
+  };
+}
+
+export async function clearTeamReferralPayoutSecrets(referralId: string) {
+  await prisma.$executeRaw`
+    UPDATE "TeamReferral"
+    SET
+      "payoutDetailsCiphertext" = NULL,
+      "payoutDetailsIv" = NULL,
+      "payoutDetailsAuthTag" = NULL,
+      "updatedAt" = CURRENT_TIMESTAMP
+    WHERE "id" = ${referralId}
+  `;
+}
+
+export function formatSortCode(sortCode: string) {
+  const digits = sortCode.replace(/\D/g, "");
+  if (digits.length !== 6) return sortCode;
+  return `${digits.slice(0, 2)}-${digits.slice(2, 4)}-${digits.slice(4, 6)}`;
+}
+
+export function maskAccountNumber(accountNumber: string) {
+  const digits = accountNumber.replace(/\D/g, "");
+  return digits.length >= 4 ? `••••${digits.slice(-4)}` : "••••";
+}

--- a/src/lib/team-referrals.ts
+++ b/src/lib/team-referrals.ts
@@ -103,6 +103,7 @@ export type TeamReferralRow = {
   rewardPence: number;
   requiredMatches: number;
   completedMatches: number;
+  payoutDetailsSubmittedAt: Date | null;
   paidAt: Date | null;
   createdAt: Date;
 };
@@ -123,6 +124,7 @@ export async function getTeamReferrals(referrerUserId?: string) {
       r."rewardPence",
       r."requiredMatches",
       COUNT(DISTINCT f."id")::int AS "completedMatches",
+      r."payoutDetailsSubmittedAt",
       r."paidAt",
       r."createdAt"
     FROM "TeamReferral" r
@@ -133,11 +135,16 @@ export async function getTeamReferrals(referrerUserId?: string) {
     LEFT JOIN "Fixture" f
       ON (f."homeTeamId" = t."id" OR f."awayTeamId" = t."id")
       AND f."status" = 'COMPLETED'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "FixtureAbandonment" abandonment
+        WHERE abandonment."fixtureId" = f."id"
+      )
     WHERE (${referrerUserId ?? null}::text IS NULL OR r."referrerUserId" = ${referrerUserId ?? null})
     GROUP BY
       r."id", r."referrerUserId", u."name", u."email", l."contactName", l."email",
       l."teamName", t."id", t."name", lg."name", r."rewardPence",
-      r."requiredMatches", r."paidAt", r."createdAt"
+      r."requiredMatches", r."payoutDetailsSubmittedAt", r."paidAt", r."createdAt"
     ORDER BY r."createdAt" DESC
   `;
 }


### PR DESCRIPTION
Adds the missing payout step for £75 player team-referral rewards. Once a referred team reaches three completed league matches, the notification cron queues an essential transactional email telling the player their reward is ready and linking to a secure payment-details page. UK bank details are validated, encrypted at rest with AES-256-GCM using REFERRAL_PAYOUT_ENCRYPTION_KEY with the existing auth secret as fallback, and shown only to the owning player and SIXFL admins. Admin referrals now distinguish awaiting details from details received and link to a secure payout view. Marking a reward paid requires submitted details and then removes the stored account number, sort code and encryption material while retaining payout/paid audit timestamps.

Also fixes the existing referral confirmation email issue: referral/payment emails no longer treat the generic `emailEnabled` channel toggle as a blocker because they are essential account/payment messages. Suppression and explicit transactional-email opt-out are still respected. Existing referral emails previously skipped specifically as `Recipient email notifications are disabled.` are recoverable and will be retried by the existing notification cron, so Anth's old skipped confirmation should self-heal after deployment.