### PR TITLE
Add temporary weekly kick-off restrictions

### DIFF
--- a/src/app/captain/team/[teamid]/weeks-unavailable/actions.ts
+++ b/src/app/captain/team/[teamid]/weeks-unavailable/actions.ts
@@ -28,11 +28,18 @@ function normaliseNote(value: FormDataEntryValue | null) {
   return note ? note.slice(0, 500) : null;
 }
 
+function normaliseTime(value: FormDataEntryValue | null) {
+  const time = String(value ?? "").trim();
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(time) ? time : null;
+}
+
 export async function saveTeamWeekUnavailabilityAction(formData: FormData) {
   const teamId = String(formData.get("teamId") ?? "").trim();
   const weekStartInput = String(formData.get("weekStart") ?? "").trim();
-  const unavailable = formData.get("unavailable") === "on";
+  const restrictionType = String(formData.get("restrictionType") ?? "AVAILABLE").trim();
   const note = normaliseNote(formData.get("note"));
+  const earliestKickoff = normaliseTime(formData.get("earliestKickoff"));
+  const latestKickoff = normaliseTime(formData.get("latestKickoff"));
 
   if (!teamId) redirect("/captain");
 
@@ -73,12 +80,36 @@ export async function saveTeamWeekUnavailabilityAction(formData: FormData) {
     );
   }
 
