### PR TITLE
Notify teams and referees when Night Board fixtures change

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check team confirmation workflow
         run: node scripts/check-team-confirmation-contract.mjs
 
+      - name: Check Night Board fixture-change notifications
+        run: node scripts/check-night-board-fixture-notifications.mjs
+
       - name: Check standard-team player payment links
         run: node scripts/check-standard-team-player-payment-links.mjs
 
@@ -111,6 +114,7 @@ jobs:
         run: |
           node scripts/check-critical-feature-contracts.mjs
           node scripts/check-team-confirmation-contract.mjs
+          node scripts/check-night-board-fixture-notifications.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
           node scripts/check-sign-in-link-activity-contract.mjs

--- a/.github/workflows/night-board-fixture-change.yml
+++ b/.github/workflows/night-board-fixture-change.yml
@@ -1,0 +1,42 @@
+name: Night Board fixture notifications
+
+on:
+  pull_request:
+    paths:
+      - "src/app/api/admin/night-board/update-match/route.ts"
+      - "src/lib/fixtures/night-board-change-notifications.ts"
+      - "src/components/admin/night-board/NightBoardSaveNotice.tsx"
+      - "src/app/(admin)/admin/layout.tsx"
+      - "scripts/check-night-board-fixture-notifications.mjs"
+      - ".github/workflows/night-board-fixture-change.yml"
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Verify notification workflow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply production source preparation
+        run: npm run prebuild
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Check Night Board notification contract
+        run: node scripts/check-night-board-fixture-notifications.mjs
+
+      - name: Type-check application
+        run: npx tsc --noEmit --pretty false

--- a/scripts/check-night-board-fixture-notifications.mjs
+++ b/scripts/check-night-board-fixture-notifications.mjs
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function requireText(source, expected, message) {
+  if (!source.includes(expected)) {
+    throw new Error(message);
+  }
+}
+
+const route = read("src/app/api/admin/night-board/update-match/route.ts");
+const notifications = read(
+  "src/lib/fixtures/night-board-change-notifications.ts",
+);
+const layout = read("src/app/(admin)/admin/layout.tsx");
+const notice = read(
+  "src/components/admin/night-board/NightBoardSaveNotice.tsx",
+);
+
+requireText(
+  route,
+  'from "@/lib/fixtures/night-board-change-notifications"',
+  "Night Board save route must use the native fixture-change notification service.",
+);
+requireText(
+  route,
+  "await queueNightBoardFixtureChangeNotifications({",
+  "Night Board save route must queue fixture-change notifications.",
+);
+
+const updatePosition = route.indexOf("await prisma.fixture.update({");
+const notificationPosition = route.indexOf(
+  "await queueNightBoardFixtureChangeNotifications({",
+);
+if (
+  updatePosition < 0 ||
+  notificationPosition < 0 ||
+  notificationPosition <= updatePosition
+) {
+  throw new Error(
+    "Night Board fixture-change notifications must be queued only after the fixture update succeeds.",
+  );
+}
+
+for (const expected of [
+  "NotificationAudience.TEAM",
+  "NotificationAudience.REFEREE",
+  "NotificationChannel.EMAIL",
+  "NotificationChannel.SMS",
+  "FixtureCaptainConfirmationStatus.PENDING",
+  '"FIXTURE_REMINDER"',
+  "queueNotificationFromTemplate({",
+]) {
+  requireText(
+    notifications,
+    expected,
+    `Night Board notification service is missing required contract: ${expected}`,
+  );
+}
+
+requireText(
+  notifications,
+  "input.before.referee?.id !== input.after.referee?.id",
+  "Referee assignment changes must notify both the removed and newly assigned referee.",
+);
+requireText(
+  route,
+  'url.searchParams.set("matchSaved", "1")',
+  "Night Board save response must carry visible notification results.",
+);
+requireText(
+  layout,
+  "import NightBoardSaveNotice",
+  "Admin layout must mount the Night Board save notice.",
+);
+requireText(
+  layout,
+  "<NightBoardSaveNotice />",
+  "Night Board save notice is not rendered.",
+);
+requireText(
+  notice,
+  "Match saved and notifications queued",
+  "Night Board save notice must clearly report successful notification queuing.",
+);
+requireText(
+  notice,
+  "some messages need attention",
+  "Night Board save notice must clearly report skipped or failed notifications.",
+);
+
+console.log(
+  "Night Board fixture-change notification contract passed: team and referee email/SMS notifications are native to Save match, stale reminders are replaced, and the admin sees delivery counts.",
+);

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -21,6 +21,7 @@ import AdminLeadEditButtonBridge from "@/components/admin/leads/AdminLeadEditBut
 import AdminDivisionSelectBridge from "@/components/admin/leagues/AdminDivisionSelectBridge";
 import AdminLeagueSeasonsBridge from "@/components/admin/leagues/AdminLeagueSeasonsBridge";
 import QueuedSmsReasonHints from "@/components/admin/messages/QueuedSmsReasonHints";
+import NightBoardSaveNotice from "@/components/admin/night-board/NightBoardSaveNotice";
 import AdminPlayerFeePaymentLabelsBridge from "@/components/admin/payments/AdminPlayerFeePaymentLabelsBridge";
 import AdminVoidPaymentChargesBridge from "@/components/admin/payments/AdminVoidPaymentChargesBridge";
 import PlayerPoolNudgeBridge from "@/components/admin/player-pool/PlayerPoolNudgeBridge";
