### PR TITLE
Fix inactive historic player status saves

### DIFF
--- a/.github/workflows/inactive-player-status.yml
+++ b/.github/workflows/inactive-player-status.yml
@@ -11,6 +11,8 @@ jobs:
   inactive-player-status:
     name: Preserve inactive historic player status
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sixfl_contract
 
     steps:
       - name: Check out repository

--- a/.github/workflows/inactive-player-status.yml
+++ b/.github/workflows/inactive-player-status.yml
@@ -1,0 +1,41 @@
+name: Inactive player status contract
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  inactive-player-status:
+    name: Preserve inactive historic player status
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply production source preparation
+        run: npm run prebuild
+
+      - name: Check inactive player status storage
+        run: node scripts/check-inactive-player-status-storage.mjs
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Validate Prisma schema and migrations
+        run: npx prisma validate
+
+      - name: Type-check application source
+        run: npx tsc --noEmit

--- a/prisma/migrations/20260829190000_allow_inactive_team_member_status/migration.sql
+++ b/prisma/migrations/20260829190000_allow_inactive_team_member_status/migration.sql
@@ -1,0 +1,33 @@
+-- The original TeamMember squad-status constraint only allowed ACTIVE and INJURED.
+-- The captain UI and status service now also use INACTIVE for historic/former players,
+-- so repair the persisted contract before those status updates are accepted.
+
+ALTER TABLE "TeamMember"
+  ADD COLUMN IF NOT EXISTS "squadStatus" TEXT NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE "TeamMember"
+  ADD COLUMN IF NOT EXISTS "squadStatusUpdatedAt" TIMESTAMP(3);
+
+ALTER TABLE "TeamMember"
+  ADD COLUMN IF NOT EXISTS "squadStatusNote" TEXT;
+
+UPDATE "TeamMember"
+SET "squadStatus" = 'ACTIVE'
+WHERE "squadStatus" IS NULL
+   OR "squadStatus" NOT IN ('ACTIVE', 'INJURED', 'INACTIVE');
+
+ALTER TABLE "TeamMember"
+  ALTER COLUMN "squadStatus" SET DEFAULT 'ACTIVE';
+
+ALTER TABLE "TeamMember"
+  ALTER COLUMN "squadStatus" SET NOT NULL;
+
+ALTER TABLE "TeamMember"
+  DROP CONSTRAINT IF EXISTS "TeamMember_squadStatus_check";
+
+ALTER TABLE "TeamMember"
+  ADD CONSTRAINT "TeamMember_squadStatus_check"
+  CHECK ("squadStatus" IN ('ACTIVE', 'INJURED', 'INACTIVE'));
+
+CREATE INDEX IF NOT EXISTS "TeamMember_teamId_squadStatus_idx"
+  ON "TeamMember"("teamId", "squadStatus");

