### PR TITLE
Show team name on lead commitment page and align reminders

### DIFF
--- a/scripts/seed-league-starter-email-template.cjs
+++ b/scripts/seed-league-starter-email-template.cjs
@@ -124,7 +124,14 @@ const templateData = {
 async function main() {
   await prisma.emailTemplate.upsert({
     where: { key: 'league-starter-guide' },
-    update: templateData,
+    update: {
+      // Keep the subject and body editable in Admin Templates. Only enforce the
+      // secure destination that prevents existing leads being sent through a
+      // duplicate registration form.
+      ctaLabel: 'YES — I WANT TO ENTER A TEAM',
+      ctaUrlKey: 'teamConfirmationUrl',
+      isActive: true,
+    },
     create: {
       key: 'league-starter-guide',
       ...templateData,

--- a/src/app/(admin)/admin/leads/team-commitment-email-actions.ts
+++ b/src/app/(admin)/admin/leads/team-commitment-email-actions.ts
@@ -1,0 +1,286 @@
+"use server";
+
+import {
+  LeadStatus,
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+  NotificationTemplateKind,
+  Prisma,
+} from "@prisma/client";
+import { revalidatePath } from "next/cache";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import {
+  ensureTeamPlaceConfirmationRecord,
+  getTeamPlaceConfirmationStatus,
+} from "@/lib/leads/teamPlaceConfirmation";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+const TEMPLATE_KEY = "team-place-confirmation-email";
+const CTA_LABEL = "YES — I WANT TO ENTER A TEAM";
+
+const TEMPLATE_BODY = [
+  "Hi {{firstName}},",
+  "",
+  "Thanks for your interest in joining SIXFL {{leagueName}}.",
+  "",
+  "We already have your contact details from your enquiry, so we won’t ask you to enter them again.",
+  "",
+  "We now just need to know whether you want to enter a team. On the short confirmation page you can also tell us:",
+  "",
+  "• your team name, if you have chosen one",
+  "• roughly how many players you currently have",
+  "",
+  "{{leagueDetails}}",
+  "",
+  "There is no payment due now and there is no long-term contract tying your team in.",
+  "",
+  "{{cta}}",
+  "",
+  "If you are not entering a team, the same page also lets you tell us that clearly so we can update our list.",
+  "",
+  "Thanks,",
+  "SIXFL",
+].join("\n");
+
+type LeagueDetailsRow = {
+  proposedStartDate: Date | null;
+  costPerTeamPerMatchPence: number | null;
+};
+
+function firstName(value: string | null | undefined) {
+  return value?.trim().split(/\s+/)[0] || "there";
+}
+
+function formatLongDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  }).format(value);
+}
+
+function formatMoney(value: number | null) {
+  if (value === null) return null;
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: value % 100 === 0 ? 0 : 2,
+  }).format(value / 100);
+}
+
+async function ensureTemplate() {
+  return prisma.notificationTemplate.upsert({
+    where: { key: TEMPLATE_KEY },
+    update: {
+      name: "Team commitment email",
+      description:
+        "Secure email asking an existing team lead for a clear decision, team name and approximate squad size without repeating contact details.",
+      kind: NotificationTemplateKind.TRANSACTIONAL,
+      channel: NotificationChannel.EMAIL,
+      audience: NotificationAudience.LEAD,
+      subject: "SIXFL {{leagueName}} — are you entering a team?",
+      body: TEMPLATE_BODY,
+      ctaLabel: CTA_LABEL,
+      ctaUrlKey: "teamConfirmationUrl",
+      isActive: true,
+    },
+    create: {
+      key: TEMPLATE_KEY,
+      name: "Team commitment email",
+      description:
+        "Secure email asking an existing team lead for a clear decision, team name and approximate squad size without repeating contact details.",
+      kind: NotificationTemplateKind.TRANSACTIONAL,
+      channel: NotificationChannel.EMAIL,
+      audience: NotificationAudience.LEAD,
+      subject: "SIXFL {{leagueName}} — are you entering a team?",
+      body: TEMPLATE_BODY,
+      ctaLabel: CTA_LABEL,
+      ctaUrlKey: "teamConfirmationUrl",
+      isActive: true,
+    },
+  });
+}
+
+export async function sendTeamCommitmentEmailAction(formData: FormData) {
+  const { user } = await requireAdmin();
+  const leadId = String(formData.get("leadId") ?? "").trim();
+
+  if (!leadId) return { ok: false, error: "Missing lead id." };
+
+  const [lead, confirmation] = await Promise.all([
+    prisma.interestLead.findUnique({
+      where: { id: leadId },
+      select: {
+        id: true,
+        interestType: true,
+        status: true,
+        convertedTeamId: true,
+        contactName: true,
+        teamName: true,
+        email: true,
+        phone: true,
+        leagueId: true,
+        league: {
+          select: {
+            id: true,
+            name: true,
+            season: true,
+            venueName: true,
+            kickoffInfo: true,
+            competition: {
+              select: {
+                currentLeague: {
+                  select: {
+                    id: true,
+                    name: true,
+                    season: true,
+                    venueName: true,
+                    kickoffInfo: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }),
+    getTeamPlaceConfirmationStatus(leadId),
+  ]);
+
+  if (!lead) return { ok: false, error: "Lead not found." };
+  if (lead.interestType !== "TEAM") {
+    return { ok: false, error: "Only team leads can receive this email." };
+  }
+  if (lead.convertedTeamId) {
+    return { ok: false, error: "This lead has already been converted into a SIXFL team." };
+  }
+  if (lead.status === LeadStatus.CLOSED) {
+    return { ok: false, error: "This lead is closed. Reopen it before sending another commitment link." };
+  }
+  if (confirmation?.status === "CONFIRMED") {
+    return { ok: false, error: "This lead has already confirmed that they want to enter a team." };
+  }
+  if (confirmation?.status === "DECLINED") {
+    return { ok: false, error: "This lead has already said they are not entering a team." };
+  }
+
+  const email = lead.email?.trim().toLowerCase();
+  if (!email) return { ok: false, error: "This lead does not have an email address." };
+  if (!lead.leagueId || !lead.league) {
+    return {
+      ok: false,
+      error: "Set a prospective league on this lead before sending the commitment email.",
+    };
+  }
+
+  const effectiveLeague = lead.league.competition?.currentLeague ?? lead.league;
+  const leagueName = `${effectiveLeague.name}${effectiveLeague.season ? ` · ${effectiveLeague.season}` : ""}`;
+  const detailsRows = await prisma.$queryRaw<LeagueDetailsRow[]>(Prisma.sql`
+    SELECT
+      "proposedStartDate" AS "proposedStartDate",
+      "costPerTeamPerMatchPence"::int AS "costPerTeamPerMatchPence"
+    FROM "League"
+    WHERE "id" = ${effectiveLeague.id}
+    LIMIT 1
+  `);
+  const details = detailsRows[0] ?? null;
+  const detailLines = [
+    `League: ${leagueName}`,
+    effectiveLeague.venueName?.trim() && effectiveLeague.venueName.trim().toUpperCase() !== "TBC"
+      ? `Venue: ${effectiveLeague.venueName.trim()}`
+      : null,
+    effectiveLeague.kickoffInfo?.trim()
+      ? `Kick-offs: ${effectiveLeague.kickoffInfo.trim()}`
+      : null,
+    details?.proposedStartDate
+      ? `Planned start: ${formatLongDate(details.proposedStartDate)}`
+      : null,
+    formatMoney(details?.costPerTeamPerMatchPence ?? null)
+      ? `Cost: ${formatMoney(details?.costPerTeamPerMatchPence ?? null)} per team per match`
+      : null,
+  ].filter(Boolean).join("\n");
+
+  await ensureTemplate();
+  const secureLink = await ensureTeamPlaceConfirmationRecord(lead.id);
+  const displayName = lead.contactName?.trim() || lead.teamName?.trim() || email;
+
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.LEAD,
+    sourceId: lead.id,
+    audience: NotificationAudience.LEAD,
+    displayName,
+    email,
+    phone: lead.phone,
+    transactionalEmailOptIn: true,
+    marketingEmailOptIn: true,
+    metadata: {
+      leadId: lead.id,
+      leagueId: effectiveLeague.id,
+      originalLeadLeagueId: lead.leagueId,
+      leagueName,
+      entityType: "TEAM_LEAD_COMMITMENT",
+    },
+  });
+
+  try {
+    const dispatch = await queueNotificationFromTemplate({
+      templateKey: TEMPLATE_KEY,
+      recipientId: recipient.id,
+      variables: {
+        firstName: firstName(lead.contactName),
+        fullName: lead.contactName?.trim() || "",
+        contactName: lead.contactName?.trim() || "",
+        teamName: lead.teamName?.trim() || "",
+        leagueName,
+        leagueDetails: detailLines,
+        teamConfirmationUrl: secureLink.url,
+      },
+      sourceType: "LEAD_TEAM_CONFIRMATION",
+      sourceId: lead.id,
+      metadata: {
+        origin: "lead_team_commitment",
+        originLabel: "Team commitment email",
+        leadId: lead.id,
+        leagueId: effectiveLeague.id,
+        leagueName,
+        ctaUrl: secureLink.url,
+      },
+      createdByUserId: user?.id ?? null,
+    });
+
+    await logNotificationDispatchToThread({ dispatch, recipient });
+    await prisma.interestLeadEmail.create({
+      data: {
+        interestLeadId: lead.id,
+        subject: dispatch.subject ?? `SIXFL ${leagueName} — are you entering a team?`,
+        body: dispatch.bodyText,
+        sentTo: email,
+      },
+    });
+
+    if (lead.status === LeadStatus.NEW) {
+      await prisma.interestLead.update({
+        where: { id: lead.id },
+        data: { status: LeadStatus.CONTACTED, contactedAt: new Date() },
+      });
+    }
+
+    revalidatePath("/admin/leads");
+    revalidatePath(`/admin/leads/${lead.id}`);
+    revalidatePath("/admin/messaging");
+
+    return { ok: true, dispatchId: dispatch.id, status: dispatch.status };
+  } catch (error) {
+    console.error("sendTeamCommitmentEmailAction error", error);
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "The commitment email could not be queued.",
+    };
+  }
+}

--- a/src/app/(admin)/admin/leads/team-confirmation-chase-actions.ts
+++ b/src/app/(admin)/admin/leads/team-confirmation-chase-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import {
+  LeadStatus,
   NotificationAudience,
   NotificationChannel,
   NotificationDispatchStatus,
@@ -26,15 +27,17 @@ const CHASE_COOLDOWN_MS = 60 * 60 * 1000;
 const TEAM_CONFIRMATION_CHASE_BODY = [
   "Hi {{firstName}},",
   "",
-  "Just a quick reminder to complete the short SIXFL team form we sent you for {{leagueName}}.",
+  "Just a quick reminder about your SIXFL {{leagueName}} enquiry.",
   "",
-  "We’re now putting the league together and your response helps us confirm which teams are still looking to play.",
+  "We already have your contact details. We now only need a clear yes or no on whether you want to enter a team.",
   "",
-  "It only takes a minute. Please use the button below to confirm your team’s place and details.",
+  "If the answer is yes, the short page also lets you add your team name if you have chosen one and tell us roughly how many players you have.",
+  "",
+  "There is no payment due now and there is no long-term contract tying your team in.",
   "",
   "{{cta}}",
   "",
-  "If you’re still interested but need a little more time, completing the form lets us know to keep your team in our planning. If you’re no longer looking to join, just reply to this email and we’ll update our list.",
+  "If you are not entering a team, please choose the no option on the same page so we can update our list and stop chasing you.",
   "",
   "Thanks,",
   "SIXFL",
@@ -48,29 +51,29 @@ async function ensureChaseTemplate() {
   return prisma.notificationTemplate.upsert({
     where: { key: TEAM_CONFIRMATION_CHASE_TEMPLATE_KEY },
     update: {
-      name: "Team place confirmation chase",
+      name: "Team commitment reminder",
       description:
-        "Friendly reminder asking a pending team lead to complete the team place confirmation form.",
+        "Reminder asking an existing team lead for a clear yes/no decision without repeating their contact details.",
       kind: NotificationTemplateKind.TRANSACTIONAL,
       channel: NotificationChannel.EMAIL,
       audience: NotificationAudience.LEAD,
-      subject: "Quick reminder — complete your SIXFL team form",
+      subject: "SIXFL {{leagueName}} — are you entering a team?",
       body: TEAM_CONFIRMATION_CHASE_BODY,
-      ctaLabel: "Complete team form",
+      ctaLabel: "YES — I WANT TO ENTER A TEAM",
       ctaUrlKey: "teamConfirmationUrl",
       isActive: true,
     },
     create: {
       key: TEAM_CONFIRMATION_CHASE_TEMPLATE_KEY,
-      name: "Team place confirmation chase",
+      name: "Team commitment reminder",
       description:
-        "Friendly reminder asking a pending team lead to complete the team place confirmation form.",
+        "Reminder asking an existing team lead for a clear yes/no decision without repeating their contact details.",
       kind: NotificationTemplateKind.TRANSACTIONAL,
       channel: NotificationChannel.EMAIL,
       audience: NotificationAudience.LEAD,
-      subject: "Quick reminder — complete your SIXFL team form",
+      subject: "SIXFL {{leagueName}} — are you entering a team?",
       body: TEAM_CONFIRMATION_CHASE_BODY,
-      ctaLabel: "Complete team form",
+      ctaLabel: "YES — I WANT TO ENTER A TEAM",
       ctaUrlKey: "teamConfirmationUrl",
       isActive: true,
     },
@@ -81,9 +84,7 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
   const { user } = await requireAdmin();
   const leadId = String(formData.get("leadId") ?? "").trim();
 
-  if (!leadId) {
-    return { ok: false, error: "Missing lead id." };
-  }
+  if (!leadId) return { ok: false, error: "Missing lead id." };
 
   const [lead, confirmation] = await Promise.all([
     prisma.interestLead.findUnique({
@@ -91,6 +92,8 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
       select: {
         id: true,
         interestType: true,
+        status: true,
+        convertedTeamId: true,
         contactName: true,
         teamName: true,
         email: true,
@@ -104,11 +107,7 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
             competition: {
               select: {
                 currentLeague: {
-                  select: {
-                    id: true,
-                    name: true,
-                    season: true,
-                  },
+                  select: { id: true, name: true, season: true },
                 },
               },
             },
@@ -119,30 +118,35 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
     getTeamPlaceConfirmationStatus(leadId),
   ]);
 
-  if (!lead) {
-    return { ok: false, error: "Lead not found." };
-  }
-
+  if (!lead) return { ok: false, error: "Lead not found." };
   if (lead.interestType !== "TEAM") {
-    return { ok: false, error: "Only team leads can receive this chase email." };
+    return { ok: false, error: "Only team leads can receive this reminder." };
   }
-
+  if (lead.convertedTeamId) {
+    return { ok: false, error: "This lead has already been converted into a SIXFL team." };
+  }
+  if (lead.status === LeadStatus.CLOSED) {
+    return { ok: false, error: "This lead is closed and should not be chased." };
+  }
+  if (confirmation?.status === "CONFIRMED") {
+    return { ok: false, error: "This lead has already confirmed that they want to enter a team." };
+  }
+  if (confirmation?.status === "DECLINED") {
+    return { ok: false, error: "This lead has already said they are not entering a team." };
+  }
   if (!confirmation?.sentAt || confirmation.status !== "PENDING") {
     return {
       ok: false,
-      error: "This team is not waiting on a confirmation form, so it does not need chasing.",
+      error: "Send the decision link first. There is not yet a pending response to chase.",
     };
   }
 
   const email = lead.email?.trim().toLowerCase();
-  if (!email) {
-    return { ok: false, error: "This lead does not have an email address." };
-  }
-
+  if (!email) return { ok: false, error: "This lead does not have an email address." };
   if (!lead.leagueId || !lead.league) {
     return {
       ok: false,
-      error: "Set a prospective league on this lead before sending a chase.",
+      error: "Set a prospective league on this lead before sending a reminder.",
     };
   }
 
@@ -166,18 +170,15 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
   if (recentChase) {
     return {
       ok: false,
-      error: "A chase has already been sent for this team within the last hour.",
+      error: "A reminder has already been sent for this team within the last hour.",
     };
   }
 
   await ensureChaseTemplate();
 
   const effectiveLeague = lead.league.competition?.currentLeague ?? lead.league;
-  const leagueName = `${effectiveLeague.name}${
-    effectiveLeague.season ? ` · ${effectiveLeague.season}` : ""
-  }`;
-  const displayName =
-    lead.contactName?.trim() || lead.teamName?.trim() || email;
+  const leagueName = `${effectiveLeague.name}${effectiveLeague.season ? ` · ${effectiveLeague.season}` : ""}`;
+  const displayName = lead.contactName?.trim() || lead.teamName?.trim() || email;
   const confirmationUrl = getTeamPlaceConfirmationUrl(lead.id);
 
   const recipient = await upsertNotificationRecipient({
@@ -196,7 +197,7 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
       leagueName,
       teamName: lead.teamName,
       contactName: lead.contactName,
-      entityType: "TEAM_LEAD_CONFIRMATION_CHASE",
+      entityType: "TEAM_LEAD_COMMITMENT_REMINDER",
     },
   });
 
@@ -215,8 +216,8 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
       sourceType: TEAM_CONFIRMATION_CHASE_SOURCE_TYPE,
       sourceId: lead.id,
       metadata: {
-        origin: "lead_team_confirmation_chase",
-        originLabel: "Team place confirmation chase",
+        origin: "lead_team_commitment_reminder",
+        originLabel: "Team commitment reminder",
         leadId: lead.id,
         leagueId: effectiveLeague.id,
         originalLeadLeagueId: lead.leagueId,
@@ -228,11 +229,10 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
     });
 
     await logNotificationDispatchToThread({ dispatch, recipient });
-
     await prisma.interestLeadEmail.create({
       data: {
         interestLeadId: lead.id,
-        subject: dispatch.subject ?? "Quick reminder — complete your SIXFL team form",
+        subject: dispatch.subject ?? `SIXFL ${leagueName} — are you entering a team?`,
         body: dispatch.bodyText,
         sentTo: email,
       },
@@ -247,10 +247,7 @@ export async function sendTeamPlaceConfirmationChaseAction(formData: FormData) {
     console.error("sendTeamPlaceConfirmationChaseAction error", error);
     return {
       ok: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "The chase email could not be queued.",
+      error: error instanceof Error ? error.message : "The reminder email could not be queued.",
     };
   }
 }

--- a/src/app/(public)/team-confirmation/[token]/page.tsx
+++ b/src/app/(public)/team-confirmation/[token]/page.tsx
@@ -2,7 +2,7 @@
 // File: src/app/(public)/team-confirmation/[token]/page.tsx
 // ========================================
 
-import { Prisma } from "@prisma/client";
+import { LeadStatus, Prisma } from "@prisma/client";
 import Link from "next/link";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
@@ -19,7 +19,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export const metadata = {
-  title: "Confirm Team Place | SIXFL",
+  title: "Confirm Your Team | SIXFL",
 };
 
 type PageProps = {
@@ -27,9 +27,10 @@ type PageProps = {
   searchParams?: Promise<{
     confirmed?: string;
     declined?: string;
+    commitmentSaved?: string;
     teamNameSaved?: string;
-    teamNameLater?: string;
     teamNameError?: string;
+    squadError?: string;
   }>;
 };
 
@@ -39,12 +40,34 @@ type LeagueConfirmationDetails = {
   costPerTeamPerMatchPence: number | null;
 };
 
+const SQUAD_SIZE_LABELS = {
+  "6": "6 players",
+  "7": "7 players",
+  "8": "8 players",
+  "9+": "9 or more players",
+  building: "still putting the squad together",
+} as const;
+
+type SquadSizeValue = keyof typeof SQUAD_SIZE_LABELS;
+
 function formatLongDate(value: Date) {
   return new Intl.DateTimeFormat("en-GB", {
     timeZone: "Europe/London",
     weekday: "long",
     day: "numeric",
     month: "long",
+  }).format(value);
+}
+
+function formatNoteDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
   }).format(value);
 }
 
@@ -69,10 +92,22 @@ function formatVenue(value: string | null | undefined) {
   return venue;
 }
 
+function parseTeamName(value: FormDataEntryValue | null) {
+  return String(value ?? "").trim().replace(/\s+/g, " ");
+}
+
+function isSquadSizeValue(value: string): value is SquadSizeValue {
+  return Object.prototype.hasOwnProperty.call(SQUAD_SIZE_LABELS, value);
+}
+
+function confirmationPath(token: string, query: string) {
+  return `/team-confirmation/${encodeURIComponent(token)}?${query}`;
+}
+
 async function getLeagueConfirmationDetails(leagueId: string | null | undefined) {
   if (!leagueId) return null;
 
-  const rows = await prisma.$queryRaw<Array<LeagueConfirmationDetails>>(Prisma.sql`
+  const rows = await prisma.$queryRaw<LeagueConfirmationDetails[]>(Prisma.sql`
     SELECT
       "proposedStartDate" AS "proposedStartDate",
       "minutesPerGame"::int AS "minutesPerGame",
@@ -85,55 +120,22 @@ async function getLeagueConfirmationDetails(leagueId: string | null | undefined)
   return rows[0] ?? null;
 }
 
-async function confirmTeamPlaceAction(formData: FormData) {
+async function confirmTeamCommitmentAction(formData: FormData) {
   "use server";
 
   const token = String(formData.get("token") ?? "").trim();
   const leadId = verifyTeamPlaceConfirmationToken(token);
+  if (!leadId) throw new Error("This confirmation link is not valid.");
 
-  if (!leadId) {
-    throw new Error("This confirmation link is not valid.");
+  const teamNameInput = parseTeamName(formData.get("teamName"));
+  const squadSizeInput = String(formData.get("squadSize") ?? "").trim();
+
+  if (teamNameInput && (teamNameInput.length < 2 || teamNameInput.length > 80)) {
+    redirect(confirmationPath(token, "teamNameError=invalid"));
   }
 
-  await confirmTeamPlaceFromLead(leadId);
-  revalidatePath("/admin/leads");
-  revalidatePath(`/admin/leads/${leadId}`);
-  redirect(`/team-confirmation/${encodeURIComponent(token)}?confirmed=1`);
-}
-
-async function declineTeamPlaceAction(formData: FormData) {
-  "use server";
-
-  const token = String(formData.get("token") ?? "").trim();
-  const leadId = verifyTeamPlaceConfirmationToken(token);
-
-  if (!leadId) {
-    throw new Error("This confirmation link is not valid.");
-  }
-
-  await declineTeamPlaceFromLead(leadId);
-  revalidatePath("/admin/leads");
-  revalidatePath(`/admin/leads/${leadId}`);
-  redirect(`/team-confirmation/${encodeURIComponent(token)}?declined=1`);
-}
-
-async function saveTeamNameAction(formData: FormData) {
-  "use server";
-
-  const token = String(formData.get("token") ?? "").trim();
-  const leadId = verifyTeamPlaceConfirmationToken(token);
-  const teamName = String(formData.get("teamName") ?? "")
-    .trim()
-    .replace(/\s+/g, " ");
-
-  if (!leadId) {
-    throw new Error("This confirmation link is not valid.");
-  }
-
-  if (teamName.length < 2 || teamName.length > 80) {
-    redirect(
-      `/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameError=invalid`,
-    );
+  if (!isSquadSizeValue(squadSizeInput)) {
+    redirect(confirmationPath(token, "squadError=invalid"));
   }
 
   const [lead, confirmation] = await Promise.all([
@@ -141,27 +143,111 @@ async function saveTeamNameAction(formData: FormData) {
       where: { id: leadId },
       select: {
         id: true,
+        interestType: true,
         status: true,
         convertedTeamId: true,
+        teamName: true,
+        message: true,
       },
     }),
     getTeamPlaceConfirmationStatus(leadId),
   ]);
 
-  if (!lead) {
-    throw new Error("Lead not found.");
+  if (!lead) throw new Error("Lead not found.");
+  if (lead.interestType !== "TEAM") {
+    throw new Error("This link is not for a team enquiry.");
   }
-
   if (lead.convertedTeamId) {
-    redirect(
-      `/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameError=team-created`,
-    );
+    redirect(confirmationPath(token, "confirmed=1"));
+  }
+  if (lead.status === LeadStatus.CLOSED || confirmation?.status === "DECLINED") {
+    redirect(confirmationPath(token, "declined=1"));
   }
 
-  const placeConfirmed = confirmation?.status === "CONFIRMED" || lead.status === "QUALIFIED";
-  if (!placeConfirmed) {
-    throw new Error("Confirm the team place before saving a team name.");
+  const wasAlreadyConfirmed =
+    confirmation?.status === "CONFIRMED" || lead.status === LeadStatus.QUALIFIED;
+
+  if (!wasAlreadyConfirmed) {
+    await confirmTeamPlaceFromLead(lead.id);
   }
+
+  const effectiveTeamName = teamNameInput || lead.teamName?.trim() || "not decided yet";
+  const commitmentNote = [
+    `Team commitment confirmed via secure link (${formatNoteDate(new Date())}).`,
+    `Team name: ${effectiveTeamName}.`,
+    `Approximate squad: ${SQUAD_SIZE_LABELS[squadSizeInput]}.`,
+  ].join(" ");
+
+  await prisma.interestLead.update({
+    where: { id: lead.id },
+    data: {
+      ...(teamNameInput ? { teamName: teamNameInput } : {}),
+      ...(!wasAlreadyConfirmed
+        ? {
+            message: lead.message?.trim()
+              ? `${lead.message.trim()}\n\n${commitmentNote}`
+              : commitmentNote,
+          }
+        : {}),
+    },
+  });
+
+  revalidatePath("/admin/leads");
+  revalidatePath(`/admin/leads/${lead.id}`);
+  revalidatePath(`/team-confirmation/${encodeURIComponent(token)}`);
+  redirect(confirmationPath(token, "confirmed=1&commitmentSaved=1"));
+}
+
+async function declineTeamAction(formData: FormData) {
+  "use server";
+
+  const token = String(formData.get("token") ?? "").trim();
+  const leadId = verifyTeamPlaceConfirmationToken(token);
+  if (!leadId) throw new Error("This confirmation link is not valid.");
+
+  const lead = await prisma.interestLead.findUnique({
+    where: { id: leadId },
+    select: { id: true, interestType: true, convertedTeamId: true },
+  });
+
+  if (!lead) throw new Error("Lead not found.");
+  if (lead.interestType !== "TEAM") throw new Error("This link is not for a team enquiry.");
+  if (lead.convertedTeamId) redirect(confirmationPath(token, "confirmed=1"));
+
+  await declineTeamPlaceFromLead(lead.id);
+  revalidatePath("/admin/leads");
+  revalidatePath(`/admin/leads/${lead.id}`);
+  revalidatePath(`/team-confirmation/${encodeURIComponent(token)}`);
+  redirect(confirmationPath(token, "declined=1"));
+}
+
+async function saveTeamNameAction(formData: FormData) {
+  "use server";
+
+  const token = String(formData.get("token") ?? "").trim();
+  const leadId = verifyTeamPlaceConfirmationToken(token);
+  const teamName = parseTeamName(formData.get("teamName"));
+
+  if (!leadId) throw new Error("This confirmation link is not valid.");
+  if (teamName.length < 2 || teamName.length > 80) {
+    redirect(confirmationPath(token, "confirmed=1&teamNameError=invalid"));
+  }
+
+  const [lead, confirmation] = await Promise.all([
+    prisma.interestLead.findUnique({
+      where: { id: leadId },
+      select: { id: true, interestType: true, convertedTeamId: true, status: true },
+    }),
+    getTeamPlaceConfirmationStatus(leadId),
+  ]);
+
+  if (!lead) throw new Error("Lead not found.");
+  if (lead.interestType !== "TEAM") throw new Error("This link is not for a team enquiry.");
+  if (lead.convertedTeamId) redirect(confirmationPath(token, "confirmed=1"));
+
+  const isConfirmed =
+    confirmation?.status === "CONFIRMED" || lead.status === LeadStatus.QUALIFIED;
+  if (!isConfirmed) throw new Error("Confirm that you want to enter a team first.");
 
   await prisma.interestLead.update({
     where: { id: lead.id },
@@ -171,9 +257,7 @@ async function saveTeamNameAction(formData: FormData) {
   revalidatePath("/admin/leads");
   revalidatePath(`/admin/leads/${lead.id}`);
   revalidatePath(`/team-confirmation/${encodeURIComponent(token)}`);
-  redirect(
-    `/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameSaved=1`,
-  );
+  redirect(confirmationPath(token, "confirmed=1&teamNameSaved=1"));
 }
 
 function InvalidLinkCard() {
@@ -181,11 +265,11 @@ function InvalidLinkCard() {
     <main className="min-h-screen bg-[#07130f] px-4 py-10 text-white">
       <section className="mx-auto max-w-2xl rounded-3xl border border-red-400/20 bg-red-500/10 p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
         <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-red-200/80">
-          Team place confirmation
+          SIXFL team decision
         </p>
-        <h1 className="mt-3 text-2xl font-semibold">This confirmation link is not valid</h1>
+        <h1 className="mt-3 text-2xl font-semibold">This link is not valid</h1>
         <p className="mt-3 text-sm leading-6 text-red-100/80">
-          Please reply to SIXFL and we’ll send you a fresh confirmation link.
+          Please reply to SIXFL and we’ll send you a fresh link.
         </p>
       </section>
     </main>
@@ -196,7 +280,6 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
   const { token } = await params;
   const sp = (await searchParams) ?? {};
   const leadId = verifyTeamPlaceConfirmationToken(token);
-
   if (!leadId) return <InvalidLinkCard />;
 
   const [lead, confirmation] = await Promise.all([
@@ -204,10 +287,10 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
       where: { id: leadId },
       select: {
         id: true,
+        interestType: true,
         contactName: true,
         teamName: true,
         area: true,
-        leagueType: true,
         status: true,
         convertedTeamId: true,
         league: {
@@ -241,7 +324,7 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
     getTeamPlaceConfirmationStatus(leadId),
   ]);
 
-  if (!lead) return <InvalidLinkCard />;
+  if (!lead || lead.interestType !== "TEAM") return <InvalidLinkCard />;
 
   const effectiveLeague = lead.league?.competition?.currentLeague ?? lead.league;
   const leagueDetails = await getLeagueConfirmationDetails(effectiveLeague?.id);
@@ -249,80 +332,68 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
     ? `${effectiveLeague.name}${effectiveLeague.season ? ` · ${effectiveLeague.season}` : ""}`
     : lead.area
       ? `${lead.area} SIXFL league`
-      : "the SIXFL league";
-  const startDateLabel = leagueDetails?.proposedStartDate
-    ? formatLongDate(leagueDetails.proposedStartDate)
-    : null;
-  const matchNightLabel = formatPreferredNight(effectiveLeague?.dayOfWeek);
-  const matchLengthLabel = leagueDetails?.minutesPerGame
-    ? `${leagueDetails.minutesPerGame} minute matches`
-    : null;
-  const fee = formatCurrencyPence(leagueDetails?.costPerTeamPerMatchPence ?? null);
-  const feeLabel = fee ? `${fee} per team per match` : null;
-  const locationLabel =
-    formatVenue(effectiveLeague?.venueName) ||
-    effectiveLeague?.area?.trim() ||
-    lead.area?.trim() ||
-    null;
-  const kickoffLabel = effectiveLeague?.kickoffInfo?.trim() || null;
+      : "your SIXFL league";
 
   const isConfirmed =
     sp.confirmed === "1" ||
     confirmation?.status === "CONFIRMED" ||
-    lead.status === "QUALIFIED";
+    lead.status === LeadStatus.QUALIFIED;
   const isDeclined =
     sp.declined === "1" ||
     confirmation?.status === "DECLINED" ||
-    lead.status === "CLOSED";
+    lead.status === LeadStatus.CLOSED;
   const savedTeamName = lead.teamName?.trim() || "";
-  const leadTitle = savedTeamName || "your team";
-  const leadCardTitle = savedTeamName || "Your team";
-  const confirmationPrompt = startDateLabel
-    ? `Please confirm whether ${leadTitle} would like a place in ${leagueName}, planned to start ${startDateLabel}.`
-    : `Please confirm whether ${leadTitle} would like a place in ${leagueName}.`;
-  const detailPills = [
-    startDateLabel ? `${startDateLabel} start` : matchNightLabel ? `${matchNightLabel} nights` : null,
-    matchLengthLabel,
-    feeLabel,
-    locationLabel,
-    kickoffLabel,
+  const firstName = lead.contactName?.trim().split(/\s+/)[0] || "there";
+  const fee = formatCurrencyPence(leagueDetails?.costPerTeamPerMatchPence ?? null);
+  const details = [
+    formatPreferredNight(effectiveLeague?.dayOfWeek)
+      ? `${formatPreferredNight(effectiveLeague?.dayOfWeek)} evenings`
+      : null,
+    formatVenue(effectiveLeague?.venueName) || effectiveLeague?.area?.trim() || lead.area?.trim(),
+    effectiveLeague?.kickoffInfo?.trim() || null,
+    leagueDetails?.proposedStartDate
+      ? `Planned start ${formatLongDate(leagueDetails.proposedStartDate)}`
+      : null,
+    leagueDetails?.minutesPerGame ? `${leagueDetails.minutesPerGame} minute matches` : null,
+    fee ? `${fee} per team per match` : null,
   ].filter((value): value is string => Boolean(value));
+
   const teamNameError =
     sp.teamNameError === "invalid"
-      ? "Please enter a team name between 2 and 80 characters."
-      : sp.teamNameError === "team-created"
-        ? "This team has already been created in SIXFL, so the lead name can no longer be changed here."
-        : null;
+      ? "Enter a team name between 2 and 80 characters, or leave it blank if it is not decided yet."
+      : null;
+  const squadError =
+    sp.squadError === "invalid" ? "Please choose the option that best describes your squad." : null;
 
   return (
     <main className="min-h-screen bg-[#07130f] px-4 py-10 text-white">
       <div className="mx-auto max-w-3xl space-y-6">
-        <section className="rounded-3xl border border-emerald-400/15 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.03))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
+        <section className="rounded-3xl border border-emerald-400/15 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.03))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)] sm:p-8">
           <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-300/80">
-            SIXFL team confirmation
+            SIXFL team decision
           </p>
           <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
             {isConfirmed
               ? lead.convertedTeamId
                 ? "Your SIXFL team is set up"
-                : "Your place is reserved"
+                : "Your team commitment is recorded"
               : isDeclined
-                ? "Your place has been released"
-                : "Confirm your team place"}
+                ? "Thanks for letting us know"
+                : `Hi ${firstName} — are you entering a team?`}
           </h1>
           <p className="mt-3 text-sm leading-6 text-white/70">
             {isConfirmed
               ? lead.convertedTeamId
-                ? `${leadCardTitle} has now been set up for ${leagueName}.`
-                : `Thanks — we’ve reserved a place for ${leadTitle} in ${leagueName}. No team or fixtures have been created automatically.`
+                ? `${savedTeamName || "Your team"} has already been set up for ${leagueName}.`
+                : `SIXFL has recorded that you want to enter a team in ${leagueName}.`
               : isDeclined
-                ? "Thanks for letting us know. We’ll release the space for another team."
-                : confirmationPrompt}
+                ? `We’ve recorded that you are not entering a team in ${leagueName}.`
+                : `We already have your contact details from your enquiry. We only need your decision and a couple of useful team details.`}
           </p>
 
-          {detailPills.length ? (
+          {details.length ? (
             <div className="mt-5 flex flex-wrap gap-2">
-              {detailPills.map((detail) => (
+              {details.map((detail) => (
                 <span
                   key={detail}
                   className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/75"
@@ -334,129 +405,158 @@ export default async function TeamConfirmationPage({ params, searchParams }: Pag
           ) : null}
         </section>
 
-        <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+        <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 sm:p-8">
           {isConfirmed ? (
-            lead.convertedTeamId ? (
-              <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100/85">
-                Your team has been set up by SIXFL. We’ll use the captain details already provided for the next steps.
-              </div>
-            ) : (
-              <div className="space-y-5">
-                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100/85">
-                  Your place is reserved. SIXFL will review the lead and create the team manually when the details are ready.
+            <div className="space-y-5">
+              {sp.commitmentSaved === "1" ? (
+                <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100">
+                  Thank you — your positive team decision has been sent to SIXFL. We have not asked you to repeat any contact details.
                 </div>
+              ) : null}
 
-                {sp.teamNameSaved === "1" && savedTeamName ? (
-                  <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm leading-6 text-sky-100/90">
-                    Team name saved as <strong>{savedTeamName}</strong>. This has updated your SIXFL enquiry but has not created a team yet.
-                  </div>
-                ) : null}
+              {sp.teamNameSaved === "1" ? (
+                <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm leading-6 text-sky-100">
+                  Team name updated successfully.
+                </div>
+              ) : null}
 
-                {sp.teamNameLater === "1" ? (
-                  <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
-                    <h2 className="text-lg font-semibold text-white">Team name not decided yet?</h2>
-                    <p className="mt-2 text-sm leading-6 text-white/65">
-                      No problem. Your place remains reserved. Keep this confirmation link and come back when you have decided your team name.
-                    </p>
-                    <Link
-                      href={`/team-confirmation/${encodeURIComponent(token)}?confirmed=1`}
-                      className="mt-4 inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-semibold text-white/85 transition hover:bg-white/[0.09]"
+              {lead.convertedTeamId ? (
+                <div className="rounded-2xl border border-white/10 bg-black/20 p-5 text-sm leading-6 text-white/70">
+                  SIXFL already has the details needed for this team. We’ll contact you with the next steps.
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+                  <h2 className="text-lg font-semibold text-white">
+                    {savedTeamName ? "Need to correct the team name?" : "Team name not decided yet?"}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-white/60">
+                    {savedTeamName
+                      ? `We currently have “${savedTeamName}”. You can correct it below before SIXFL creates the team.`
+                      : "That’s fine. Your commitment is already recorded and you can add the team name here when it is decided."}
+                  </p>
+
+                  {teamNameError ? (
+                    <div className="mt-4 rounded-xl border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                      {teamNameError}
+                    </div>
+                  ) : null}
+
+                  <form action={saveTeamNameAction} className="mt-5 flex flex-col gap-3 sm:flex-row">
+                    <input type="hidden" name="token" value={token} />
+                    <input
+                      name="teamName"
+                      type="text"
+                      required
+                      minLength={2}
+                      maxLength={80}
+                      defaultValue={savedTeamName}
+                      placeholder="e.g. Richmond Rovers"
+                      className="min-w-0 flex-1 rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition placeholder:text-white/30 focus:border-emerald-400/50"
+                    />
+                    <button
+                      type="submit"
+                      className="rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-emerald-500"
                     >
-                      Add team name now
-                    </Link>
-                  </div>
-                ) : (
-                  <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
-                    <h2 className="text-lg font-semibold text-white">
-                      {savedTeamName ? "Confirm or update your team name" : "Confirm your team name"}
-                    </h2>
-                    <p className="mt-2 text-sm leading-6 text-white/60">
-                      {savedTeamName
-                        ? "Check the name below. You can update it here while SIXFL is still preparing your team."
-                        : "If you already know the team name, add it now. If not, you can come back to this same link and confirm it later."}
-                    </p>
-
-                    {teamNameError ? (
-                      <div className="mt-4 rounded-xl border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-                        {teamNameError}
-                      </div>
-                    ) : null}
-
-                    <form action={saveTeamNameAction} className="mt-5 space-y-4">
-                      <input type="hidden" name="token" value={token} />
-                      <label className="block">
-                        <span className="text-sm font-semibold text-white/80">Team name</span>
-                        <input
-                          name="teamName"
-                          type="text"
-                          required
-                          minLength={2}
-                          maxLength={80}
-                          defaultValue={savedTeamName}
-                          placeholder="e.g. Richmond Rovers"
-                          className="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition placeholder:text-white/30 focus:border-emerald-400/50"
-                        />
-                      </label>
-                      <div className="flex flex-col gap-3 sm:flex-row">
-                        <button
-                          type="submit"
-                          className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(16,185,129,0.2)] transition hover:bg-emerald-500"
-                        >
-                          {savedTeamName ? "Update team name" : "Save team name"}
-                        </button>
-                        <Link
-                          href={`/team-confirmation/${encodeURIComponent(token)}?confirmed=1&teamNameLater=1`}
-                          className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/75 transition hover:bg-white/[0.08]"
-                        >
-                          I’ll confirm the team name later
-                        </Link>
-                      </div>
-                    </form>
-                  </div>
-                )}
-              </div>
-            )
+                      {savedTeamName ? "Update team name" : "Save team name"}
+                    </button>
+                  </form>
+                </div>
+              )}
+            </div>
           ) : isDeclined ? (
-            <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm leading-6 text-amber-100/85">
-              No problem. Your team will not be included in fixture planning unless you contact SIXFL again.
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 p-4 text-sm leading-6 text-amber-100/90">
+                Your enquiry has been updated and SIXFL will not continue chasing you for a team decision.
+              </div>
+              <p className="text-sm leading-6 text-white/60">
+                Changed your mind? Reply to the SIXFL email and we can reopen the enquiry.
+              </p>
             </div>
           ) : (
-            <div className="space-y-5">
+            <div className="space-y-6">
               <div>
-                <h2 className="text-lg font-semibold text-white">{leadCardTitle}</h2>
+                <h2 className="text-xl font-semibold text-white">What we need from you</h2>
                 <p className="mt-2 text-sm leading-6 text-white/60">
-                  Confirming reserves a place only. SIXFL will create the actual team manually once the team details are ready.
+                  A clear yes or no, your team name if it is decided, and a rough idea of how many players you have. We do not need your name, email, phone number or area again.
                 </p>
               </div>
 
-              <div className="rounded-2xl border border-emerald-400/15 bg-emerald-500/[0.06] px-4 py-3 text-sm leading-6 text-white/70">
-                By reserving a place, you’re simply letting us know you’d like us to hold a place for your team while we finalise the league. There’s no payment due and you’re not committing to take part at this stage.
-              </div>
+              {(teamNameError || squadError) ? (
+                <div className="rounded-2xl border border-rose-400/20 bg-rose-500/10 p-4 text-sm text-rose-100">
+                  {teamNameError || squadError}
+                </div>
+              ) : null}
 
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <form action={confirmTeamPlaceAction}>
+              <form action={confirmTeamCommitmentAction} className="space-y-5 rounded-2xl border border-emerald-400/15 bg-emerald-500/[0.05] p-5">
+                <input type="hidden" name="token" value={token} />
+
+                <label className="block">
+                  <span className="text-sm font-semibold text-white/85">Team name</span>
+                  <span className="mt-1 block text-xs leading-5 text-white/45">
+                    Leave this blank if you have not decided it yet.
+                  </span>
+                  <input
+                    name="teamName"
+                    type="text"
+                    minLength={2}
+                    maxLength={80}
+                    defaultValue={savedTeamName}
+                    placeholder="e.g. Richmond Rovers"
+                    className="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition placeholder:text-white/30 focus:border-emerald-400/50"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-semibold text-white/85">Roughly how many players do you have?</span>
+                  <span className="mt-1 block text-xs leading-5 text-white/45">
+                    This helps us understand how close your squad is. It does not limit the final squad size.
+                  </span>
+                  <select
+                    name="squadSize"
+                    defaultValue="building"
+                    required
+                    className="mt-2 w-full rounded-xl border border-white/10 bg-[#0b1713] px-4 py-3 text-white outline-none transition focus:border-emerald-400/50"
+                  >
+                    <option value="building">Still putting the squad together</option>
+                    <option value="6">6 players</option>
+                    <option value="7">7 players</option>
+                    <option value="8">8 players</option>
+                    <option value="9+">9 or more players</option>
+                  </select>
+                </label>
+
+                <div className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/55">
+                  Clicking yes tells SIXFL you intend to enter a team. There is no payment due now and there is no long-term contract tying your team in.
+                </div>
+
+                <button
+                  type="submit"
+                  className="inline-flex w-full items-center justify-center rounded-xl bg-emerald-600 px-5 py-3.5 text-sm font-bold text-white shadow-[0_16px_40px_rgba(16,185,129,0.24)] transition hover:bg-emerald-500"
+                >
+                  YES — I WANT TO ENTER A TEAM
+                </button>
+              </form>
+
+              <div className="border-t border-white/10 pt-5">
+                <form action={declineTeamAction}>
                   <input type="hidden" name="token" value={token} />
                   <button
                     type="submit"
-                    className="inline-flex w-full items-center justify-center rounded-xl bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(16,185,129,0.24)] transition hover:bg-emerald-500 sm:w-auto"
+                    className="inline-flex w-full items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/70 transition hover:bg-white/[0.08]"
                   >
-                    Yes, reserve our team place
-                  </button>
-                </form>
-
-                <form action={declineTeamPlaceAction}>
-                  <input type="hidden" name="token" value={token} />
-                  <button
-                    type="submit"
-                    className="inline-flex w-full items-center justify-center rounded-xl border border-white/10 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-white/75 transition hover:bg-white/[0.08] sm:w-auto"
-                  >
-                    No, release our place
+                    No — I’m not entering a team
                   </button>
                 </form>
               </div>
             </div>
           )}
         </section>
+
+        <div className="text-center text-xs text-white/40">
+          <Link href="https://www.sixfl.co.uk" className="transition hover:text-white/70">
+            SIXFL · 6-a-side football. Done properly.
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/src/components/admin/leads/LeadConfirmationChaseButton.tsx
+++ b/src/components/admin/leads/LeadConfirmationChaseButton.tsx
@@ -25,11 +25,13 @@ export default function LeadConfirmationChaseButton({
       const result = await sendTeamPlaceConfirmationChaseAction(formData);
 
       if (!result?.ok) {
-        alert(result?.error || "Failed to send chase email.");
+        alert(result?.error || "Failed to send the decision reminder.");
         return;
       }
 
-      alert("Chase email sent. It includes a fresh link to complete the team form.");
+      alert(
+        "Decision reminder sent. It uses the same secure link and asks only whether they are entering, their team name and approximate squad size.",
+      );
       router.refresh();
     });
   }
@@ -39,10 +41,10 @@ export default function LeadConfirmationChaseButton({
       type="button"
       onClick={handleClick}
       disabled={!canChase || pending}
-      title="Send a friendly reminder to complete the team confirmation form"
+      title="Remind this lead to give SIXFL a clear team decision"
       className="inline-flex h-9 items-center justify-center rounded-xl border border-amber-300/30 bg-amber-400/10 px-3 text-xs font-bold tracking-[0.1em] text-amber-100 transition hover:border-amber-300/50 hover:bg-amber-400/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
     >
-      {pending ? "Sending chase…" : "Chase form"}
+      {pending ? "Sending reminder…" : "Send reminder"}
     </button>
   );
 }

--- a/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
+++ b/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
@@ -6,7 +6,7 @@
 
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { sendTeamPlaceConfirmationSystemEmailAction } from "@/app/(admin)/admin/leads/[id]/response-email-actions";
+import { sendTeamCommitmentEmailAction } from "@/app/(admin)/admin/leads/team-commitment-email-actions";
 
 export default function LeadConfirmationQuickSendButton({
   leadId,
@@ -27,14 +27,18 @@ export default function LeadConfirmationQuickSendButton({
       const formData = new FormData();
       formData.append("leadId", leadId);
 
-      const result = await sendTeamPlaceConfirmationSystemEmailAction(formData);
+      const result = await sendTeamCommitmentEmailAction(formData);
 
       if (!result?.ok) {
-        alert(result?.error || "Failed to send confirmation email.");
+        alert(result?.error || "Failed to send the team commitment email.");
         return;
       }
 
-      alert("Confirmation email sent.");
+      alert(
+        alreadySent
+          ? "Commitment link resent. It asks only for their decision, team name and approximate squad size."
+          : "Commitment link sent. It asks only for their decision, team name and approximate squad size.",
+      );
       router.refresh();
     });
   }
@@ -44,10 +48,14 @@ export default function LeadConfirmationQuickSendButton({
       type="button"
       onClick={handleClick}
       disabled={!canSend || pending}
-      title={canSend ? "Send team place confirmation email" : "Set an email and prospective league before sending"}
+      title={
+        canSend
+          ? "Send the secure team commitment link"
+          : "Set an email and prospective league before sending"
+      }
       className="inline-flex h-9 items-center justify-center rounded-xl border border-sky-400/30 bg-sky-500/10 px-3 text-xs font-bold tracking-[0.12em] text-sky-200 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
     >
-      {pending ? "Sending" : alreadySent ? "Resend link" : "Send link"}
+      {pending ? "Sending…" : alreadySent ? "Resend decision link" : "Send decision link"}
     </button>
   );
 }

--- a/src/components/admin/leads/LeadEmailForm.tsx
+++ b/src/components/admin/leads/LeadEmailForm.tsx
@@ -4,27 +4,17 @@
 
 "use client";
 
-// ========================================
-// Imports
-// ========================================
-
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import TemplateSelect from "@/components/admin/leads/TemplateSelect";
-import {
-  sendLeadEmailWithResponseLinksAction,
-  sendTeamPlaceConfirmationSystemEmailAction,
-} from "@/app/(admin)/admin/leads/[id]/response-email-actions";
+import { sendLeadEmailWithResponseLinksAction } from "@/app/(admin)/admin/leads/[id]/response-email-actions";
+import { sendTeamCommitmentEmailAction } from "@/app/(admin)/admin/leads/team-commitment-email-actions";
 import {
   buildBaseEmailTemplateContext,
   mergeEmailTemplateContext,
   resolveTemplateText,
 } from "@/lib/email/template-context";
 import type { InterestType } from "@prisma/client";
-
-// ========================================
-// Types
-// ========================================
 
 type LeadEmailTemplateOption = {
   id: string;
@@ -102,10 +92,6 @@ function restoreServerResolvedTokens(value: string) {
   );
 }
 
-// ========================================
-// Component
-// ========================================
-
 export default function LeadEmailForm({
   leadId,
   email,
@@ -118,7 +104,6 @@ export default function LeadEmailForm({
   showTeamConfirmationShortcut = false,
 }: Props) {
   const router = useRouter();
-
   const [selectedTemplateId, setSelectedTemplateId] = useState("");
   const [targetTeamId, setTargetTeamId] = useState("");
   const [subject, setSubject] = useState("");
@@ -126,11 +111,7 @@ export default function LeadEmailForm({
   const [sending, setSending] = useState(false);
 
   const templateOptions = useMemo(
-    () =>
-      templates.map((template) => ({
-        value: template.id,
-        label: template.name,
-      })),
+    () => templates.map((template) => ({ value: template.id, label: template.name })),
     [templates],
   );
 
@@ -143,7 +124,6 @@ export default function LeadEmailForm({
 
   const templateContext = useMemo(() => {
     const derivedFullName = fullName?.trim() || firstName?.trim() || "";
-
     return mergeEmailTemplateContext(
       buildBaseEmailTemplateContext({
         firstName,
@@ -159,7 +139,6 @@ export default function LeadEmailForm({
       setTargetTeamId("");
       return;
     }
-
     if (!targetTeamId && managedTeamOptions.length > 0) {
       setTargetTeamId(managedTeamOptions[0].value);
     }
@@ -178,37 +157,32 @@ export default function LeadEmailForm({
 
   function handleTemplateChange(value: string) {
     setSelectedTemplateId(value);
-
     const template = templates.find((item) => item.id === value) ?? null;
-
     if (!template) {
       setSubject("");
       setBody("");
       return;
     }
-
     setSubject(resolveTemplateForLead(template.subject));
     setBody(resolveTemplateForLead(template.body));
   }
 
   async function handleQuickConfirmationSend() {
     setSending(true);
-
     try {
       const formData = new FormData();
       formData.append("leadId", leadId);
-
-      const result = await sendTeamPlaceConfirmationSystemEmailAction(formData);
-
+      const result = await sendTeamCommitmentEmailAction(formData);
       if (!result?.ok) {
-        alert(result?.error || "Failed to send confirmation email.");
+        alert(result?.error || "Failed to send the team decision email.");
         return;
       }
-
-      alert("Team place confirmation email sent successfully.");
+      alert(
+        "Team decision email sent. The lead will only be asked for their decision, team name and approximate squad size.",
+      );
       router.refresh();
     } catch {
-      alert("Something went wrong while sending the confirmation email.");
+      alert("Something went wrong while sending the team decision email.");
     } finally {
       setSending(false);
     }
@@ -217,7 +191,6 @@ export default function LeadEmailForm({
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setSending(true);
-
     try {
       const formData = new FormData();
       formData.append("leadId", leadId);
@@ -230,12 +203,10 @@ export default function LeadEmailForm({
       formData.append("targetTeamId", targetTeamId);
 
       const result = await sendLeadEmailWithResponseLinksAction(formData);
-
       if (!result?.ok) {
         alert(result?.error || "Failed to send email.");
         return;
       }
-
       alert("Email sent successfully.");
       router.refresh();
     } catch {
@@ -251,7 +222,6 @@ export default function LeadEmailForm({
       setBody("");
       return;
     }
-
     setSubject(resolveTemplateForLead(selectedTemplate.subject));
     setBody(resolveTemplateForLead(selectedTemplate.body));
   }
@@ -260,11 +230,9 @@ export default function LeadEmailForm({
     <div className="space-y-4">
       {showTeamConfirmationShortcut ? (
         <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4">
-          <div className="text-sm font-semibold text-emerald-50">
-            Team place confirmation
-          </div>
+          <div className="text-sm font-semibold text-emerald-50">Team decision link</div>
           <p className="mt-1 text-sm leading-6 text-emerald-100/75">
-            Send the system confirmation email with the Yes, confirm our team place button.
+            Send a secure link that recognises the existing lead. It asks only whether they want to enter, their team name and approximate squad size.
           </p>
           <button
             type="button"
@@ -272,7 +240,7 @@ export default function LeadEmailForm({
             disabled={sending || !email}
             className="mt-3 inline-flex rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {sending ? "Sending..." : "Send confirmation email"}
+            {sending ? "Sending..." : "Send team decision email"}
           </button>
         </div>
       ) : null}
@@ -283,33 +251,22 @@ export default function LeadEmailForm({
       >
         <div>
           <label className="mb-1 block text-sm text-white/70">Email template</label>
-
           <TemplateSelect
             label=""
             value={selectedTemplateId}
             options={templateOptions}
             onChange={handleTemplateChange}
             disabled={sending}
-            placeholder={
-              templates.length > 0
-                ? "Select email template"
-                : "No matching templates available"
-            }
+            placeholder={templates.length > 0 ? "Select email template" : "No matching templates available"}
           />
-
           {selectedTemplate?.description ? (
-            <p className="mt-2 text-xs text-white/45">
-              {selectedTemplate.description}
-            </p>
+            <p className="mt-2 text-xs text-white/45">{selectedTemplate.description}</p>
           ) : null}
         </div>
 
         {requiresManagedTeam ? (
           <div>
-            <label className="mb-1 block text-sm text-white/70">
-              Managed team link
-            </label>
-
+            <label className="mb-1 block text-sm text-white/70">Managed team link</label>
             <TemplateSelect
               label=""
               value={targetTeamId}
@@ -352,7 +309,6 @@ export default function LeadEmailForm({
             <label className="block text-sm text-white/70">Message</label>
             <span className="text-xs text-white/40">Plain text email</span>
           </div>
-
           <div className="mt-2 rounded-xl border border-white/10 bg-black/30 transition focus-within:border-emerald-400">
             <textarea
               rows={14}
@@ -363,10 +319,7 @@ export default function LeadEmailForm({
               placeholder={`Hi ${firstName || "there"},\n\nThanks for your interest in SIXFL...\n\nWe’ll be in touch shortly.`}
             />
           </div>
-
-          <div className="mt-2 text-xs text-white/40">
-            This email will be sent directly to the lead.
-          </div>
+          <div className="mt-2 text-xs text-white/40">This email will be sent directly to the lead.</div>
         </div>
 
         <div className="flex gap-3">
@@ -377,7 +330,6 @@ export default function LeadEmailForm({
           >
             {sending ? "Sending..." : "Send email"}
           </button>
-
           <button
             type="button"
             onClick={resetTemplate}


### PR DESCRIPTION
Makes every secure team-decision link ask only for the useful next-stage information: a clear yes/no decision, team name (optional if not yet decided), and approximate squad size. Updates the resend and reminder actions to use the same secure lead-specific journey, blocks reminders after a decision, and keeps the editable League starter email linked to this page.