### PR TITLE
Repair legacy capped player shares for Dynamo Kebab

### DIFF
--- a/prisma/migrations/20260827222500_repair_legacy_capped_player_shares/migration.sql
+++ b/prisma/migrations/20260827222500_repair_legacy_capped_player_shares/migration.sql
@@ -1,0 +1,37 @@
+-- Repair the two legacy capped Dynamo Kebab player-fee rows from the
+-- 25 Aug 2026 fixture against Wenlock Warriors.
+--
+-- The captain allocated £8.00 to these players, but before the durable
+-- captainAssignedAmountPence field existed the capped £5.00 amount became the
+-- only surviving value. Do not change the real amount charged/paid: only
+-- restore the captain-facing allocation used for display and fixture coverage.
+WITH target_fees AS (
+  SELECT pmf."id"
+  FROM "PlayerMatchFee" pmf
+  JOIN "Fixture" f ON f."id" = pmf."fixtureId"
+  JOIN "Team" fee_team ON fee_team."id" = pmf."teamId"
+  JOIN "Team" home_team ON home_team."id" = f."homeTeamId"
+  JOIN "Team" away_team ON away_team."id" = f."awayTeamId"
+  JOIN "TeamMemberProfile" profile ON profile."teamMemberId" = pmf."teamMemberId"
+  WHERE fee_team."name" = 'Dynamo Kebab'
+    AND home_team."name" = 'Dynamo Kebab'
+    AND away_team."name" = 'Wenlock Warriors'
+    AND f."kickoffAt" >= TIMESTAMP '2026-08-25 00:00:00'
+    AND f."kickoffAt" < TIMESTAMP '2026-08-26 00:00:00'
+    AND pmf."amountPence" = 500
+    AND pmf."captainAssignedAmountPence" = 500
+    AND profile."playerMatchFeeCapPence" = 500
+    AND pmf."status"::text IN ('OPEN', 'PAID')
+)
+UPDATE "PlayerMatchFee" pmf
+SET
+  "captainAssignedAmountPence" = 800,
+  "note" = CASE
+    WHEN COALESCE(pmf."note", '') ~* 'Player fee cap applied: captain share £8([.]00)?; player charged £5([.]00)?[.]'
+      THEN pmf."note"
+    WHEN NULLIF(BTRIM(COALESCE(pmf."note", '')), '') IS NULL
+      THEN 'Player fee cap applied: captain share £8.00; player charged £5.00.'
+    ELSE pmf."note" || E'\nPlayer fee cap applied: captain share £8.00; player charged £5.00.'
+  END
+FROM target_fees target
+WHERE pmf."id" = target."id";

--- a/prisma/migrations/20260827222500_repair_legacy_capped_player_shares/migration.sql
+++ b/prisma/migrations/20260827222500_repair_legacy_capped_player_shares/migration.sql
@@ -27,8 +27,13 @@ UPDATE "PlayerMatchFee" pmf
 SET
   "captainAssignedAmountPence" = 800,
   "note" = CASE
-    WHEN COALESCE(pmf."note", '') ~* 'Player fee cap applied: captain share £8([.]00)?; player charged £5([.]00)?[.]'
-      THEN pmf."note"
+    WHEN COALESCE(pmf."note", '') ~* 'Player fee cap applied:'
+      THEN REGEXP_REPLACE(
+        pmf."note",
+        'Player fee cap applied:[^\r\n]*',
+        'Player fee cap applied: captain share £8.00; player charged £5.00.',
+        'i'
+      )
     WHEN NULLIF(BTRIM(COALESCE(pmf."note", '')), '') IS NULL
       THEN 'Player fee cap applied: captain share £8.00; player charged £5.00.'
     ELSE pmf."note" || E'\nPlayer fee cap applied: captain share £8.00; player charged £5.00.'

--- a/prisma/migrations/20260827222500_repair_legacy_capped_player_shares/migration.sql
+++ b/prisma/migrations/20260827222500_repair_legacy_capped_player_shares/migration.sql
@@ -5,6 +5,11 @@
 -- captainAssignedAmountPence field existed the capped £5.00 amount became the
 -- only surviving value. Do not change the real amount charged/paid: only
 -- restore the captain-facing allocation used for display and fixture coverage.
+--
+-- This deliberately targets the exact historical team/fixture/date and the
+-- two £5 rows visible in that ledger. It does not depend on TeamMemberProfile,
+-- so the migration remains replayable on a clean database where no legacy rows
+-- exist.
 WITH target_fees AS (
   SELECT pmf."id"
   FROM "PlayerMatchFee" pmf
@@ -12,7 +17,6 @@ WITH target_fees AS (
   JOIN "Team" fee_team ON fee_team."id" = pmf."teamId"
   JOIN "Team" home_team ON home_team."id" = f."homeTeamId"
   JOIN "Team" away_team ON away_team."id" = f."awayTeamId"
-  JOIN "TeamMemberProfile" profile ON profile."teamMemberId" = pmf."teamMemberId"
   WHERE fee_team."name" = 'Dynamo Kebab'
     AND home_team."name" = 'Dynamo Kebab'
     AND away_team."name" = 'Wenlock Warriors'
@@ -20,7 +24,6 @@ WITH target_fees AS (
     AND f."kickoffAt" < TIMESTAMP '2026-08-26 00:00:00'
     AND pmf."amountPence" = 500
     AND pmf."captainAssignedAmountPence" = 500
-    AND profile."playerMatchFeeCapPence" = 500
     AND pmf."status"::text IN ('OPEN', 'PAID')
 )
 UPDATE "PlayerMatchFee" pmf


### PR DESCRIPTION
Repairs the two historical £5 capped player-fee rows on Dynamo Kebab v Wenlock Warriors (25 Aug 2026) where the captain originally allocated £8 but the legacy record only retained the £5 capped charge.

Safety:
- targets only Dynamo Kebab's exact 25 Aug fixture against Wenlock Warriors, where the surviving player amount and assigned amount are both £5 and the status is OPEN/PAID
- changes only captainAssignedAmountPence from 500 to 800 and restores the structured £8 captain-share / £5 player-charge note
- leaves PlayerMatchFee.amountPence at £5, so Stripe/cash accounting is untouched
- does not alter paidAt, payment tokens, transactions, team credit, or charge amounts
- migration is replayable on a clean database and simply updates zero rows when the historical fixture is absent

Future capped allocations are already protected by the durable assigned-share logic merged in #342; this PR is a targeted historical data repair for the rows created before that protection existed.