### PR TITLE
Track and report magic-link sign-in activity

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Check last-minute replacement resolution
         run: node scripts/check-last-minute-replacement-resolution.mjs
 
+      - name: Check sign-in link activity
+        run: node scripts/check-sign-in-link-activity-contract.mjs
+
       - name: Check AI prediction matchup integrity
         run: node scripts/check-ai-prediction-matchup-integrity.mjs
 
@@ -110,6 +113,7 @@ jobs:
           node scripts/check-team-confirmation-contract.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
+          node scripts/check-sign-in-link-activity-contract.mjs
           node scripts/check-ai-prediction-matchup-integrity.mjs
           node scripts/check-ai-prediction-text-team-integrity.mjs
           npx tsx scripts/check-ai-predictor-opponent-adjusted.ts

--- a/.github/workflows/sign-in-link-activity.yml
+++ b/.github/workflows/sign-in-link-activity.yml
@@ -1,0 +1,54 @@
+name: Sign-in link activity
+
+on:
+  pull_request:
+    paths:
+      - "src/auth.ts"
+      - "src/lib/auth/sign-in-link-activity.ts"
+      - "src/app/(admin)/admin/sign-in-activity/**"
+      - "src/components/admin/AdminSidebar.tsx"
+      - "prisma/migrations/**"
+      - "scripts/check-sign-in-link-activity-contract.mjs"
+      - ".github/workflows/sign-in-link-activity.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/auth.ts"
+      - "src/lib/auth/sign-in-link-activity.ts"
+      - "src/app/(admin)/admin/sign-in-activity/**"
+      - "src/components/admin/AdminSidebar.tsx"
+      - "prisma/migrations/**"
+      - "scripts/check-sign-in-link-activity-contract.mjs"
+      - ".github/workflows/sign-in-link-activity.yml"
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Track, report and type-check magic links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply the production source-preparation chain
+        run: npm run prebuild
+
+      - name: Check sign-in link activity contract
+        run: node scripts/check-sign-in-link-activity-contract.mjs
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Type-check application source
+        run: npx tsc --noEmit

--- a/prisma/migrations/20260828233000_add_sign_in_link_activity/migration.sql
+++ b/prisma/migrations/20260828233000_add_sign_in_link_activity/migration.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "SignInLinkActivity" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT,
+  "emailNormalized" TEXT NOT NULL,
+  "userNameSnapshot" TEXT,
+  "accountTypeSnapshot" TEXT,
+  "teamIdSnapshot" TEXT,
+  "teamNameSnapshot" TEXT,
+  "callbackUrl" TEXT,
+  "linkHost" TEXT,
+  "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "sentAt" TIMESTAMP(3),
+  "usedAt" TIMESTAMP(3),
+  "failedAt" TIMESTAMP(3),
+  "failureReason" TEXT,
+  "providerMessageId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "SignInLinkActivity_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "SignInLinkActivity_email_requested_idx"
+  ON "SignInLinkActivity" ("emailNormalized", "requestedAt" DESC);
+
+CREATE INDEX IF NOT EXISTS "SignInLinkActivity_user_requested_idx"
+  ON "SignInLinkActivity" ("userId", "requestedAt" DESC);
+
+CREATE INDEX IF NOT EXISTS "SignInLinkActivity_requested_idx"
+  ON "SignInLinkActivity" ("requestedAt" DESC);
+
+CREATE INDEX IF NOT EXISTS "SignInLinkActivity_used_idx"
+  ON "SignInLinkActivity" ("usedAt");

