### PR TITLE
Align reassurance contracts and production-build verification

### DIFF
--- a/.github/workflows/player-pool-profile-reminders.yml
+++ b/.github/workflows/player-pool-profile-reminders.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sixfl
+      NEXTAUTH_SECRET: player-pool-reminder-ci-secret
+      NEXTAUTH_URL: http://localhost:3000
+      NEXT_PUBLIC_SITE_URL: http://localhost:3000
+      RESEND_API_KEY: re_player_pool_reminder_ci_placeholder
+      EMAIL_FROM: SIXFL <noreply@sixfl.test>
+      EMAIL_REPLY_DOMAIN: replies.sixfl.test
+      CRON_SECRET: player-pool-reminder-ci-cron-secret
 
     steps:
       - name: Check out repository
@@ -41,3 +48,6 @@ jobs:
 
       - name: Type-check application source
         run: npx tsc --noEmit
+
+      - name: Build the production application
+        run: npx next build

--- a/scripts/check-team-confirmation-contract.mjs
+++ b/scripts/check-team-confirmation-contract.mjs
@@ -79,9 +79,13 @@ expect(
 
 expect(
   reassuranceAction.includes(
-    'export const TEAM_REASSURANCE_SMS_TEMPLATE_KEY = "team-lead-reassurance-sms"',
+    'const TEAM_REASSURANCE_SMS_TEMPLATE_KEY = "team-lead-reassurance-sms"',
   ) && reassuranceAction.includes("DEFAULT_SMS_BODY"),
   "the reassurance flow must define a dedicated editable system SMS template",
+);
+expect(
+  !reassuranceAction.includes("export const TEAM_REASSURANCE"),
+  "the reassurance server-action module must export only async actions",
 );
 expect(
   reassuranceAction.includes(


### PR DESCRIPTION
## What changed

- updates the team reassurance contract to accept the valid Next.js server-action structure now deployed on `main`
- explicitly prevents ordinary constants from being exported by that `"use server"` module
- extends the PlayerPool reminder workflow through a complete Next.js production build
- supplies inert CI-only email configuration so build-time module evaluation is covered without production credentials

## Why

The production repair is already live. This follow-up removes the stale contract expectation that still made GitHub Actions red and ensures future PlayerPool/reminder changes are checked through the same compilation path used for deployment.

## Safety

The CI values are placeholders used only during compilation. The workflow does not connect to production or send email.