### PR TITLE
Reset stale team confirmations when Night Board fixtures change

### DIFF
--- a/.github/workflows/night-board-fixture-change.yml
+++ b/.github/workflows/night-board-fixture-change.yml
@@ -7,7 +7,10 @@ on:
       - "src/lib/fixtures/night-board-change-notifications.ts"
       - "src/components/admin/night-board/NightBoardSaveNotice.tsx"
       - "src/app/(admin)/admin/layout.tsx"
+      - "scripts/apply-admin-team-kickoff-summary.cjs"
+      - "scripts/apply-night-board-confirmation-reset-hardening.cjs"
       - "scripts/check-night-board-fixture-notifications.mjs"
+      - "prisma/migrations/20260829214500_reset_stale_units_microwave_confirmations/migration.sql"
       - ".github/workflows/night-board-fixture-change.yml"
   workflow_dispatch:
 

--- a/prisma/migrations/20260829214500_reset_stale_units_microwave_confirmations/migration.sql
+++ b/prisma/migrations/20260829214500_reset_stale_units_microwave_confirmations/migration.sql
@@ -1,0 +1,33 @@
+-- This fixture was moved to 21:15 on 29 August before the Night Board
+-- fixture-change workflow was deployed. Its earlier team responses must not
+-- continue to count against the amended kick-off.
+UPDATE "FixtureCaptainConfirmation" AS confirmation
+SET
+  "status" = 'PENDING',
+  "confirmedAt" = NULL,
+  "issueRaisedAt" = NULL,
+  "lastChasedAt" = NULL,
+  "confirmedByUserId" = NULL,
+  "note" = 'Fixture time changed on the Night Board. Team needs to confirm the updated 21:15 kick-off.',
+  "updatedAt" = CURRENT_TIMESTAMP
+FROM "Fixture" AS fixture
+JOIN "Team" AS home_team ON home_team."id" = fixture."homeTeamId"
+JOIN "Team" AS away_team ON away_team."id" = fixture."awayTeamId"
+JOIN "League" AS league ON league."id" = fixture."leagueId"
+WHERE confirmation."fixtureId" = fixture."id"
+  AND fixture."publishedAt" IS NOT NULL
+  AND fixture."status" = 'SCHEDULED'
+  AND fixture."kickoffAt" >= TIMESTAMP '2026-09-02 00:00:00'
+  AND fixture."kickoffAt" < TIMESTAMP '2026-09-03 00:00:00'
+  AND LOWER(league."name") = 'northallerton wednesday mens'
+  AND (
+    (
+      LOWER(home_team."name") = 'the units'
+      AND LOWER(away_team."name") = 'microwave afc'
+    )
+    OR (
+      LOWER(home_team."name") = 'microwave afc'
+      AND LOWER(away_team."name") = 'the units'
+    )
+  )
+  AND confirmation."status" IN ('CONFIRMED', 'ISSUE_RAISED');

--- a/scripts/apply-admin-team-kickoff-summary.cjs
+++ b/scripts/apply-admin-team-kickoff-summary.cjs
@@ -60,6 +60,7 @@ if (changed) {
   console.log("Admin Teams earliest kick-off summary already applied.");
 }
 
-// Run this last so it extends the fully prepared Admin Leads source, including
-// the existing include/exclude filters, without being overwritten later.
+// Run these last so they extend the fully prepared native admin source without
+// being overwritten by an earlier compatibility step.
 require("./apply-admin-lead-prospective-league-filter.cjs");
+require("./apply-night-board-confirmation-reset-hardening.cjs");