--- a/scripts/check-sign-in-link-activity-contract.mjs
+++ b/scripts/check-sign-in-link-activity-contract.mjs
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function expectOrder(source, markers, message) {
+  let previousIndex = -1;
+  for (const marker of markers) {
+    const index = source.indexOf(marker, previousIndex + 1);
+    if (index === -1 || index <= previousIndex) {
+      failures.push(message);
+      return;
+    }
+    previousIndex = index;
+  }
+}
+
+const auth = read("src/auth.ts");
+const activityService = read("src/lib/auth/sign-in-link-activity.ts");
+const report = read("src/app/(admin)/admin/sign-in-activity/page.tsx");
+const sidebar = read("src/components/admin/AdminSidebar.tsx");
+const migration = read(
+  "prisma/migrations/20260828233000_add_sign_in_link_activity/migration.sql",
+);
+
+expect(
+  migration,
+  'CREATE TABLE IF NOT EXISTS "SignInLinkActivity"',
+  "A durable sign-in link activity table must be deployed.",
+);
+expect(
+  migration,
+  '"emailNormalized" TEXT NOT NULL',
+  "Sign-in activity must be attributable by normalized email.",
+);
+expect(
+  migration,
+  '"usedAt" TIMESTAMP(3)',
+  "Successful magic-link use must be distinguishable from email sends.",
+);
+
+expect(
+  activityService,
+  "readMagicLinkContext",
+  "The activity service must strip the magic link down to safe diagnostic context.",
+);
+expect(
+  activityService,
+  'parsed.searchParams.get("callbackUrl")',
+  "The report must retain the destination without persisting the sign-in token.",
+);
+expect(
+  activityService,
+  "markLatestSignInLinkUsed",
+  "Successful sign-ins must mark the latest outstanding link as used.",
+);
+expect(
+  activityService.includes('"callbackUrl"') && !activityService.includes('"token" TEXT'),
+  true,
+  "The tracking table must not store the magic-link security token.",
+);
+
+expectOrder(
+  auth,
+  [
+    "const activityId = await startSignInLinkActivity({",
+    "const result = await resend.emails.send({",
+    "await markSignInLinkSent({",
+  ],
+  "Each permitted sign-in email must be recorded before send and marked sent after provider acceptance.",
+);
+expect(
+  auth,
+  "await markSignInLinkFailed({ activityId, error });",
+  "Failed sign-in email sends must be recorded.",
+);
+expect(
+  auth,
+  "markLatestSignInLinkUsed({",
+  "A successful email sign-in must update its activity record.",
+);
+
+expect(
+  report,
+  "Sign-in activity",
+  "Admin must have a visible sign-in activity report.",
+);
+expect(
+  report,
+  'INTERVAL \'30 days\'',
+  "The report must calculate the requested 30-day usage view.",
+);
+expect(
+  report,
+  "FREQUENT_LINK_THRESHOLD = 3",
+  "Frequent sign-in link users must be flagged consistently.",
+);
+expect(
+  report,
+  'FROM "Session"',
+  "The report must show currently valid sessions for diagnosis.",
+);
+expect(
+  sidebar,
+  'href: "/admin/sign-in-activity"',
+  "The report must remain accessible under Back end functions.",
+);
+
+if (failures.length) {
+  console.error("\nSIGN-IN LINK ACTIVITY CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log("Sign-in link activity contract passed.");

--- a/scripts/check-sign-in-link-activity-contract.mjs
+++ b/scripts/check-sign-in-link-activity-contract.mjs
@@ -13,8 +13,12 @@ function read(relativePath) {
   return fs.readFileSync(absolutePath, "utf8");
 }
 
+function assert(condition, message) {
+  if (!condition) failures.push(message);
+}
+
 function expect(source, marker, message) {
-  if (!source.includes(marker)) failures.push(message);
+  assert(source.includes(marker), message);
 }
 
 function expectOrder(source, markers, message) {
@@ -68,9 +72,9 @@ expect(
   "markLatestSignInLinkUsed",
   "Successful sign-ins must mark the latest outstanding link as used.",
 );
-expect(
-  activityService.includes('"callbackUrl"') && !activityService.includes('"token" TEXT'),
-  true,
+assert(
+  activityService.includes('"callbackUrl"') &&
+    !activityService.includes('"token" TEXT'),
   "The tracking table must not store the magic-link security token.",
 );
 

--- a/src/app/(admin)/admin/sign-in-activity/page.tsx
+++ b/src/app/(admin)/admin/sign-in-activity/page.tsx
@@ -1,0 +1,671 @@
+import Link from "next/link";
+
+import { ensureSignInLinkActivityTable } from "@/lib/auth/sign-in-link-activity";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Sign-in Activity | SIXFL Admin",
+};
+
+const FREQUENT_LINK_THRESHOLD = 3;
+
+type SearchParams = {
+  q?: string;
+  view?: string;
+};
+
+type SignInSummaryRow = {
+  email: string;
+  userId: string | null;
+  userName: string | null;
+  accountType: string | null;
+  teams: string | null;
+  links7: number;
+  links30: number;
+  links90: number;
+  linksTotal: number;
+  used30: number;
+  usedTotal: number;
+  unused30: number;
+  failed30: number;
+  activeSessions: number;
+  lastRequestedAt: Date | null;
+  lastSentAt: Date | null;
+  lastUsedAt: Date | null;
+  lastCallbackUrl: string | null;
+  lastLinkHost: string | null;
+};
+
+type SignInEventRow = {
+  id: string;
+  email: string;
+  userId: string | null;
+  userName: string | null;
+  accountType: string | null;
+  teamName: string | null;
+  requestedAt: Date;
+  sentAt: Date | null;
+  usedAt: Date | null;
+  failedAt: Date | null;
+  failureReason: string | null;
+  callbackUrl: string | null;
+  linkHost: string | null;
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-GB").format(value);
+}
+
+function formatDateTime(value: Date | null) {
+  if (!value) return "—";
+
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(value);
+}
+
+function accountTypeLabel(value: string | null) {
+  if (!value) return "User";
+
+  return value
+    .toLowerCase()
+    .replaceAll("_", " ")
+    .replace(/^./, (character) => character.toUpperCase());
+}
+
+function normaliseSummary(row: SignInSummaryRow): SignInSummaryRow {
+  return {
+    ...row,
+    links7: Number(row.links7 ?? 0),
+    links30: Number(row.links30 ?? 0),
+    links90: Number(row.links90 ?? 0),
+    linksTotal: Number(row.linksTotal ?? 0),
+    used30: Number(row.used30 ?? 0),
+    usedTotal: Number(row.usedTotal ?? 0),
+    unused30: Number(row.unused30 ?? 0),
+    failed30: Number(row.failed30 ?? 0),
+    activeSessions: Number(row.activeSessions ?? 0),
+  };
+}
+
+function eventStatus(row: SignInEventRow) {
+  if (row.failedAt) {
+    return {
+      label: "Failed",
+      classes: "border-red-400/25 bg-red-500/10 text-red-100",
+    };
+  }
+
+  if (row.usedAt) {
+    return {
+      label: "Used successfully",
+      classes: "border-emerald-400/25 bg-emerald-500/10 text-emerald-100",
+    };
+  }
+
+  if (row.sentAt) {
+    return {
+      label: "Sent · not used",
+      classes: "border-amber-400/25 bg-amber-500/10 text-amber-100",
+    };
+  }
+
+  return {
+    label: "Requested",
+    classes: "border-white/10 bg-white/[0.04] text-white/65",
+  };
+}
+
+function destinationLabel(value: string | null) {
+  if (!value) return "Default dashboard";
+
+  try {
+    const parsed = new URL(value, "https://www.sixfl.co.uk");
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return value;
+  }
+}
+
+async function loadSignInSummaries() {
+  const rows = await prisma.$queryRaw<SignInSummaryRow[]>`
+    WITH activity AS (
+      SELECT
+        "emailNormalized",
+        MAX("userId") FILTER (WHERE "userId" IS NOT NULL) AS "userIdSnapshot",
+        MAX("userNameSnapshot") FILTER (WHERE "userNameSnapshot" IS NOT NULL) AS "userNameSnapshot",
+        MAX("accountTypeSnapshot") FILTER (WHERE "accountTypeSnapshot" IS NOT NULL) AS "accountTypeSnapshot",
+        (COUNT(*) FILTER (
+          WHERE "sentAt" IS NOT NULL
+            AND "requestedAt" >= NOW() - INTERVAL '7 days'
+        ))::int AS "links7",
+        (COUNT(*) FILTER (
+          WHERE "sentAt" IS NOT NULL
+            AND "requestedAt" >= NOW() - INTERVAL '30 days'
+        ))::int AS "links30",
+        (COUNT(*) FILTER (
+          WHERE "sentAt" IS NOT NULL
+            AND "requestedAt" >= NOW() - INTERVAL '90 days'
+        ))::int AS "links90",
+        (COUNT(*) FILTER (WHERE "sentAt" IS NOT NULL))::int AS "linksTotal",
+        (COUNT(*) FILTER (
+          WHERE "usedAt" IS NOT NULL
+            AND "requestedAt" >= NOW() - INTERVAL '30 days'
+        ))::int AS "used30",
+        (COUNT(*) FILTER (WHERE "usedAt" IS NOT NULL))::int AS "usedTotal",
+        (COUNT(*) FILTER (
+          WHERE "sentAt" IS NOT NULL
+            AND "usedAt" IS NULL
+            AND "failedAt" IS NULL
+            AND "requestedAt" >= NOW() - INTERVAL '30 days'
+            AND "requestedAt" < NOW() - INTERVAL '24 hours'
+        ))::int AS "unused30",
+        (COUNT(*) FILTER (
+          WHERE "failedAt" IS NOT NULL
+            AND "requestedAt" >= NOW() - INTERVAL '30 days'
+        ))::int AS "failed30",
+        MAX("requestedAt") AS "lastRequestedAt",
+        MAX("sentAt") AS "lastSentAt",
+        MAX("usedAt") AS "lastUsedAt"
+      FROM "SignInLinkActivity"
+      GROUP BY "emailNormalized"
+    ),
+    memberships AS (
+      SELECT
+        tm."userId",
+        STRING_AGG(
+          DISTINCT CONCAT(t."name", ' · ', tm."role"::text),
+          ' | '
+        ) AS "teams"
+      FROM "TeamMember" tm
+      JOIN "Team" t ON t."id" = tm."teamId"
+      GROUP BY tm."userId"
+    ),
+    active_sessions AS (
+      SELECT
+        "userId",
+        COUNT(*)::int AS "activeSessions"
+      FROM "Session"
+      WHERE "expires" > NOW()
+      GROUP BY "userId"
+    ),
+    latest_activity AS (
+      SELECT DISTINCT ON ("emailNormalized")
+        "emailNormalized",
+        "callbackUrl",
+        "linkHost"
+      FROM "SignInLinkActivity"
+      ORDER BY "emailNormalized", "requestedAt" DESC
+    )
+    SELECT
+      activity."emailNormalized" AS "email",
+      COALESCE(user_account."id", activity."userIdSnapshot") AS "userId",
+      COALESCE(user_account."name", activity."userNameSnapshot") AS "userName",
+      CASE
+        WHEN user_account."role"::text IN ('ADMIN', 'REFEREE') THEN user_account."role"::text
+        ELSE COALESCE(activity."accountTypeSnapshot", 'USER')
+      END AS "accountType",
+      memberships."teams" AS "teams",
+      activity."links7" AS "links7",
+      activity."links30" AS "links30",
+      activity."links90" AS "links90",
+      activity."linksTotal" AS "linksTotal",
+      activity."used30" AS "used30",
+      activity."usedTotal" AS "usedTotal",
+      activity."unused30" AS "unused30",
+      activity."failed30" AS "failed30",
+      COALESCE(active_sessions."activeSessions", 0)::int AS "activeSessions",
+      activity."lastRequestedAt" AS "lastRequestedAt",
+      activity."lastSentAt" AS "lastSentAt",
+      activity."lastUsedAt" AS "lastUsedAt",
+      latest_activity."callbackUrl" AS "lastCallbackUrl",
+      latest_activity."linkHost" AS "lastLinkHost"
+    FROM activity
+    LEFT JOIN "User" user_account
+      ON LOWER(BTRIM(user_account."email")) = activity."emailNormalized"
+    LEFT JOIN memberships
+      ON memberships."userId" = COALESCE(user_account."id", activity."userIdSnapshot")
+    LEFT JOIN active_sessions
+      ON active_sessions."userId" = COALESCE(user_account."id", activity."userIdSnapshot")
+    LEFT JOIN latest_activity
+      ON latest_activity."emailNormalized" = activity."emailNormalized"
+    ORDER BY activity."links30" DESC, activity."lastRequestedAt" DESC
+  `;
+
+  return rows.map(normaliseSummary);
+}
+
+async function loadRecentEvents() {
+  return prisma.$queryRaw<SignInEventRow[]>`
+    SELECT
+      activity."id",
+      activity."emailNormalized" AS "email",
+      COALESCE(user_account."id", activity."userId") AS "userId",
+      COALESCE(user_account."name", activity."userNameSnapshot") AS "userName",
+      CASE
+        WHEN user_account."role"::text IN ('ADMIN', 'REFEREE') THEN user_account."role"::text
+        ELSE COALESCE(activity."accountTypeSnapshot", 'USER')
+      END AS "accountType",
+      activity."teamNameSnapshot" AS "teamName",
+      activity."requestedAt",
+      activity."sentAt",
+      activity."usedAt",
+      activity."failedAt",
+      activity."failureReason",
+      activity."callbackUrl",
+      activity."linkHost"
+    FROM "SignInLinkActivity" activity
+    LEFT JOIN "User" user_account
+      ON LOWER(BTRIM(user_account."email")) = activity."emailNormalized"
+    ORDER BY activity."requestedAt" DESC
+    LIMIT 100
+  `;
+}
+
+function StatCard({
+  label,
+  value,
+  helper,
+  tone = "default",
+}: {
+  label: string;
+  value: number;
+  helper: string;
+  tone?: "default" | "emerald" | "amber" | "sky";
+}) {
+  const classes =
+    tone === "emerald"
+      ? "border-emerald-400/20 bg-emerald-500/10"
+      : tone === "amber"
+        ? "border-amber-400/20 bg-amber-500/10"
+        : tone === "sky"
+          ? "border-sky-400/20 bg-sky-500/10"
+          : "border-white/10 bg-white/[0.04]";
+
+  return (
+    <div className={`rounded-3xl border p-5 ${classes}`}>
+      <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/45">
+        {label}
+      </p>
+      <p className="mt-2 text-3xl font-semibold text-white">{formatNumber(value)}</p>
+      <p className="mt-2 text-sm leading-6 text-white/55">{helper}</p>
+    </div>
+  );
+}
+
+export default async function AdminSignInActivityPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  await requireAdmin();
+  await ensureSignInLinkActivityTable();
+
+  const params = (await searchParams) ?? {};
+  const query = (params.q ?? "").trim().toLowerCase();
+  const frequentOnly = params.view === "frequent";
+
+  const [summaries, recentEvents] = await Promise.all([
+    loadSignInSummaries(),
+    loadRecentEvents(),
+  ]);
+
+  const matchesQuery = (email: string, name: string | null, teams?: string | null) =>
+    !query ||
+    email.toLowerCase().includes(query) ||
+    name?.toLowerCase().includes(query) ||
+    teams?.toLowerCase().includes(query);
+
+  const visibleSummaries = summaries.filter((row) => {
+    if (frequentOnly && row.links30 < FREQUENT_LINK_THRESHOLD) return false;
+    return matchesQuery(row.email, row.userName, row.teams);
+  });
+  const visibleEvents = recentEvents.filter((row) =>
+    matchesQuery(row.email, row.userName, row.teamName),
+  );
+
+  const frequentUsers = summaries.filter(
+    (row) => row.links30 >= FREQUENT_LINK_THRESHOLD,
+  ).length;
+  const linksSent30 = summaries.reduce((total, row) => total + row.links30, 0);
+  const linksUsed30 = summaries.reduce((total, row) => total + row.used30, 0);
+  const unusedLinks30 = summaries.reduce((total, row) => total + row.unused30, 0);
+  const failedLinks30 = summaries.reduce((total, row) => total + row.failed30, 0);
+  const generatedAt = formatDateTime(new Date());
+
+  return (
+    <div className="mx-auto max-w-[1600px] space-y-7 pb-12">
+      <section className="overflow-hidden rounded-3xl border border-emerald-400/20 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.18),transparent_38%),linear-gradient(180deg,rgba(255,255,255,0.055),rgba(255,255,255,0.025))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.34)] sm:p-8">
+        <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-emerald-300/80">
+          Login reliability report
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          Sign-in activity
+        </h1>
+        <p className="mt-3 max-w-4xl text-sm leading-7 text-white/65 sm:text-base">
+          Records every SIXFL magic-link email accepted for sending and whether that link
+          was then used successfully. Use the frequent-user list to identify people who
+          may be losing their saved session or opening links in a different browser.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2 text-xs text-white/45">
+          <span className="rounded-full border border-white/10 bg-black/20 px-3 py-1.5">
+            Calculated live at {generatedAt}
+          </span>
+          <span className="rounded-full border border-white/10 bg-black/20 px-3 py-1.5">
+            Tracking begins when this feature is deployed
+          </span>
+          <span className="rounded-full border border-white/10 bg-black/20 px-3 py-1.5">
+            Security tokens are never stored
+          </span>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        <StatCard
+          label="People tracked"
+          value={summaries.length}
+          helper="Distinct email addresses that have received a recorded sign-in link."
+          tone="sky"
+        />
+        <StatCard
+          label="Links sent · 30 days"
+          value={linksSent30}
+          helper="Sign-in emails accepted by the email provider during the last 30 days."
+          tone="emerald"
+        />
+        <StatCard
+          label="Links used · 30 days"
+          value={linksUsed30}
+          helper="Recorded links that led to a successful SIXFL sign-in."
+        />
+        <StatCard
+          label="Frequent users"
+          value={frequentUsers}
+          helper={`People sent ${FREQUENT_LINK_THRESHOLD} or more sign-in links in 30 days.`}
+          tone="amber"
+        />
+        <StatCard
+          label="Unused / failed · 30 days"
+          value={unusedLinks30 + failedLinks30}
+          helper="Unused links older than 24 hours, plus emails that failed to send."
+          tone="amber"
+        />
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/35">
+              Per-user report
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              Who is repeatedly requesting sign-in emails?
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">
+              Three or more links in 30 days is flagged for review. A high link count with
+              successful uses usually suggests the browser is not retaining the session.
+            </p>
+          </div>
+
+          <div className="flex w-full flex-col gap-3 lg:max-w-3xl sm:flex-row">
+            <div className="flex rounded-2xl border border-white/10 bg-black/20 p-1">
+              <Link
+                href={`/admin/sign-in-activity${query ? `?q=${encodeURIComponent(query)}` : ""}`}
+                className={`rounded-xl px-3 py-2 text-xs font-semibold transition ${
+                  !frequentOnly
+                    ? "bg-emerald-500 text-black"
+                    : "text-white/55 hover:text-white"
+                }`}
+              >
+                All users
+              </Link>
+              <Link
+                href={`/admin/sign-in-activity?view=frequent${query ? `&q=${encodeURIComponent(query)}` : ""}`}
+                className={`rounded-xl px-3 py-2 text-xs font-semibold transition ${
+                  frequentOnly
+                    ? "bg-amber-400 text-black"
+                    : "text-white/55 hover:text-white"
+                }`}
+              >
+                Frequent only
+              </Link>
+            </div>
+
+            <form action="/admin/sign-in-activity" className="flex flex-1 gap-2">
+              {frequentOnly ? <input type="hidden" name="view" value="frequent" /> : null}
+              <input
+                name="q"
+                defaultValue={params.q ?? ""}
+                placeholder="Search name, email or team"
+                className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-emerald-400/50"
+              />
+              <button
+                type="submit"
+                className="rounded-2xl bg-emerald-500 px-4 py-3 text-sm font-semibold text-black transition hover:bg-emerald-400"
+              >
+                Search
+              </button>
+            </form>
+          </div>
+        </div>
+
+        <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
+          <table className="min-w-[1450px] divide-y divide-white/10 text-left text-sm">
+            <thead className="bg-black/25 text-white/45">
+              <tr>
+                <th className="px-4 py-3 font-semibold">User</th>
+                <th className="px-4 py-3 font-semibold">Account / team</th>
+                <th className="px-4 py-3 text-right font-semibold">7 days</th>
+                <th className="px-4 py-3 text-right font-semibold">30 days</th>
+                <th className="px-4 py-3 text-right font-semibold">90 days</th>
+                <th className="px-4 py-3 text-right font-semibold">Used · 30d</th>
+                <th className="px-4 py-3 text-right font-semibold">Unused · 30d</th>
+                <th className="px-4 py-3 text-right font-semibold">Sessions</th>
+                <th className="px-4 py-3 font-semibold">Last link</th>
+                <th className="px-4 py-3 font-semibold">Last successful use</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/10">
+              {visibleSummaries.length === 0 ? (
+                <tr>
+                  <td colSpan={10} className="px-4 py-10 text-center text-white/45">
+                    No sign-in activity matches this view yet.
+                  </td>
+                </tr>
+              ) : null}
+
+              {visibleSummaries.map((row) => {
+                const frequent = row.links30 >= FREQUENT_LINK_THRESHOLD;
+
+                return (
+                  <tr key={row.email} className="align-top text-white/70">
+                    <td className="px-4 py-4">
+                      <div className="font-semibold text-white">
+                        {row.userName || "Unnamed user"}
+                      </div>
+                      <div className="mt-1 text-xs text-white/45">{row.email}</div>
+                      {frequent ? (
+                        <span className="mt-2 inline-flex rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-amber-100">
+                          Frequent sign-in links
+                        </span>
+                      ) : null}
+                      <div className="mt-2">
+                        <Link
+                          href={`/admin/users?q=${encodeURIComponent(row.email)}`}
+                          className="text-xs font-semibold text-emerald-300 hover:text-emerald-200"
+                        >
+                          Open user record
+                        </Link>
+                      </div>
+                    </td>
+                    <td className="px-4 py-4">
+                      <span className="inline-flex rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-xs font-semibold text-white/70">
+                        {accountTypeLabel(row.accountType)}
+                      </span>
+                      <div className="mt-2 max-w-sm text-xs leading-5 text-white/45">
+                        {row.teams || "No currently linked team"}
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-right font-semibold text-white">
+                      {formatNumber(row.links7)}
+                    </td>
+                    <td className={`px-4 py-4 text-right font-semibold ${frequent ? "text-amber-200" : "text-white"}`}>
+                      {formatNumber(row.links30)}
+                      <div className="mt-1 text-[10px] font-normal text-white/35">
+                        {formatNumber(row.linksTotal)} total
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-right">{formatNumber(row.links90)}</td>
+                    <td className="px-4 py-4 text-right text-emerald-200">
+                      {formatNumber(row.used30)}
+                      <div className="mt-1 text-[10px] text-white/35">
+                        {formatNumber(row.usedTotal)} total
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-right">
+                      <span className={row.unused30 > 0 ? "text-amber-200" : "text-white/55"}>
+                        {formatNumber(row.unused30)}
+                      </span>
+                      {row.failed30 > 0 ? (
+                        <div className="mt-1 text-[10px] text-red-200">
+                          {formatNumber(row.failed30)} failed
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-4 text-right">
+                      {formatNumber(row.activeSessions)}
+                      <div className="mt-1 text-[10px] text-white/35">valid now</div>
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="whitespace-nowrap text-white/70">
+                        {formatDateTime(row.lastRequestedAt)}
+                      </div>
+                      <div className="mt-1 max-w-xs truncate text-[10px] text-white/35" title={row.lastCallbackUrl || undefined}>
+                        {destinationLabel(row.lastCallbackUrl)}
+                      </div>
+                      {row.lastLinkHost ? (
+                        <div className="mt-1 text-[10px] text-white/30">{row.lastLinkHost}</div>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap">
+                      {formatDateTime(row.lastUsedAt)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-white/35">
+              Recent events
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              Latest sign-in link history
+            </h2>
+          </div>
+          <p className="text-sm text-white/45">
+            Showing {Math.min(visibleEvents.length, 100)} recent event{visibleEvents.length === 1 ? "" : "s"}
+          </p>
+        </div>
+
+        <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
+          <table className="min-w-[1100px] divide-y divide-white/10 text-left text-sm">
+            <thead className="bg-black/25 text-white/45">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Requested</th>
+                <th className="px-4 py-3 font-semibold">User</th>
+                <th className="px-4 py-3 font-semibold">Status</th>
+                <th className="px-4 py-3 font-semibold">Destination</th>
+                <th className="px-4 py-3 font-semibold">Successful use</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/10">
+              {visibleEvents.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-white/45">
+                    No individual sign-in link events have been recorded yet.
+                  </td>
+                </tr>
+              ) : null}
+
+              {visibleEvents.map((row) => {
+                const status = eventStatus(row);
+
+                return (
+                  <tr key={row.id} className="align-top text-white/70">
+                    <td className="px-4 py-4 whitespace-nowrap">
+                      {formatDateTime(row.requestedAt)}
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="font-semibold text-white">
+                        {row.userName || "Unnamed user"}
+                      </div>
+                      <div className="mt-1 text-xs text-white/45">{row.email}</div>
+                      <div className="mt-1 text-[10px] text-white/30">
+                        {accountTypeLabel(row.accountType)}
+                        {row.teamName ? ` · ${row.teamName}` : ""}
+                      </div>
+                    </td>
+                    <td className="px-4 py-4">
+                      <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${status.classes}`}>
+                        {status.label}
+                      </span>
+                      {row.failureReason ? (
+                        <div className="mt-2 max-w-md text-xs leading-5 text-red-100/70">
+                          {row.failureReason}
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="max-w-md truncate text-white/65" title={row.callbackUrl || undefined}>
+                        {destinationLabel(row.callbackUrl)}
+                      </div>
+                      {row.linkHost ? (
+                        <div className="mt-1 text-[10px] text-white/30">{row.linkHost}</div>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-4 whitespace-nowrap">
+                      {formatDateTime(row.usedAt)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-sky-400/15 bg-sky-500/[0.06] p-5 sm:p-6">
+        <h2 className="text-xl font-semibold text-white">How to interpret the report</h2>
+        <div className="mt-3 grid gap-4 text-sm leading-7 text-white/60 lg:grid-cols-3">
+          <p>
+            <strong className="text-white">Many links and many successful uses:</strong>{" "}
+            the person can sign in, but their browser or in-app browser may not be keeping the session.
+          </p>
+          <p>
+            <strong className="text-white">Many links but few successful uses:</strong>{" "}
+            they may be opening an older email, switching browsers, using private mode or allowing links to expire.
+          </p>
+          <p>
+            <strong className="text-white">Several active sessions:</strong>{" "}
+            they may use more than one device or browser. This is information for diagnosis, not automatically a fault.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,12 @@ import {
   getCaptainLoginContext,
   getPendingCaptainContext,
 } from "@/lib/auth/pendingCaptain";
+import {
+  markLatestSignInLinkUsed,
+  markSignInLinkFailed,
+  markSignInLinkSent,
+  startSignInLinkActivity,
+} from "@/lib/auth/sign-in-link-activity";
 
 const LOGIN_CTA_LABEL = "Sign in to SIXFL";
 const CTA_PLACEHOLDER = "{{cta}}";
@@ -114,6 +120,57 @@ async function getPendingSquadActivationContext(email: string) {
   };
 }
 
+function buildSignInLinkActivityContext(input: {
+  existingUser: {
+    id: string;
+    name: string | null;
+    role: string;
+    teamMembers: Array<{
+      role: string;
+      team: { id: string; name: string };
+    }>;
+  } | null;
+  pendingCaptain: Awaited<ReturnType<typeof getPendingCaptainContext>>;
+  captainLoginContext: Awaited<ReturnType<typeof getCaptainLoginContext>>;
+  pendingSquadActivation: Awaited<ReturnType<typeof getPendingSquadActivationContext>>;
+}) {
+  const membership = input.existingUser?.teamMembers[0] ?? null;
+  const team = membership?.team
+    ? membership.team
+    : input.pendingCaptain
+      ? { id: input.pendingCaptain.teamId, name: input.pendingCaptain.teamName }
+      : input.captainLoginContext
+        ? {
+            id: input.captainLoginContext.teamId,
+            name: input.captainLoginContext.teamName,
+          }
+        : input.pendingSquadActivation
+          ? {
+              id: input.pendingSquadActivation.teamId,
+              name: input.pendingSquadActivation.teamName,
+            }
+          : null;
+
+  const accountType =
+    input.existingUser?.role === "ADMIN" || input.existingUser?.role === "REFEREE"
+      ? input.existingUser.role
+      : membership?.role
+        ? membership.role
+        : input.pendingCaptain || input.captainLoginContext
+          ? "CAPTAIN"
+          : input.pendingSquadActivation
+            ? "INVITED_PLAYER"
+            : "USER";
+
+  return {
+    userId: input.existingUser?.id ?? input.captainLoginContext?.captainUserId ?? null,
+    userName: input.existingUser?.name ?? input.pendingSquadActivation?.firstName ?? null,
+    accountType,
+    teamId: team?.id ?? null,
+    teamName: team?.name ?? null,
+  };
+}
+
 async function buildLoginMagicLinkEmail(input: {
   email: string;
   url: string;
@@ -194,6 +251,19 @@ export const authOptions: NextAuthOptions = {
         ] = await Promise.all([
           prisma.user.findUnique({
             where: { email },
+            select: {
+              id: true,
+              name: true,
+              role: true,
+              teamMembers: {
+                orderBy: { createdAt: "asc" },
+                take: 1,
+                select: {
+                  role: true,
+                  team: { select: { id: true, name: true } },
+                },
+              },
+            },
           }),
           getPendingCaptainContext(email),
           getCaptainLoginContext(email),
@@ -212,14 +282,39 @@ export const authOptions: NextAuthOptions = {
           url,
           pendingCaptain,
         });
-
-        await resend.emails.send({
-          from,
-          to,
-          subject: emailContent.subject,
-          text: emailContent.text,
-          html: emailContent.html,
+        const activityContext = buildSignInLinkActivityContext({
+          existingUser,
+          pendingCaptain,
+          captainLoginContext,
+          pendingSquadActivation,
         });
+        const activityId = await startSignInLinkActivity({
+          email,
+          magicLinkUrl: url,
+          ...activityContext,
+        });
+
+        try {
+          const result = await resend.emails.send({
+            from,
+            to,
+            subject: emailContent.subject,
+            text: emailContent.text,
+            html: emailContent.html,
+          });
+
+          if (result.error) {
+            throw new Error(result.error.message || "Resend rejected the sign-in email.");
+          }
+
+          await markSignInLinkSent({
+            activityId,
+            providerMessageId: result.data?.id ?? null,
+          });
+        } catch (error) {
+          await markSignInLinkFailed({ activityId, error });
+          throw error;
+        }
       },
       from: process.env.EMAIL_FROM!,
     }),
@@ -235,10 +330,16 @@ export const authOptions: NextAuthOptions = {
 
   events: {
     async signIn({ user }) {
-      await recordSuccessfulLogin({
-        userId: user.id,
-        email: user.email,
-      });
+      await Promise.all([
+        recordSuccessfulLogin({
+          userId: user.id,
+          email: user.email,
+        }),
+        markLatestSignInLinkUsed({
+          userId: user.id,
+          email: user.email,
+        }),
+      ]);
     },
   },
 

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -324,6 +324,12 @@ const navigationGroups = [
         description: "Missing emails",
       },
       {
+        name: "Sign-in activity",
+        href: "/admin/sign-in-activity",
+        icon: ShieldCheckIcon,
+        description: "Magic-link use",
+      },
+      {
         name: "Player data health",
         href: "/admin/players/data-health",
         icon: WrenchScrewdriverIcon,

--- a/src/lib/auth/sign-in-link-activity.ts
+++ b/src/lib/auth/sign-in-link-activity.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@/lib/prisma";
+
+let ensureTablePromise: Promise<void> | null = null;
+
+function normaliseEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function trimOptional(value: string | null | undefined, maximumLength = 500) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, maximumLength) : null;
+}
+
+function describeError(error: unknown) {
+  if (error instanceof Error) return error.message.slice(0, 1_000);
+
+  try {
+    return JSON.stringify(error).slice(0, 1_000);
+  } catch {
+    return String(error).slice(0, 1_000);
+  }
+}
+
+function readMagicLinkContext(magicLinkUrl: string) {
+  try {
+    const parsed = new URL(magicLinkUrl);
+    const callbackUrl = parsed.searchParams.get("callbackUrl");
+
+    return {
+      linkHost: trimOptional(parsed.host, 255),
+      callbackUrl: trimOptional(callbackUrl, 2_000),
+    };
+  } catch {
+    return { linkHost: null, callbackUrl: null };
+  }
+}
+
+export async function ensureSignInLinkActivityTable() {
+  if (!ensureTablePromise) {
+    ensureTablePromise = (async () => {
+      await prisma.$executeRaw`
+        CREATE TABLE IF NOT EXISTS "SignInLinkActivity" (
+          "id" TEXT NOT NULL,
+          "userId" TEXT,
+          "emailNormalized" TEXT NOT NULL,
+          "userNameSnapshot" TEXT,
+          "accountTypeSnapshot" TEXT,
+          "teamIdSnapshot" TEXT,
+          "teamNameSnapshot" TEXT,
+          "callbackUrl" TEXT,
+          "linkHost" TEXT,
+          "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          "sentAt" TIMESTAMP(3),
+          "usedAt" TIMESTAMP(3),
+          "failedAt" TIMESTAMP(3),
+          "failureReason" TEXT,
+          "providerMessageId" TEXT,
+          "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          CONSTRAINT "SignInLinkActivity_pkey" PRIMARY KEY ("id")
+        )
+      `;
+
+      await prisma.$executeRaw`
+        CREATE INDEX IF NOT EXISTS "SignInLinkActivity_email_requested_idx"
+        ON "SignInLinkActivity" ("emailNormalized", "requestedAt" DESC)
+      `;
+      await prisma.$executeRaw`
+        CREATE INDEX IF NOT EXISTS "SignInLinkActivity_user_requested_idx"
+        ON "SignInLinkActivity" ("userId", "requestedAt" DESC)
+      `;
+      await prisma.$executeRaw`
+        CREATE INDEX IF NOT EXISTS "SignInLinkActivity_requested_idx"
+        ON "SignInLinkActivity" ("requestedAt" DESC)
+      `;
+      await prisma.$executeRaw`
+        CREATE INDEX IF NOT EXISTS "SignInLinkActivity_used_idx"
+        ON "SignInLinkActivity" ("usedAt")
+      `;
+    })().catch((error) => {
+      ensureTablePromise = null;
+      throw error;
+    });
+  }
+
+  await ensureTablePromise;
+}
+
+export type StartSignInLinkActivityInput = {
+  email: string;
+  magicLinkUrl: string;
+  userId?: string | null;
+  userName?: string | null;
+  accountType?: string | null;
+  teamId?: string | null;
+  teamName?: string | null;
+};
+
+export async function startSignInLinkActivity(
+  input: StartSignInLinkActivityInput,
+): Promise<string | null> {
+  const email = normaliseEmail(input.email);
+  if (!email) return null;
+
+  const id = randomUUID();
+  const linkContext = readMagicLinkContext(input.magicLinkUrl);
+
+  try {
+    await ensureSignInLinkActivityTable();
+    await prisma.$executeRaw`
+      INSERT INTO "SignInLinkActivity" (
+        "id",
+        "userId",
+        "emailNormalized",
+        "userNameSnapshot",
+        "accountTypeSnapshot",
+        "teamIdSnapshot",
+        "teamNameSnapshot",
+        "callbackUrl",
+        "linkHost",
+        "requestedAt",
+        "createdAt",
+        "updatedAt"
+      ) VALUES (
+        ${id},
+        ${trimOptional(input.userId, 255)},
+        ${email},
+        ${trimOptional(input.userName, 255)},
+        ${trimOptional(input.accountType, 100)},
+        ${trimOptional(input.teamId, 255)},
+        ${trimOptional(input.teamName, 255)},
+        ${linkContext.callbackUrl},
+        ${linkContext.linkHost},
+        NOW(),
+        NOW(),
+        NOW()
+      )
+    `;
+
+    return id;
+  } catch (error) {
+    console.warn("Could not start sign-in link activity record", error);
+    return null;
+  }
+}
+
+export async function markSignInLinkSent(input: {
+  activityId: string | null;
+  providerMessageId?: string | null;
+}) {
+  if (!input.activityId) return;
+
+  try {
+    await ensureSignInLinkActivityTable();
+    await prisma.$executeRaw`
+      UPDATE "SignInLinkActivity"
+      SET
+        "sentAt" = NOW(),
+        "providerMessageId" = ${trimOptional(input.providerMessageId, 255)},
+        "failureReason" = NULL,
+        "failedAt" = NULL,
+        "updatedAt" = NOW()
+      WHERE "id" = ${input.activityId}
+    `;
+  } catch (error) {
+    console.warn("Could not mark sign-in link as sent", error);
+  }
+}
+
+export async function markSignInLinkFailed(input: {
+  activityId: string | null;
+  error: unknown;
+}) {
+  if (!input.activityId) return;
+
+  try {
+    await ensureSignInLinkActivityTable();
+    await prisma.$executeRaw`
+      UPDATE "SignInLinkActivity"
+      SET
+        "failedAt" = NOW(),
+        "failureReason" = ${describeError(input.error)},
+        "updatedAt" = NOW()
+      WHERE "id" = ${input.activityId}
+    `;
+  } catch (error) {
+    console.warn("Could not mark sign-in link as failed", error);
+  }
+}
+
+export async function markLatestSignInLinkUsed(input: {
+  email?: string | null;
+  userId?: string | null;
+}) {
+  const email = input.email ? normaliseEmail(input.email) : "";
+  if (!email) return;
+
+  try {
+    await ensureSignInLinkActivityTable();
+
+    if (input.userId?.trim()) {
+      await prisma.$executeRaw`
+        WITH candidate AS (
+          SELECT "id"
+          FROM "SignInLinkActivity"
+          WHERE "emailNormalized" = ${email}
+            AND "sentAt" IS NOT NULL
+            AND "usedAt" IS NULL
+            AND "failedAt" IS NULL
+            AND "requestedAt" >= NOW() - INTERVAL '48 hours'
+          ORDER BY "requestedAt" DESC
+          LIMIT 1
+        )
+        UPDATE "SignInLinkActivity" activity
+        SET
+          "usedAt" = NOW(),
+          "userId" = ${input.userId.trim()},
+          "updatedAt" = NOW()
+        FROM candidate
+        WHERE activity."id" = candidate."id"
+      `;
+      return;
+    }
+
+    await prisma.$executeRaw`
+      WITH candidate AS (
+        SELECT "id"
+        FROM "SignInLinkActivity"
+        WHERE "emailNormalized" = ${email}
+          AND "sentAt" IS NOT NULL
+          AND "usedAt" IS NULL
+          AND "failedAt" IS NULL
+          AND "requestedAt" >= NOW() - INTERVAL '48 hours'
+        ORDER BY "requestedAt" DESC
+        LIMIT 1
+      )
+      UPDATE "SignInLinkActivity" activity
+      SET
+        "usedAt" = NOW(),
+        "updatedAt" = NOW()
+      FROM candidate
+      WHERE activity."id" = candidate."id"
+    `;
+  } catch (error) {
+    console.warn("Could not mark sign-in link as used", error);
+  }
+}

--- a/src/lib/auth/sign-in-link-activity.ts
+++ b/src/lib/auth/sign-in-link-activity.ts
@@ -4,6 +4,9 @@ import { prisma } from "@/lib/prisma";
 
 let ensureTablePromise: Promise<void> | null = null;
 
+const SENSITIVE_CALLBACK_PARAMETER =
+  /(?:^|_)(?:token|code|secret|key|signature|password|credential)(?:$|_)/i;
+
 function normaliseEmail(value: string) {
   return value.trim().toLowerCase();
 }
@@ -23,6 +26,24 @@ function describeError(error: unknown) {
   }
 }
 
+function sanitiseCallbackUrl(value: string | null) {
+  if (!value?.trim()) return null;
+
+  try {
+    const parsed = new URL(value, "https://sixfl.invalid");
+
+    for (const parameter of Array.from(parsed.searchParams.keys())) {
+      if (SENSITIVE_CALLBACK_PARAMETER.test(parameter)) {
+        parsed.searchParams.set(parameter, "[redacted]");
+      }
+    }
+
+    return trimOptional(`${parsed.pathname}${parsed.search}${parsed.hash}`, 2_000);
+  } catch {
+    return null;
+  }
+}
+
 function readMagicLinkContext(magicLinkUrl: string) {
   try {
     const parsed = new URL(magicLinkUrl);
@@ -30,7 +51,7 @@ function readMagicLinkContext(magicLinkUrl: string) {
 
     return {
       linkHost: trimOptional(parsed.host, 255),
-      callbackUrl: trimOptional(callbackUrl, 2_000),
+      callbackUrl: sanitiseCallbackUrl(callbackUrl),
     };
   } catch {
     return { linkHost: null, callbackUrl: null };


### PR DESCRIPTION
## What changed

- records every permitted SIXFL sign-in email request
- records whether Resend accepted it, whether sending failed, and whether the link was later used successfully
- stores only safe diagnostic context (email, account/team snapshot, destination and host); the magic-link token is never stored
- adds **Admin → Back end functions → Sign-in activity**
- reports per-user link counts for 7, 30 and 90 days, successful uses, unused links older than 24 hours, failures, active sessions and recent event history
- flags users receiving 3 or more sign-in links in 30 days
- adds a migration plus a runtime table safeguard so login emails are not blocked by deployment ordering
- adds a permanent CI contract for the tracking and report flow

## Why

Some users may be requesting a new magic link every time they return to SIXFL. This provides evidence to distinguish repeated session loss from links that are never successfully used, so affected users can be contacted and asked how they open the site.

## Important

Tracking starts when this change is deployed; it cannot reconstruct sign-in emails sent before deployment.