@@ -74,6 +75,7 @@ export default async function AdminLayout({
         }
       `}</style>
       <QueuedSmsReasonHints />
+      <NightBoardSaveNotice />
       <FixtureChangeNotificationSubmitBridge />
       <FixtureCardResultLinksBridge />
       <FixtureSeasonWordingBridge />

--- a/src/app/(admin)/admin/leads/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/leads/[id]/edit/page.tsx
@@ -51,6 +51,14 @@ function getInterestType(value: FormDataEntryValue | null) {
   return allowed.includes(parsed as InterestType) ? (parsed as InterestType) : "TEAM";
 }
 
+function formatCalledAt(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Europe/London",
+  }).format(value);
+}
+
 function Field({
   label,
   name,
@@ -73,6 +81,29 @@ function Field({
       />
     </label>
   );
+}
+
+async function markLeadCalledAction(formData: FormData) {
+  "use server";
+
+  await requireAdmin();
+
+  const leadId = String(formData.get("leadId") ?? "").trim();
+  if (!leadId) redirect("/admin/leads?error=missing_lead");
+
+  const calledAt = new Date();
+  await prisma.interestLead.update({
+    where: { id: leadId },
+    data: {
+      status: "CONTACTED",
+      contactedAt: calledAt,
+    },
+  });
+
+  revalidatePath("/admin/leads");
+  revalidatePath(`/admin/leads/${leadId}`);
+  revalidatePath(`/admin/leads/${leadId}/edit`);
+  redirect(`/admin/leads/${leadId}/edit?called=1`);
 }
 
 async function updateLeadDetailsAction(formData: FormData) {
@@ -156,7 +187,7 @@ export default async function EditLeadPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams?: Promise<{ error?: string }>;
+  searchParams?: Promise<{ error?: string; called?: string }>;
 }) {
   await requireAdmin();
 
@@ -176,6 +207,7 @@ export default async function EditLeadPage({
       status: true,
       interestType: true,
       leagueId: true,
+      contactedAt: true,
     },
   });
 
@@ -200,7 +232,7 @@ export default async function EditLeadPage({
         <div>
           <p className="text-sm text-white/55">Admin • Edit lead</p>
           <h1 className="mt-2 text-3xl font-black text-white">{lead.contactName}</h1>
-          <p className="mt-2 text-sm text-white/60">Update the lead type and contact details before emailing, texting or converting the lead.</p>
+          <p className="mt-2 text-sm text-white/60">Update the lead, record phone calls and keep notes on what they have told you.</p>
         </div>
 
         <Link
@@ -214,6 +246,33 @@ export default async function EditLeadPage({
       {errorMessage ? (
         <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">{errorMessage}</div>
       ) : null}
+
+      {sp.called === "1" ? (
+        <div className="rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+          Call recorded. This lead now shows as Contacted.
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-sky-400/20 bg-sky-500/[0.07] p-5 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-sky-200/70">Phone contact</p>
+            <h2 className="mt-2 text-xl font-bold text-white">{lead.contactedAt ? "This lead has been called" : "Have you called this lead?"}</h2>
+            <p className="mt-2 text-sm text-white/60">
+              {lead.contactedAt ? `Last recorded call/contact: ${formatCalledAt(lead.contactedAt)}` : "Click once after you make the call. It records the time and changes the lead to Contacted."}
+            </p>
+          </div>
+          <form action={markLeadCalledAction}>
+            <input type="hidden" name="leadId" value={lead.id} />
+            <button
+              type="submit"
+              className="inline-flex h-12 shrink-0 items-center justify-center rounded-xl border border-sky-300/30 bg-sky-400/15 px-5 text-sm font-bold text-sky-50 transition hover:bg-sky-400/25"
+            >
+              ✓ Mark as called
+            </button>
+          </form>
+        </div>
+      </section>
 
       <form action={updateLeadDetailsAction} className="rounded-3xl border border-emerald-400/20 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.12),transparent_42%),rgba(255,255,255,0.04)] p-6 shadow-[0_20px_80px_rgba(0,0,0,0.28)]">
         <input type="hidden" name="leadId" value={lead.id} />
@@ -257,13 +316,15 @@ export default async function EditLeadPage({
         </div>
 
         <label className="mt-4 block space-y-2">
-          <span className="text-sm font-medium text-white/60">Message / notes</span>
+          <span className="text-sm font-medium text-white/60">Conversation / lead notes</span>
           <textarea
             name="message"
-            rows={6}
+            rows={7}
             defaultValue={lead.message ?? ""}
+            placeholder="Example: Spoke to James. Has 7 players, interested in Wednesday league, checking with the rest of the team and asked me to call again next week."
             className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm leading-6 text-white outline-none transition placeholder:text-white/35 focus:border-emerald-500/60"
           />
+          <span className="block text-xs leading-5 text-white/40">Use this for the useful details from calls so you can see what was discussed when you come back to the lead.</span>
         </label>
 
         <div className="mt-6 flex flex-wrap gap-3">
@@ -271,7 +332,7 @@ export default async function EditLeadPage({
             type="submit"
             className="inline-flex items-center rounded-xl border border-emerald-400/30 bg-emerald-500/20 px-5 py-3 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-500/30"
           >
-            Save lead details
+            Save lead details & notes
           </button>
 
           <Link

--- a/src/app/api/admin/leads/call-status/route.ts
+++ b/src/app/api/admin/leads/call-status/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  await requireAdmin();
+
+  const leads = await prisma.interestLead.findMany({
+    select: { id: true, contactedAt: true },
+  });
+
+  return NextResponse.json({
+    leads: leads.map((lead) => ({
+      id: lead.id,
+      contactedAt: lead.contactedAt?.toISOString() ?? null,
+    })),
+  });
+}
+
+export async function POST(request: Request) {
+  await requireAdmin();
+
+  const payload = (await request.json().catch(() => null)) as { leadId?: string } | null;
+  const leadId = String(payload?.leadId ?? "").trim();
+  if (!leadId) return NextResponse.json({ error: "Lead ID is required." }, { status: 400 });
+
+  const lead = await prisma.interestLead.findUnique({ where: { id: leadId }, select: { id: true, status: true } });
+  if (!lead) return NextResponse.json({ error: "Lead not found." }, { status: 404 });
+
+  const contactedAt = new Date();
+  await prisma.interestLead.update({
+    where: { id: leadId },
+    data: { contactedAt, status: lead.status === "NEW" ? "CONTACTED" : undefined },
+  });
+
+  return NextResponse.json({ ok: true, leadId, contactedAt: contactedAt.toISOString() });
+}

--- a/src/app/api/admin/night-board/update-match/route.ts
+++ b/src/app/api/admin/night-board/update-match/route.ts
@@ -4,9 +4,18 @@
 
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
-import { FixtureStatus, NotificationDispatchStatus, Prisma, UserRole } from "@prisma/client";
+import {
+  FixtureStatus,
+  NotificationDispatchStatus,
+  Prisma,
+  UserRole,
+} from "@prisma/client";
 
 import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";
+import {
+  queueNightBoardFixtureChangeNotifications,
+  type NightBoardFixtureNotificationSummary,
+} from "@/lib/fixtures/night-board-change-notifications";
 import {
   cancelQueuedMatchFeeNotificationDispatches,
   queueFixtureMatchFeeEmails,
@@ -37,7 +46,10 @@ function parseFixtureStatus(value: string) {
     : FixtureStatus.SCHEDULED;
 }
 
-function parseOperationalKickoff(input: { currentKickoffAt: Date; timeInput: string }) {
+function parseOperationalKickoff(input: {
+  currentKickoffAt: Date;
+  timeInput: string;
+}) {
   const time = input.timeInput.trim();
   if (!/^\d{2}:\d{2}$/.test(time)) return input.currentKickoffAt;
   return parseLondonDateTime(toLondonDateInputValue(input.currentKickoffAt), time);
@@ -45,7 +57,9 @@ function parseOperationalKickoff(input: { currentKickoffAt: Date; timeInput: str
 
 function getSafeReturnTo(value: FormDataEntryValue | null) {
   const returnTo = String(value ?? "").trim();
-  return returnTo.startsWith("/admin/night-board") ? returnTo : "/admin/night-board";
+  return returnTo.startsWith("/admin/night-board")
+    ? returnTo
+    : "/admin/night-board";
 }
 
 function getExistingTeamFee(input: {
@@ -60,6 +74,78 @@ function getExistingTeamFee(input: {
   return existing?.amountPence ?? input.fixtureMatchFeePence ?? null;
 }
 
+function emptyNotificationSummary(
+  reason: string,
+): NightBoardFixtureNotificationSummary {
+  const emptyCounts = () => ({
+    emailQueued: 0,
+    emailSkipped: 0,
+    emailExisting: 0,
+    emailFailed: 0,
+    smsQueued: 0,
+    smsSkipped: 0,
+    smsExisting: 0,
+    smsFailed: 0,
+  });
+
+  return {
+    kind: "none",
+    reason,
+    teamChangeLines: [],
+    refereeChangeLines: [],
+    team: emptyCounts(),
+    referee: emptyCounts(),
+    remindersQueued: 0,
+    remindersSkipped: 0,
+  };
+}
+
+function buildReturnToWithSaveNotice(input: {
+  returnTo: string;
+  notifications: NightBoardFixtureNotificationSummary;
+  notificationError: boolean;
+}) {
+  const url = new URL(input.returnTo, "https://night-board.invalid");
+  const { team, referee } = input.notifications;
+
+  url.searchParams.set("matchSaved", "1");
+  url.searchParams.set("notificationKind", input.notifications.kind);
+  if (input.notifications.reason) {
+    url.searchParams.set("notificationReason", input.notifications.reason);
+  }
+
+  const counts = {
+    teamEmailQueued: team.emailQueued,
+    teamEmailSkipped: team.emailSkipped,
+    teamEmailExisting: team.emailExisting,
+    teamEmailFailed: team.emailFailed,
+    teamSmsQueued: team.smsQueued,
+    teamSmsSkipped: team.smsSkipped,
+    teamSmsExisting: team.smsExisting,
+    teamSmsFailed: team.smsFailed,
+    refereeEmailQueued: referee.emailQueued,
+    refereeEmailSkipped: referee.emailSkipped,
+    refereeEmailExisting: referee.emailExisting,
+    refereeEmailFailed: referee.emailFailed,
+    refereeSmsQueued: referee.smsQueued,
+    refereeSmsSkipped: referee.smsSkipped,
+    refereeSmsExisting: referee.smsExisting,
+    refereeSmsFailed: referee.smsFailed,
+    fixtureRemindersQueued: input.notifications.remindersQueued,
+    fixtureRemindersSkipped: input.notifications.remindersSkipped,
+  };
+
+  for (const [key, value] of Object.entries(counts)) {
+    if (value > 0) url.searchParams.set(key, String(value));
+  }
+
+  if (input.notificationError) {
+    url.searchParams.set("notificationError", "1");
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 async function clearStaleRefereeNightAssignment(input: {
   fixtureId: string;
   nextRefereeId: string | null;
@@ -72,7 +158,9 @@ async function clearStaleRefereeNightAssignment(input: {
   `);
 
   const staleNightIds = rows
-    .filter((row) => !input.nextRefereeId || row.refereeId !== input.nextRefereeId)
+    .filter(
+      (row) => !input.nextRefereeId || row.refereeId !== input.nextRefereeId,
+    )
     .map((row) => row.refereeNightId);
 
   if (staleNightIds.length === 0) return [] as string[];
