### PR TITLE
Make missing-email player edit links reliable

### DIFF
--- a/src/app/captain/team/[teamid]/player-payments/page.tsx
+++ b/src/app/captain/team/[teamid]/player-payments/page.tsx
@@ -102,12 +102,12 @@ export default async function SquadPaymentsPage(props: Props) {
                       {member.role.replaceAll("_", " ")}
                     </span>
                   </div>
-                  <Link
+                  <a
                     href={`/captain/team/${team.id}/captain-squad/${member.id}/edit`}
                     className="inline-flex min-h-9 items-center justify-center rounded-full border border-white/10 bg-black/20 px-4 text-xs font-semibold text-white/80 transition hover:bg-white/[0.06] hover:text-white"
                   >
                     Add email or mark inactive
-                  </Link>
+                  </a>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
Fixes the Squad payments warning buttons that could send the first click back to the captain overview before working on the second click.

The player-specific "Add email or mark inactive" controls now use a normal browser navigation to the exact player edit URL instead of the Next.js client router. This avoids stale client-route/cache behaviour while leaving the rest of the captain navigation unchanged.

No payment, squad-status or email-readiness logic is changed.