### PR TITLE
Fix reassurance email server action export

### DIFF
--- a/src/app/(admin)/admin/leads/reassurance-email-actions.ts
+++ b/src/app/(admin)/admin/leads/reassurance-email-actions.ts
@@ -18,10 +18,12 @@ import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
-export const TEAM_REASSURANCE_TEMPLATE_KEY = "team-lead-reassurance-email";
-export const TEAM_REASSURANCE_SOURCE_TYPE = "LEAD_REASSURANCE_EMAIL";
-export const TEAM_REASSURANCE_SMS_TEMPLATE_KEY = "team-lead-reassurance-sms";
-export const TEAM_REASSURANCE_SMS_SOURCE_TYPE = "LEAD_REASSURANCE_SMS";
+// A module-level "use server" file may only export async server actions.
+// Keep implementation constants private so Next.js can expose the action.
+const TEAM_REASSURANCE_TEMPLATE_KEY = "team-lead-reassurance-email";
+const TEAM_REASSURANCE_SOURCE_TYPE = "LEAD_REASSURANCE_EMAIL";
+const TEAM_REASSURANCE_SMS_TEMPLATE_KEY = "team-lead-reassurance-sms";
+const TEAM_REASSURANCE_SMS_SOURCE_TYPE = "LEAD_REASSURANCE_SMS";
 
 const DEFAULT_SUBJECT = "Everything you need to know about joining SIXFL ⚽";
 const DEFAULT_CTA_LABEL = "YES — I WANT TO ENTER A TEAM";


### PR DESCRIPTION
Fixes the deployment error where Next.js could not expose sendLeadReassuranceEmailAction. The module-level `use server` file was also exporting string constants; those are now private implementation constants so the only exported value is the async server action.