@@ -108,7 +196,9 @@ async function clearStaleRefereeNightAssignment(input: {
     `),
   ]);
 
-  await Promise.all(staleNightIds.map((nightId) => recalculateRefereeNightCashup(nightId)));
+  await Promise.all(
+    staleNightIds.map((nightId) => recalculateRefereeNightCashup(nightId)),
+  );
   return staleNightIds;
 }
 
@@ -141,7 +231,10 @@ async function resyncMatchFeeMessages(input: {
     select: { id: true },
   });
 
-  if (input.status === FixtureStatus.POSTPONED || input.status === FixtureStatus.CANCELLED) {
+  if (
+    input.status === FixtureStatus.POSTPONED ||
+    input.status === FixtureStatus.CANCELLED
+  ) {
     await cancelQueuedMatchFeeNotificationDispatches(
       allCharges.map((charge) => charge.id),
       prisma,
@@ -201,18 +294,24 @@ async function resyncMatchFeeMessages(input: {
     mode: shouldRequeueInitialRequest ? "all" : "reminders_only",
   });
 
-  return { queued: queued.queued, activeChargeCount: chargeSync.activeCharges.length };
+  return {
+    queued: queued.queued,
+    activeChargeCount: chargeSync.activeCharges.length,
+  };
 }
 
 export async function POST(request: Request) {
-  await requireAdmin();
+  const { user } = await requireAdmin();
 
   const formData = await request.formData();
   const fixtureId = String(formData.get("fixtureId") ?? "").trim();
   const returnTo = getSafeReturnTo(formData.get("returnTo"));
 
   if (!fixtureId) {
-    return NextResponse.json({ ok: false, error: "Missing fixture id.", returnTo }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "Missing fixture id.", returnTo },
+      { status: 400 },
+    );
   }
 
   const fixture = await prisma.fixture.findUnique({
@@ -224,15 +323,44 @@ export async function POST(request: Request) {
       status: true,
       matchFeePence: true,
       refereeId: true,
-      league: { select: { name: true, season: true, slug: true } },
+      publishedAt: true,
+      pitch: true,
+      venueId: true,
+      league: {
+        select: {
+          name: true,
+          season: true,
+          slug: true,
+          venueName: true,
+        },
+      },
+      venue: { select: { id: true, name: true } },
+      referee: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          createdFromLeadId: true,
+        },
+      },
       homeTeam: { select: { id: true, name: true, logoUrl: true } },
       awayTeam: { select: { id: true, name: true, logoUrl: true } },
-      paymentCharges: { select: { id: true, teamId: true, amountPence: true, status: true } },
+      paymentCharges: {
+        select: {
+          id: true,
+          teamId: true,
+          amountPence: true,
+          status: true,
+        },
+      },
     },
   });
 
   if (!fixture) {
-    return NextResponse.json({ ok: false, error: "Fixture not found.", returnTo }, { status: 404 });
+    return NextResponse.json(
+      { ok: false, error: "Fixture not found.", returnTo },
+      { status: 404 },
+    );
   }
 
   if (fixture.status === FixtureStatus.COMPLETED) {
@@ -250,20 +378,59 @@ export async function POST(request: Request) {
   const refereeId = String(formData.get("refereeId") ?? "").trim() || null;
   const venueId = String(formData.get("venueId") ?? "").trim() || null;
   const kickoffTime = String(formData.get("kickoffTime") ?? "").trim();
-  const status = parseFixtureStatus(String(formData.get("status") ?? "").trim());
-  const kickoffAt = parseOperationalKickoff({ currentKickoffAt: fixture.kickoffAt, timeInput: kickoffTime });
+  const status = parseFixtureStatus(
+    String(formData.get("status") ?? "").trim(),
+  );
+  const kickoffAt = parseOperationalKickoff({
+    currentKickoffAt: fixture.kickoffAt,
+    timeInput: kickoffTime,
+  });
 
-  const referee = refereeId
-    ? await prisma.user.findFirst({
-        where: { id: refereeId, role: { in: [UserRole.REFEREE, UserRole.ADMIN] } },
-        select: { id: true },
-      })
-    : null;
+  const [referee, venue] = await Promise.all([
+    refereeId
+      ? prisma.user.findFirst({
+          where: {
+            id: refereeId,
+            role: { in: [UserRole.REFEREE, UserRole.ADMIN] },
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            createdFromLeadId: true,
+          },
+        })
+      : Promise.resolve(null),
+    venueId
+      ? prisma.venue.findUnique({
+          where: { id: venueId },
+          select: { id: true, name: true },
+        })
+      : Promise.resolve(null),
+  ]);
+
+  if (refereeId && !referee) {
+    return NextResponse.json(
+      { ok: false, error: "Selected referee was not found.", returnTo },
+      { status: 400 },
+    );
+  }
+
+  if (venueId && !venue) {
+    return NextResponse.json(
+      { ok: false, error: "Selected venue was not found.", returnTo },
+      { status: 400 },
+    );
+  }
 
   const nextRefereeId = referee?.id ?? null;
-  const changedRefereeNightIds = fixture.refereeId !== nextRefereeId
-    ? await clearStaleRefereeNightAssignment({ fixtureId: fixture.id, nextRefereeId })
-    : [];
+  const changedRefereeNightIds =
+    fixture.refereeId !== nextRefereeId
+      ? await clearStaleRefereeNightAssignment({
+          fixtureId: fixture.id,
+          nextRefereeId,
+        })
+      : [];
 
   await prisma.fixture.update({
     where: { id: fixture.id },
@@ -300,6 +467,48 @@ export async function POST(request: Request) {
     awayMatchFeePence,
   });
 
+  let notificationError = false;
+  let notifications: NightBoardFixtureNotificationSummary;
+
+  try {
+    notifications = await queueNightBoardFixtureChangeNotifications({
+      fixtureId: fixture.id,
+      leagueId: fixture.leagueId,
+      leagueName: fixture.league.name,
+      leagueSeason: fixture.league.season,
+      leagueSlug: fixture.league.slug,
+      publishedAt: fixture.publishedAt,
+      homeTeam: fixture.homeTeam,
+      awayTeam: fixture.awayTeam,
+      before: {
+        kickoffAt: fixture.kickoffAt,
+        venueId: fixture.venueId,
+        venueName: fixture.venue?.name ?? fixture.league.venueName ?? null,
+        pitch: fixture.pitch,
+        status: fixture.status,
+        referee: fixture.referee,
+      },
+      after: {
+        kickoffAt,
+        venueId,
+        venueName: venue?.name ?? fixture.league.venueName ?? null,
+        pitch: pitch || null,
+        status,
+        referee,
+      },
+      createdByUserId: user?.id ?? null,
+    });
+  } catch (error) {
+    notificationError = true;
+    notifications = emptyNotificationSummary(
+      "The match was saved, but SIXFL could not finish checking the fixture-change notifications.",
+    );
+    console.error("Night Board match saved but notification sync failed", {
+      fixtureId: fixture.id,
+      error,
+    });
+  }
+
   revalidatePath("/admin/night-board");
   revalidatePath("/admin/fixtures");
   revalidatePath("/admin/referee-nights");
@@ -315,5 +524,17 @@ export async function POST(request: Request) {
     revalidatePath(`/leagues/${fixture.league.slug}/fixtures`);
   }
 
-  return NextResponse.json({ ok: true, returnTo, staleRefereeNightMessagesCleared: changedRefereeNightIds.length, ...sync });
+  const noticeReturnTo = buildReturnToWithSaveNotice({
+    returnTo,
+    notifications,
+    notificationError,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    returnTo: noticeReturnTo,
+    staleRefereeNightMessagesCleared: changedRefereeNightIds.length,
+    notifications,
+    ...sync,
+  });
 }

--- a/src/app/api/admin/night-board/update-match/route.ts
+++ b/src/app/api/admin/night-board/update-match/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@prisma/client";
 
 import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";
+import { getFixtureTeamKickoffWindowViolations } from "@/lib/fixtures/kickoff-window";
 import {
   queueNightBoardFixtureChangeNotifications,
   type NightBoardFixtureNotificationSummary,
@@ -385,6 +386,29 @@ export async function POST(request: Request) {
     currentKickoffAt: fixture.kickoffAt,
     timeInput: kickoffTime,
   });
+
+  const changedKickoffViolations =
+    kickoffAt.getTime() === fixture.kickoffAt.getTime()
+      ? []
+      : await getFixtureTeamKickoffWindowViolations({
+          homeTeamId: fixture.homeTeam.id,
+          awayTeamId: fixture.awayTeam.id,
+          kickoffAt,
+        });
+
+  if (changedKickoffViolations.length > 0) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          changedKickoffViolations[0]?.message ??
+          "This kick-off is outside the team availability window.",
+        kickoffWindowViolations: changedKickoffViolations,
+        returnTo,
+      },
+      { status: 409 },
+    );
+  }
 
   const [referee, venue] = await Promise.all([
     refereeId

--- a/src/components/RouteScopedBridges.tsx
+++ b/src/components/RouteScopedBridges.tsx
@@ -3,6 +3,10 @@
 import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 
+const AdminLeadCallStatusBridge = dynamic(
+  () => import("@/components/admin/leads/AdminLeadCallStatusBridge"),
+  { ssr: false },
+);
 const LeagueFreeKitOfferBridge = dynamic(
   () => import("@/components/admin/leagues/LeagueFreeKitOfferBridge"),
   { ssr: false },
@@ -97,6 +101,7 @@ export default function RouteScopedBridges() {
   if (isPlayerTeamRoot) return <TemporaryPlayerPassLauncher />;
 
   const isAdmin = pathname.startsWith("/admin");
+  const isAdminLeadsRoot = pathname === "/admin/leads";
   const isCaptain = pathname.startsWith("/captain/");
   const isPlayer = pathname.startsWith("/player/");
   const isCaptainMatchFees = /^\/captain\/team\/[^/]+\/match-fees\/?$/.test(pathname);
@@ -112,6 +117,7 @@ export default function RouteScopedBridges() {
   return (
     <>
       {isAdmin ? <AdminRefereeControlsLabelBridge /> : null}
+      {isAdminLeadsRoot ? <AdminLeadCallStatusBridge /> : null}
       {isAdminRefereeNightsRoot ? <RefereeNightCleanupBridge /> : null}
 
       {(isAdminLeagues || isCaptain || isPublicLeague) ? <LeagueFreeKitOfferBridge /> : null}

--- a/src/components/admin/leads/AdminLeadCallStatusBridge.tsx
+++ b/src/components/admin/leads/AdminLeadCallStatusBridge.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect } from "react";
+
+type CallStatus = { id: string; contactedAt: string | null };
+
+type StatusResponse = { leads?: CallStatus[] };
+
+function formatCalledAt(value: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(new Date(value));
+}
+
+function getLeadId(row: HTMLTableRowElement) {
+  const href = Array.from(row.querySelectorAll<HTMLAnchorElement>('a[href^="/admin/leads/"]'))
+    .map((link) => link.getAttribute("href") ?? "")
+    .find((value) => /^\/admin\/leads\/[^/]+(?:$|\?)/.test(value));
+  if (!href) return null;
+  return /^\/admin\/leads\/([^/?#]+)/.exec(href)?.[1] ?? null;
+}
+
+function buildCell(leadId: string, contactedAt: string | null) {
+  const cell = document.createElement("td");
+  cell.dataset.leadCalledCell = leadId;
+  cell.className = "px-4 py-3";
+
+  if (contactedAt) {
+    cell.innerHTML = `<div class="inline-flex rounded-full border border-sky-400/25 bg-sky-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-sky-200">✓ Called</div><div class="mt-1 whitespace-nowrap text-[11px] text-white/40">${formatCalledAt(contactedAt)}</div>`;
+    return cell;
+  }
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "inline-flex min-h-9 items-center justify-center rounded-xl border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs font-bold text-amber-100 transition hover:bg-amber-500/20 disabled:cursor-wait disabled:opacity-60";
+  button.textContent = "Mark called";
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+    button.textContent = "Saving…";
+    try {
+      const response = await fetch("/api/admin/leads/call-status", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ leadId }),
+      });
+      if (!response.ok) throw new Error("Could not mark lead as called.");
+      window.location.reload();
+    } catch (error) {
+      console.error(error);
+      button.disabled = false;
+      button.textContent = "Try again";
+    }
+  });
+  cell.appendChild(button);
+  return cell;
+}
+
+export default function AdminLeadCallStatusBridge() {
+  useEffect(() => {
+    let disposed = false;
+
+    async function install() {
+      const table = document.querySelector<HTMLTableElement>("table");
+      if (!table || table.dataset.leadCalledInstalled === "true") return;
+
+      const response = await fetch("/api/admin/leads/call-status", { cache: "no-store" });
+      if (!response.ok || disposed) return;
+      const payload = (await response.json()) as StatusResponse;
+      const statuses = new Map((payload.leads ?? []).map((lead) => [lead.id, lead.contactedAt]));
+
+      const headerRow = table.querySelector<HTMLTableRowElement>("thead tr");
+      const actionHeader = headerRow?.lastElementChild;
+      if (headerRow && actionHeader) {
+        const th = document.createElement("th");
+        th.className = "px-4 py-3 font-semibold";
+        th.textContent = "Called";
+        headerRow.insertBefore(th, actionHeader);
+      }
+
+      table.querySelectorAll<HTMLTableRowElement>("tbody tr").forEach((row) => {
+        const leadId = getLeadId(row);
+        const actionCell = row.lastElementChild;
+        if (!leadId || !actionCell) return;
+        row.insertBefore(buildCell(leadId, statuses.get(leadId) ?? null), actionCell);
+      });
+
+      table.dataset.leadCalledInstalled = "true";
+    }
+
+    void install().catch((error) => console.error("Lead call status could not be loaded", error));
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/admin/night-board/NightBoardSaveNotice.tsx
+++ b/src/components/admin/night-board/NightBoardSaveNotice.tsx
@@ -1,0 +1,266 @@
+// ========================================
+// File: src/components/admin/night-board/NightBoardSaveNotice.tsx
+// ========================================
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+type SaveNotice = {
+  kind: string;
+  reason: string | null;
+  notificationError: boolean;
+  teamEmailQueued: number;
+  teamEmailSkipped: number;
+  teamEmailExisting: number;
+  teamEmailFailed: number;
+  teamSmsQueued: number;
+  teamSmsSkipped: number;
+  teamSmsExisting: number;
+  teamSmsFailed: number;
+  refereeEmailQueued: number;
+  refereeEmailSkipped: number;
+  refereeEmailExisting: number;
+  refereeEmailFailed: number;
+  refereeSmsQueued: number;
+  refereeSmsSkipped: number;
+  refereeSmsExisting: number;
+  refereeSmsFailed: number;
+  fixtureRemindersQueued: number;
+  fixtureRemindersSkipped: number;
+};
+
+const NOTICE_KEYS = [
+  "matchSaved",
+  "notificationKind",
+  "notificationReason",
+  "notificationError",
+  "teamEmailQueued",
+  "teamEmailSkipped",
+  "teamEmailExisting",
+  "teamEmailFailed",
+  "teamSmsQueued",
+  "teamSmsSkipped",
+  "teamSmsExisting",
+  "teamSmsFailed",
+  "refereeEmailQueued",
+  "refereeEmailSkipped",
+  "refereeEmailExisting",
+  "refereeEmailFailed",
+  "refereeSmsQueued",
+  "refereeSmsSkipped",
+  "refereeSmsExisting",
+  "refereeSmsFailed",
+  "fixtureRemindersQueued",
+  "fixtureRemindersSkipped",
+] as const;
+
+function readCount(searchParams: URLSearchParams, key: string) {
+  const value = Number(searchParams.get(key) ?? 0);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function countLabel(value: number, singular: string, plural = `${singular}s`) {
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function joinLabels(labels: string[]) {
+  if (labels.length <= 1) return labels[0] ?? "";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")} and ${labels.at(-1)}`;
+}
+
+function queuedLabels(notice: SaveNotice) {
+  return [
+    notice.teamEmailQueued
+      ? countLabel(notice.teamEmailQueued, "team email")
+      : null,
+    notice.teamSmsQueued
+      ? countLabel(notice.teamSmsQueued, "team SMS", "team SMS")
+      : null,
+    notice.refereeEmailQueued
+      ? countLabel(notice.refereeEmailQueued, "referee email")
+      : null,
+    notice.refereeSmsQueued
+      ? countLabel(notice.refereeSmsQueued, "referee SMS", "referee SMS")
+      : null,
+  ].filter((label): label is string => Boolean(label));
+}
+
+function missedLabels(notice: SaveNotice) {
+  const teamMissed =
+    notice.teamEmailSkipped +
+    notice.teamEmailFailed +
+    notice.teamSmsSkipped +
+    notice.teamSmsFailed;
+  const refereeMissed =
+    notice.refereeEmailSkipped +
+    notice.refereeEmailFailed +
+    notice.refereeSmsSkipped +
+    notice.refereeSmsFailed;
+
+  return [
+    teamMissed ? countLabel(teamMissed, "team message") : null,
+    refereeMissed ? countLabel(refereeMissed, "referee message") : null,
+  ].filter((label): label is string => Boolean(label));
+}
+
+function existingTotal(notice: SaveNotice) {
+  return (
+    notice.teamEmailExisting +
+    notice.teamSmsExisting +
+    notice.refereeEmailExisting +
+    notice.refereeSmsExisting
+  );
+}
+
+function buildNoticeCopy(notice: SaveNotice) {
+  const queued = queuedLabels(notice);
+  const missed = missedLabels(notice);
+  const existing = existingTotal(notice);
+
+  if (notice.notificationError) {
+    return {
+      tone: "error" as const,
+      title: "Match saved — notification check failed",
+      detail:
+        notice.reason ||
+        "The match was saved, but SIXFL could not finish queuing the change notifications. Contact the teams and referee manually.",
+    };
+  }
+
+  if (missed.length > 0) {
+    const sentPart = queued.length > 0 ? `${joinLabels(queued)} queued. ` : "";
+    return {
+      tone: "warning" as const,
+      title: "Match saved — some messages need attention",
+      detail: `${sentPart}${joinLabels(
+        missed,
+      )} could not be queued. Check the team and referee contact details and contact them manually where needed.`,
+    };
+  }
+
+  if (queued.length > 0) {
+    const reminderPart = notice.fixtureRemindersQueued
+      ? ` ${countLabel(
+          notice.fixtureRemindersQueued,
+          "future fixture reminder",
+        )} also rescheduled.`
+      : "";
+    return {
+      tone: "success" as const,
+      title: "Match saved and notifications queued",
+      detail: `${joinLabels(queued)} queued.${reminderPart}`,
+    };
+  }
+
+  if (existing > 0) {
+    return {
+      tone: "info" as const,
+      title: "Match saved",
+      detail: `${countLabel(
+        existing,
+        "notification",
+      )} for this exact change had already been queued or sent, so SIXFL did not duplicate it.`,
+    };
+  }
+
+  return {
+    tone: "info" as const,
+    title: "Match saved",
+    detail:
+      notice.reason ||
+      "No material fixture details changed, so no team or referee notification was needed.",
+  };
+}
+
+export default function NightBoardSaveNotice() {
+  const [notice, setNotice] = useState<SaveNotice | null>(null);
+
+  useEffect(() => {
+    if (window.location.pathname !== "/admin/night-board") return;
+
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchParams.get("matchSaved") !== "1") return;
+
+    setNotice({
+      kind: searchParams.get("notificationKind") || "none",
+      reason: searchParams.get("notificationReason"),
+      notificationError: searchParams.get("notificationError") === "1",
+      teamEmailQueued: readCount(searchParams, "teamEmailQueued"),
+      teamEmailSkipped: readCount(searchParams, "teamEmailSkipped"),
+      teamEmailExisting: readCount(searchParams, "teamEmailExisting"),
+      teamEmailFailed: readCount(searchParams, "teamEmailFailed"),
+      teamSmsQueued: readCount(searchParams, "teamSmsQueued"),
+      teamSmsSkipped: readCount(searchParams, "teamSmsSkipped"),
+      teamSmsExisting: readCount(searchParams, "teamSmsExisting"),
+      teamSmsFailed: readCount(searchParams, "teamSmsFailed"),
+      refereeEmailQueued: readCount(searchParams, "refereeEmailQueued"),
+      refereeEmailSkipped: readCount(searchParams, "refereeEmailSkipped"),
+      refereeEmailExisting: readCount(searchParams, "refereeEmailExisting"),
+      refereeEmailFailed: readCount(searchParams, "refereeEmailFailed"),
+      refereeSmsQueued: readCount(searchParams, "refereeSmsQueued"),
+      refereeSmsSkipped: readCount(searchParams, "refereeSmsSkipped"),
+      refereeSmsExisting: readCount(searchParams, "refereeSmsExisting"),
+      refereeSmsFailed: readCount(searchParams, "refereeSmsFailed"),
+      fixtureRemindersQueued: readCount(
+        searchParams,
+        "fixtureRemindersQueued",
+      ),
+      fixtureRemindersSkipped: readCount(
+        searchParams,
+        "fixtureRemindersSkipped",
+      ),
+    });
+  }, []);
+
+  if (!notice) return null;
+
+  const copy = buildNoticeCopy(notice);
+  const toneClass =
+    copy.tone === "success"
+      ? "border-emerald-400/35 bg-emerald-950/95 text-emerald-50"
+      : copy.tone === "error"
+        ? "border-red-400/40 bg-red-950/95 text-red-50"
+        : copy.tone === "warning"
+          ? "border-amber-400/40 bg-amber-950/95 text-amber-50"
+          : "border-sky-400/35 bg-sky-950/95 text-sky-50";
+
+  function dismiss() {
+    const url = new URL(window.location.href);
+    for (const key of NOTICE_KEYS) {
+      url.searchParams.delete(key);
+    }
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+    setNotice(null);
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed right-4 top-20 z-[90] w-[min(34rem,calc(100vw-2rem))] rounded-2xl border px-4 py-4 shadow-2xl backdrop-blur ${toneClass}`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="text-sm font-semibold">{copy.title}</div>
+          <div className="mt-1 text-xs leading-5 opacity-85">
+            {copy.detail}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="shrink-0 rounded-lg border border-white/20 px-2 py-1 text-xs font-semibold opacity-80 transition hover:opacity-100"
+          aria-label="Dismiss match save notification"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/fixtures/kickoff-window.ts
+++ b/src/lib/fixtures/kickoff-window.ts
@@ -1,7 +1,10 @@
+import "server-only";
+
 import {
   formatTimeInLondon,
   getLondonMinutesSinceMidnight,
 } from "@/lib/datetime/london";
+import { prisma } from "@/lib/prisma";
 
 export type TeamKickoffWindow = {
   name: string;
@@ -118,7 +121,6 @@ export async function getFixtureTeamKickoffWindowViolations(input: {
   awayTeamId: string;
   kickoffAt: Date;
 }) {
-  const { prisma } = await import("@/lib/prisma");
   const teams = await prisma.team.findMany({
     where: {
       id: {

--- a/src/lib/fixtures/kickoff-window.ts
+++ b/src/lib/fixtures/kickoff-window.ts
@@ -113,6 +113,10 @@ export function getFixtureKickoffWindowViolations(
     .filter((violation): violation is TeamKickoffWindowViolation => Boolean(violation));
 }
 
+/**
+ * Server-side convenience helper for routes that only have fixture team IDs.
+ * The shared rule calculator above remains independent of Prisma.
+ */
 export async function getFixtureTeamKickoffWindowViolations(input: {
   homeTeamId: string;
   awayTeamId: string;

--- a/src/lib/fixtures/kickoff-window.ts
+++ b/src/lib/fixtures/kickoff-window.ts
@@ -1,10 +1,7 @@
-import "server-only";
-
 import {
   formatTimeInLondon,
   getLondonMinutesSinceMidnight,
 } from "@/lib/datetime/london";
-import { prisma } from "@/lib/prisma";
 
 export type TeamKickoffWindow = {
   name: string;
@@ -121,6 +118,7 @@ export async function getFixtureTeamKickoffWindowViolations(input: {
   awayTeamId: string;
   kickoffAt: Date;
 }) {
+  const { prisma } = await import("@/lib/prisma");
   const teams = await prisma.team.findMany({
     where: {
       id: {

--- a/src/lib/fixtures/kickoff-window.ts
+++ b/src/lib/fixtures/kickoff-window.ts
@@ -113,6 +113,29 @@ export function getFixtureKickoffWindowViolations(
     .filter((violation): violation is TeamKickoffWindowViolation => Boolean(violation));
 }
 
+export async function getFixtureTeamKickoffWindowViolations(input: {
+  homeTeamId: string;
+  awayTeamId: string;
+  kickoffAt: Date;
+}) {
+  const { prisma } = await import("@/lib/prisma");
+  const teams = await prisma.team.findMany({
+    where: {
+      id: {
+        in: [input.homeTeamId, input.awayTeamId],
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      earliestKickoffTime: true,
+      latestKickoffTime: true,
+    },
+  });
+
+  return getFixtureKickoffWindowViolations(input.kickoffAt, teams);
+}
+
 export function assertFixtureKickoffWindow(
   kickoffAt: Date,
   teams: TeamKickoffWindow[],

--- a/src/lib/fixtures/night-board-change-notifications.ts
+++ b/src/lib/fixtures/night-board-change-notifications.ts
@@ -1,0 +1,1027 @@
+// ========================================
+// File: src/lib/fixtures/night-board-change-notifications.ts
+// ========================================
+
+import { createHash } from "node:crypto";
+import {
+  FixtureCaptainConfirmationStatus,
+  FixtureStatus,
+  NotificationAudience,
+  NotificationChannel,
+  NotificationDispatchStatus,
+  NotificationRecipientSourceType,
+  Prisma,
+} from "@prisma/client";
+
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import {
+  queueDirectNotification,
+  queueNotificationFromTemplate,
+} from "@/lib/notifications/service";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
+import { prisma } from "@/lib/prisma";
+import { getRefereeProfileByUserId } from "@/lib/referees/profile";
+import { getPublicSiteUrl } from "@/lib/stripe/client";
+import { getFixturePlaceholderTeamIds } from "@/lib/teams/fixture-placeholders";
+
+const TEAM_CHANGE_SOURCE_TYPE = "FIXTURE_NIGHT_BOARD_CHANGE_NOTICE";
+const TEAM_STATUS_SOURCE_TYPE = "FIXTURE_NIGHT_BOARD_STATUS_NOTICE";
+const REFEREE_CHANGE_SOURCE_TYPE = "FIXTURE_NIGHT_BOARD_REFEREE_NOTICE";
+
+const STALE_CONFIRMATION_SOURCE_TYPES = [
+  "FIXTURE_CONFIRMATION_INITIAL_EMAIL",
+  "FIXTURE_CONFIRMATION_AUTO_EMAIL_72H",
+  "FIXTURE_CONFIRMATION_AUTO_EMAIL_24H",
+  "FIXTURE_CONFIRMATION_CHASE_SMS",
+  "FIXTURE_CONFIRMATION_AUTO_SMS_72H",
+  "FIXTURE_CONFIRMATION_AUTO_SMS_24H",
+] as const;
+
+export type NightBoardNotificationReferee = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  createdFromLeadId: string | null;
+};
+
+export type NightBoardFixtureNotificationState = {
+  kickoffAt: Date;
+  venueId: string | null;
+  venueName: string | null;
+  pitch: string | null;
+  status: FixtureStatus;
+  referee: NightBoardNotificationReferee | null;
+};
+
+export type NightBoardNotificationTeam = {
+  id: string;
+  name: string;
+  logoUrl: string | null;
+};
+
+export type NightBoardNotificationDeliveryCounts = {
+  emailQueued: number;
+  emailSkipped: number;
+  emailExisting: number;
+  emailFailed: number;
+  smsQueued: number;
+  smsSkipped: number;
+  smsExisting: number;
+  smsFailed: number;
+};
+
+export type NightBoardFixtureNotificationSummary = {
+  kind:
+    | "none"
+    | "change"
+    | "cancelled"
+    | "postponed"
+    | "completed"
+    | "referee";
+  reason: string | null;
+  teamChangeLines: string[];
+  refereeChangeLines: string[];
+  team: NightBoardNotificationDeliveryCounts;
+  referee: NightBoardNotificationDeliveryCounts;
+  remindersQueued: number;
+  remindersSkipped: number;
+};
+
+type DeliveryOutcome = "queued" | "skipped" | "existing" | "failed";
+type RefereeNoticeAction = "assigned" | "removed" | "updated";
+
+function emptyDeliveryCounts(): NightBoardNotificationDeliveryCounts {
+  return {
+    emailQueued: 0,
+    emailSkipped: 0,
+    emailExisting: 0,
+    emailFailed: 0,
+    smsQueued: 0,
+    smsSkipped: 0,
+    smsExisting: 0,
+    smsFailed: 0,
+  };
+}
+
+function recordOutcome(
+  counts: NightBoardNotificationDeliveryCounts,
+  channel: NotificationChannel,
+  outcome: DeliveryOutcome,
+) {
+  const prefix = channel === NotificationChannel.EMAIL ? "email" : "sms";
+  const suffix = outcome.charAt(0).toUpperCase() + outcome.slice(1);
+  const key = `${prefix}${suffix}` as keyof NightBoardNotificationDeliveryCounts;
+  counts[key] += 1;
+}
+
+function cleanOptional(value: string | null | undefined) {
+  return value?.trim() || null;
+}
+
+function valuesDiffer(
+  left: string | null | undefined,
+  right: string | null | undefined,
+) {
+  return cleanOptional(left) !== cleanOptional(right);
+}
+
+function formatKickoff(value: Date) {
+  return formatDateTimeInLondon(value, {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatStatus(status: FixtureStatus) {
+  return status.charAt(0) + status.slice(1).toLowerCase();
+}
+
+function leagueLabel(input: {
+  leagueName: string;
+  leagueSeason: string | null;
+}) {
+  return input.leagueSeason
+    ? `${input.leagueName} · ${input.leagueSeason}`
+    : input.leagueName;
+}
+
+function fixtureSummary(input: {
+  homeTeamName: string;
+  awayTeamName: string;
+  state: NightBoardFixtureNotificationState;
+}) {
+  return [
+    `${input.homeTeamName} vs ${input.awayTeamName}`,
+    `Kick-off: ${formatKickoff(input.state.kickoffAt)}`,
+    `Venue: ${input.state.venueName || "TBC"}`,
+    `Pitch: ${input.state.pitch?.trim() || "TBC"}`,
+    `Status: ${formatStatus(input.state.status)}`,
+  ].join("\n");
+}
+
+function buildTeamChangeLines(input: {
+  before: NightBoardFixtureNotificationState;
+  after: NightBoardFixtureNotificationState;
+}) {
+  const lines: string[] = [];
+
+  if (input.before.kickoffAt.getTime() !== input.after.kickoffAt.getTime()) {
+    lines.push(
+      `Kick-off: ${formatKickoff(input.before.kickoffAt)} → ${formatKickoff(
+        input.after.kickoffAt,
+      )}`,
+    );
+  }
+
+  if (
+    valuesDiffer(input.before.venueId, input.after.venueId) ||
+    valuesDiffer(input.before.venueName, input.after.venueName)
+  ) {
+    lines.push(
+      `Venue: ${input.before.venueName || "TBC"} → ${
+        input.after.venueName || "TBC"
+      }`,
+    );
+  }
+
+  if (input.before.status !== input.after.status) {
+    lines.push(
+      `Status: ${formatStatus(input.before.status)} → ${formatStatus(
+        input.after.status,
+      )}`,
+    );
+  }
+
+  return lines;
+}
+
+function buildRefereeChangeLines(input: {
+  before: NightBoardFixtureNotificationState;
+  after: NightBoardFixtureNotificationState;
+  teamChangeLines: string[];
+}) {
+  const lines = [...input.teamChangeLines];
+
+  if (valuesDiffer(input.before.pitch, input.after.pitch)) {
+    lines.push(
+      `Pitch: ${input.before.pitch?.trim() || "TBC"} → ${
+        input.after.pitch?.trim() || "TBC"
+      }`,
+    );
+  }
+
+  if (input.before.referee?.id !== input.after.referee?.id) {
+    lines.push(
+      `Referee: ${
+        input.before.referee?.name ||
+        input.before.referee?.email ||
+        "Unassigned"
+      } → ${
+        input.after.referee?.name ||
+        input.after.referee?.email ||
+        "Unassigned"
+      }`,
+    );
+  }
+
+  return lines;
+}
+
+function changeHash(input: {
+  fixtureId: string;
+  before: NightBoardFixtureNotificationState;
+  after: NightBoardFixtureNotificationState;
+}) {
+  return createHash("sha1")
+    .update(
+      JSON.stringify({
+        fixtureId: input.fixtureId,
+        before: {
+          kickoffAt: input.before.kickoffAt.toISOString(),
+          venueId: input.before.venueId,
+          pitch: cleanOptional(input.before.pitch),
+          status: input.before.status,
+          refereeId: input.before.referee?.id ?? null,
+        },
+        after: {
+          kickoffAt: input.after.kickoffAt.toISOString(),
+          venueId: input.after.venueId,
+          pitch: cleanOptional(input.after.pitch),
+          status: input.after.status,
+          refereeId: input.after.referee?.id ?? null,
+        },
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function captainFixtureUrl(teamId: string, fixtureId: string) {
+  return new URL(
+    `/captain/team/${teamId}/fixtures?fixtureId=${encodeURIComponent(
+      fixtureId,
+    )}`,
+    `${getPublicSiteUrl()}/`,
+  ).toString();
+}
+
+function refereeDashboardUrl() {
+  return new URL("/referee", `${getPublicSiteUrl()}/`).toString();
+}
+
+async function cancelQueuedStaleFixtureMessages(fixtureId: string) {
+  await Promise.all([
+    prisma.notificationDispatch.updateMany({
+      where: {
+        sourceType: { in: [...STALE_CONFIRMATION_SOURCE_TYPES] },
+        sourceId: { startsWith: `${fixtureId}:` },
+        status: NotificationDispatchStatus.QUEUED,
+      },
+      data: {
+        status: NotificationDispatchStatus.CANCELLED,
+        cancelledAt: new Date(),
+        failureReason:
+          "Fixture details changed on the Night Board before this confirmation message was sent.",
+      },
+    }),
+    prisma.notificationDispatch.updateMany({
+      where: {
+        sourceType: "FIXTURE_REMINDER",
+        OR: [
+          { sourceId: fixtureId },
+          { sourceId: { startsWith: `${fixtureId}:` } },
+        ],
+        status: NotificationDispatchStatus.QUEUED,
+      },
+      data: {
+        status: NotificationDispatchStatus.CANCELLED,
+        cancelledAt: new Date(),
+        failureReason:
+          "Fixture details changed on the Night Board before this reminder was sent.",
+      },
+    }),
+  ]);
+}
+
+async function resetConfirmedTeams(input: {
+  fixtureId: string;
+  teamIds: string[];
+  status: FixtureStatus;
+}) {
+  const note =
+    input.status === FixtureStatus.SCHEDULED
+      ? "Fixture changed on the Night Board after the previous confirmation. Team needs to reconfirm."
+      : input.status === FixtureStatus.CANCELLED
+        ? "Fixture cancelled on the Night Board. No reconfirmation is required."
+        : "Fixture postponed on the Night Board. No reconfirmation is required until a replacement is confirmed.";
+
+  await prisma.fixtureCaptainConfirmation.updateMany({
+    where: {
+      fixtureId: input.fixtureId,
+      teamId: { in: input.teamIds },
+      status: FixtureCaptainConfirmationStatus.CONFIRMED,
+    },
+    data: {
+      status: FixtureCaptainConfirmationStatus.PENDING,
+      confirmedAt: null,
+      confirmedByUserId: null,
+      note,
+    },
+  });
+}
+
+async function queueOnce(input: {
+  recipientId: string;
+  channel: NotificationChannel;
+  audience: NotificationAudience;
+  subject?: string | null;
+  body: string;
+  sourceType: string;
+  sourceId: string;
+  metadata: Prisma.InputJsonValue;
+  emailBranding?: {
+    teamName?: string | null;
+    teamLogoUrl?: string | null;
+    leagueName?: string | null;
+  };
+  emailCta?: { label: string; url: string };
+  createdByUserId?: string | null;
+}): Promise<DeliveryOutcome> {
+  const existing = await prisma.notificationDispatch.findFirst({
+    where: {
+      recipientId: input.recipientId,
+      channel: input.channel,
+      sourceType: input.sourceType,
+      sourceId: input.sourceId,
+      status: {
+        in: [
+          NotificationDispatchStatus.QUEUED,
+          NotificationDispatchStatus.PROCESSING,
+          NotificationDispatchStatus.SENT,
+        ],
+      },
+    },
+    select: { id: true },
+  });
+
+  if (existing) return "existing";
+
+  try {
+    const dispatch = await queueDirectNotification({
+      recipientId: input.recipientId,
+      channel: input.channel,
+      audience: input.audience,
+      subject: input.subject,
+      body: input.body,
+      isTransactional: true,
+      sourceType: input.sourceType,
+      sourceId: input.sourceId,
+      metadata: input.metadata,
+      emailBranding: input.emailBranding,
+      emailCta: input.emailCta,
+      createdByUserId: input.createdByUserId,
+    });
+
+    return dispatch.status === NotificationDispatchStatus.QUEUED
+      ? "queued"
+      : "skipped";
+  } catch (error) {
+    console.error("Could not queue Night Board fixture-change notification", {
+      recipientId: input.recipientId,
+      channel: input.channel,
+      sourceType: input.sourceType,
+      sourceId: input.sourceId,
+      error,
+    });
+    return "failed";
+  }
+}
+
+async function upsertRefereeRecipient(
+  referee: NightBoardNotificationReferee,
+) {
+  const [profile, lead] = await Promise.all([
+    getRefereeProfileByUserId(referee.id).catch((error) => {
+      console.warn("Could not load referee profile for fixture-change notice", {
+        refereeId: referee.id,
+        error,
+      });
+      return null;
+    }),
+    referee.createdFromLeadId
+      ? prisma.interestLead.findUnique({
+          where: { id: referee.createdFromLeadId },
+          select: { phone: true },
+        })
+      : Promise.resolve(null),
+  ]);
+
+  return upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.REFEREE,
+    sourceId: referee.id,
+    audience: NotificationAudience.REFEREE,
+    displayName: referee.name || referee.email || "Referee",
+    email: referee.email,
+    phone: profile?.phone ?? lead?.phone ?? null,
+    marketingEmailOptIn: true,
+    marketingSmsOptIn: true,
+    transactionalEmailOptIn: true,
+    transactionalSmsOptIn: true,
+    metadata: {
+      userId: referee.id,
+      entityType: "REFEREE",
+      origin: "night_board_fixture_change",
+    },
+  });
+}
+
+function teamEmailCopy(input: {
+  status: FixtureStatus;
+  contactName: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  changeLines: string[];
+  currentFixture: string;
+}) {
+  if (
+    input.status === FixtureStatus.CANCELLED ||
+    input.status === FixtureStatus.POSTPONED
+  ) {
+    const adjective =
+      input.status === FixtureStatus.CANCELLED ? "cancelled" : "postponed";
+    const nextStep =
+      input.status === FixtureStatus.CANCELLED
+        ? "No reconfirmation is needed."
+        : "No reconfirmation is needed until a replacement is confirmed.";
+
+    return {
+      subject: `SIXFL fixture ${adjective}: ${input.homeTeamName} vs ${input.awayTeamName}`,
+      body: [
+        `Hi ${input.contactName},`,
+        "",
+        `IMPORTANT: this SIXFL fixture has been ${adjective}.`,
+        "",
+        "This update replaces the previous fixture details.",
+        "",
+        "What changed:",
+        ...input.changeLines.map((line) => `- ${line}`),
+        "",
+        "Current fixture:",
+        input.currentFixture,
+        "",
+        nextStep,
+        "",
+        "{{cta}}",
+        "",
+        "Please contact SIXFL directly if you have any questions.",
+      ].join("\n"),
+      ctaLabel: "Open fixture",
+    };
+  }
+
+  return {
+    subject: `IMPORTANT fixture update: ${input.homeTeamName} vs ${input.awayTeamName}`,
+    body: [
+      `Hi ${input.contactName},`,
+      "",
+      "IMPORTANT: the details of a SIXFL fixture involving your team have changed.",
+      "",
+      "The updated details below replace the previous fixture information.",
+      "",
+      "What changed:",
+      ...input.changeLines.map((line) => `- ${line}`),
+      "",
+      "Updated fixture:",
+      input.currentFixture,
+      "",
+      "Please check your SIXFL dashboard and confirm the updated fixture.",
+      "",
+      "{{cta}}",
+      "",
+      "If this creates a problem, contact SIXFL rather than the other team so we can manage it properly.",
+    ].join("\n"),
+    ctaLabel: "Open updated fixture",
+  };
+}
+
+function teamSmsCopy(input: {
+  status: FixtureStatus;
+  homeTeamName: string;
+  awayTeamName: string;
+  after: NightBoardFixtureNotificationState;
+  dashboardUrl: string;
+}) {
+  const fixtureName = `${input.homeTeamName} vs ${input.awayTeamName}`;
+
+  if (input.status === FixtureStatus.CANCELLED) {
+    return `SIXFL: ${fixtureName}, scheduled for ${formatKickoff(
+      input.after.kickoffAt,
+    )}, has been cancelled. This replaces the previous fixture details. ${input.dashboardUrl}`;
+  }
+
+  if (input.status === FixtureStatus.POSTPONED) {
+    return `SIXFL: ${fixtureName}, scheduled for ${formatKickoff(
+      input.after.kickoffAt,
+    )}, has been postponed. This replaces the previous fixture details. ${input.dashboardUrl}`;
+  }
+
+  return `SIXFL fixture update: ${fixtureName} is now ${formatKickoff(
+    input.after.kickoffAt,
+  )} at ${input.after.venueName || "venue TBC"}. Please review and confirm: ${
+    input.dashboardUrl
+  }`;
+}
+
+function refereeCopy(input: {
+  action: RefereeNoticeAction;
+  firstName: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  before: NightBoardFixtureNotificationState;
+  after: NightBoardFixtureNotificationState;
+  changeLines: string[];
+  dashboardUrl: string;
+}) {
+  const fixtureName = `${input.homeTeamName} vs ${input.awayTeamName}`;
+
+  if (input.action === "removed") {
+    return {
+      subject: `SIXFL referee assignment removed: ${fixtureName}`,
+      body: [
+        `Hi ${input.firstName},`,
+        "",
+        `You are no longer assigned to referee ${fixtureName}.`,
+        "",
+        "Previous fixture details:",
+        fixtureSummary({
+          homeTeamName: input.homeTeamName,
+          awayTeamName: input.awayTeamName,
+          state: input.before,
+        }),
+        "",
+        "Please check your SIXFL referee dashboard for your current assignments.",
+        "",
+        "{{cta}}",
+      ].join("\n"),
+      sms: `SIXFL referee update: you are no longer assigned to ${fixtureName} on ${formatKickoff(
+        input.before.kickoffAt,
+      )}. Check your dashboard: ${input.dashboardUrl}`,
+      ctaLabel: "Open referee dashboard",
+    };
+  }
+
+  if (input.action === "assigned") {
+    return {
+      subject: `SIXFL referee assignment: ${fixtureName}`,
+      body: [
+        `Hi ${input.firstName},`,
+        "",
+        `You have been assigned to referee ${fixtureName}.`,
+        "",
+        "Fixture details:",
+        fixtureSummary({
+          homeTeamName: input.homeTeamName,
+          awayTeamName: input.awayTeamName,
+          state: input.after,
+        }),
+        "",
+        "Please check your SIXFL referee dashboard.",
+        "",
+        "{{cta}}",
+      ].join("\n"),
+      sms: `SIXFL referee assignment: ${fixtureName}, ${formatKickoff(
+        input.after.kickoffAt,
+      )}, ${input.after.venueName || "venue TBC"}, ${
+        input.after.pitch?.trim() || "pitch TBC"
+      }. Check your dashboard: ${input.dashboardUrl}`,
+      ctaLabel: "Open referee dashboard",
+    };
+  }
+
+  const statusSentence =
+    input.after.status === FixtureStatus.CANCELLED
+      ? "This fixture has been cancelled."
+      : input.after.status === FixtureStatus.POSTPONED
+        ? "This fixture has been postponed."
+        : "The details of one of your assigned fixtures have changed.";
+
+  return {
+    subject: `SIXFL referee fixture update: ${fixtureName}`,
+    body: [
+      `Hi ${input.firstName},`,
+      "",
+      statusSentence,
+      "",
+      "What changed:",
+      ...input.changeLines.map((line) => `- ${line}`),
+      "",
+      "Current fixture:",
+      fixtureSummary({
+        homeTeamName: input.homeTeamName,
+        awayTeamName: input.awayTeamName,
+        state: input.after,
+      }),
+      "",
+      "Please check your SIXFL referee dashboard.",
+      "",
+      "{{cta}}",
+    ].join("\n"),
+    sms: `SIXFL referee update: ${fixtureName} is now ${formatKickoff(
+      input.after.kickoffAt,
+    )}, ${input.after.venueName || "venue TBC"}, ${
+      input.after.pitch?.trim() || "pitch TBC"
+    } (${formatStatus(input.after.status)}). Check your dashboard: ${
+      input.dashboardUrl
+    }`,
+    ctaLabel: "Open referee dashboard",
+  };
+}
+
+async function rescheduleFixtureReminderEmails(input: {
+  fixtureId: string;
+  leagueId: string;
+  leagueName: string;
+  leagueSeason: string | null;
+  leagueSlug: string | null;
+  kickoffAt: Date;
+  homeTeam: NightBoardNotificationTeam;
+  awayTeam: NightBoardNotificationTeam;
+  teamIds: string[];
+  createdByUserId?: string | null;
+}) {
+  let queued = 0;
+  let skipped = 0;
+  const now = Date.now();
+  const schedules = [48, 6]
+    .map(
+      (hoursBeforeKickoff) =>
+        new Date(input.kickoffAt.getTime() - hoursBeforeKickoff * 60 * 60 * 1000),
+    )
+    .filter((scheduledFor) => scheduledFor.getTime() > now);
+
+  if (schedules.length === 0) return { queued, skipped };
+
+  const fixturesUrl = input.leagueSlug
+    ? new URL(`/leagues/${input.leagueSlug}/fixtures`, `${getPublicSiteUrl()}/`).toString()
+    : new URL("/leagues", `${getPublicSiteUrl()}/`).toString();
+  const fixtureName = `${input.homeTeam.name} vs ${input.awayTeam.name}`;
+  const displayLeague = leagueLabel(input);
+
+  for (const teamId of input.teamIds) {
+    const currentTeam =
+      teamId === input.homeTeam.id ? input.homeTeam : input.awayTeam;
+    const { recipient } = await upsertTeamNotificationRecipient(teamId);
+
+    for (const scheduledFor of schedules) {
+      const sourceId = `${input.fixtureId}:${teamId}:${scheduledFor.toISOString()}`;
+      const existing = await prisma.notificationDispatch.findFirst({
+        where: {
+          recipientId: recipient.id,
+          channel: NotificationChannel.EMAIL,
+          sourceType: "FIXTURE_REMINDER",
+          sourceId,
+          status: {
+            in: [
+              NotificationDispatchStatus.QUEUED,
+              NotificationDispatchStatus.PROCESSING,
+              NotificationDispatchStatus.SENT,
+            ],
+          },
+        },
+        select: { id: true },
+      });
+
+      if (existing) {
+        skipped += 1;
+        continue;
+      }
+
+      try {
+        const dispatch = await queueNotificationFromTemplate({
+          templateKey: "fixture-reminder-email",
+          recipientId: recipient.id,
+          sourceType: "FIXTURE_REMINDER",
+          sourceId,
+          scheduledFor,
+          createdByUserId: input.createdByUserId,
+          metadata: {
+            kind: "fixture_reminder",
+            trigger: "night_board_fixture_change",
+            fixtureId: input.fixtureId,
+            leagueId: input.leagueId,
+            teamId,
+            fixtureName,
+          },
+          variables: {
+            firstName: recipient.displayName?.trim() || currentTeam.name,
+            leagueName: input.leagueName,
+            fixtureName,
+            kickoffLabel: formatKickoff(input.kickoffAt),
+            fixturesUrl,
+          },
+          emailBranding: {
+            teamName: currentTeam.name,
+            teamLogoUrl: currentTeam.logoUrl,
+            leagueName: displayLeague,
+          },
+        });
+
+        if (dispatch.status === NotificationDispatchStatus.QUEUED) {
+          queued += 1;
+        } else {
+          skipped += 1;
+        }
+      } catch (error) {
+        skipped += 1;
+        console.error("Could not reschedule fixture reminder after Night Board change", {
+          fixtureId: input.fixtureId,
+          teamId,
+          scheduledFor,
+          error,
+        });
+      }
+    }
+  }
+
+  return { queued, skipped };
+}
+
+export async function queueNightBoardFixtureChangeNotifications(input: {
+  fixtureId: string;
+  leagueId: string;
+  leagueName: string;
+  leagueSeason: string | null;
+  leagueSlug: string | null;
+  publishedAt: Date | null;
+  homeTeam: NightBoardNotificationTeam;
+  awayTeam: NightBoardNotificationTeam;
+  before: NightBoardFixtureNotificationState;
+  after: NightBoardFixtureNotificationState;
+  createdByUserId?: string | null;
+}): Promise<NightBoardFixtureNotificationSummary> {
+  const team = emptyDeliveryCounts();
+  const referee = emptyDeliveryCounts();
+  const teamChangeLines = buildTeamChangeLines(input);
+  const refereeChangeLines = buildRefereeChangeLines({
+    before: input.before,
+    after: input.after,
+    teamChangeLines,
+  });
+  const summary: NightBoardFixtureNotificationSummary = {
+    kind: "none",
+    reason: null,
+    teamChangeLines,
+    refereeChangeLines,
+    team,
+    referee,
+    remindersQueued: 0,
+    remindersSkipped: 0,
+  };
+
+  if (!input.publishedAt) {
+    summary.reason =
+      "Draft fixture changes are not sent until the fixture has been published.";
+    return summary;
+  }
+
+  if (teamChangeLines.length === 0 && refereeChangeLines.length === 0) {
+    summary.reason = "No fixture details changed, so no notifications were needed.";
+    return summary;
+  }
+
+  if (input.after.status === FixtureStatus.CANCELLED) {
+    summary.kind = "cancelled";
+  } else if (input.after.status === FixtureStatus.POSTPONED) {
+    summary.kind = "postponed";
+  } else if (input.after.status === FixtureStatus.COMPLETED) {
+    summary.kind = "completed";
+  } else if (teamChangeLines.length > 0) {
+    summary.kind = "change";
+  } else {
+    summary.kind = "referee";
+  }
+
+  const hash = changeHash({
+    fixtureId: input.fixtureId,
+    before: input.before,
+    after: input.after,
+  });
+  const allTeamIds = [input.homeTeam.id, input.awayTeam.id];
+  const placeholderTeamIds = await getFixturePlaceholderTeamIds(allTeamIds);
+  const teamIds = allTeamIds.filter((teamId) => !placeholderTeamIds.has(teamId));
+  const shouldNotifyTeams =
+    teamChangeLines.length > 0 &&
+    input.after.status !== FixtureStatus.COMPLETED &&
+    teamIds.length > 0;
+
+  if (teamChangeLines.length > 0) {
+    await cancelQueuedStaleFixtureMessages(input.fixtureId);
+  }
+
+  if (shouldNotifyTeams) {
+    await resetConfirmedTeams({
+      fixtureId: input.fixtureId,
+      teamIds,
+      status: input.after.status,
+    });
+
+    const currentFixture = fixtureSummary({
+      homeTeamName: input.homeTeam.name,
+      awayTeamName: input.awayTeam.name,
+      state: input.after,
+    });
+    const sourceType =
+      input.after.status === FixtureStatus.CANCELLED ||
+      input.after.status === FixtureStatus.POSTPONED
+        ? TEAM_STATUS_SOURCE_TYPE
+        : TEAM_CHANGE_SOURCE_TYPE;
+    const sourceId = `${input.fixtureId}:${hash}`;
+    const brandingLeague = leagueLabel(input);
+
+    for (const teamId of teamIds) {
+      const currentTeam =
+        teamId === input.homeTeam.id ? input.homeTeam : input.awayTeam;
+      const { recipient, snapshot } =
+        await upsertTeamNotificationRecipient(teamId);
+      const dashboardUrl = captainFixtureUrl(teamId, input.fixtureId);
+      const emailCopy = teamEmailCopy({
+        status: input.after.status,
+        contactName: snapshot.primaryContact.name ?? currentTeam.name,
+        homeTeamName: input.homeTeam.name,
+        awayTeamName: input.awayTeam.name,
+        changeLines: teamChangeLines,
+        currentFixture,
+      });
+      const metadata = {
+        kind: "night_board_fixture_change",
+        fixtureId: input.fixtureId,
+        leagueId: input.leagueId,
+        teamId,
+        changeHash: hash,
+        changeLines: teamChangeLines,
+        status: input.after.status,
+      };
+
+      recordOutcome(
+        team,
+        NotificationChannel.EMAIL,
+        await queueOnce({
+          recipientId: recipient.id,
+          channel: NotificationChannel.EMAIL,
+          audience: NotificationAudience.TEAM,
+          subject: emailCopy.subject,
+          body: emailCopy.body,
+          sourceType,
+          sourceId,
+          metadata,
+          emailBranding: {
+            teamName: currentTeam.name,
+            teamLogoUrl: currentTeam.logoUrl,
+            leagueName: brandingLeague,
+          },
+          emailCta: { label: emailCopy.ctaLabel, url: dashboardUrl },
+          createdByUserId: input.createdByUserId,
+        }),
+      );
+
+      recordOutcome(
+        team,
+        NotificationChannel.SMS,
+        await queueOnce({
+          recipientId: recipient.id,
+          channel: NotificationChannel.SMS,
+          audience: NotificationAudience.TEAM,
+          body: teamSmsCopy({
+            status: input.after.status,
+            homeTeamName: input.homeTeam.name,
+            awayTeamName: input.awayTeam.name,
+            after: input.after,
+            dashboardUrl,
+          }),
+          sourceType,
+          sourceId,
+          metadata,
+          createdByUserId: input.createdByUserId,
+        }),
+      );
+    }
+  }
+
+  const kickoffChanged =
+    input.before.kickoffAt.getTime() !== input.after.kickoffAt.getTime();
+  if (
+    kickoffChanged &&
+    input.after.status === FixtureStatus.SCHEDULED &&
+    teamIds.length > 0
+  ) {
+    const reminders = await rescheduleFixtureReminderEmails({
+      fixtureId: input.fixtureId,
+      leagueId: input.leagueId,
+      leagueName: input.leagueName,
+      leagueSeason: input.leagueSeason,
+      leagueSlug: input.leagueSlug,
+      kickoffAt: input.after.kickoffAt,
+      homeTeam: input.homeTeam,
+      awayTeam: input.awayTeam,
+      teamIds,
+      createdByUserId: input.createdByUserId,
+    });
+    summary.remindersQueued = reminders.queued;
+    summary.remindersSkipped = reminders.skipped;
+  }
+
+  const refereeNotices: Array<{
+    action: RefereeNoticeAction;
+    referee: NightBoardNotificationReferee;
+  }> = [];
+
+  if (input.before.referee?.id !== input.after.referee?.id) {
+    if (input.before.referee) {
+      refereeNotices.push({ action: "removed", referee: input.before.referee });
+    }
+    if (input.after.referee) {
+      refereeNotices.push({ action: "assigned", referee: input.after.referee });
+    }
+  } else if (input.after.referee && refereeChangeLines.length > 0) {
+    refereeNotices.push({ action: "updated", referee: input.after.referee });
+  }
+
+  const refereeUrl = refereeDashboardUrl();
+
+  for (const notice of refereeNotices) {
+    const recipient = await upsertRefereeRecipient(notice.referee);
+    const firstName =
+      notice.referee.name?.trim().split(/\s+/)[0] ||
+      notice.referee.email ||
+      "there";
+    const copy = refereeCopy({
+      action: notice.action,
+      firstName,
+      homeTeamName: input.homeTeam.name,
+      awayTeamName: input.awayTeam.name,
+      before: input.before,
+      after: input.after,
+      changeLines: refereeChangeLines,
+      dashboardUrl: refereeUrl,
+    });
+    const sourceId = `${input.fixtureId}:${hash}:${notice.action}:${notice.referee.id}`;
+    const metadata = {
+      kind: "night_board_referee_fixture_change",
+      fixtureId: input.fixtureId,
+      leagueId: input.leagueId,
+      refereeId: notice.referee.id,
+      action: notice.action,
+      changeHash: hash,
+      changeLines: refereeChangeLines,
+      status: input.after.status,
+    };
+
+    recordOutcome(
+      referee,
+      NotificationChannel.EMAIL,
+      await queueOnce({
+        recipientId: recipient.id,
+        channel: NotificationChannel.EMAIL,
+        audience: NotificationAudience.REFEREE,
+        subject: copy.subject,
+        body: copy.body,
+        sourceType: REFEREE_CHANGE_SOURCE_TYPE,
+        sourceId,
+        metadata,
+        emailCta: { label: copy.ctaLabel, url: refereeUrl },
+        createdByUserId: input.createdByUserId,
+      }),
+    );
+
+    recordOutcome(
+      referee,
+      NotificationChannel.SMS,
+      await queueOnce({
+        recipientId: recipient.id,
+        channel: NotificationChannel.SMS,
+        audience: NotificationAudience.REFEREE,
+        body: copy.sms,
+        sourceType: REFEREE_CHANGE_SOURCE_TYPE,
+        sourceId,
+        metadata,
+        createdByUserId: input.createdByUserId,
+      }),
+    );
+  }
+
+  if (!shouldNotifyTeams && refereeNotices.length === 0) {
+    summary.reason =
+      input.after.status === FixtureStatus.COMPLETED
+        ? "The fixture was marked completed; no team reconfirmation notice was sent."
+        : "The saved change did not require a team or referee notification.";
+  } else if (placeholderTeamIds.size > 0 && teamChangeLines.length > 0) {
+    summary.reason =
+      "A provisional team was present, so notifications were only sent to confirmed teams.";
+  }
+
+  return summary;
+}


### PR DESCRIPTION
## What this fixes

Changing a published fixture from **Save match** on the Night Board previously updated the fixture and payment reminder timing, but did not create the proper fixture-change message.

## Changes

- queue transactional email and SMS notices for both teams after a material kick-off, venue or status change
- reset previous team confirmations so the amended fixture must be reconfirmed
- notify the assigned referee when time, venue, pitch or status changes
- notify both the removed and newly assigned referee when the referee assignment changes
- cancel stale confirmation/reminder messages and recreate future fixture reminder emails around a changed kick-off
- show an explicit Night Board result banner with queued, skipped or failed message counts
- add a CI contract so Night Board saves cannot silently lose this behaviour

## Safety

- notices are created only after the fixture update succeeds
- unpublished/draft fixtures remain blocked from communication
- duplicate delivery is prevented per recipient, channel and exact change
- a failed notification does not undo the saved fixture; the admin banner says manual contact is required