### PR TITLE
Keep Night Board referee assignments in sync

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Check last-minute replacement resolution
         run: node scripts/check-last-minute-replacement-resolution.mjs
 
+      - name: Check Night Board referee-night sync
+        run: node scripts/check-night-board-referee-night-sync.mjs
+
       - name: Check AI prediction matchup integrity
         run: node scripts/check-ai-prediction-matchup-integrity.mjs
 
@@ -110,6 +113,7 @@ jobs:
           node scripts/check-team-confirmation-contract.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
+          node scripts/check-night-board-referee-night-sync.mjs
           node scripts/check-ai-prediction-matchup-integrity.mjs
           node scripts/check-ai-prediction-text-team-integrity.mjs
           npx tsx scripts/check-ai-predictor-opponent-adjusted.ts

--- a/docs/critical-feature-contracts.md
+++ b/docs/critical-feature-contracts.md
@@ -84,7 +84,15 @@ When a critical feature currently depends on a preparation script, its final beh
 - the lead can explicitly choose to confirm the team name later and return to the same link without losing the reserved place;
 - once the lead has been converted into an actual team, the public confirmation page must not allow the lead team name to be changed.
 
-These assertions live in `scripts/check-critical-feature-contracts.mjs` and dedicated executable contract scripts such as `scripts/check-team-confirmation-contract.mjs`; the critical-feature workflow runs them after the complete production source-preparation chain.
+### Referee and Night Board operations
+
+- saving a Night Board fixture must immediately pass the updated fixture through the central referee-night assignment synchroniser;
+- the fixture must be linked to the correct referee night before the save response is returned;
+- old and newly affected referee nights must both be recalculated and revalidated;
+- the Night Board confirmation warning check must repair legacy or direct assignments before reporting that a referee-night link is missing;
+- if automatic repair fails, the operational warning must remain visible rather than being silently suppressed.
+
+These assertions live in `scripts/check-critical-feature-contracts.mjs` and dedicated executable contract scripts such as `scripts/check-team-confirmation-contract.mjs` and `scripts/check-night-board-referee-night-sync.mjs`; the critical-feature workflow runs them after the complete production source-preparation chain.
 
 ## Areas to add next
 
@@ -95,7 +103,7 @@ The contract framework should continue to expand when these areas are changed:
 - fixture publication and availability;
 - result entry, disputes and correction workflows;
 - captain/player/admin preview boundaries;
-- referee and night-board operations;
+- additional referee and night-board operations;
 - notification delivery and template ownership.
 
 Do not create a large fragile snapshot of whole pages. Protect the business rules and user-visible controls that must survive future work.