--- a/scripts/apply-night-board-confirmation-reset-hardening.cjs
+++ b/scripts/apply-night-board-confirmation-reset-hardening.cjs
@@ -1,0 +1,264 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const files = {
+  route: "src/app/api/admin/night-board/update-match/route.ts",
+  notifications: "src/lib/fixtures/night-board-change-notifications.ts",
+};
+
+function read(relativePath) {
+  const absolutePath = path.join(root, ...relativePath.split("/"));
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Night Board confirmation reset hardening: ${relativePath} was not found.`);
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, ...relativePath.split("/")), source, "utf8");
+}
+
+function replaceOnce(source, before, after, label) {
+  if (source.includes(after)) {
+    return { source, changed: false };
+  }
+  if (!source.includes(before)) {
+    throw new Error(`Night Board confirmation reset hardening: ${label} anchor was not found.`);
+  }
+  return { source: source.replace(before, after), changed: true };
+}
+
+function patchNotificationService() {
+  let source = read(files.notifications);
+  let changed = false;
+
+  function replace(before, after, label) {
+    const result = replaceOnce(source, before, after, label);
+    source = result.source;
+    changed = result.changed || changed;
+  }
+
+  replace(
+    "async function resetConfirmedTeams(input: {",
+    "async function resetTeamResponses(input: {",
+    "reset helper name",
+  );
+
+  replace(
+    "      status: FixtureCaptainConfirmationStatus.CONFIRMED,",
+    `      status: {
+        in: [
+          FixtureCaptainConfirmationStatus.PENDING,
+          FixtureCaptainConfirmationStatus.CONFIRMED,
+          FixtureCaptainConfirmationStatus.ISSUE_RAISED,
+        ],
+      },`,
+    "all confirmation response states",
+  );
+
+  replace(
+    `      confirmedAt: null,
+      confirmedByUserId: null,
+      note,`,
+    `      confirmedAt: null,
+      issueRaisedAt: null,
+      lastChasedAt: null,
+      confirmedByUserId: null,
+      note,`,
+    "clear stale response timestamps",
+  );
+
+  replace(
+    "    await resetConfirmedTeams({",
+    "    await resetTeamResponses({",
+    "reset helper call",
+  );
+
+  const required = [
+    "async function resetTeamResponses(input: {",
+    "FixtureCaptainConfirmationStatus.ISSUE_RAISED",
+    "issueRaisedAt: null",
+    "lastChasedAt: null",
+    "await resetTeamResponses({",
+  ];
+  for (const token of required) {
+    if (!source.includes(token)) {
+      throw new Error(`Night Board confirmation reset hardening: notification service is missing ${token}.`);
+    }
+  }
+
+  if (changed) write(files.notifications, source);
+  return changed;
+}
+
+function patchUpdateRoute() {
+  let source = read(files.route);
+  let changed = false;
+
+  function replace(before, after, label) {
+    const result = replaceOnce(source, before, after, label);
+    source = result.source;
+    changed = result.changed || changed;
+  }
+
+  replace(
+    `import {
+  FixtureStatus,`,
+    `import {
+  FixtureCaptainConfirmationStatus,
+  FixtureStatus,`,
+    "confirmation status import",
+  );
+
+  if (!source.includes("function getConfirmationResetNote(")) {
+    const anchor = "function buildReturnToWithSaveNotice(input: {";
+    const helper = `function getConfirmationResetNote(status: FixtureStatus) {
+  if (status === FixtureStatus.SCHEDULED) {
+    return "Fixture details changed on the Night Board. Team needs to confirm the updated fixture.";
+  }
+  if (status === FixtureStatus.CANCELLED) {
+    return "Fixture cancelled on the Night Board. The previous team response is no longer current.";
+  }
+  return "Fixture postponed on the Night Board. The previous team response is no longer current.";
+}
+
+`;
+    if (!source.includes(anchor)) {
+      throw new Error("Night Board confirmation reset hardening: save notice helper anchor was not found.");
+    }
+    source = source.replace(anchor, `${helper}${anchor}`);
+    changed = true;
+  }
+
+  if (!source.includes("const teamFacingDetailsChanged =")) {
+    const anchor = "  const nextRefereeId = referee?.id ?? null;";
+    const calculation = `  const previousVenueName = fixture.venue?.name ?? fixture.league.venueName ?? null;
+  const nextVenueName = venue?.name ?? fixture.league.venueName ?? null;
+  const teamFacingDetailsChanged =
+    kickoffAt.getTime() !== fixture.kickoffAt.getTime() ||
+    fixture.venueId !== venueId ||
+    previousVenueName !== nextVenueName ||
+    fixture.status !== status;
+  const shouldResetTeamResponses =
+    Boolean(fixture.publishedAt) &&
+    teamFacingDetailsChanged &&
+    status !== FixtureStatus.COMPLETED;
+
+`;
+    if (!source.includes(anchor)) {
+      throw new Error("Night Board confirmation reset hardening: referee assignment anchor was not found.");
+    }
+    source = source.replace(anchor, `${calculation}${anchor}`);
+    changed = true;
+  }
+
+  replace(
+    `  await prisma.fixture.update({
+    where: { id: fixture.id },
+    data: {
+      kickoffAt,
+      pitch: pitch || null,
+      venueId,
+      refereeId: nextRefereeId,
+      status,
+    },
+  });`,
+    `  await prisma.$transaction(async (tx) => {
+    await tx.fixture.update({
+      where: { id: fixture.id },
+      data: {
+        kickoffAt,
+        pitch: pitch || null,
+        venueId,
+        refereeId: nextRefereeId,
+        status,
+      },
+    });
+
+    if (shouldResetTeamResponses) {
+      await tx.fixtureCaptainConfirmation.updateMany({
+        where: {
+          fixtureId: fixture.id,
+          teamId: { in: [fixture.homeTeam.id, fixture.awayTeam.id] },
+          status: {
+            in: [
+              FixtureCaptainConfirmationStatus.PENDING,
+              FixtureCaptainConfirmationStatus.CONFIRMED,
+              FixtureCaptainConfirmationStatus.ISSUE_RAISED,
+            ],
+          },
+        },
+        data: {
+          status: FixtureCaptainConfirmationStatus.PENDING,
+          confirmedAt: null,
+          issueRaisedAt: null,
+          lastChasedAt: null,
+          confirmedByUserId: null,
+          note: getConfirmationResetNote(status),
+        },
+      });
+    }
+  });`,
+    "atomic fixture and confirmation update",
+  );
+
+  const required = [
+    "FixtureCaptainConfirmationStatus.ISSUE_RAISED",
+    "const teamFacingDetailsChanged =",
+    "const shouldResetTeamResponses =",
+    "await prisma.$transaction(async (tx) => {",
+    "await tx.fixtureCaptainConfirmation.updateMany({",
+    "issueRaisedAt: null",
+    "lastChasedAt: null",
+    "note: getConfirmationResetNote(status)",
+  ];
+  for (const token of required) {
+    if (!source.includes(token)) {
+      throw new Error(`Night Board confirmation reset hardening: update route is missing ${token}.`);
+    }
+  }
+
+  const transactionPosition = source.indexOf("await prisma.$transaction(async (tx) => {");
+  const fixtureUpdatePosition = source.indexOf("await tx.fixture.update({", transactionPosition);
+  const confirmationResetPosition = source.indexOf(
+    "await tx.fixtureCaptainConfirmation.updateMany({",
+    transactionPosition,
+  );
+  const paymentSyncPosition = source.indexOf("const sync = await resyncMatchFeeMessages({");
+  const notificationPosition = source.indexOf(
+    "await queueNightBoardFixtureChangeNotifications({",
+  );
+
+  if (
+    transactionPosition < 0 ||
+    fixtureUpdatePosition < transactionPosition ||
+    confirmationResetPosition < fixtureUpdatePosition ||
+    paymentSyncPosition < confirmationResetPosition ||
+    notificationPosition < paymentSyncPosition
+  ) {
+    throw new Error(
+      "Night Board confirmation reset hardening: confirmations must reset atomically before payment and notification follow-up work.",
+    );
+  }
+
+  if (changed) write(files.route, source);
+  return changed;
+}
+
+function applyAll() {
+  return [patchNotificationService(), patchUpdateRoute()].filter(Boolean).length;
+}
+
+const firstPassChangedFiles = applyAll();
+const secondPassChangedFiles = applyAll();
+
+if (secondPassChangedFiles !== 0) {
+  throw new Error("Night Board confirmation reset hardening is not idempotent.");
+}
+
+if (firstPassChangedFiles > 0) {
+  console.log(`Night Board confirmation reset hardening applied to ${firstPassChangedFiles} file(s).`);
+} else {
+  console.log("Night Board confirmation reset hardening already applied.");
+}

--- a/scripts/check-night-board-fixture-notifications.mjs
+++ b/scripts/check-night-board-fixture-notifications.mjs
@@ -21,6 +21,9 @@ const layout = read("src/app/(admin)/admin/layout.tsx");
 const notice = read(
   "src/components/admin/night-board/NightBoardSaveNotice.tsx",
 );
+const repairMigration = read(
+  "prisma/migrations/20260829214500_reset_stale_units_microwave_confirmations/migration.sql",
+);
 
 requireText(
   route,
@@ -33,17 +36,52 @@ requireText(
   "Night Board save route must queue fixture-change notifications.",
 );
 
-const updatePosition = route.indexOf("await prisma.fixture.update({");
+for (const expected of [
+  "await prisma.$transaction(async (tx) => {",
+  "await tx.fixture.update({",
+  "await tx.fixtureCaptainConfirmation.updateMany({",
+  "const teamFacingDetailsChanged =",
+  "const shouldResetTeamResponses =",
+  "Boolean(fixture.publishedAt)",
+  "status !== FixtureStatus.COMPLETED",
+  "FixtureCaptainConfirmationStatus.PENDING",
+  "FixtureCaptainConfirmationStatus.CONFIRMED",
+  "FixtureCaptainConfirmationStatus.ISSUE_RAISED",
+  "confirmedAt: null",
+  "issueRaisedAt: null",
+  "lastChasedAt: null",
+  "confirmedByUserId: null",
+  "note: getConfirmationResetNote(status)",
+]) {
+  requireText(
+    route,
+    expected,
+    `Night Board save route is missing confirmation invalidation safeguard: ${expected}`,
+  );
+}
+
+const transactionPosition = route.indexOf(
+  "await prisma.$transaction(async (tx) => {",
+);
+const updatePosition = route.indexOf("await tx.fixture.update({");
+const confirmationResetPosition = route.indexOf(
+  "await tx.fixtureCaptainConfirmation.updateMany({",
+);
+const paymentSyncPosition = route.indexOf(
+  "const sync = await resyncMatchFeeMessages({",
+);
 const notificationPosition = route.indexOf(
   "await queueNightBoardFixtureChangeNotifications({",
 );
 if (
-  updatePosition < 0 ||
-  notificationPosition < 0 ||
-  notificationPosition <= updatePosition
+  transactionPosition < 0 ||
+  updatePosition <= transactionPosition ||
+  confirmationResetPosition <= updatePosition ||
+  paymentSyncPosition <= confirmationResetPosition ||
+  notificationPosition <= paymentSyncPosition
 ) {
   throw new Error(
-    "Night Board fixture-change notifications must be queued only after the fixture update succeeds.",
+    "Night Board team responses must be invalidated in the same transaction as the fixture update, before payment or notification follow-up work can fail.",
   );
 }
 
@@ -53,6 +91,11 @@ for (const expected of [
   "NotificationChannel.EMAIL",
   "NotificationChannel.SMS",
   "FixtureCaptainConfirmationStatus.PENDING",
+  "FixtureCaptainConfirmationStatus.CONFIRMED",
+  "FixtureCaptainConfirmationStatus.ISSUE_RAISED",
+  "async function resetTeamResponses(input: {",
+  "issueRaisedAt: null",
+  "lastChasedAt: null",
   '"FIXTURE_REMINDER"',
   "queueNotificationFromTemplate({",
 ]) {
@@ -94,6 +137,26 @@ requireText(
   "Night Board save notice must clearly report skipped or failed notifications.",
 );
 
+for (const expected of [
+  "northallerton wednesday mens",
+  "the units",
+  "microwave afc",
+  "2026-09-02",
+  "'CONFIRMED'",
+  "'ISSUE_RAISED'",
+  '"status" = \'PENDING\'',
+  '"confirmedAt" = NULL',
+  '"issueRaisedAt" = NULL',
+  '"lastChasedAt" = NULL',
+  '"confirmedByUserId" = NULL',
+]) {
+  requireText(
+    repairMigration,
+    expected,
+    `The targeted stale-response repair is missing required safeguard: ${expected}`,
+  );
+}
+
 console.log(
-  "Night Board fixture-change notification contract passed: team and referee email/SMS notifications are native to Save match, stale reminders are replaced, and the admin sees delivery counts.",
+  "Night Board fixture-change contract passed: changed published fixtures invalidate confirmed and issue-raised team responses atomically, stale timestamps are cleared, the affected Northallerton fixture is repaired, team/referee notifications remain native, and the admin sees delivery counts.",
 );


### PR DESCRIPTION
## What was wrong

A captain response belongs to the exact fixture details they saw. After the kick-off changes, the Night Board could still display an earlier **Confirmed** or **Issue raised** response as though it applied to the amended fixture.

The recently added notification workflow reset only `CONFIRMED` rows and did not invalidate `ISSUE_RAISED`. More importantly, that reset happened later in the notification step, after the fixture had already been saved, so a notification-side failure could leave the fixture changed while its old team responses remained current.

The Units v Microwave Afc was changed before that workflow was deployed, so its existing responses also need a targeted repair.

## Changes

- changes to a published fixture's kick-off, venue or status now reset both teams' responses in the **same database transaction** as the fixture update
- invalidates `CONFIRMED`, `ISSUE_RAISED` and existing `PENDING` response state consistently
- clears stale confirmation, issue, chase and confirming-user timestamps
- leaves referee-only and pitch-only changes out of the team reconfirmation rule
- keeps completed fixtures protected from an unnecessary reset
- hardens the notification service's fallback reset so it also handles `ISSUE_RAISED`
- adds a targeted migration that changes the current The Units v Microwave Afc responses to **Pending** for the amended 21:15 fixture
- expands the permanent Night Board contract so this cannot silently regress

## Safety

- the fixture update and response invalidation commit or roll back together
- notification or reminder failures cannot preserve an old response against new fixture details
- the data repair is narrowly limited by date, league, teams, published/scheduled state and old response status
- the source-preparation patch is idempotent and fails loudly if its native anchors move
- no payment amount, result, team membership or referee assignment logic is changed