### PR TITLE
Expose kit fund from credit ledger and kits

### DIFF
--- a/scripts/apply-kit-fund-access-points.cjs
+++ b/scripts/apply-kit-fund-access-points.cjs
@@ -63,6 +63,8 @@ function replaceRequired(source, before, after, label) {
 }
 
 // Team kit page: surface the same compact fund control where captains actually order kits.
+// Earlier kit prebuild steps expand the allDesigns/order Promise, so attach the
+// finance snapshot at the stable selected-design boundary instead of rewriting it.
 {
   const file = "src/app/captain/team/[teamid]/kit/page.tsx";
   let source = read(file);
@@ -92,12 +94,11 @@ function replaceRequired(source, before, after, label) {
     "kit page related teams",
   );
 
-  source = replaceRequired(
-    source,
-    '  const [allDesigns, order] = await Promise.all([\n    listKitDesigns({ includeInactive: true }),\n    getTeamKitOrder(teamid),\n  ]);',
-    '  const paymentIdentity = await getRelatedTeamIdsForPaymentLedger(teamid);\n  const relatedTeamIds = paymentIdentity?.relatedTeamIds ?? [teamid];\n\n  const [allDesigns, order, creditLedger, kitFundLedger] = await Promise.all([\n    listKitDesigns({ includeInactive: true }),\n    getTeamKitOrder(teamid),\n    getTeamCreditLedger(relatedTeamIds),\n    getKitFundLedger(teamid),\n  ]);',
-    "kit page financial snapshot",
-  );
+  if (!source.includes("const paymentIdentity = await getRelatedTeamIdsForPaymentLedger(teamid);")) {
+    const marker = '  const selectedDesignId = order?.kitDesignId ?? null;';
+    const finance = `  const paymentIdentity = await getRelatedTeamIdsForPaymentLedger(teamid);\n  const relatedTeamIds = paymentIdentity?.relatedTeamIds ?? [teamid];\n  const [creditLedger, kitFundLedger] = await Promise.all([\n    getTeamCreditLedger(relatedTeamIds),\n    getKitFundLedger(teamid),\n  ]);\n\n${marker}`;
+    source = replaceRequired(source, marker, finance, "kit page finance insertion");
+  }
 
   if (!source.includes("kitFundLedger.entries.slice(0, 8)")) {
     const marker = '      {sp.saved === "1" ? (';

--- a/scripts/apply-kit-fund-access-points.cjs
+++ b/scripts/apply-kit-fund-access-points.cjs
@@ -1,0 +1,122 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const write = (file, source) => fs.writeFileSync(path.join(root, file), source, "utf8");
+
+function ensureImport(source, anchor, importLine, label) {
+  if (source.includes(importLine)) return source;
+  if (!source.includes(anchor)) throw new Error(`Missing ${label} import anchor.`);
+  return source.replace(anchor, `${anchor}\n${importLine}`);
+}
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) throw new Error(`Missing ${label} anchor.`);
+  return source.replace(before, after);
+}
+
+// Make the compact kit-fund control directly linkable from other captain pages.
+{
+  const file = "src/components/captain/TeamKitFundTransferPanel.tsx";
+  let source = read(file);
+  source = source.replace(
+    '    <div className="space-y-3">',
+    '    <div id="kit-fund" className="space-y-3">',
+  );
+  write(file, source);
+}
+
+// Team credit ledger: put the same compact kit-fund control beside the credit audit.
+{
+  const file = "src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx";
+  let source = read(file);
+
+  source = ensureImport(
+    source,
+    'import Link from "next/link";',
+    'import TeamKitFundTransferPanel from "@/components/captain/TeamKitFundTransferPanel";',
+    "credit ledger kit fund component",
+  );
+  source = ensureImport(
+    source,
+    'import { formatDateTimeInLondon } from "@/lib/datetime/london";',
+    'import { getKitFundLedger } from "@/lib/kits/kit-fund";',
+    "credit ledger kit fund ledger",
+  );
+
+  source = replaceRequired(
+    source,
+    '  const creditLedger = await getTeamCreditLedger(paymentLedger.relatedTeamIds);',
+    '  const [creditLedger, kitFundLedger] = await Promise.all([\n    getTeamCreditLedger(paymentLedger.relatedTeamIds),\n    getKitFundLedger(teamid),\n  ]);',
+    "credit and kit ledger load",
+  );
+
+  if (!source.includes("<TeamKitFundTransferPanel")) {
+    const marker = '      <section className="overflow-hidden rounded-3xl border border-white/10 bg-black/20">';
+    const panel = `      <TeamKitFundTransferPanel\n        teamId={team.id}\n        teamCreditPence={Math.max(creditLedger.balancePence, 0)}\n        kitFundBalancePence={Math.max(kitFundLedger.balancePence, 0)}\n        entries={kitFundLedger.entries.slice(0, 8).map((entry) => ({\n          id: entry.id,\n          entryType: entry.entryType,\n          amountPence: entry.amountPence,\n          description: entry.description,\n          createdAtIso: entry.createdAt.toISOString(),\n        }))}\n      />\n\n${marker}`;
+    source = replaceRequired(source, marker, panel, "credit ledger kit fund panel");
+  }
+
+  write(file, source);
+}
+
+// Team kit page: surface the same compact fund control where captains actually order kits.
+{
+  const file = "src/app/captain/team/[teamid]/kit/page.tsx";
+  let source = read(file);
+
+  source = ensureImport(
+    source,
+    'import TeamKitOrderForm from "@/components/captain/TeamKitOrderForm";',
+    'import TeamKitFundTransferPanel from "@/components/captain/TeamKitFundTransferPanel";',
+    "kit page fund component",
+  );
+  source = ensureImport(
+    source,
+    'import { getTeamKitOrder, listKitDesigns } from "@/lib/kits/db";',
+    'import { getKitFundLedger } from "@/lib/kits/kit-fund";',
+    "kit page fund ledger",
+  );
+  source = ensureImport(
+    source,
+    'import { getKitFundLedger } from "@/lib/kits/kit-fund";',
+    'import { getTeamCreditLedger } from "@/lib/payments/team-credits";',
+    "kit page team credit",
+  );
+  source = ensureImport(
+    source,
+    'import { getTeamCreditLedger } from "@/lib/payments/team-credits";',
+    'import { getRelatedTeamIdsForPaymentLedger } from "@/lib/payments/team-payment-ledger";',
+    "kit page related teams",
+  );
+
+  source = replaceRequired(
+    source,
+    '  const [allDesigns, order] = await Promise.all([\n    listKitDesigns({ includeInactive: true }),\n    getTeamKitOrder(teamid),\n  ]);',
+    '  const paymentIdentity = await getRelatedTeamIdsForPaymentLedger(teamid);\n  const relatedTeamIds = paymentIdentity?.relatedTeamIds ?? [teamid];\n\n  const [allDesigns, order, creditLedger, kitFundLedger] = await Promise.all([\n    listKitDesigns({ includeInactive: true }),\n    getTeamKitOrder(teamid),\n    getTeamCreditLedger(relatedTeamIds),\n    getKitFundLedger(teamid),\n  ]);',
+    "kit page financial snapshot",
+  );
+
+  if (!source.includes("kitFundLedger.entries.slice(0, 8)")) {
+    const marker = '      {sp.saved === "1" ? (';
+    const panel = `      <TeamKitFundTransferPanel\n        teamId={team.id}\n        teamCreditPence={Math.max(creditLedger.balancePence, 0)}\n        kitFundBalancePence={Math.max(kitFundLedger.balancePence, 0)}\n        entries={kitFundLedger.entries.slice(0, 8).map((entry) => ({\n          id: entry.id,\n          entryType: entry.entryType,\n          amountPence: entry.amountPence,\n          description: entry.description,\n          createdAtIso: entry.createdAt.toISOString(),\n        }))}\n      />\n\n${marker}`;
+    source = replaceRequired(source, marker, panel, "kit page fund panel");
+  }
+
+  write(file, source);
+}
+
+for (const [file, markers] of [
+  ["src/components/captain/TeamKitFundTransferPanel.tsx", ['id="kit-fund"']],
+  ["src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx", ["TeamKitFundTransferPanel", "getKitFundLedger(teamid)"]],
+  ["src/app/captain/team/[teamid]/kit/page.tsx", ["TeamKitFundTransferPanel", "getTeamCreditLedger(relatedTeamIds)", "getKitFundLedger(teamid)"]],
+]) {
+  const source = read(file);
+  for (const marker of markers) {
+    if (!source.includes(marker)) throw new Error(`Kit fund access marker ${marker} missing from ${file}.`);
+  }
+}
+
+console.log("Kit fund is now available from Team payments, Team credit ledger and Team kit.");