--- a/scripts/check-night-board-referee-night-sync.mjs
+++ b/scripts/check-night-board-referee-night-sync.mjs
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function expectOrder(source, markers, message) {
+  let previousIndex = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker, previousIndex + 1);
+    if (index === -1 || index <= previousIndex) {
+      failures.push(message);
+      return;
+    }
+    previousIndex = index;
+  }
+}
+
+const updateRoutePath =
+  "src/app/api/admin/night-board/update-match/route.ts";
+const warningRoutePath =
+  "src/app/api/admin/night-board/referee-confirmation-warnings/route.ts";
+const assignmentSyncPath = "src/lib/referee-night-assignment-sync.ts";
+
+const updateRoute = read(updateRoutePath);
+const warningRoute = read(warningRoutePath);
+const assignmentSync = read(assignmentSyncPath);
+
+expect(
+  updateRoute,
+  "syncPublishedFixtureRefereeNightAssignmentAndRecalculate",
+  "Saving a Night Board fixture must use the central referee-night assignment synchroniser.",
+);
+expectOrder(
+  updateRoute,
+  [
+    "await prisma.fixture.update({",
+    "await syncPublishedFixtureRefereeNightAssignmentAndRecalculate({",
+    "const sync = await resyncMatchFeeMessages({",
+  ],
+  "The updated fixture must be synchronised into its referee night immediately after the fixture save and before the response is returned.",
+);
+expect(
+  updateRoute,
+  "new Set([...changedRefereeNightIds, ...syncedRefereeNightIds])",
+  "Night Board saves must revalidate both the old and newly synchronised referee nights.",
+);
+expect(
+  updateRoute,
+  "refereeNightsSynced: syncedRefereeNightIds.length",
+  "Night Board save responses must retain a referee-night synchronisation diagnostic.",
+);
+
+expect(
+  warningRoute,
+  "syncPublishedFixtureRefereeNightAssignmentsAndRecalculate",
+  "The Night Board referee warning check must repair legacy missing referee-night links through the central synchroniser.",
+);
+expectOrder(
+  warningRoute,
+  [
+    "const fixtureIds = assignedFixtures.map((fixture) => fixture.id);",
+    "await syncPublishedFixtureRefereeNightAssignmentsAndRecalculate({",
+    "const rows = await prisma.$queryRaw<ConfirmationRow[]>",
+  ],
+  "Legacy/direct referee assignments must be repaired before the Night Board decides that a referee-night link is missing.",
+);
+expect(
+  warningRoute,
+  "console.error(\"Night Board referee-night synchronisation failed\", error);",
+  "A failed automatic repair must remain observable while allowing the operational warning to be shown.",
+);
+
+expect(
+  assignmentSync,
+  'ON CONFLICT ("fixtureId") DO UPDATE',
+  "The central referee-night synchroniser must continue to keep one authoritative night link per fixture.",
+);
+
+if (failures.length) {
+  console.error("\nNIGHT BOARD REFEREE-NIGHT SYNC CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log("Night Board referee-night sync contract passed.");

--- a/src/app/api/admin/night-board/referee-confirmation-warnings/route.ts
+++ b/src/app/api/admin/night-board/referee-confirmation-warnings/route.ts
@@ -6,6 +6,9 @@ import { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 
 import { ensureRefereeNightConfirmationColumns } from "@/lib/referee-night-confirmations";
+import {
+  syncPublishedFixtureRefereeNightAssignmentsAndRecalculate,
+} from "@/lib/referee-night-assignment-sync";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
@@ -67,7 +70,7 @@ function warningLevel(firstKickoff: Date) {
 }
 
 export async function GET(request: NextRequest) {
-  await requireAdmin();
+  const { user } = await requireAdmin();
   await ensureRefereeNightConfirmationColumns();
 
   const leagueId = request.nextUrl.searchParams.get("leagueId")?.trim() ?? "";
@@ -135,6 +138,19 @@ export async function GET(request: NextRequest) {
   }
 
   const fixtureIds = assignedFixtures.map((fixture) => fixture.id);
+
+  // Repair fixtures created or edited through older/direct assignment paths before
+  // deciding whether the referee night is missing. Keep the warning available as a
+  // fallback if repair cannot complete, rather than hiding the operational problem.
+  try {
+    await syncPublishedFixtureRefereeNightAssignmentsAndRecalculate({
+      fixtureIds,
+      createdByUserId: user?.id ?? null,
+    });
+  } catch (error) {
+    console.error("Night Board referee-night synchronisation failed", error);
+  }
+
   const rows = await prisma.$queryRaw<ConfirmationRow[]>(Prisma.sql`
     SELECT
       rnf."fixtureId",

--- a/src/app/api/admin/night-board/update-match/route.ts
+++ b/src/app/api/admin/night-board/update-match/route.ts
@@ -13,6 +13,9 @@ import {
   syncFixtureMatchFeeCharges,
 } from "@/lib/payments/fixture-match-fees";
 import { prisma } from "@/lib/prisma";
+import {
+  syncPublishedFixtureRefereeNightAssignmentAndRecalculate,
+} from "@/lib/referee-night-assignment-sync";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { recalculateRefereeNightCashup } from "@/lib/referee-nights";
 
@@ -205,7 +208,7 @@ async function resyncMatchFeeMessages(input: {
 }
 
 export async function POST(request: Request) {
-  await requireAdmin();
+  const { user } = await requireAdmin();
 
   const formData = await request.formData();
   const fixtureId = String(formData.get("fixtureId") ?? "").trim();
@@ -276,6 +279,15 @@ export async function POST(request: Request) {
     },
   });
 
+  const syncedRefereeNightIds =
+    await syncPublishedFixtureRefereeNightAssignmentAndRecalculate({
+      fixtureId: fixture.id,
+      createdByUserId: user?.id ?? null,
+    });
+  const affectedRefereeNightIds = Array.from(
+    new Set([...changedRefereeNightIds, ...syncedRefereeNightIds]),
+  );
+
   const homeMatchFeePence = getExistingTeamFee({
     fixtureMatchFeePence: fixture.matchFeePence,
     teamId: fixture.homeTeam.id,
@@ -306,7 +318,7 @@ export async function POST(request: Request) {
   revalidatePath(`/admin/leagues/${fixture.leagueId}/fixtures`);
   revalidatePath(`/admin/leagues/${fixture.leagueId}`);
 
-  for (const refereeNightId of changedRefereeNightIds) {
+  for (const refereeNightId of affectedRefereeNightIds) {
     revalidatePath(`/admin/referee-nights/${refereeNightId}`);
   }
 
@@ -315,5 +327,11 @@ export async function POST(request: Request) {
     revalidatePath(`/leagues/${fixture.league.slug}/fixtures`);
   }
 
-  return NextResponse.json({ ok: true, returnTo, staleRefereeNightMessagesCleared: changedRefereeNightIds.length, ...sync });
+  return NextResponse.json({
+    ok: true,
+    returnTo,
+    staleRefereeNightMessagesCleared: changedRefereeNightIds.length,
+    refereeNightsSynced: syncedRefereeNightIds.length,
+    ...sync,
+  });
 }


### PR DESCRIPTION
## What changed

- synchronises the updated fixture into the central `RefereeNight` flow immediately after every Night Board save
- recalculates and revalidates both the old and newly affected referee nights
- repairs legacy/direct fixture assignments before the Night Board decides that the referee-night link is missing
- keeps the existing warning as a fallback if automatic repair fails
- adds a permanent referee/night-board feature contract and runs it in blocking CI

## Why

A referee could be assigned to fixtures on the Night Board while those fixtures were not linked to an active `RefereeNight`. That meant the referee appeared allocated but the confirmation/chasing flow could not manage the night.

## Verification

- dedicated `check-night-board-referee-night-sync.mjs` contract added
- full critical-feature workflow includes the new contract before type-checking
- no database migration or notification-template change required