--- a/scripts/check-inactive-player-status-storage.mjs
+++ b/scripts/check-inactive-player-status-storage.mjs
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const migration = read(
+  "prisma/migrations/20260829190000_allow_inactive_team_member_status/migration.sql",
+);
+const statusService = read("src/lib/managed-squad/squadStatus.ts");
+const captainAction = read(
+  "src/app/captain/team/[teamid]/squad/status-actions.ts",
+);
+const reminderJob = read(
+  "src/app/api/jobs/managed-squad-availability-reminders/route.ts",
+);
+const packageJson = read("package.json");
+
+expect(
+  migration.includes(
+    'DROP CONSTRAINT IF EXISTS "TeamMember_squadStatus_check"',
+  ),
+  "The legacy ACTIVE/INJURED-only squad-status constraint must be removed.",
+);
+expect(
+  migration.includes(
+    `CHECK ("squadStatus" IN ('ACTIVE', 'INJURED', 'INACTIVE'))`,
+  ),
+  "The persisted TeamMember squad-status contract must allow INACTIVE.",
+);
+expect(
+  migration.includes(
+    `"squadStatus" NOT IN ('ACTIVE', 'INJURED', 'INACTIVE')`,
+  ),
+  "Unexpected historic squad-status values must be repaired before the new constraint is installed.",
+);
+expect(
+  packageJson.includes('"start": "prisma migrate deploy'),
+  "Production startup must continue to deploy Prisma migrations before serving requests.",
+);
+
+expect(
+  statusService.includes(
+    'export type TeamMemberSquadStatus = "ACTIVE" | "INJURED" | "INACTIVE";',
+  ),
+  "The squad-status service must retain the inactive historic-player state.",
+);
+expect(
+  !statusService.includes('ALTER TABLE "TeamMember"'),
+  "Request handling must not run TeamMember ALTER TABLE statements.",
+);
+expect(
+  statusService.includes(
+    "owned by Prisma migrations; request handling must never run ALTER TABLE",
+  ),
+  "The compatibility helper must document that schema ownership moved to migrations.",
+);
+expect(
+  statusService.includes('"squadStatus" = ${input.status}'),
+  "The central squad-status service must continue to persist the selected status.",
+);
+expect(
+  statusService.includes('input.status === "INACTIVE"'),
+  "Inactive players must continue to receive future-activity cleanup.",
+);
+
+expect(
+  captainAction.includes(
+    'cleanText(value).toUpperCase() === "INACTIVE" ? "INACTIVE" : "ACTIVE"',
+  ),
+  "Captains must continue to be able to choose inactive or active status.",
+);
+expect(
+  captainAction.includes("updateCaptainSquadMemberActivityAction"),
+  "The captain edit page must retain its player activity action.",
+);
+
+expect(
+  reminderJob.includes(
+    `"squadStatus" IN ('INJURED', 'INACTIVE')`,
+  ),
+  "Managed-squad availability reminders must exclude both injured and inactive players.",
+);
+expect(
+  reminderJob.includes("skippedInactiveMembers"),
+  "The managed-squad reminder job must report how many inactive players it excluded.",
+);
+
+if (failures.length > 0) {
+  console.error("\nINACTIVE PLAYER STATUS STORAGE CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log("Inactive player status storage contract passed.");

--- a/src/app/api/jobs/managed-squad-availability-reminders/route.ts
+++ b/src/app/api/jobs/managed-squad-availability-reminders/route.ts
@@ -18,6 +18,11 @@ import { backfillTeamMemberProfilesFromProspects } from "@/lib/teamMemberProfile
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+type UnavailableMemberRow = {
+  id: string;
+  squadStatus: "INJURED" | "INACTIVE";
+};
+
 function addDays(date: Date, days: number) {
   return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
 }
@@ -113,16 +118,22 @@ async function runManagedSquadAvailabilityReminderJob() {
     : [];
 
   const memberIds = members.map((member) => member.id);
-  const injuredRows = memberIds.length
-    ? await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
-        SELECT "id"
+  const unavailableRows = memberIds.length
+    ? await prisma.$queryRaw<UnavailableMemberRow[]>(Prisma.sql`
+        SELECT "id", "squadStatus"
         FROM "TeamMember"
         WHERE "id" IN (${Prisma.join(memberIds)})
-          AND "squadStatus" = 'INJURED'
+          AND "squadStatus" IN ('INJURED', 'INACTIVE')
       `)
     : [];
-  const injuredMemberIds = new Set(injuredRows.map((row) => row.id));
-  const activeMembers = members.filter((member) => !injuredMemberIds.has(member.id));
+  const unavailableMemberIds = new Set(unavailableRows.map((row) => row.id));
+  const activeMembers = members.filter((member) => !unavailableMemberIds.has(member.id));
+  const skippedInjuredMembers = unavailableRows.filter(
+    (row) => row.squadStatus === "INJURED",
+  ).length;
+  const skippedInactiveMembers = unavailableRows.filter(
+    (row) => row.squadStatus === "INACTIVE",
+  ).length;
 
   const membersByTeamId = new Map<string, typeof activeMembers>();
 
@@ -136,7 +147,8 @@ async function runManagedSquadAvailabilityReminderJob() {
   const summary = {
     scannedFixtures: fixtures.length,
     scannedMembers: members.length,
-    skippedInjuredMembers: injuredMemberIds.size,
+    skippedInjuredMembers,
+    skippedInactiveMembers,
     queuedDispatches: 0,
     alreadySent: 0,
     skipped: 0,

--- a/src/lib/managed-squad/squadStatus.ts
+++ b/src/lib/managed-squad/squadStatus.ts
@@ -43,26 +43,14 @@ const FUTURE_FIXTURE_STATUSES = [
   FixtureStatus.POSTPONED,
 ];
 
-export async function ensureTeamMemberSquadStatusColumns(db: DbClient = prisma) {
-  await db.$executeRaw(Prisma.sql`
-    ALTER TABLE "TeamMember"
-      ADD COLUMN IF NOT EXISTS "squadStatus" TEXT NOT NULL DEFAULT 'ACTIVE'
-  `);
-
-  await db.$executeRaw(Prisma.sql`
-    ALTER TABLE "TeamMember"
-      ADD COLUMN IF NOT EXISTS "squadStatusUpdatedAt" TIMESTAMP(3)
-  `);
-
-  await db.$executeRaw(Prisma.sql`
-    ALTER TABLE "TeamMember"
-      ADD COLUMN IF NOT EXISTS "squadStatusNote" TEXT
-  `);
-
-  await db.$executeRaw(Prisma.sql`
-    CREATE INDEX IF NOT EXISTS "TeamMember_teamId_squadStatus_idx"
-      ON "TeamMember"("teamId", "squadStatus")
-  `);
+/**
+ * Compatibility entry point retained for callers that pre-date the real schema
+ * migration. The TeamMember squad-status columns, constraint and index are now
+ * owned by Prisma migrations; request handling must never run ALTER TABLE.
+ */
+export function ensureTeamMemberSquadStatusColumns(db: DbClient = prisma) {
+  void db;
+  return Promise.resolve();
 }
 
 async function cancelQueuedAvailabilityChasesForUnavailablePlayer(input: {


### PR DESCRIPTION
## What caused the error

The captain UI and status service were correctly trying to save `INACTIVE`, but the production database constraint still allowed only `ACTIVE` and `INJURED`. PostgreSQL therefore rejected the main status update and the page showed the generic save error.

## What changed

- adds a real migration that replaces the old constraint with `ACTIVE`, `INJURED` and `INACTIVE`
- normalises any unexpected legacy value before installing the repaired constraint
- stops request handling from repeatedly running `ALTER TABLE` for squad-status storage
- keeps the existing safe cleanup of future availability, selections and open player-fee requests
- ensures inactive players are also excluded from managed-squad availability reminders
- adds a dedicated blocking CI contract to protect the database constraint and reminder behaviour

## Deployment

The existing production start command runs `prisma migrate deploy` before the application starts, so the constraint repair is applied automatically during deployment.

## Verification

The new workflow runs the full production source-preparation chain, the inactive-player contract, Prisma generation/validation and the complete TypeScript check.