### PR TITLE
Add team lead reassurance email action

### DIFF
--- a/scripts/seed-league-starter-email-template.cjs
+++ b/scripts/seed-league-starter-email-template.cjs
@@ -138,19 +138,31 @@ async function main() {
     }),
   ]);
 
-  const sourceTemplate = systemTemplate || campaignTemplate;
+  const sourceTemplate = campaignTemplate || systemTemplate;
 
   await prisma.notificationTemplate.upsert({
     where: { key: SYSTEM_TEMPLATE_KEY },
     update: {
-      // Preserve any wording changed in the System Templates editor. Only keep
+      // If the old campaign version still exists, this is the one-time move:
+      // carry across the wording the admin has already edited before removing it.
+      ...(campaignTemplate
+        ? {
+            name: 'Team lead reassurance email',
+            description:
+              campaignTemplate.description?.trim() ||
+              'Friendly league starter information for an existing team lead, including costs, squad size, no long-term contract and advance fixture availability.',
+            subject: campaignTemplate.subject.trim() || DEFAULT_SUBJECT,
+            body: campaignTemplate.body.trim() || DEFAULT_BODY,
+          }
+        : {}),
+      // On later starts, preserve wording changed in System Templates. Only keep
       // the operational classification and secure lead-link destination fixed.
       kind: 'TRANSACTIONAL',
       channel: 'EMAIL',
       audience: 'LEAD',
       ctaLabel:
-        systemTemplate?.ctaLabel?.trim() ||
         campaignTemplate?.ctaLabel?.trim() ||
+        systemTemplate?.ctaLabel?.trim() ||
         DEFAULT_CTA_LABEL,
       ctaUrlKey: 'signupUrl',
       isActive: true,

--- a/scripts/seed-league-starter-email-template.cjs
+++ b/scripts/seed-league-starter-email-template.cjs
@@ -2,7 +2,12 @@ const { PrismaClient } = require('@prisma/client');
 
 const prisma = new PrismaClient();
 
-const body = `Hi {{firstName}},
+const CAMPAIGN_TEMPLATE_KEY = 'league-starter-guide';
+const SYSTEM_TEMPLATE_KEY = 'team-lead-reassurance-email';
+const DEFAULT_SUBJECT = 'Everything you need to know about joining SIXFL ⚽';
+const DEFAULT_CTA_LABEL = 'YES — I WANT TO ENTER A TEAM';
+
+const DEFAULT_BODY = `Hi {{firstName}},
 
 Thanks for your interest in joining SIXFL {{leagueName}} ⚽
 
@@ -109,41 +114,78 @@ SIXFL
 
 6-a-side football. Done properly.`;
 
-const templateData = {
-  name: 'League starter guide',
-  description: 'Friendly starter email for existing team leads. The CTA uses their secure lead record so they confirm intent without re-entering contact details.',
-  audience: 'LEAD',
-  interestType: 'TEAM',
-  subject: 'Everything you need to know about joining SIXFL ⚽',
-  body,
-  ctaLabel: 'YES — I WANT TO ENTER A TEAM',
-  ctaUrlKey: 'teamConfirmationUrl',
-  isActive: true,
-};
-
 async function main() {
-  await prisma.emailTemplate.upsert({
-    where: { key: 'league-starter-guide' },
+  const [campaignTemplate, systemTemplate] = await Promise.all([
+    prisma.emailTemplate.findUnique({
+      where: { key: CAMPAIGN_TEMPLATE_KEY },
+      select: {
+        name: true,
+        description: true,
+        subject: true,
+        body: true,
+        ctaLabel: true,
+      },
+    }),
+    prisma.notificationTemplate.findUnique({
+      where: { key: SYSTEM_TEMPLATE_KEY },
+      select: {
+        name: true,
+        description: true,
+        subject: true,
+        body: true,
+        ctaLabel: true,
+      },
+    }),
+  ]);
+
+  const sourceTemplate = systemTemplate || campaignTemplate;
+
+  await prisma.notificationTemplate.upsert({
+    where: { key: SYSTEM_TEMPLATE_KEY },
     update: {
-      // Keep the subject and body editable in Admin Templates. Only enforce the
-      // secure destination that prevents existing leads being sent through a
-      // duplicate registration form.
-      ctaLabel: 'YES — I WANT TO ENTER A TEAM',
-      ctaUrlKey: 'teamConfirmationUrl',
+      // Preserve any wording changed in the System Templates editor. Only keep
+      // the operational classification and secure lead-link destination fixed.
+      kind: 'TRANSACTIONAL',
+      channel: 'EMAIL',
+      audience: 'LEAD',
+      ctaLabel:
+        systemTemplate?.ctaLabel?.trim() ||
+        campaignTemplate?.ctaLabel?.trim() ||
+        DEFAULT_CTA_LABEL,
+      ctaUrlKey: 'signupUrl',
       isActive: true,
     },
     create: {
-      key: 'league-starter-guide',
-      ...templateData,
+      key: SYSTEM_TEMPLATE_KEY,
+      name: 'Team lead reassurance email',
+      description:
+        sourceTemplate?.description?.trim() ||
+        'Friendly league starter information for an existing team lead, including costs, squad size, no long-term contract and advance fixture availability.',
+      kind: 'TRANSACTIONAL',
+      channel: 'EMAIL',
+      audience: 'LEAD',
+      subject: sourceTemplate?.subject?.trim() || DEFAULT_SUBJECT,
+      body: sourceTemplate?.body?.trim() || DEFAULT_BODY,
+      ctaLabel: sourceTemplate?.ctaLabel?.trim() || DEFAULT_CTA_LABEL,
+      // The reassurance sender supplies the secure team-decision URL through
+      // this supported CTA variable.
+      ctaUrlKey: 'signupUrl',
+      isActive: true,
     },
   });
 
-  console.log('League starter guide email template is available.');
+  // The template now belongs to the operational system flow and should not
+  // appear as a separate campaign template as well.
+  await prisma.emailTemplate.deleteMany({
+    where: { key: CAMPAIGN_TEMPLATE_KEY },
+  });
+
+  console.log('Team lead reassurance email is available in System Templates.');
 }
 
 main()
   .catch((error) => {
-    console.error('league starter template seed failed', error);
+    console.error('team lead reassurance template migration failed', error);
     process.exit(1);
   })
   .finally(() => prisma.$disconnect());

--- a/src/app/(admin)/admin/leads/reassurance-email-actions.ts
+++ b/src/app/(admin)/admin/leads/reassurance-email-actions.ts
@@ -1,0 +1,410 @@
+"use server";
+
+import {
+  LeadStatus,
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+  NotificationTemplateKind,
+  Prisma,
+} from "@prisma/client";
+import { revalidatePath } from "next/cache";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import { ensureTeamPlaceConfirmationRecord } from "@/lib/leads/teamPlaceConfirmation";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const TEAM_REASSURANCE_TEMPLATE_KEY = "team-lead-reassurance-email";
+export const TEAM_REASSURANCE_SOURCE_TYPE = "LEAD_REASSURANCE_EMAIL";
+
+const DEFAULT_SUBJECT = "Everything you need to know about joining SIXFL ⚽";
+const DEFAULT_CTA_LABEL = "YES — I WANT TO ENTER A TEAM";
+
+const DEFAULT_BODY = `Hi {{firstName}},
+
+Thanks for your interest in joining SIXFL {{leagueName}} ⚽
+
+If you’re thinking about entering a team, here’s everything you need to know. We’ve tried to make getting started as simple as possible.
+
+⚽ YOUR SIXFL LEAGUE
+
+📍 Venue: {{venueName}}
+🕐 Kick-offs: {{kickoffInfo}}
+🏁 Planned start: {{proposedStartDate}}
+💷 Cost: {{costPerTeamPerMatch}} per team, per match
+
+That’s the team price, not per player.
+
+For example, at £40 with 8 players, that works out at just £5 each for the match.
+
+🏆 WHAT DO YOU GET?
+
+SIXFL is designed to feel like a proper football league rather than just turning up for a casual game.
+
+✅ Regular organised league fixtures
+✅ Referees and match-night management
+✅ Live league tables, fixtures and results
+✅ Your own team and player accounts
+✅ Team statistics and match information
+✅ SIXFL AI match predictions
+✅ A properly structured local competition
+
+6-a-side football. Done properly.
+
+👥 HOW MANY PLAYERS DO I NEED?
+
+Matches are 6-a-side.
+
+You can use up to 9 players on a match night:
+
+6 players + up to 3 rolling substitutes
+
+Your overall squad can be bigger than nine — you simply choose which players are playing each fixture.
+
+Don’t have every player confirmed yet?
+
+That’s OK.
+
+You can still get your team started while you organise the rest of your squad.
+
+🚀 HOW GETTING STARTED WORKS
+
+1️⃣ Confirm you want to enter
+We already have your contact details from your enquiry, so there is no need to fill them in again.
+
+2️⃣ Tell us your team name
+If you have decided it, add it now. If not, you can confirm it later.
+
+3️⃣ We get the league ready
+As teams commit, we confirm the league, venue, start date and match-night details.
+
+4️⃣ Start playing
+Once the league launches, your fixtures, results and league table are all managed through SIXFL.
+
+💷 WHAT DO I PAY — AND AM I TIED IN?
+
+The standard match fee is {{costPerTeamPerMatch}} per team for each weekly fixture.
+
+Simply confirming you want to enter does not mean you are suddenly being charged match fees.
+
+There’s no long-term contract tying your team in. You pay for your football as you play.
+
+We also know that running an amateur football team means there will occasionally be weeks when you simply can’t get a team together — holidays, work commitments and other plans happen.
+
+If you know in advance that your team can’t play on a particular week, let us know and we’ll do our best to work around it when arranging the fixtures.
+
+The more notice you can give us, the easier it is for us to accommodate.
+
+You can also tell us about a one-off time restriction — for example, if your team can play one week but only after 8pm.
+
+We organise the league to make regular football easy to fit around real life, not to tie teams into something they can’t manage.
+
+🏆 INTERESTED, BUT NOT QUITE READY?
+
+You do not need to have everything organised today.
+
+Maybe you:
+• still need another player or two
+• need to check with your mates
+• haven’t decided on a team name
+• want to know a little more about the league first
+
+That’s completely fine.
+
+When you are ready to move forward, use the button below. We already have your details — it is simply your way of telling us you want to enter a team.
+
+{{cta}}
+
+GOT A QUESTION?
+
+Just reply to this email.
+
+We’re happy to help and there’s no need to figure everything out on your own.
+
+See you on the pitch,
+
+SIXFL
+
+6-a-side football. Done properly.`;
+
+type LeagueDetailsRow = {
+  proposedStartDate: Date | null;
+  minutesPerGame: number | null;
+  costPerTeamPerMatchPence: number | null;
+  targetTeamCount: number | null;
+};
+
+function getFirstName(value: string | null | undefined) {
+  return value?.trim().split(/\s+/)[0] || "there";
+}
+
+function formatLongDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  }).format(value);
+}
+
+function formatCurrencyPence(value: number | null) {
+  if (value === null) return "To be confirmed";
+
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: value % 100 === 0 ? 0 : 2,
+  }).format(value / 100);
+}
+
+function formatVenueName(value: string | null | undefined) {
+  const venueName = value?.trim();
+  if (!venueName || venueName.toUpperCase() === "TBC") return "To be confirmed";
+  return venueName;
+}
+
+async function ensureReassuranceTemplate() {
+  const existing = await prisma.notificationTemplate.findUnique({
+    where: { key: TEAM_REASSURANCE_TEMPLATE_KEY },
+    select: { ctaLabel: true },
+  });
+
+  return prisma.notificationTemplate.upsert({
+    where: { key: TEAM_REASSURANCE_TEMPLATE_KEY },
+    update: {
+      kind: NotificationTemplateKind.TRANSACTIONAL,
+      channel: NotificationChannel.EMAIL,
+      audience: NotificationAudience.LEAD,
+      ctaLabel: existing?.ctaLabel?.trim() || DEFAULT_CTA_LABEL,
+      // The system mailer supplies the lead-specific decision URL through this
+      // supported variable. The recipient is never sent to a blank lead form.
+      ctaUrlKey: "signupUrl",
+      isActive: true,
+    },
+    create: {
+      key: TEAM_REASSURANCE_TEMPLATE_KEY,
+      name: "Team lead reassurance email",
+      description:
+        "Friendly league starter information for an existing team lead, including costs, squad size, no long-term contract and advance fixture availability.",
+      kind: NotificationTemplateKind.TRANSACTIONAL,
+      channel: NotificationChannel.EMAIL,
+      audience: NotificationAudience.LEAD,
+      subject: DEFAULT_SUBJECT,
+      body: DEFAULT_BODY,
+      ctaLabel: DEFAULT_CTA_LABEL,
+      ctaUrlKey: "signupUrl",
+      isActive: true,
+    },
+  });
+}
+
+export async function sendLeadReassuranceEmailAction(formData: FormData) {
+  const { user } = await requireAdmin();
+  const leadId = String(formData.get("leadId") ?? "").trim();
+
+  if (!leadId) return { ok: false, error: "Missing lead id." };
+
+  const lead = await prisma.interestLead.findUnique({
+    where: { id: leadId },
+    select: {
+      id: true,
+      interestType: true,
+      status: true,
+      convertedTeamId: true,
+      contactName: true,
+      teamName: true,
+      email: true,
+      phone: true,
+      area: true,
+      leagueId: true,
+      league: {
+        select: {
+          id: true,
+          name: true,
+          season: true,
+          venueName: true,
+          kickoffInfo: true,
+          format: true,
+          competition: {
+            select: {
+              currentLeague: {
+                select: {
+                  id: true,
+                  name: true,
+                  season: true,
+                  venueName: true,
+                  kickoffInfo: true,
+                  format: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!lead) return { ok: false, error: "Lead not found." };
+  if (lead.interestType !== "TEAM") {
+    return { ok: false, error: "Only team leads can receive the reassurance email." };
+  }
+  if (lead.convertedTeamId) {
+    return { ok: false, error: "This lead has already been converted into a SIXFL team." };
+  }
+  if (lead.status === LeadStatus.CLOSED) {
+    return { ok: false, error: "This lead is closed. Reopen it before sending another email." };
+  }
+
+  const email = lead.email?.trim().toLowerCase();
+  if (!email) return { ok: false, error: "This lead does not have an email address." };
+  if (!lead.leagueId || !lead.league) {
+    return {
+      ok: false,
+      error: "Set a prospective league on this lead before sending the reassurance email.",
+    };
+  }
+
+  const effectiveLeague = lead.league.competition?.currentLeague ?? lead.league;
+  const detailsRows = await prisma.$queryRaw<LeagueDetailsRow[]>(Prisma.sql`
+    SELECT
+      "proposedStartDate" AS "proposedStartDate",
+      "minutesPerGame"::int AS "minutesPerGame",
+      "costPerTeamPerMatchPence"::int AS "costPerTeamPerMatchPence",
+      "targetTeamCount"::int AS "targetTeamCount"
+    FROM "League"
+    WHERE "id" = ${effectiveLeague.id}
+    LIMIT 1
+  `);
+  const details = detailsRows[0] ?? null;
+  const leagueName = `${effectiveLeague.name}${
+    effectiveLeague.season ? ` · ${effectiveLeague.season}` : ""
+  }`;
+  const venueName = formatVenueName(effectiveLeague.venueName);
+  const kickoffInfo = effectiveLeague.kickoffInfo?.trim() || "To be confirmed";
+  const proposedStartDate = details?.proposedStartDate
+    ? formatLongDate(details.proposedStartDate)
+    : "To be confirmed";
+  const costPerTeamPerMatch = formatCurrencyPence(
+    details?.costPerTeamPerMatchPence ?? null,
+  );
+  const secureLink = await ensureTeamPlaceConfirmationRecord(lead.id);
+
+  await ensureReassuranceTemplate();
+
+  const displayName = lead.contactName?.trim() || lead.teamName?.trim() || email;
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.LEAD,
+    sourceId: lead.id,
+    audience: NotificationAudience.LEAD,
+    displayName,
+    email,
+    phone: lead.phone,
+    transactionalEmailOptIn: true,
+    marketingEmailOptIn: true,
+    metadata: {
+      leadId: lead.id,
+      leagueId: effectiveLeague.id,
+      originalLeadLeagueId: lead.leagueId,
+      leagueName,
+      teamName: lead.teamName,
+      contactName: lead.contactName,
+      entityType: "TEAM_LEAD_REASSURANCE",
+    },
+  });
+
+  const leagueDetailsBlock = [
+    `League: ${leagueName}`,
+    `Venue: ${venueName}`,
+    `Kick-offs: ${kickoffInfo}`,
+    `Planned start: ${proposedStartDate}`,
+    details?.minutesPerGame ? `Match length: ${details.minutesPerGame} minutes` : null,
+    `Cost: ${costPerTeamPerMatch} per team per match`,
+    details?.targetTeamCount ? `Number of teams: ${details.targetTeamCount}` : null,
+    effectiveLeague.format?.trim()
+      ? `Format: ${effectiveLeague.format.trim()}`
+      : "Format: Weekly 6-a-side fixtures",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  try {
+    const dispatch = await queueNotificationFromTemplate({
+      templateKey: TEAM_REASSURANCE_TEMPLATE_KEY,
+      recipientId: recipient.id,
+      variables: {
+        firstName: getFirstName(lead.contactName),
+        fullName: lead.contactName?.trim() || "",
+        contactName: lead.contactName?.trim() || "",
+        teamName: lead.teamName?.trim() || "",
+        area: lead.area?.trim() || "",
+        leagueName,
+        venueName,
+        kickoffInfo,
+        proposedStartDate,
+        minutesPerGame: details?.minutesPerGame
+          ? String(details.minutesPerGame)
+          : "To be confirmed",
+        costPerTeamPerMatch,
+        targetTeamCount: details?.targetTeamCount
+          ? String(details.targetTeamCount)
+          : "",
+        format: effectiveLeague.format?.trim() || "Weekly 6-a-side fixtures",
+        leagueDetails: leagueDetailsBlock,
+        leagueDetailsBlock,
+        // The system template uses signupUrl as its supported CTA destination,
+        // but the value is the secure decision page for this existing lead.
+        signupUrl: secureLink.url,
+        teamConfirmationUrl: secureLink.url,
+      },
+      sourceType: TEAM_REASSURANCE_SOURCE_TYPE,
+      sourceId: lead.id,
+      metadata: {
+        origin: "lead_reassurance_email",
+        originLabel: "Team lead reassurance email",
+        leadId: lead.id,
+        leagueId: effectiveLeague.id,
+        originalLeadLeagueId: lead.leagueId,
+        leagueName,
+        teamName: lead.teamName,
+        ctaUrl: secureLink.url,
+      },
+      createdByUserId: user?.id ?? null,
+    });
+
+    await logNotificationDispatchToThread({ dispatch, recipient });
+    await prisma.interestLeadEmail.create({
+      data: {
+        interestLeadId: lead.id,
+        subject: dispatch.subject ?? DEFAULT_SUBJECT,
+        body: dispatch.bodyText,
+        sentTo: email,
+      },
+    });
+
+    if (lead.status === LeadStatus.NEW) {
+      await prisma.interestLead.update({
+        where: { id: lead.id },
+        data: { status: LeadStatus.CONTACTED, contactedAt: new Date() },
+      });
+    }
+
+    revalidatePath("/admin/leads");
+    revalidatePath(`/admin/leads/${lead.id}`);
+    revalidatePath("/admin/templates");
+    revalidatePath("/admin/messaging");
+
+    return { ok: true, dispatchId: dispatch.id, status: dispatch.status };
+  } catch (error) {
+    console.error("sendLeadReassuranceEmailAction error", error);
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "The reassurance email could not be queued.",
+    };
+  }
+}

--- a/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
+++ b/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
@@ -6,7 +6,9 @@
 
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
+
 import { sendTeamCommitmentEmailAction } from "@/app/(admin)/admin/leads/team-commitment-email-actions";
+import { sendLeadReassuranceEmailAction } from "@/app/(admin)/admin/leads/reassurance-email-actions";
 
 export default function LeadConfirmationQuickSendButton({
   leadId,
@@ -18,12 +20,35 @@ export default function LeadConfirmationQuickSendButton({
   alreadySent?: boolean;
 }) {
   const router = useRouter();
-  const [pending, startTransition] = useTransition();
+  const [sendingReassurance, startReassuranceTransition] = useTransition();
+  const [sendingDecision, startDecisionTransition] = useTransition();
+  const pending = sendingReassurance || sendingDecision;
 
-  function handleClick() {
+  function handleReassuranceClick() {
     if (!canSend || pending) return;
 
-    startTransition(async () => {
+    startReassuranceTransition(async () => {
+      const formData = new FormData();
+      formData.append("leadId", leadId);
+
+      const result = await sendLeadReassuranceEmailAction(formData);
+
+      if (!result?.ok) {
+        alert(result?.error || "Failed to send the reassurance email.");
+        return;
+      }
+
+      alert(
+        "Reassurance email sent. It explains the league, costs, squad size, no long-term contract and fixture flexibility, and includes the secure team decision link.",
+      );
+      router.refresh();
+    });
+  }
+
+  function handleDecisionClick() {
+    if (!canSend || pending) return;
+
+    startDecisionTransition(async () => {
       const formData = new FormData();
       formData.append("leadId", leadId);
 
@@ -44,18 +69,38 @@ export default function LeadConfirmationQuickSendButton({
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={!canSend || pending}
-      title={
-        canSend
-          ? "Send the secure team commitment link"
-          : "Set an email and prospective league before sending"
-      }
-      className="inline-flex h-9 items-center justify-center rounded-xl border border-sky-400/30 bg-sky-500/10 px-3 text-xs font-bold tracking-[0.12em] text-sky-200 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
-    >
-      {pending ? "Sending…" : alreadySent ? "Resend decision link" : "Send decision link"}
-    </button>
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={handleReassuranceClick}
+        disabled={!canSend || pending}
+        title={
+          canSend
+            ? "Send the friendly SIXFL league starter and reassurance email"
+            : "Set an email and prospective league before sending"
+        }
+        className="inline-flex min-h-9 max-w-[150px] items-center justify-center rounded-xl border border-violet-400/30 bg-violet-500/10 px-3 py-2 text-center text-xs font-bold leading-4 tracking-[0.08em] text-violet-100 transition hover:bg-violet-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
+      >
+        {sendingReassurance ? "Sending…" : "Reassurance email"}
+      </button>
+
+      <button
+        type="button"
+        onClick={handleDecisionClick}
+        disabled={!canSend || pending}
+        title={
+          canSend
+            ? "Send the secure team commitment link"
+            : "Set an email and prospective league before sending"
+        }
+        className="inline-flex min-h-9 max-w-[150px] items-center justify-center rounded-xl border border-sky-400/30 bg-sky-500/10 px-3 py-2 text-center text-xs font-bold leading-4 tracking-[0.12em] text-sky-200 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/[0.03] disabled:text-white/30"
+      >
+        {sendingDecision
+          ? "Sending…"
+          : alreadySent
+            ? "Resend decision link"
+            : "Send decision link"}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
Adds a Reassurance email button beside the team decision actions on the Leads page. It sends the full friendly league starter email with league-specific costs, squad guidance, no long-term contract and advance fixture-flexibility information, plus the secure existing-lead decision link. Moves the editable starter copy from Campaign Templates into System Templates as “Team lead reassurance email”, preserving any wording already edited before removing the old campaign copy.