-  if (unavailable) {
+  if (restrictionType === "UNAVAILABLE") {
     await upsertTeamWeekUnavailability({
       teamId,
       leagueId: currentLeagueId,
       weekStart,
       note,
+      restrictionType: "UNAVAILABLE",
+      submittedByUserId: access.user?.id ?? null,
+    });
+  } else if (restrictionType === "TIME_RESTRICTION") {
+    if (!earliestKickoff && !latestKickoff) {
+      redirectToPage(
+        teamId,
+        "?error=Choose%20an%20earliest%20or%20latest%20kick-off%20time%20for%20that%20week.",
+      );
+    }
+    if (earliestKickoff && latestKickoff && earliestKickoff > latestKickoff) {
+      redirectToPage(
+        teamId,
+        "?error=The%20earliest%20kick-off%20cannot%20be%20later%20than%20the%20latest%20kick-off.",
+      );
+    }
+    await upsertTeamWeekUnavailability({
+      teamId,
+      leagueId: currentLeagueId,
+      weekStart,
+      note,
+      restrictionType: "TIME_RESTRICTION",
+      earliestKickoff,
+      latestKickoff,
       submittedByUserId: access.user?.id ?? null,
     });
   } else {
@@ -93,8 +124,10 @@ export async function saveTeamWeekUnavailabilityAction(formData: FormData) {
 
   redirectToPage(
     teamId,
-    unavailable
+    restrictionType === "UNAVAILABLE"
       ? "?saved=Team%20unavailability%20saved."
-      : "?saved=The%20week%20has%20been%20removed%20from%20team%20unavailability.",
+      : restrictionType === "TIME_RESTRICTION"
+        ? "?saved=Temporary%20kick-off%20time%20restriction%20saved."
+        : "?saved=The%20week%20has%20been%20returned%20to%20normal%20availability.",
   );
 }

--- a/src/app/captain/team/[teamid]/weeks-unavailable/page.tsx
+++ b/src/app/captain/team/[teamid]/weeks-unavailable/page.tsx
@@ -22,7 +22,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata = {
-  title: "Weeks unavailable | SIXFL",
+  title: "Fixture planning | SIXFL",
 };
 
 type SearchParams = {
@@ -36,6 +36,21 @@ function decodeMessage(value?: string) {
 
 function weekKey(value: Date) {
   return value.toISOString().slice(0, 10);
+}
+
+function restrictionSummary(input: {
+  type: "UNAVAILABLE" | "TIME_RESTRICTION" | "AVAILABLE";
+  earliestKickoff?: string | null;
+  latestKickoff?: string | null;
+}) {
+  if (input.type === "UNAVAILABLE") return "Team unavailable";
+  if (input.type !== "TIME_RESTRICTION") return "Assumed available";
+  if (input.earliestKickoff && input.latestKickoff) {
+    return `Can only play ${input.earliestKickoff}–${input.latestKickoff}`;
+  }
+  if (input.earliestKickoff) return `Can only play from ${input.earliestKickoff}`;
+  if (input.latestKickoff) return `Can only play up to ${input.latestKickoff}`;
+  return "Temporary time restriction";
 }
 
 export default async function TeamWeeksUnavailablePage({
@@ -100,17 +115,17 @@ export default async function TeamWeeksUnavailablePage({
               Advance fixture planning
             </p>
             <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
-              Tell us when your team cannot play
+              Tell us about a week you cannot play normally
             </h1>
             <p className="mt-4 max-w-3xl text-sm leading-6 text-white/70 sm:text-base">
-              Your team is assumed available every week. Only tick a week when you already know you will not be able to field a team. No action is needed when you are available.
+              Your team is assumed available every week. Use this page only when you already know a specific future week will be different — either you cannot field a team, or you need a temporary kick-off restriction such as “after 8pm”.
             </p>
             <div className="mt-5 flex flex-wrap gap-2">
               <span className="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs font-medium text-white/75">
                 {context.currentLeague?.name ?? context.team.league?.name ?? "No league assigned"}
               </span>
               <span className="rounded-full border border-amber-400/20 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-100">
-                {noticeCount} future unavailable week{noticeCount === 1 ? "" : "s"}
+                {noticeCount} future notice{noticeCount === 1 ? "" : "s"}
               </span>
             </div>
           </div>
@@ -135,9 +150,12 @@ export default async function TeamWeeksUnavailablePage({
       ) : null}
 
       <section className="rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-5 sm:p-6">
-        <h2 className="text-xl font-semibold text-white">How this works</h2>
+        <h2 className="text-xl font-semibold text-white">Please tell us as early as you can</h2>
         <p className="mt-2 max-w-4xl text-sm leading-6 text-amber-50/75">
-          SIXFL will see your notice while preparing draft fixtures. You can change it until fixtures for that league week are published. Once published, contact SIXFL rather than using this page as a late cancellation tool.
+          The earlier SIXFL knows about a week off or a one-off time restriction, the easier it is to build fixtures around it. These restrictions are for specific weeks only. If your team needs a permanent kick-off restriction every week, contact SIXFL and we can record that separately.
+        </p>
+        <p className="mt-3 max-w-4xl text-xs leading-5 text-amber-50/55">
+          You can change a notice until fixtures for that league week are published. Once published, contact SIXFL rather than using this page as a late cancellation or fixture-change tool.
         </p>
       </section>
 
@@ -146,80 +164,135 @@ export default async function TeamWeeksUnavailablePage({
           const key = weekKey(weekStart);
           const notice = noticeByWeek.get(key) ?? null;
           const locked = publishedWeekKeys.has(key);
+          const currentType = notice?.restrictionType ?? "AVAILABLE";
 
           return (
             <form
               key={key}
               action={saveTeamWeekUnavailabilityAction}
               className={`rounded-3xl border p-5 sm:p-6 ${
-                notice
+                currentType === "UNAVAILABLE"
                   ? "border-red-400/25 bg-red-500/[0.08]"
-                  : locked
-                    ? "border-white/10 bg-white/[0.025]"
-                    : "border-white/10 bg-white/[0.04]"
+                  : currentType === "TIME_RESTRICTION"
+                    ? "border-amber-400/25 bg-amber-500/[0.07]"
+                    : locked
+                      ? "border-white/10 bg-white/[0.025]"
+                      : "border-white/10 bg-white/[0.04]"
               }`}
             >
               <input type="hidden" name="teamId" value={teamid} />
               <input type="hidden" name="weekStart" value={key} />
 
-              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.65fr)_auto] lg:items-center">
-                <label className={`flex items-start gap-4 ${locked ? "cursor-not-allowed" : "cursor-pointer"}`}>
-                  <input
-                    type="checkbox"
-                    name="unavailable"
-                    defaultChecked={Boolean(notice)}
-                    disabled={locked}
-                    className="mt-1 h-5 w-5 rounded border-white/20 bg-black/30 text-emerald-400 accent-emerald-400"
-                  />
-                  <span>
-                    <span className="block text-base font-semibold text-white">
-                      Week commencing {key.split("-").reverse().join("/")}
-                    </span>
-                    <span className="mt-1 block text-sm text-white/55">
-                      {formatWeekLabel(weekStart)}
-                    </span>
-                    <span className={`mt-2 inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${
-                      notice
-                        ? "border-red-400/25 bg-red-500/10 text-red-100"
+              <div className="grid gap-5 xl:grid-cols-[minmax(260px,0.85fr)_minmax(0,1.35fr)_auto] xl:items-start">
+                <div>
+                  <div className="text-base font-semibold text-white">
+                    Week commencing {key.split("-").reverse().join("/")}
+                  </div>
+                  <div className="mt-1 text-sm text-white/55">{formatWeekLabel(weekStart)}</div>
+                  <span className={`mt-3 inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${
+                    currentType === "UNAVAILABLE"
+                      ? "border-red-400/25 bg-red-500/10 text-red-100"
+                      : currentType === "TIME_RESTRICTION"
+                        ? "border-amber-400/25 bg-amber-500/10 text-amber-100"
                         : locked
                           ? "border-white/10 bg-white/5 text-white/50"
                           : "border-emerald-400/20 bg-emerald-500/10 text-emerald-100"
-                    }`}>
-                      {notice
-                        ? "Team marked unavailable"
-                        : locked
-                          ? "Fixtures published - locked"
-                          : "Assumed available"}
-                    </span>
+                  }`}>
+                    {locked
+                      ? "Fixtures published - locked"
+                      : restrictionSummary({
+                          type: currentType,
+                          earliestKickoff: notice?.earliestKickoff,
+                          latestKickoff: notice?.latestKickoff,
+                        })}
                   </span>
-                </label>
-
-                <div>
-                  <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
-                    Optional note
-                  </label>
-                  <input
-                    name="note"
-                    defaultValue={notice?.note ?? ""}
-                    disabled={locked}
-                    maxLength={500}
-                    placeholder="Example: several players away"
-                    className="h-12 w-full rounded-2xl border border-white/10 bg-black/30 px-4 text-sm text-white outline-none placeholder:text-white/30 focus:border-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-50"
-                  />
                 </div>
 
                 {locked ? (
-                  <div className="max-w-xs text-sm leading-6 text-white/45 lg:text-right">
+                  <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm leading-6 text-white/50">
                     Fixtures for this week have already been published. Contact SIXFL if circumstances have changed.
                   </div>
                 ) : (
+                  <div className="space-y-4">
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <label className="rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.05] p-4 text-sm text-white/75">
+                        <input
+                          type="radio"
+                          name="restrictionType"
+                          value="AVAILABLE"
+                          defaultChecked={currentType === "AVAILABLE"}
+                          className="mr-2 accent-emerald-400"
+                        />
+                        Normal availability
+                      </label>
+                      <label className="rounded-2xl border border-red-400/20 bg-red-500/[0.05] p-4 text-sm text-white/75">
+                        <input
+                          type="radio"
+                          name="restrictionType"
+                          value="UNAVAILABLE"
+                          defaultChecked={currentType === "UNAVAILABLE"}
+                          className="mr-2 accent-red-400"
+                        />
+                        Cannot play that week
+                      </label>
+                      <label className="rounded-2xl border border-amber-400/20 bg-amber-500/[0.05] p-4 text-sm text-white/75">
+                        <input
+                          type="radio"
+                          name="restrictionType"
+                          value="TIME_RESTRICTION"
+                          defaultChecked={currentType === "TIME_RESTRICTION"}
+                          className="mr-2 accent-amber-400"
+                        />
+                        Temporary time restriction
+                      </label>
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <label className="text-sm font-medium text-white/65">
+                        <span className="mb-2 block">Earliest kick-off</span>
+                        <input
+                          type="time"
+                          name="earliestKickoff"
+                          defaultValue={notice?.earliestKickoff ?? ""}
+                          className="h-12 w-full rounded-2xl border border-white/10 bg-black/30 px-4 text-sm text-white outline-none focus:border-amber-400/40"
+                        />
+                        <span className="mt-2 block text-xs font-normal text-white/40">Example: 20:00 means “we can only play from 8pm”.</span>
+                      </label>
+                      <label className="text-sm font-medium text-white/65">
+                        <span className="mb-2 block">Latest kick-off</span>
+                        <input
+                          type="time"
+                          name="latestKickoff"
+                          defaultValue={notice?.latestKickoff ?? ""}
+                          className="h-12 w-full rounded-2xl border border-white/10 bg-black/30 px-4 text-sm text-white outline-none focus:border-amber-400/40"
+                        />
+                        <span className="mt-2 block text-xs font-normal text-white/40">Leave blank if you only have an earliest-time restriction.</span>
+                      </label>
+                    </div>
+
+                    <label className="block">
+                      <span className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
+                        Optional note
+                      </span>
+                      <input
+                        name="note"
+                        defaultValue={notice?.note ?? ""}
+                        maxLength={500}
+                        placeholder="Example: work commitments — after 8pm only"
+                        className="h-12 w-full rounded-2xl border border-white/10 bg-black/30 px-4 text-sm text-white outline-none placeholder:text-white/30 focus:border-emerald-400/40"
+                      />
+                    </label>
+                  </div>
+                )}
+
+                {!locked ? (
                   <button
                     type="submit"
                     className="inline-flex min-h-12 items-center justify-center rounded-2xl bg-emerald-400 px-5 text-sm font-semibold text-black transition hover:bg-emerald-300"
                   >
                     Save this week
                   </button>
-                )}
+                ) : null}
               </div>
             </form>
           );

--- a/src/lib/team-week-unavailability.ts
+++ b/src/lib/team-week-unavailability.ts
@@ -15,6 +15,9 @@ export type TeamWeekUnavailability = {
   leagueId: string | null;
   weekStart: Date;
   note: string | null;
+  restrictionType: "UNAVAILABLE" | "TIME_RESTRICTION";
+  earliestKickoff: string | null;
+  latestKickoff: string | null;
   submittedByUserId: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -41,11 +44,26 @@ export async function ensureTeamWeekUnavailabilityTable() {
           "leagueId" TEXT REFERENCES "League"("id") ON DELETE SET NULL,
           "weekStart" TIMESTAMP(3) NOT NULL,
           "note" TEXT,
+          "restrictionType" TEXT NOT NULL DEFAULT 'UNAVAILABLE',
+          "earliestKickoff" TEXT,
+          "latestKickoff" TEXT,
           "submittedByUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL,
           "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
           "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
           CONSTRAINT "TeamWeekUnavailability_teamId_weekStart_key" UNIQUE ("teamId", "weekStart")
         )
+      `);
+      await prisma.$executeRawUnsafe(`
+        ALTER TABLE "TeamWeekUnavailability"
+        ADD COLUMN IF NOT EXISTS "restrictionType" TEXT NOT NULL DEFAULT 'UNAVAILABLE'
+      `);
+      await prisma.$executeRawUnsafe(`
+        ALTER TABLE "TeamWeekUnavailability"
+        ADD COLUMN IF NOT EXISTS "earliestKickoff" TEXT
+      `);
+      await prisma.$executeRawUnsafe(`
+        ALTER TABLE "TeamWeekUnavailability"
+        ADD COLUMN IF NOT EXISTS "latestKickoff" TEXT
       `);
       await prisma.$executeRawUnsafe(`
         CREATE INDEX IF NOT EXISTS "TeamWeekUnavailability_weekStart_idx"
@@ -142,6 +160,9 @@ export async function listTeamWeekUnavailability(input: {
       "leagueId",
       "weekStart",
       "note",
+      CASE WHEN "restrictionType" = 'TIME_RESTRICTION' THEN 'TIME_RESTRICTION' ELSE 'UNAVAILABLE' END AS "restrictionType",
+      "earliestKickoff",
+      "latestKickoff",
       "submittedByUserId",
       "createdAt",
       "updatedAt"
@@ -172,6 +193,9 @@ export async function listUpcomingTeamWeekUnavailability(input: {
       u."leagueId",
       u."weekStart",
       u."note",
+      CASE WHEN u."restrictionType" = 'TIME_RESTRICTION' THEN 'TIME_RESTRICTION' ELSE 'UNAVAILABLE' END AS "restrictionType",
+      u."earliestKickoff",
+      u."latestKickoff",
       u."submittedByUserId",
       u."createdAt",
       u."updatedAt",
@@ -198,10 +222,16 @@ export async function upsertTeamWeekUnavailability(input: {
   leagueId: string | null;
   weekStart: Date;
   note: string | null;
+  restrictionType?: "UNAVAILABLE" | "TIME_RESTRICTION";
+  earliestKickoff?: string | null;
+  latestKickoff?: string | null;
   submittedByUserId: string | null;
 }) {
   await ensureTeamWeekUnavailabilityTable();
   const id = randomUUID();
+  const restrictionType = input.restrictionType === "TIME_RESTRICTION" ? "TIME_RESTRICTION" : "UNAVAILABLE";
+  const earliestKickoff = restrictionType === "TIME_RESTRICTION" ? input.earliestKickoff ?? null : null;
+  const latestKickoff = restrictionType === "TIME_RESTRICTION" ? input.latestKickoff ?? null : null;
 
   await prisma.$executeRaw(Prisma.sql`
     INSERT INTO "TeamWeekUnavailability" (
@@ -210,6 +240,9 @@ export async function upsertTeamWeekUnavailability(input: {
       "leagueId",
       "weekStart",
       "note",
+      "restrictionType",
+      "earliestKickoff",
+      "latestKickoff",
       "submittedByUserId",
       "createdAt",
       "updatedAt"
@@ -219,6 +252,9 @@ export async function upsertTeamWeekUnavailability(input: {
       ${input.leagueId},
       ${input.weekStart},
       ${input.note},
+      ${restrictionType},
+      ${earliestKickoff},
+      ${latestKickoff},
       ${input.submittedByUserId},
       NOW(),
       NOW()
@@ -227,6 +263,9 @@ export async function upsertTeamWeekUnavailability(input: {
     DO UPDATE SET
       "leagueId" = EXCLUDED."leagueId",
       "note" = EXCLUDED."note",
+      "restrictionType" = EXCLUDED."restrictionType",
+      "earliestKickoff" = EXCLUDED."earliestKickoff",
+      "latestKickoff" = EXCLUDED."latestKickoff",
       "submittedByUserId" = EXCLUDED."submittedByUserId",
       "updatedAt" = NOW()
   `);


### PR DESCRIPTION
Extends the existing advance fixture-planning feature so captains can report more than a full week off.

Changes:
- adds a temporary time restriction option for a specific week, e.g. “after 8pm only”
- supports earliest and/or latest kick-off times for that week
- keeps normal availability and full-week unavailability options
- makes clear that these are one-off weekly restrictions, not permanent team preferences
- tells captains to contact SIXFL for a permanent recurring time restriction
- adds stronger wording that giving notice early makes fixture planning easier
- stores the restriction type and time window alongside the existing TeamWeekUnavailability record without removing historic data

The existing published-fixture lock remains in place, so this cannot be used as a late fixture-change tool after fixtures have been published.