### PR TITLE
Fix late-fee balances staying falsely paid

### DIFF
--- a/src/lib/payments/charge-summary.ts
+++ b/src/lib/payments/charge-summary.ts
@@ -76,8 +76,13 @@ export function getDisplayChargeStatus(input: {
   amountPence: number;
   paidPence: number;
 }) {
-  if (input.storedStatus === "VOID" || input.storedStatus === "PAID") {
-    return input.storedStatus;
+  // VOID is an explicit accounting decision and remains authoritative. PAID is
+  // different: the charge total can legitimately increase afterwards (for example
+  // when a £10 late-payment admin fee is applied). In that case the financial
+  // coverage must reopen the charge instead of a stale PAID flag hiding the new
+  // balance.
+  if (input.storedStatus === "VOID") {
+    return "VOID";
   }
 
   if (input.paidPence >= input.amountPence) {
@@ -88,7 +93,7 @@ export function getDisplayChargeStatus(input: {
     return "PART_PAID";
   }
 
-  return input.storedStatus;
+  return "OPEN";
 }
 
 export function getDisplayChargeOutstandingPence(input: {


### PR DESCRIPTION
Fixes stale PAID charge status after a charge total increases, including when a £10 late-payment admin fee is applied.

The displayed charge status is now derived from actual financial coverage unless the charge is explicitly VOID. This means a £50 charge with £40 settled shows PART PAID and £10 outstanding instead of trusting an old PAID flag and forcing the balance to £0.

This is deliberately a shared charge-summary fix so Captain Team Payments, overview summaries and credit/payment calculations use the same financial truth. No transactions or payment history are changed.