### PR TITLE
Add exact email record lookup to Admin Email Audit

### DIFF
--- a/src/app/(admin)/admin/email-audit/layout.tsx
+++ b/src/app/(admin)/admin/email-audit/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import EmailRecordLookup from "@/components/admin/email-audit/EmailRecordLookup";
+
+export default function EmailAuditLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <EmailRecordLookup />
+      {children}
+    </>
+  );
+}

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -11,7 +11,6 @@ import { prisma } from "@/lib/prisma";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 import AdminTeamContactPhoneFallbackBridge from "@/components/admin/communications/AdminTeamContactPhoneFallbackBridge";
 import ProspectCommunicationCtaBridge from "@/components/admin/communications/ProspectCommunicationCtaBridge";
-import EmailRecordLookup from "@/components/admin/email-audit/EmailRecordLookup";
 import EmailBrandOptionBridge from "@/components/admin/email-templates/EmailBrandOptionBridge";
 import EmailTemplateListControlsBridge from "@/components/admin/email-templates/EmailTemplateListControlsBridge";
 import PlayerPoolTemplateCtaBridge from "@/components/admin/email-templates/PlayerPoolTemplateCtaBridge";
@@ -115,10 +114,7 @@ export default async function AdminLayout({
           />
         </aside>
 
-        <main className="w-full min-w-0 flex-1">
-          <EmailRecordLookup />
-          {children}
-        </main>
+        <main className="w-full min-w-0 flex-1">{children}</main>
       </div>
     </div>
   );

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/prisma";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 import AdminTeamContactPhoneFallbackBridge from "@/components/admin/communications/AdminTeamContactPhoneFallbackBridge";
 import ProspectCommunicationCtaBridge from "@/components/admin/communications/ProspectCommunicationCtaBridge";
+import EmailRecordLookup from "@/components/admin/email-audit/EmailRecordLookup";
 import EmailBrandOptionBridge from "@/components/admin/email-templates/EmailBrandOptionBridge";
 import EmailTemplateListControlsBridge from "@/components/admin/email-templates/EmailTemplateListControlsBridge";
 import PlayerPoolTemplateCtaBridge from "@/components/admin/email-templates/PlayerPoolTemplateCtaBridge";
@@ -114,7 +115,10 @@ export default async function AdminLayout({
           />
         </aside>
 
-        <main className="w-full min-w-0 flex-1">{children}</main>
+        <main className="w-full min-w-0 flex-1">
+          <EmailRecordLookup />
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/src/app/api/admin/email-lookup/route.ts
+++ b/src/app/api/admin/email-lookup/route.ts
@@ -1,0 +1,315 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type LookupMatch = {
+  source: string;
+  title: string;
+  detail: string;
+  effect: string;
+  href: string | null;
+  recordId: string | null;
+  tone: "default" | "amber" | "emerald" | "sky";
+};
+
+type NotificationRecipientRow = {
+  id: string;
+  sourceType: string;
+  sourceId: string;
+  displayName: string | null;
+  email: string | null;
+};
+
+type PlayerPoolRow = {
+  id: string;
+  firstName: string;
+  lastName: string | null;
+  status: string;
+  leagueName: string | null;
+};
+
+type DuplicateAttemptRow = {
+  id: string;
+  teamId: string;
+  displayName: string;
+  matchType: string;
+  matchedRecordId: string | null;
+  matchedTeamId: string | null;
+  reason: string;
+  createdAt: Date;
+};
+
+function normaliseEmail(value: string | null | undefined) {
+  const email = value?.trim().toLowerCase() ?? "";
+  if (!email || !/^[^\s@]+@[^\s@]+$/.test(email)) return null;
+  return email;
+}
+
+function sameEmail(value: string | null | undefined, email: string) {
+  return normaliseEmail(value) === email;
+}
+
+function fullName(firstName: string, lastName: string | null) {
+  return [firstName, lastName].filter(Boolean).join(" ").trim();
+}
+
+function formatAttemptDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Europe/London",
+  }).format(value);
+}
+
+export async function GET(request: Request) {
+  await requireAdmin();
+
+  const url = new URL(request.url);
+  const email = normaliseEmail(url.searchParams.get("email"));
+  if (!email) {
+    return NextResponse.json(
+      { ok: false, error: "Enter a valid email address." },
+      { status: 400 },
+    );
+  }
+
+  const [users, teams, prospects, leads, optionalTables] = await Promise.all([
+    prisma.user.findMany({
+      where: { email: { equals: email, mode: "insensitive" } },
+      select: { id: true, name: true, email: true, role: true },
+    }),
+    prisma.team.findMany({
+      where: {
+        OR: [
+          { contactEmail: { equals: email, mode: "insensitive" } },
+          { secondaryContactEmail: { equals: email, mode: "insensitive" } },
+          { captainInviteSentTo: { equals: email, mode: "insensitive" } },
+        ],
+      },
+      select: {
+        id: true,
+        name: true,
+        contactName: true,
+        contactEmail: true,
+        secondaryContactName: true,
+        secondaryContactEmail: true,
+        captainInviteSentTo: true,
+      },
+    }),
+    prisma.teamPlayerProspect.findMany({
+      where: { email: { equals: email, mode: "insensitive" } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        status: true,
+        team: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.interestLead.findMany({
+      where: { email: { equals: email, mode: "insensitive" } },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        contactName: true,
+        interestType: true,
+        status: true,
+        league: { select: { name: true } },
+      },
+    }),
+    prisma.$queryRaw<Array<{ playerPool: boolean; duplicateAttempts: boolean }>>(Prisma.sql`
+      SELECT
+        to_regclass('"PlayerPoolProfile"') IS NOT NULL AS "playerPool",
+        to_regclass('"PlayerDuplicateAttempt"') IS NOT NULL AS "duplicateAttempts"
+    `),
+  ]);
+
+  const tableState = optionalTables[0] ?? {
+    playerPool: false,
+    duplicateAttempts: false,
+  };
+
+  const [notificationRecipients, playerPoolRows, duplicateAttempts] =
+    await Promise.all([
+      prisma.$queryRaw<NotificationRecipientRow[]>(Prisma.sql`
+        SELECT
+          "id",
+          "sourceType"::text AS "sourceType",
+          "sourceId",
+          "displayName",
+          COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email"
+        FROM "NotificationRecipient"
+        WHERE LOWER(COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), ''))) = ${email}
+        ORDER BY "updatedAt" DESC
+        LIMIT 20
+      `),
+      tableState.playerPool
+        ? prisma.$queryRaw<PlayerPoolRow[]>(Prisma.sql`
+            SELECT
+              profile."id",
+              prospect."firstName",
+              prospect."lastName",
+              profile."status"::text AS "status",
+              league."name" AS "leagueName"
+            FROM "PlayerPoolProfile" profile
+            JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"
+            LEFT JOIN "League" league ON league."id" = profile."leagueId"
+            WHERE LOWER(BTRIM(COALESCE(profile."emailNormalized", prospect."email", ''))) = ${email}
+               OR LOWER(BTRIM(COALESCE(prospect."email", ''))) = ${email}
+            ORDER BY profile."updatedAt" DESC
+            LIMIT 20
+          `)
+        : Promise.resolve([] as PlayerPoolRow[]),
+      tableState.duplicateAttempts
+        ? prisma.$queryRaw<DuplicateAttemptRow[]>(Prisma.sql`
+            SELECT
+              "id",
+              "teamId",
+              "displayName",
+              "matchType",
+              "matchedRecordId",
+              "matchedTeamId",
+              "reason",
+              "createdAt"
+            FROM "PlayerDuplicateAttempt"
+            WHERE LOWER(BTRIM(COALESCE("email", ''))) = ${email}
+            ORDER BY "createdAt" DESC
+            LIMIT 10
+          `)
+        : Promise.resolve([] as DuplicateAttemptRow[]),
+    ]);
+
+  const matches: LookupMatch[] = [];
+
+  for (const attempt of duplicateAttempts) {
+    const teamId = attempt.matchedTeamId || attempt.teamId;
+    matches.push({
+      source: "Blocked player creation attempt",
+      title: `${attempt.displayName || email} · ${attempt.matchType.replaceAll("_", " ")}`,
+      detail: `${attempt.reason} Attempted ${formatAttemptDate(attempt.createdAt)}.`,
+      effect:
+        "This is the exact duplicate-player safeguard result. It explains what stopped the player being added.",
+      href: teamId ? `/admin/teams/${teamId}` : null,
+      recordId: attempt.matchedRecordId,
+      tone: "amber",
+    });
+  }
+
+  for (const user of users) {
+    matches.push({
+      source: "User account",
+      title: user.name || "Unnamed user",
+      detail: `${user.email || email} · ${user.role}`,
+      effect:
+        "An existing User can be reused as the player identity. It does not automatically mean the add should fail.",
+      href: `/admin/users?q=${encodeURIComponent(email)}`,
+      recordId: user.id,
+      tone: "sky",
+    });
+  }
+
+  for (const prospect of prospects) {
+    const name = fullName(prospect.firstName, prospect.lastName) || "Unnamed prospect";
+    matches.push({
+      source: prospect.team ? "Team player prospect" : "Unassigned player prospect",
+      title: prospect.team ? `${name} · ${prospect.team.name}` : name,
+      detail: `Status: ${prospect.status}`,
+      effect:
+        "This record can stop a second player record being created. The existing prospect should be reused, moved or resolved instead.",
+      href: prospect.team
+        ? `/admin/teams/${prospect.team.id}/prospects`
+        : "/admin/player-pool",
+      recordId: prospect.id,
+      tone: "amber",
+    });
+  }
+
+  for (const profile of playerPoolRows) {
+    const name = fullName(profile.firstName, profile.lastName) || "Unnamed PlayerPool profile";
+    matches.push({
+      source: "PlayerPool profile",
+      title: name,
+      detail: `${profile.leagueName || "League not set"} · Status: ${profile.status}`,
+      effect:
+        "This is an existing PlayerPool identity and should be reused rather than creating another prospect/player record.",
+      href: `/admin/player-pool/${profile.id}`,
+      recordId: profile.id,
+      tone: "amber",
+    });
+  }
+
+  for (const lead of leads) {
+    matches.push({
+      source: "Interest lead",
+      title: lead.contactName || "Unnamed lead",
+      detail: `${lead.interestType} · ${lead.status}${lead.league?.name ? ` · ${lead.league.name}` : ""}`,
+      effect:
+        "A lead record by itself does not block somebody being set up as a player.",
+      href: `/admin/leads/${lead.id}`,
+      recordId: lead.id,
+      tone: "emerald",
+    });
+  }
+
+  for (const team of teams) {
+    if (sameEmail(team.contactEmail, email)) {
+      matches.push({
+        source: "Team primary contact",
+        title: team.name,
+        detail: team.contactName || email,
+        effect: "A team contact email by itself does not block player creation.",
+        href: `/admin/teams/${team.id}`,
+        recordId: team.id,
+        tone: "default",
+      });
+    }
+    if (sameEmail(team.secondaryContactEmail, email)) {
+      matches.push({
+        source: "Team secondary contact",
+        title: team.name,
+        detail: team.secondaryContactName || email,
+        effect: "A team contact email by itself does not block player creation.",
+        href: `/admin/teams/${team.id}`,
+        recordId: team.id,
+        tone: "default",
+      });
+    }
+    if (sameEmail(team.captainInviteSentTo, email)) {
+      matches.push({
+        source: "Captain invitation",
+        title: team.name,
+        detail: `Invitation sent to ${email}`,
+        effect: "A captain invitation by itself does not block player creation.",
+        href: `/admin/teams/${team.id}`,
+        recordId: team.id,
+        tone: "default",
+      });
+    }
+  }
+
+  for (const recipient of notificationRecipients) {
+    matches.push({
+      source: "Notification recipient",
+      title: recipient.displayName || recipient.sourceType,
+      detail: `${recipient.sourceType} · source ${recipient.sourceId}`,
+      effect:
+        "A notification-recipient record is communication metadata and does not by itself block player creation.",
+      href: null,
+      recordId: recipient.id,
+      tone: "default",
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    email,
+    matchCount: matches.length,
+    matches,
+  });
+}

--- a/src/components/admin/email-audit/EmailRecordLookup.tsx
+++ b/src/components/admin/email-audit/EmailRecordLookup.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+
+type LookupMatch = {
+  source: string;
+  title: string;
+  detail: string;
+  effect: string;
+  href: string | null;
+  recordId: string | null;
+  tone: "default" | "amber" | "emerald" | "sky";
+};
+
+type LookupResponse = {
+  ok: boolean;
+  email?: string;
+  matchCount?: number;
+  matches?: LookupMatch[];
+  error?: string;
+};
+
+function toneClasses(tone: LookupMatch["tone"]) {
+  if (tone === "amber") return "border-amber-400/25 bg-amber-500/[0.08]";
+  if (tone === "emerald") return "border-emerald-400/25 bg-emerald-500/[0.08]";
+  if (tone === "sky") return "border-sky-400/25 bg-sky-500/[0.08]";
+  return "border-white/10 bg-white/[0.04]";
+}
+
+export default function EmailRecordLookup() {
+  const pathname = usePathname();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<LookupResponse | null>(null);
+
+  const matches = useMemo(() => result?.matches ?? [], [result]);
+
+  if (pathname !== "/admin/email-audit") return null;
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const query = email.trim();
+    if (!query) return;
+
+    setLoading(true);
+    setResult(null);
+    try {
+      const response = await fetch(
+        `/api/admin/email-lookup?email=${encodeURIComponent(query)}`,
+        { cache: "no-store" },
+      );
+      const payload = (await response.json()) as LookupResponse;
+      setResult(payload);
+    } catch (error) {
+      console.error("Email record lookup failed", error);
+      setResult({ ok: false, error: "Could not complete the lookup. Please try again." });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="mx-auto mb-7 max-w-[1450px] overflow-hidden rounded-3xl border border-amber-400/20 bg-[radial-gradient(circle_at_top_left,rgba(245,158,11,0.12),transparent_32%),rgba(255,255,255,0.035)] p-5 shadow-[0_20px_70px_rgba(0,0,0,0.28)] sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-200/75">
+            Find the actual record
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Exact email lookup</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
+            Paste an email address to see every current SIXFL identity that uses it, plus any recent blocked player-creation attempts and the exact reason they were stopped.
+          </p>
+        </div>
+
+        <form onSubmit={submit} className="flex w-full max-w-2xl flex-col gap-3 sm:flex-row">
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="player@example.com"
+            className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none transition placeholder:text-white/30 focus:border-amber-400/50"
+          />
+          <button
+            type="submit"
+            disabled={loading || !email.trim()}
+            className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-amber-300/25 bg-amber-500/15 px-5 text-sm font-bold text-amber-50 transition hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {loading ? "Searching…" : "Find records"}
+          </button>
+        </form>
+      </div>
+
+      {result?.ok === false ? (
+        <div className="mt-5 rounded-2xl border border-red-400/25 bg-red-500/10 p-4 text-sm text-red-100">
+          {result.error || "No result was returned."}
+        </div>
+      ) : null}
+
+      {result?.ok ? (
+        <div className="mt-6 space-y-4">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-white">{result.email}</p>
+              <p className="mt-1 text-xs text-white/45">
+                {result.matchCount === 1 ? "1 matching record" : `${result.matchCount ?? 0} matching records`}
+              </p>
+            </div>
+            <p className="text-xs text-white/40">
+              Lead records are shown for completeness, but a lead by itself does not block player creation.
+            </p>
+          </div>
+
+          {matches.length ? (
+            <div className="grid gap-3 xl:grid-cols-2">
+              {matches.map((match, index) => (
+                <article
+                  key={`${match.source}-${match.recordId ?? index}-${index}`}
+                  className={`rounded-2xl border p-4 ${toneClasses(match.tone)}`}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="text-[10px] font-bold uppercase tracking-[0.17em] text-white/40">
+                        {match.source}
+                      </p>
+                      <h3 className="mt-2 break-words text-base font-semibold text-white">
+                        {match.title}
+                      </h3>
+                      <p className="mt-1 text-sm leading-6 text-white/60">{match.detail}</p>
+                    </div>
+
+                    {match.href ? (
+                      <Link
+                        href={match.href}
+                        className="shrink-0 rounded-xl border border-white/15 bg-white/[0.06] px-3 py-2 text-xs font-bold text-white/80 transition hover:bg-white/10 hover:text-white"
+                      >
+                        Open
+                      </Link>
+                    ) : null}
+                  </div>
+
+                  <div className="mt-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs leading-5 text-white/55">
+                    {match.effect}
+                  </div>
+
+                  {match.recordId ? (
+                    <p className="mt-2 break-all text-[10px] text-white/25">Record: {match.recordId}</p>
+                  ) : null}
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-6 text-center text-sm text-white/50">
+              No current SIXFL record was found for this exact email address.
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed

- adds an **Exact email lookup** panel to Admin → Email Audit
- searches current User, Team contact, captain invite, TeamPlayerProspect, PlayerPool, InterestLead and NotificationRecipient records
- shows recent `PlayerDuplicateAttempt` entries for that email, including the exact reason a player creation attempt was blocked
- adds direct links to the relevant admin user, team, prospect, PlayerPool profile or lead where possible
- clearly labels that an InterestLead by itself does **not** block player creation
- clearly labels existing prospect/PlayerPool identities as records that should be reused or resolved instead of duplicated

## Why

This makes it possible to paste an email such as `arijeadesina2008@gmail.com` and immediately see where SIXFL already knows that person, rather than checking Users, Leads, PlayerPool and team prospects separately.

## Safety

- admin-only API protected with `requireAdmin()`
- exact case-insensitive email matching only
- read-only diagnostic feature; it does not merge, move, delete or alter any identity records