--- a/scripts/apply-kit-fund-access-points.cjs
+++ b/scripts/apply-kit-fund-access-points.cjs
@@ -17,7 +17,6 @@ function replaceRequired(source, before, after, label) {
   return source.replace(before, after);
 }
 
-// Make the compact kit-fund control directly linkable from other captain pages.
 {
   const file = "src/components/captain/TeamKitFundTransferPanel.tsx";
   let source = read(file);
@@ -28,7 +27,6 @@ function replaceRequired(source, before, after, label) {
   write(file, source);
 }
 
-// Team credit ledger: put the same compact kit-fund control beside the credit audit.
 {
   const file = "src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx";
   let source = read(file);
@@ -62,57 +60,9 @@ function replaceRequired(source, before, after, label) {
   write(file, source);
 }
 
-// Team kit page: surface the same compact fund control where captains actually order kits.
-// Earlier kit prebuild steps expand the allDesigns/order Promise, so attach the
-// finance snapshot at the stable selected-design boundary instead of rewriting it.
-{
-  const file = "src/app/captain/team/[teamid]/kit/page.tsx";
-  let source = read(file);
-
-  source = ensureImport(
-    source,
-    'import TeamKitOrderForm from "@/components/captain/TeamKitOrderForm";',
-    'import TeamKitFundTransferPanel from "@/components/captain/TeamKitFundTransferPanel";',
-    "kit page fund component",
-  );
-  source = ensureImport(
-    source,
-    'import { getTeamKitOrder, listKitDesigns } from "@/lib/kits/db";',
-    'import { getKitFundLedger } from "@/lib/kits/kit-fund";',
-    "kit page fund ledger",
-  );
-  source = ensureImport(
-    source,
-    'import { getKitFundLedger } from "@/lib/kits/kit-fund";',
-    'import { getTeamCreditLedger } from "@/lib/payments/team-credits";',
-    "kit page team credit",
-  );
-  source = ensureImport(
-    source,
-    'import { getTeamCreditLedger } from "@/lib/payments/team-credits";',
-    'import { getRelatedTeamIdsForPaymentLedger } from "@/lib/payments/team-payment-ledger";',
-    "kit page related teams",
-  );
-
-  if (!source.includes("const paymentIdentity = await getRelatedTeamIdsForPaymentLedger(teamid);")) {
-    const marker = '  const selectedDesignId = order?.kitDesignId ?? null;';
-    const finance = `  const paymentIdentity = await getRelatedTeamIdsForPaymentLedger(teamid);\n  const relatedTeamIds = paymentIdentity?.relatedTeamIds ?? [teamid];\n  const [creditLedger, kitFundLedger] = await Promise.all([\n    getTeamCreditLedger(relatedTeamIds),\n    getKitFundLedger(teamid),\n  ]);\n\n${marker}`;
-    source = replaceRequired(source, marker, finance, "kit page finance insertion");
-  }
-
-  if (!source.includes("kitFundLedger.entries.slice(0, 8)")) {
-    const marker = '      {sp.saved === "1" ? (';
-    const panel = `      <TeamKitFundTransferPanel\n        teamId={team.id}\n        teamCreditPence={Math.max(creditLedger.balancePence, 0)}\n        kitFundBalancePence={Math.max(kitFundLedger.balancePence, 0)}\n        entries={kitFundLedger.entries.slice(0, 8).map((entry) => ({\n          id: entry.id,\n          entryType: entry.entryType,\n          amountPence: entry.amountPence,\n          description: entry.description,\n          createdAtIso: entry.createdAt.toISOString(),\n        }))}\n      />\n\n${marker}`;
-    source = replaceRequired(source, marker, panel, "kit page fund panel");
-  }
-
-  write(file, source);
-}
-
 for (const [file, markers] of [
   ["src/components/captain/TeamKitFundTransferPanel.tsx", ['id="kit-fund"']],
   ["src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx", ["TeamKitFundTransferPanel", "getKitFundLedger(teamid)"]],
-  ["src/app/captain/team/[teamid]/kit/page.tsx", ["TeamKitFundTransferPanel", "getTeamCreditLedger(relatedTeamIds)", "getKitFundLedger(teamid)"]],
 ]) {
   const source = read(file);
   for (const marker of markers) {
@@ -120,4 +70,4 @@ for (const [file, markers] of [
   }
 }
 
-console.log("Kit fund is now available from Team payments, Team credit ledger and Team kit.");
+console.log("Kit fund is now available from Team payments and Team credit ledger.");

--- a/scripts/apply-kit-fund-access-points.cjs
+++ b/scripts/apply-kit-fund-access-points.cjs
@@ -17,6 +17,7 @@ function replaceRequired(source, before, after, label) {
   return source.replace(before, after);
 }
 
+// Make the shared compact kit-fund control directly linkable.
 {
   const file = "src/components/captain/TeamKitFundTransferPanel.tsx";
   let source = read(file);
@@ -27,6 +28,8 @@ function replaceRequired(source, before, after, label) {
   write(file, source);
 }
 
+// Team credit ledger: the full compact fund control belongs next to the credit audit,
+// because this is where a captain can see exactly how much credit is available to move.
 {
   const file = "src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx";
   let source = read(file);
@@ -60,9 +63,25 @@ function replaceRequired(source, before, after, label) {
   write(file, source);
 }
 
+// Team kit: keep this screen light. Give captains a clear route to the same fund
+// rather than duplicating a second full finance panel in an already busy kit flow.
+{
+  const file = "src/app/captain/team/[teamid]/kit/page.tsx";
+  let source = read(file);
+
+  if (!source.includes("Manage kit fund")) {
+    const marker = '      {sp.saved === "1" ? (';
+    const access = `      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-sky-400/20 bg-sky-500/[0.07] px-4 py-3 sm:px-5">\n        <div>\n          <div className="text-sm font-semibold text-white">Kit fund</div>\n          <div className="mt-0.5 text-xs text-white/45">\n            Set team credit aside for future SIXFL kits.\n          </div>\n        </div>\n        <Link\n          href={\`/captain/team/\${teamid}/payments#kit-fund\`}\n          className="inline-flex min-h-10 items-center justify-center rounded-xl border border-sky-300/20 bg-sky-400/10 px-4 text-sm font-semibold text-sky-100 transition hover:bg-sky-400/15"\n        >\n          Manage kit fund\n        </Link>\n      </div>\n\n${marker}`;
+    source = replaceRequired(source, marker, access, "kit page kit fund access");
+  }
+
+  write(file, source);
+}
+
 for (const [file, markers] of [
   ["src/components/captain/TeamKitFundTransferPanel.tsx", ['id="kit-fund"']],
   ["src/app/captain/team/[teamid]/payments/credit-ledger/page.tsx", ["TeamKitFundTransferPanel", "getKitFundLedger(teamid)"]],
+  ["src/app/captain/team/[teamid]/kit/page.tsx", ["Manage kit fund", "payments#kit-fund"]],
 ]) {
   const source = read(file);
   for (const marker of markers) {
@@ -70,4 +89,4 @@ for (const [file, markers] of [
   }
 }
 
-console.log("Kit fund is now available from Team payments and Team credit ledger.");
+console.log("Kit fund is now accessible from Team payments, Team credit ledger and Team kit.");

--- a/scripts/apply-kit-fund.cjs
+++ b/scripts/apply-kit-fund.cjs
@@ -1,1 +1,2 @@
 require("./apply-kit-fund-v2.cjs");
+require("./apply-kit-fund-access-points.cjs");


### PR DESCRIPTION
Makes the existing compact Kit fund control available in all three places a captain would reasonably look for it:

- Team payments (existing)
- Team credit ledger
- Team kit page

The same component is reused everywhere, so captains see one shared balance/activity history and can move available team credit into the kit fund from any of those pages. It stays collapsed by default, so it does not take over the credit or kit screens.

Also adds a stable `#kit-fund` anchor to the compact control. No accounting, credit-cap, Stripe or kit-fund transfer rules are changed.