### PR TITLE
Fix lead called status to track actual phone calls

### DIFF
--- a/prisma/migrations/20260829152000_add_lead_phone_call_tracking/migration.sql
+++ b/prisma/migrations/20260829152000_add_lead_phone_call_tracking/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "LeadPhoneCall" (
+  "leadId" TEXT NOT NULL,
+  "calledAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "LeadPhoneCall_pkey" PRIMARY KEY ("leadId")
+);
+
+ALTER TABLE "LeadPhoneCall"
+ADD CONSTRAINT "LeadPhoneCall_leadId_fkey"
+FOREIGN KEY ("leadId") REFERENCES "InterestLead"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/app/api/admin/leads/call-status/route.ts
+++ b/src/app/api/admin/leads/call-status/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
@@ -6,17 +7,23 @@ import { requireAdmin } from "@/lib/requireAdmin";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+type LeadPhoneCallRow = {
+  leadId: string;
+  calledAt: Date;
+};
+
 export async function GET() {
   await requireAdmin();
 
-  const leads = await prisma.interestLead.findMany({
-    select: { id: true, contactedAt: true },
-  });
+  const calls = await prisma.$queryRaw<LeadPhoneCallRow[]>(Prisma.sql`
+    SELECT "leadId", "calledAt"
+    FROM "LeadPhoneCall"
+  `);
 
   return NextResponse.json({
-    leads: leads.map((lead) => ({
-      id: lead.id,
-      contactedAt: lead.contactedAt?.toISOString() ?? null,
+    leads: calls.map((call) => ({
+      id: call.leadId,
+      calledAt: call.calledAt.toISOString(),
     })),
   });
 }
@@ -28,14 +35,29 @@ export async function POST(request: Request) {
   const leadId = String(payload?.leadId ?? "").trim();
   if (!leadId) return NextResponse.json({ error: "Lead ID is required." }, { status: 400 });
 
-  const lead = await prisma.interestLead.findUnique({ where: { id: leadId }, select: { id: true, status: true } });
+  const lead = await prisma.interestLead.findUnique({
+    where: { id: leadId },
+    select: { id: true, status: true },
+  });
   if (!lead) return NextResponse.json({ error: "Lead not found." }, { status: 404 });
 
-  const contactedAt = new Date();
-  await prisma.interestLead.update({
-    where: { id: leadId },
-    data: { contactedAt, status: lead.status === "NEW" ? "CONTACTED" : undefined },
-  });
+  const calledAt = new Date();
 
-  return NextResponse.json({ ok: true, leadId, contactedAt: contactedAt.toISOString() });
+  await prisma.$transaction([
+    prisma.$executeRaw(Prisma.sql`
+      INSERT INTO "LeadPhoneCall" ("leadId", "calledAt")
+      VALUES (${leadId}, ${calledAt})
+      ON CONFLICT ("leadId")
+      DO UPDATE SET "calledAt" = EXCLUDED."calledAt"
+    `),
+    prisma.interestLead.update({
+      where: { id: leadId },
+      data: {
+        contactedAt: calledAt,
+        status: lead.status === "NEW" ? "CONTACTED" : undefined,
+      },
+    }),
+  ]);
+
+  return NextResponse.json({ ok: true, leadId, calledAt: calledAt.toISOString() });
 }

--- a/src/components/admin/leads/AdminLeadCallStatusBridge.tsx
+++ b/src/components/admin/leads/AdminLeadCallStatusBridge.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-type CallStatus = { id: string; contactedAt: string | null };
+type CallStatus = { id: string; calledAt: string | null };
 
 type StatusResponse = { leads?: CallStatus[] };
 
@@ -25,13 +25,13 @@ function getLeadId(row: HTMLTableRowElement) {
   return /^\/admin\/leads\/([^/?#]+)/.exec(href)?.[1] ?? null;
 }
 
-function buildCell(leadId: string, contactedAt: string | null) {
+function buildCell(leadId: string, calledAt: string | null) {
   const cell = document.createElement("td");
   cell.dataset.leadCalledCell = leadId;
   cell.className = "px-4 py-3";
 
-  if (contactedAt) {
-    cell.innerHTML = `<div class="inline-flex rounded-full border border-sky-400/25 bg-sky-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-sky-200">✓ Called</div><div class="mt-1 whitespace-nowrap text-[11px] text-white/40">${formatCalledAt(contactedAt)}</div>`;
+  if (calledAt) {
+    cell.innerHTML = `<div class="inline-flex rounded-full border border-sky-400/25 bg-sky-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-sky-200">✓ Called</div><div class="mt-1 whitespace-nowrap text-[11px] text-white/40">${formatCalledAt(calledAt)}</div>`;
     return cell;
   }
 
@@ -71,7 +71,7 @@ export default function AdminLeadCallStatusBridge() {
       const response = await fetch("/api/admin/leads/call-status", { cache: "no-store" });
       if (!response.ok || disposed) return;
       const payload = (await response.json()) as StatusResponse;
-      const statuses = new Map((payload.leads ?? []).map((lead) => [lead.id, lead.contactedAt]));
+      const statuses = new Map((payload.leads ?? []).map((lead) => [lead.id, lead.calledAt]));
 
       const headerRow = table.querySelector<HTMLTableRowElement>("thead tr");
       const actionHeader = headerRow?.lastElementChild;


### PR DESCRIPTION
Stops the main Leads page from treating general contactedAt timestamps as phone calls. Adds a dedicated LeadPhoneCall table, records calls only when Mark called is clicked, and displays Called only from those explicit phone-call records. Existing email/SMS/contacted timestamps will no longer make leads appear called.