### PR TITLE
Stop squad email fix links bouncing admins to overview

### DIFF
--- a/src/app/captain/team/[teamid]/captain-squad/layout.tsx
+++ b/src/app/captain/team/[teamid]/captain-squad/layout.tsx
@@ -3,7 +3,6 @@
 // ========================================
 
 import type { ReactNode } from "react";
-import { redirect } from "next/navigation";
 
 import PlayerDashboardLoginEmailButtons from "@/components/captain/PlayerDashboardLoginEmailButtons";
 import { requireCaptain } from "@/lib/requireCaptain";
@@ -18,13 +17,9 @@ export default async function CaptainSquadLayout({
   const { teamid } = await params;
   const access = await requireCaptain(teamid);
 
-  if (access.isAdmin) {
-    redirect(`/admin/teams/${teamid}/captain-preview`);
-  }
-
   return (
     <>
-      <PlayerDashboardLoginEmailButtons />
+      {!access.isAdmin ? <PlayerDashboardLoginEmailButtons /> : null}
       {children}
     </>
   );


### PR DESCRIPTION
Fixes the first-click problem from Squad payments when an active player is missing an email.

Root cause: the warning links correctly target the captain-squad player edit route, which contains both the email field and the Active/Inactive control, but the parent captain-squad layout forcibly redirected every admin request to the admin captain-preview/overview before the player edit page could render.

This change removes that broad admin redirect from the captain-squad layout so nested player edit pages can open for admins. Captain authentication remains enforced. The captain-only dashboard-login helper is hidden for admins.

No player, payment, squad-status or email data is changed by this PR; it only fixes routing/access to the existing edit screen.