### PR TITLE
Extend admin identity lookup to phone and name

### DIFF
--- a/src/app/api/admin/email-lookup/route.ts
+++ b/src/app/api/admin/email-lookup/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 
+import { normalizePhoneNumber } from "@/lib/messaging/phone";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
+
+type QueryType = "email" | "phone" | "name";
 
 type LookupMatch = {
   source: string;
@@ -17,18 +20,73 @@ type LookupMatch = {
   tone: "default" | "amber" | "emerald" | "sky";
 };
 
+type UserRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string;
+};
+
+type MembershipRow = {
+  membershipId: string;
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  memberRole: string;
+  teamId: string;
+  teamName: string;
+  phone: string | null;
+};
+
+type ProspectRow = {
+  id: string;
+  firstName: string;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  status: string;
+  teamId: string | null;
+  teamName: string | null;
+};
+
+type LeadRow = {
+  id: string;
+  contactName: string;
+  email: string | null;
+  phone: string | null;
+  interestType: string;
+  status: string;
+  leagueName: string | null;
+};
+
+type TeamContactRow = {
+  id: string;
+  name: string;
+  contactName: string | null;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  secondaryContactName: string | null;
+  secondaryContactEmail: string | null;
+  secondaryContactPhone: string | null;
+  captainInviteSentTo: string | null;
+};
+
 type NotificationRecipientRow = {
   id: string;
   sourceType: string;
-  sourceId: string;
+  sourceId: string | null;
   displayName: string | null;
   email: string | null;
+  phone: string | null;
 };
 
 type PlayerPoolRow = {
   id: string;
+  prospectId: string;
   firstName: string;
   lastName: string | null;
+  email: string | null;
+  phone: string | null;
   status: string;
   leagueName: string | null;
 };
@@ -37,6 +95,8 @@ type DuplicateAttemptRow = {
   id: string;
   teamId: string;
   displayName: string;
+  email: string | null;
+  phone: string | null;
   matchType: string;
   matchedRecordId: string | null;
   matchedTeamId: string | null;
@@ -50,8 +110,26 @@ function normaliseEmail(value: string | null | undefined) {
   return email;
 }
 
+function normaliseName(value: string | null | undefined) {
+  const name = value?.trim().replace(/\s+/g, " ").toLowerCase() ?? "";
+  return name.length >= 2 ? name : null;
+}
+
+function normalisePhoneDigits(value: string | null | undefined) {
+  const phone = normalizePhoneNumber(value);
+  return phone?.replace(/^\+/, "") ?? null;
+}
+
 function sameEmail(value: string | null | undefined, email: string) {
   return normaliseEmail(value) === email;
+}
+
+function sameName(value: string | null | undefined, name: string) {
+  return normaliseName(value) === name;
+}
+
+function samePhone(value: string | null | undefined, phoneDigits: string) {
+  return normalisePhoneDigits(value) === phoneDigits;
 }
 
 function fullName(firstName: string, lastName: string | null) {
@@ -66,124 +144,464 @@ function formatAttemptDate(value: Date) {
   }).format(value);
 }
 
+function identityStrengthCopy(queryType: QueryType) {
+  if (queryType === "name") {
+    return "This is an exact name match only. Check the email or mobile number before deciding it is the same person.";
+  }
+  return "This is a contact-identity match and is strong evidence that this is the existing player record.";
+}
+
 export async function GET(request: Request) {
   await requireAdmin();
 
   const url = new URL(request.url);
-  const email = normaliseEmail(url.searchParams.get("email"));
-  if (!email) {
+  const rawQuery = (url.searchParams.get("q") ?? url.searchParams.get("email") ?? "").trim();
+  if (!rawQuery) {
     return NextResponse.json(
-      { ok: false, error: "Enter a valid email address." },
+      { ok: false, error: "Enter an email address, mobile number or full player name." },
       { status: 400 },
     );
   }
 
-  const [users, teams, prospects, leads, optionalTables] = await Promise.all([
-    prisma.user.findMany({
-      where: { email: { equals: email, mode: "insensitive" } },
-      select: { id: true, name: true, email: true, role: true },
-    }),
-    prisma.team.findMany({
-      where: {
-        OR: [
-          { contactEmail: { equals: email, mode: "insensitive" } },
-          { secondaryContactEmail: { equals: email, mode: "insensitive" } },
-          { captainInviteSentTo: { equals: email, mode: "insensitive" } },
-        ],
-      },
-      select: {
-        id: true,
-        name: true,
-        contactName: true,
-        contactEmail: true,
-        secondaryContactName: true,
-        secondaryContactEmail: true,
-        captainInviteSentTo: true,
-      },
-    }),
-    prisma.teamPlayerProspect.findMany({
-      where: { email: { equals: email, mode: "insensitive" } },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        email: true,
-        status: true,
-        team: { select: { id: true, name: true } },
-      },
-    }),
-    prisma.interestLead.findMany({
-      where: { email: { equals: email, mode: "insensitive" } },
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        contactName: true,
-        interestType: true,
-        status: true,
-        league: { select: { name: true } },
-      },
-    }),
-    prisma.$queryRaw<Array<{ playerPool: boolean; duplicateAttempts: boolean }>>(Prisma.sql`
-      SELECT
-        to_regclass('"PlayerPoolProfile"') IS NOT NULL AS "playerPool",
-        to_regclass('"PlayerDuplicateAttempt"') IS NOT NULL AS "duplicateAttempts"
-    `),
-  ]);
+  const email = normaliseEmail(rawQuery);
+  const phoneDigits = email ? null : normalisePhoneDigits(rawQuery);
+  const name = email || phoneDigits ? null : normaliseName(rawQuery);
+  const queryType: QueryType = email ? "email" : phoneDigits ? "phone" : "name";
+
+  if (!email && !phoneDigits && !name) {
+    return NextResponse.json(
+      { ok: false, error: "Enter a valid email address, mobile number or full player name." },
+      { status: 400 },
+    );
+  }
+
+  const optionalTables = await prisma.$queryRaw<
+    Array<{ playerPool: boolean; duplicateAttempts: boolean; teamMemberProfile: boolean }>
+  >(Prisma.sql`
+    SELECT
+      to_regclass('"PlayerPoolProfile"') IS NOT NULL AS "playerPool",
+      to_regclass('"PlayerDuplicateAttempt"') IS NOT NULL AS "duplicateAttempts",
+      to_regclass('"TeamMemberProfile"') IS NOT NULL AS "teamMemberProfile"
+  `);
 
   const tableState = optionalTables[0] ?? {
     playerPool: false,
     duplicateAttempts: false,
+    teamMemberProfile: false,
   };
 
-  const [notificationRecipients, playerPoolRows, duplicateAttempts] =
-    await Promise.all([
+  let users: UserRow[] = [];
+  let memberships: MembershipRow[] = [];
+  let prospects: ProspectRow[] = [];
+  let leads: LeadRow[] = [];
+  let teams: TeamContactRow[] = [];
+  let notificationRecipients: NotificationRecipientRow[] = [];
+  let playerPoolRows: PlayerPoolRow[] = [];
+  let duplicateAttempts: DuplicateAttemptRow[] = [];
+
+  if (queryType === "email" && email) {
+    [users, memberships, prospects, leads, teams, notificationRecipients] = await Promise.all([
+      prisma.$queryRaw<UserRow[]>(Prisma.sql`
+        SELECT "id", "name", "email", "role"::text AS "role"
+        FROM "User"
+        WHERE LOWER(BTRIM(COALESCE("email", ''))) = ${email}
+        ORDER BY "name" NULLS LAST, "id"
+      `),
+      prisma.$queryRaw<MembershipRow[]>(Prisma.sql`
+        SELECT
+          member."id" AS "membershipId",
+          player_user."id" AS "userId",
+          player_user."name" AS "userName",
+          player_user."email" AS "userEmail",
+          member."role"::text AS "memberRole",
+          team."id" AS "teamId",
+          team."name" AS "teamName",
+          profile."phone" AS "phone"
+        FROM "TeamMember" member
+        JOIN "User" player_user ON player_user."id" = member."userId"
+        JOIN "Team" team ON team."id" = member."teamId"
+        LEFT JOIN "TeamMemberProfile" profile ON profile."teamMemberId" = member."id"
+        WHERE LOWER(BTRIM(COALESCE(player_user."email", ''))) = ${email}
+        ORDER BY team."name", member."id"
+      `),
+      prisma.$queryRaw<ProspectRow[]>(Prisma.sql`
+        SELECT
+          prospect."id",
+          prospect."firstName",
+          prospect."lastName",
+          prospect."email",
+          prospect."phone",
+          prospect."status",
+          team."id" AS "teamId",
+          team."name" AS "teamName"
+        FROM "TeamPlayerProspect" prospect
+        LEFT JOIN "Team" team ON team."id" = prospect."teamId"
+        WHERE LOWER(BTRIM(COALESCE(prospect."email", ''))) = ${email}
+        ORDER BY prospect."updatedAt" DESC
+      `),
+      prisma.$queryRaw<LeadRow[]>(Prisma.sql`
+        SELECT
+          lead."id",
+          lead."contactName",
+          lead."email",
+          lead."phone",
+          lead."interestType"::text AS "interestType",
+          lead."status"::text AS "status",
+          league."name" AS "leagueName"
+        FROM "InterestLead" lead
+        LEFT JOIN "League" league ON league."id" = lead."leagueId"
+        WHERE LOWER(BTRIM(COALESCE(lead."email", ''))) = ${email}
+        ORDER BY lead."createdAt" DESC
+      `),
+      prisma.$queryRaw<TeamContactRow[]>(Prisma.sql`
+        SELECT
+          "id", "name", "contactName", "contactEmail", "contactPhone",
+          "secondaryContactName", "secondaryContactEmail", "secondaryContactPhone",
+          "captainInviteSentTo"
+        FROM "Team"
+        WHERE LOWER(BTRIM(COALESCE("contactEmail", ''))) = ${email}
+           OR LOWER(BTRIM(COALESCE("secondaryContactEmail", ''))) = ${email}
+           OR LOWER(BTRIM(COALESCE("captainInviteSentTo", ''))) = ${email}
+        ORDER BY "name"
+      `),
       prisma.$queryRaw<NotificationRecipientRow[]>(Prisma.sql`
         SELECT
           "id",
           "sourceType"::text AS "sourceType",
           "sourceId",
           "displayName",
-          COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email"
+          COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email",
+          COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')) AS "phone"
         FROM "NotificationRecipient"
         WHERE LOWER(COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), ''))) = ${email}
         ORDER BY "updatedAt" DESC
         LIMIT 20
       `),
-      tableState.playerPool
-        ? prisma.$queryRaw<PlayerPoolRow[]>(Prisma.sql`
-            SELECT
-              profile."id",
-              prospect."firstName",
-              prospect."lastName",
-              profile."status"::text AS "status",
-              league."name" AS "leagueName"
-            FROM "PlayerPoolProfile" profile
-            JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"
-            LEFT JOIN "League" league ON league."id" = profile."leagueId"
-            WHERE LOWER(BTRIM(COALESCE(profile."emailNormalized", prospect."email", ''))) = ${email}
-               OR LOWER(BTRIM(COALESCE(prospect."email", ''))) = ${email}
-            ORDER BY profile."updatedAt" DESC
-            LIMIT 20
-          `)
-        : Promise.resolve([] as PlayerPoolRow[]),
-      tableState.duplicateAttempts
-        ? prisma.$queryRaw<DuplicateAttemptRow[]>(Prisma.sql`
-            SELECT
-              "id",
-              "teamId",
-              "displayName",
-              "matchType",
-              "matchedRecordId",
-              "matchedTeamId",
-              "reason",
-              "createdAt"
-            FROM "PlayerDuplicateAttempt"
-            WHERE LOWER(BTRIM(COALESCE("email", ''))) = ${email}
-            ORDER BY "createdAt" DESC
-            LIMIT 10
-          `)
-        : Promise.resolve([] as DuplicateAttemptRow[]),
     ]);
+
+    playerPoolRows = tableState.playerPool
+      ? await prisma.$queryRaw<PlayerPoolRow[]>(Prisma.sql`
+          SELECT
+            profile."id",
+            prospect."id" AS "prospectId",
+            prospect."firstName",
+            prospect."lastName",
+            prospect."email",
+            prospect."phone",
+            profile."status"::text AS "status",
+            league."name" AS "leagueName"
+          FROM "PlayerPoolProfile" profile
+          JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"
+          LEFT JOIN "League" league ON league."id" = profile."leagueId"
+          WHERE LOWER(BTRIM(COALESCE(profile."emailNormalized", prospect."email", ''))) = ${email}
+             OR LOWER(BTRIM(COALESCE(prospect."email", ''))) = ${email}
+          ORDER BY profile."updatedAt" DESC
+          LIMIT 20
+        `)
+      : [];
+
+    duplicateAttempts = tableState.duplicateAttempts
+      ? await prisma.$queryRaw<DuplicateAttemptRow[]>(Prisma.sql`
+          SELECT
+            "id", "teamId", "displayName", "email", "phone", "matchType",
+            "matchedRecordId", "matchedTeamId", "reason", "createdAt"
+          FROM "PlayerDuplicateAttempt"
+          WHERE LOWER(BTRIM(COALESCE("email", ''))) = ${email}
+          ORDER BY "createdAt" DESC
+          LIMIT 20
+        `)
+      : [];
+  }
+
+  if (queryType === "phone" && phoneDigits) {
+    [prospects, leads, teams, notificationRecipients] = await Promise.all([
+      prisma.$queryRaw<ProspectRow[]>(Prisma.sql`
+        SELECT
+          prospect."id",
+          prospect."firstName",
+          prospect."lastName",
+          prospect."email",
+          prospect."phone",
+          prospect."status",
+          team."id" AS "teamId",
+          team."name" AS "teamName"
+        FROM "TeamPlayerProspect" prospect
+        LEFT JOIN "Team" team ON team."id" = prospect."teamId"
+        WHERE CASE
+          WHEN REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g') LIKE '0%'
+            THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g') FROM 2)
+          WHEN REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g') LIKE '44%'
+            THEN REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g')
+          ELSE '44' || REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g')
+        END = ${phoneDigits}
+        ORDER BY prospect."updatedAt" DESC
+      `),
+      prisma.$queryRaw<LeadRow[]>(Prisma.sql`
+        SELECT
+          lead."id",
+          lead."contactName",
+          lead."email",
+          lead."phone",
+          lead."interestType"::text AS "interestType",
+          lead."status"::text AS "status",
+          league."name" AS "leagueName"
+        FROM "InterestLead" lead
+        LEFT JOIN "League" league ON league."id" = lead."leagueId"
+        WHERE REGEXP_REPLACE(
+          COALESCE(NULLIF(BTRIM(lead."phoneNormalized"), ''), NULLIF(BTRIM(lead."phone"), '')),
+          '[^0-9]', '', 'g'
+        ) = ${phoneDigits}
+        ORDER BY lead."createdAt" DESC
+      `),
+      prisma.$queryRaw<TeamContactRow[]>(Prisma.sql`
+        SELECT
+          "id", "name", "contactName", "contactEmail", "contactPhone",
+          "secondaryContactName", "secondaryContactEmail", "secondaryContactPhone",
+          "captainInviteSentTo"
+        FROM "Team"
+        WHERE CASE
+          WHEN REGEXP_REPLACE(COALESCE("contactPhone", ''), '[^0-9]', '', 'g') LIKE '0%'
+            THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE("contactPhone", ''), '[^0-9]', '', 'g') FROM 2)
+          WHEN REGEXP_REPLACE(COALESCE("contactPhone", ''), '[^0-9]', '', 'g') LIKE '44%'
+            THEN REGEXP_REPLACE(COALESCE("contactPhone", ''), '[^0-9]', '', 'g')
+          ELSE '44' || REGEXP_REPLACE(COALESCE("contactPhone", ''), '[^0-9]', '', 'g')
+        END = ${phoneDigits}
+        OR CASE
+          WHEN REGEXP_REPLACE(COALESCE("secondaryContactPhone", ''), '[^0-9]', '', 'g') LIKE '0%'
+            THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE("secondaryContactPhone", ''), '[^0-9]', '', 'g') FROM 2)
+          WHEN REGEXP_REPLACE(COALESCE("secondaryContactPhone", ''), '[^0-9]', '', 'g') LIKE '44%'
+            THEN REGEXP_REPLACE(COALESCE("secondaryContactPhone", ''), '[^0-9]', '', 'g')
+          ELSE '44' || REGEXP_REPLACE(COALESCE("secondaryContactPhone", ''), '[^0-9]', '', 'g')
+        END = ${phoneDigits}
+        ORDER BY "name"
+      `),
+      prisma.$queryRaw<NotificationRecipientRow[]>(Prisma.sql`
+        SELECT
+          "id",
+          "sourceType"::text AS "sourceType",
+          "sourceId",
+          "displayName",
+          COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email",
+          COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')) AS "phone"
+        FROM "NotificationRecipient"
+        WHERE REGEXP_REPLACE(
+          COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')),
+          '[^0-9]', '', 'g'
+        ) = ${phoneDigits}
+        ORDER BY "updatedAt" DESC
+        LIMIT 20
+      `),
+    ]);
+
+    memberships = tableState.teamMemberProfile
+      ? await prisma.$queryRaw<MembershipRow[]>(Prisma.sql`
+          WITH profile_phones AS (
+            SELECT
+              profile."teamMemberId",
+              profile."phone",
+              CASE
+                WHEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') LIKE '0%'
+                  THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') FROM 2)
+                WHEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g') LIKE '44%'
+                  THEN REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g')
+                ELSE '44' || REGEXP_REPLACE(COALESCE(profile."phone", ''), '[^0-9]', '', 'g')
+              END AS "phoneNormalized"
+            FROM "TeamMemberProfile" profile
+            WHERE NULLIF(BTRIM(profile."phone"), '') IS NOT NULL
+          )
+          SELECT
+            member."id" AS "membershipId",
+            player_user."id" AS "userId",
+            player_user."name" AS "userName",
+            player_user."email" AS "userEmail",
+            member."role"::text AS "memberRole",
+            team."id" AS "teamId",
+            team."name" AS "teamName",
+            profile_phones."phone" AS "phone"
+          FROM profile_phones
+          JOIN "TeamMember" member ON member."id" = profile_phones."teamMemberId"
+          JOIN "User" player_user ON player_user."id" = member."userId"
+          JOIN "Team" team ON team."id" = member."teamId"
+          WHERE profile_phones."phoneNormalized" = ${phoneDigits}
+          ORDER BY team."name", member."id"
+        `)
+      : [];
+
+    users = memberships.length
+      ? await prisma.$queryRaw<UserRow[]>(Prisma.sql`
+          SELECT DISTINCT player_user."id", player_user."name", player_user."email", player_user."role"::text AS "role"
+          FROM "User" player_user
+          WHERE player_user."id" IN (${Prisma.join(memberships.map((row) => row.userId))})
+          ORDER BY player_user."name" NULLS LAST, player_user."id"
+        `)
+      : [];
+
+    playerPoolRows = tableState.playerPool
+      ? await prisma.$queryRaw<PlayerPoolRow[]>(Prisma.sql`
+          SELECT
+            profile."id",
+            prospect."id" AS "prospectId",
+            prospect."firstName",
+            prospect."lastName",
+            prospect."email",
+            prospect."phone",
+            profile."status"::text AS "status",
+            league."name" AS "leagueName"
+          FROM "PlayerPoolProfile" profile
+          JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"
+          LEFT JOIN "League" league ON league."id" = profile."leagueId"
+          WHERE CASE
+            WHEN REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g') LIKE '0%'
+              THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g') FROM 2)
+            WHEN REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g') LIKE '44%'
+              THEN REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g')
+            ELSE '44' || REGEXP_REPLACE(COALESCE(prospect."phone", ''), '[^0-9]', '', 'g')
+          END = ${phoneDigits}
+          ORDER BY profile."updatedAt" DESC
+          LIMIT 20
+        `)
+      : [];
+
+    duplicateAttempts = tableState.duplicateAttempts
+      ? await prisma.$queryRaw<DuplicateAttemptRow[]>(Prisma.sql`
+          SELECT
+            "id", "teamId", "displayName", "email", "phone", "matchType",
+            "matchedRecordId", "matchedTeamId", "reason", "createdAt"
+          FROM "PlayerDuplicateAttempt"
+          WHERE CASE
+            WHEN REGEXP_REPLACE(COALESCE("phone", ''), '[^0-9]', '', 'g') LIKE '0%'
+              THEN '44' || SUBSTRING(REGEXP_REPLACE(COALESCE("phone", ''), '[^0-9]', '', 'g') FROM 2)
+            WHEN REGEXP_REPLACE(COALESCE("phone", ''), '[^0-9]', '', 'g') LIKE '44%'
+              THEN REGEXP_REPLACE(COALESCE("phone", ''), '[^0-9]', '', 'g')
+            ELSE '44' || REGEXP_REPLACE(COALESCE("phone", ''), '[^0-9]', '', 'g')
+          END = ${phoneDigits}
+          ORDER BY "createdAt" DESC
+          LIMIT 20
+        `)
+      : [];
+  }
+
+  if (queryType === "name" && name) {
+    [users, memberships, prospects, leads, teams, notificationRecipients] = await Promise.all([
+      prisma.$queryRaw<UserRow[]>(Prisma.sql`
+        SELECT "id", "name", "email", "role"::text AS "role"
+        FROM "User"
+        WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE("name", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+        ORDER BY "email" NULLS LAST, "id"
+      `),
+      prisma.$queryRaw<MembershipRow[]>(Prisma.sql`
+        SELECT
+          member."id" AS "membershipId",
+          player_user."id" AS "userId",
+          player_user."name" AS "userName",
+          player_user."email" AS "userEmail",
+          member."role"::text AS "memberRole",
+          team."id" AS "teamId",
+          team."name" AS "teamName",
+          profile."phone" AS "phone"
+        FROM "TeamMember" member
+        JOIN "User" player_user ON player_user."id" = member."userId"
+        JOIN "Team" team ON team."id" = member."teamId"
+        LEFT JOIN "TeamMemberProfile" profile ON profile."teamMemberId" = member."id"
+        WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE(player_user."name", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+        ORDER BY team."name", member."id"
+      `),
+      prisma.$queryRaw<ProspectRow[]>(Prisma.sql`
+        SELECT
+          prospect."id",
+          prospect."firstName",
+          prospect."lastName",
+          prospect."email",
+          prospect."phone",
+          prospect."status",
+          team."id" AS "teamId",
+          team."name" AS "teamName"
+        FROM "TeamPlayerProspect" prospect
+        LEFT JOIN "Team" team ON team."id" = prospect."teamId"
+        WHERE LOWER(
+          REGEXP_REPLACE(
+            BTRIM(CONCAT_WS(' ', prospect."firstName", prospect."lastName")),
+            '[[:space:]]+', ' ', 'g'
+          )
+        ) = ${name}
+        ORDER BY prospect."updatedAt" DESC
+      `),
+      prisma.$queryRaw<LeadRow[]>(Prisma.sql`
+        SELECT
+          lead."id",
+          lead."contactName",
+          lead."email",
+          lead."phone",
+          lead."interestType"::text AS "interestType",
+          lead."status"::text AS "status",
+          league."name" AS "leagueName"
+        FROM "InterestLead" lead
+        LEFT JOIN "League" league ON league."id" = lead."leagueId"
+        WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE(lead."contactName", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+        ORDER BY lead."createdAt" DESC
+      `),
+      prisma.$queryRaw<TeamContactRow[]>(Prisma.sql`
+        SELECT
+          "id", "name", "contactName", "contactEmail", "contactPhone",
+          "secondaryContactName", "secondaryContactEmail", "secondaryContactPhone",
+          "captainInviteSentTo"
+        FROM "Team"
+        WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE("contactName", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+           OR LOWER(REGEXP_REPLACE(BTRIM(COALESCE("secondaryContactName", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+        ORDER BY "name"
+      `),
+      prisma.$queryRaw<NotificationRecipientRow[]>(Prisma.sql`
+        SELECT
+          "id",
+          "sourceType"::text AS "sourceType",
+          "sourceId",
+          "displayName",
+          COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email",
+          COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')) AS "phone"
+        FROM "NotificationRecipient"
+        WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE("displayName", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+        ORDER BY "updatedAt" DESC
+        LIMIT 20
+      `),
+    ]);
+
+    playerPoolRows = tableState.playerPool
+      ? await prisma.$queryRaw<PlayerPoolRow[]>(Prisma.sql`
+          SELECT
+            profile."id",
+            prospect."id" AS "prospectId",
+            prospect."firstName",
+            prospect."lastName",
+            prospect."email",
+            prospect."phone",
+            profile."status"::text AS "status",
+            league."name" AS "leagueName"
+          FROM "PlayerPoolProfile" profile
+          JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"
+          LEFT JOIN "League" league ON league."id" = profile."leagueId"
+          WHERE LOWER(
+            REGEXP_REPLACE(
+              BTRIM(CONCAT_WS(' ', prospect."firstName", prospect."lastName")),
+              '[[:space:]]+', ' ', 'g'
+            )
+          ) = ${name}
+          ORDER BY profile."updatedAt" DESC
+          LIMIT 20
+        `)
+      : [];
+
+    duplicateAttempts = tableState.duplicateAttempts
+      ? await prisma.$queryRaw<DuplicateAttemptRow[]>(Prisma.sql`
+          SELECT
+            "id", "teamId", "displayName", "email", "phone", "matchType",
+            "matchedRecordId", "matchedTeamId", "reason", "createdAt"
+          FROM "PlayerDuplicateAttempt"
+          WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE("displayName", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+          ORDER BY "createdAt" DESC
+          LIMIT 20
+        `)
+      : [];
+  }
 
   const matches: LookupMatch[] = [];
 
@@ -191,12 +609,58 @@ export async function GET(request: Request) {
     const teamId = attempt.matchedTeamId || attempt.teamId;
     matches.push({
       source: "Blocked player creation attempt",
-      title: `${attempt.displayName || email} · ${attempt.matchType.replaceAll("_", " ")}`,
+      title: `${attempt.displayName || rawQuery} · ${attempt.matchType.replaceAll("_", " ")}`,
       detail: `${attempt.reason} Attempted ${formatAttemptDate(attempt.createdAt)}.`,
       effect:
         "This is the exact duplicate-player safeguard result. It explains what stopped the player being added.",
-      href: teamId ? `/admin/teams/${teamId}` : null,
+      href: teamId ? `/admin/teams/${teamId}/players` : null,
       recordId: attempt.matchedRecordId,
+      tone: "amber",
+    });
+  }
+
+  for (const membership of memberships) {
+    matches.push({
+      source: "Squad membership",
+      title: `${membership.userName || membership.userEmail || "Unnamed player"} · ${membership.teamName}`,
+      detail: `${membership.memberRole}${membership.userEmail ? ` · ${membership.userEmail}` : ""}${membership.phone ? ` · ${membership.phone}` : ""}`,
+      effect: identityStrengthCopy(queryType),
+      href: `/admin/teams/${membership.teamId}/players`,
+      recordId: membership.membershipId,
+      tone: queryType === "name" ? "sky" : "amber",
+    });
+  }
+
+  for (const prospect of prospects) {
+    const prospectName = fullName(prospect.firstName, prospect.lastName) || "Unnamed prospect";
+    matches.push({
+      source: prospect.teamName ? "Team player prospect" : "Unassigned player prospect",
+      title: prospect.teamName ? `${prospectName} · ${prospect.teamName}` : prospectName,
+      detail: `Status: ${prospect.status}${prospect.email ? ` · ${prospect.email}` : ""}${prospect.phone ? ` · ${prospect.phone}` : ""}`,
+      effect:
+        queryType === "name"
+          ? `${identityStrengthCopy(queryType)} If it is the same person, this prospect can block creation of another player identity.`
+          : "This record can stop a second player record being created. The existing prospect should be reused, moved or resolved instead.",
+      href: prospect.teamId
+        ? `/admin/teams/${prospect.teamId}/prospects`
+        : "/admin/player-pool",
+      recordId: prospect.id,
+      tone: "amber",
+    });
+  }
+
+  for (const profile of playerPoolRows) {
+    const profileName = fullName(profile.firstName, profile.lastName) || "Unnamed PlayerPool profile";
+    matches.push({
+      source: "PlayerPool profile",
+      title: profileName,
+      detail: `${profile.leagueName || "League not set"} · Status: ${profile.status}${profile.email ? ` · ${profile.email}` : ""}${profile.phone ? ` · ${profile.phone}` : ""}`,
+      effect:
+        queryType === "name"
+          ? `${identityStrengthCopy(queryType)} If confirmed, reuse this PlayerPool identity rather than creating another.`
+          : "This is an existing PlayerPool identity and should be reused rather than creating another prospect/player record.",
+      href: `/admin/player-pool/${profile.id}`,
+      recordId: profile.id,
       tone: "amber",
     });
   }
@@ -205,42 +669,16 @@ export async function GET(request: Request) {
     matches.push({
       source: "User account",
       title: user.name || "Unnamed user",
-      detail: `${user.email || email} · ${user.role}`,
+      detail: `${user.email || "No email"} · ${user.role}`,
       effect:
-        "An existing User can be reused as the player identity. It does not automatically mean the add should fail.",
-      href: `/admin/users?q=${encodeURIComponent(email)}`,
+        queryType === "name"
+          ? identityStrengthCopy(queryType)
+          : "An existing User can be reused as the player identity. It does not automatically mean the add should fail.",
+      href: user.email
+        ? `/admin/users?q=${encodeURIComponent(user.email)}`
+        : `/admin/users?q=${encodeURIComponent(user.name || rawQuery)}`,
       recordId: user.id,
       tone: "sky",
-    });
-  }
-
-  for (const prospect of prospects) {
-    const name = fullName(prospect.firstName, prospect.lastName) || "Unnamed prospect";
-    matches.push({
-      source: prospect.team ? "Team player prospect" : "Unassigned player prospect",
-      title: prospect.team ? `${name} · ${prospect.team.name}` : name,
-      detail: `Status: ${prospect.status}`,
-      effect:
-        "This record can stop a second player record being created. The existing prospect should be reused, moved or resolved instead.",
-      href: prospect.team
-        ? `/admin/teams/${prospect.team.id}/prospects`
-        : "/admin/player-pool",
-      recordId: prospect.id,
-      tone: "amber",
-    });
-  }
-
-  for (const profile of playerPoolRows) {
-    const name = fullName(profile.firstName, profile.lastName) || "Unnamed PlayerPool profile";
-    matches.push({
-      source: "PlayerPool profile",
-      title: name,
-      detail: `${profile.leagueName || "League not set"} · Status: ${profile.status}`,
-      effect:
-        "This is an existing PlayerPool identity and should be reused rather than creating another prospect/player record.",
-      href: `/admin/player-pool/${profile.id}`,
-      recordId: profile.id,
-      tone: "amber",
     });
   }
 
@@ -248,7 +686,7 @@ export async function GET(request: Request) {
     matches.push({
       source: "Interest lead",
       title: lead.contactName || "Unnamed lead",
-      detail: `${lead.interestType} · ${lead.status}${lead.league?.name ? ` · ${lead.league.name}` : ""}`,
+      detail: `${lead.interestType} · ${lead.status}${lead.leagueName ? ` · ${lead.leagueName}` : ""}${lead.email ? ` · ${lead.email}` : ""}${lead.phone ? ` · ${lead.phone}` : ""}`,
       effect:
         "A lead record by itself does not block somebody being set up as a player.",
       href: `/admin/leads/${lead.id}`,
@@ -258,29 +696,39 @@ export async function GET(request: Request) {
   }
 
   for (const team of teams) {
-    if (sameEmail(team.contactEmail, email)) {
+    if (
+      (queryType === "email" && email && sameEmail(team.contactEmail, email)) ||
+      (queryType === "phone" && phoneDigits && samePhone(team.contactPhone, phoneDigits)) ||
+      (queryType === "name" && name && sameName(team.contactName, name))
+    ) {
       matches.push({
         source: "Team primary contact",
         title: team.name,
-        detail: team.contactName || email,
-        effect: "A team contact email by itself does not block player creation.",
+        detail: `${team.contactName || "Unnamed contact"}${team.contactEmail ? ` · ${team.contactEmail}` : ""}${team.contactPhone ? ` · ${team.contactPhone}` : ""}`,
+        effect: "A team contact record by itself does not block player creation.",
         href: `/admin/teams/${team.id}`,
         recordId: team.id,
         tone: "default",
       });
     }
-    if (sameEmail(team.secondaryContactEmail, email)) {
+
+    if (
+      (queryType === "email" && email && sameEmail(team.secondaryContactEmail, email)) ||
+      (queryType === "phone" && phoneDigits && samePhone(team.secondaryContactPhone, phoneDigits)) ||
+      (queryType === "name" && name && sameName(team.secondaryContactName, name))
+    ) {
       matches.push({
         source: "Team secondary contact",
         title: team.name,
-        detail: team.secondaryContactName || email,
-        effect: "A team contact email by itself does not block player creation.",
+        detail: `${team.secondaryContactName || "Unnamed contact"}${team.secondaryContactEmail ? ` · ${team.secondaryContactEmail}` : ""}${team.secondaryContactPhone ? ` · ${team.secondaryContactPhone}` : ""}`,
+        effect: "A team contact record by itself does not block player creation.",
         href: `/admin/teams/${team.id}`,
         recordId: team.id,
         tone: "default",
       });
     }
-    if (sameEmail(team.captainInviteSentTo, email)) {
+
+    if (queryType === "email" && email && sameEmail(team.captainInviteSentTo, email)) {
       matches.push({
         source: "Captain invitation",
         title: team.name,
@@ -297,7 +745,7 @@ export async function GET(request: Request) {
     matches.push({
       source: "Notification recipient",
       title: recipient.displayName || recipient.sourceType,
-      detail: `${recipient.sourceType} · source ${recipient.sourceId}`,
+      detail: `${recipient.sourceType}${recipient.email ? ` · ${recipient.email}` : ""}${recipient.phone ? ` · ${recipient.phone}` : ""}${recipient.sourceId ? ` · source ${recipient.sourceId}` : ""}`,
       effect:
         "A notification-recipient record is communication metadata and does not by itself block player creation.",
       href: null,
@@ -308,7 +756,9 @@ export async function GET(request: Request) {
 
   return NextResponse.json({
     ok: true,
-    email,
+    query: rawQuery,
+    queryType,
+    normalisedQuery: email ?? phoneDigits ?? name,
     matchCount: matches.length,
     matches,
   });

--- a/src/components/admin/email-audit/EmailRecordLookup.tsx
+++ b/src/components/admin/email-audit/EmailRecordLookup.tsx
@@ -16,7 +16,9 @@ type LookupMatch = {
 
 type LookupResponse = {
   ok: boolean;
-  email?: string;
+  query?: string;
+  queryType?: "email" | "phone" | "name";
+  normalisedQuery?: string;
   matchCount?: number;
   matches?: LookupMatch[];
   error?: string;
@@ -29,9 +31,16 @@ function toneClasses(tone: LookupMatch["tone"]) {
   return "border-white/10 bg-white/[0.04]";
 }
 
+function queryTypeLabel(type: LookupResponse["queryType"]) {
+  if (type === "email") return "Email match";
+  if (type === "phone") return "Mobile-number match";
+  if (type === "name") return "Exact-name match";
+  return "Identity match";
+}
+
 export default function EmailRecordLookup() {
   const pathname = usePathname();
-  const [email, setEmail] = useState("");
+  const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<LookupResponse | null>(null);
 
@@ -41,20 +50,20 @@ export default function EmailRecordLookup() {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const query = email.trim();
-    if (!query) return;
+    const value = query.trim();
+    if (!value) return;
 
     setLoading(true);
     setResult(null);
     try {
       const response = await fetch(
-        `/api/admin/email-lookup?email=${encodeURIComponent(query)}`,
+        `/api/admin/email-lookup?q=${encodeURIComponent(value)}`,
         { cache: "no-store" },
       );
       const payload = (await response.json()) as LookupResponse;
       setResult(payload);
     } catch (error) {
-      console.error("Email record lookup failed", error);
+      console.error("Identity record lookup failed", error);
       setResult({ ok: false, error: "Could not complete the lookup. Please try again." });
     } finally {
       setLoading(false);
@@ -66,30 +75,42 @@ export default function EmailRecordLookup() {
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-200/75">
-            Find the actual record
+            Find the actual person record
           </p>
-          <h2 className="mt-2 text-2xl font-semibold text-white">Exact email lookup</h2>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Identity lookup</h2>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-            Paste an email address to see every current SIXFL identity that uses it, plus any recent blocked player-creation attempts and the exact reason they were stopped.
+            Search by email address, mobile number or full player name. This checks squad memberships, Users, prospects, PlayerPool, leads, team contacts and recent blocked player-creation attempts.
           </p>
         </div>
 
         <form onSubmit={submit} className="flex w-full max-w-2xl flex-col gap-3 sm:flex-row">
           <input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder="player@example.com"
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Email, mobile number or full player name"
             className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none transition placeholder:text-white/30 focus:border-amber-400/50"
           />
           <button
             type="submit"
-            disabled={loading || !email.trim()}
+            disabled={loading || !query.trim()}
             className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-amber-300/25 bg-amber-500/15 px-5 text-sm font-bold text-amber-50 transition hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {loading ? "Searching…" : "Find records"}
+            {loading ? "Searching…" : "Find identity"}
           </button>
         </form>
+      </div>
+
+      <div className="mt-4 grid gap-2 text-xs text-white/45 sm:grid-cols-3">
+        <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2">
+          <span className="font-semibold text-white/70">Email:</span> exact, case-insensitive match
+        </div>
+        <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2">
+          <span className="font-semibold text-white/70">Mobile:</span> normalised UK number match
+        </div>
+        <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2">
+          <span className="font-semibold text-white/70">Name:</span> exact full-name match; verify contact details
+        </div>
       </div>
 
       {result?.ok === false ? (
@@ -100,15 +121,20 @@ export default function EmailRecordLookup() {
 
       {result?.ok ? (
         <div className="mt-6 space-y-4">
-          <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <p className="text-sm font-semibold text-white">{result.email}</p>
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-semibold text-white">{result.query}</p>
+                <span className="rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-white/50">
+                  {queryTypeLabel(result.queryType)}
+                </span>
+              </div>
               <p className="mt-1 text-xs text-white/45">
                 {result.matchCount === 1 ? "1 matching record" : `${result.matchCount ?? 0} matching records`}
               </p>
             </div>
-            <p className="text-xs text-white/40">
-              Lead records are shown for completeness, but a lead by itself does not block player creation.
+            <p className="max-w-2xl text-xs leading-5 text-white/40 sm:text-right">
+              Lead and notification records are shown for completeness. They do not by themselves block player creation. Name matches are clues only until the contact details agree.
             </p>
           </div>
 
@@ -127,7 +153,7 @@ export default function EmailRecordLookup() {
                       <h3 className="mt-2 break-words text-base font-semibold text-white">
                         {match.title}
                       </h3>
-                      <p className="mt-1 text-sm leading-6 text-white/60">{match.detail}</p>
+                      <p className="mt-1 break-words text-sm leading-6 text-white/60">{match.detail}</p>
                     </div>
 
                     {match.href ? (
@@ -152,7 +178,7 @@ export default function EmailRecordLookup() {
             </div>
           ) : (
             <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-6 text-center text-sm text-white/50">
-              No current SIXFL record was found for this exact email address.
+              No current SIXFL record was found for this exact identity search.
             </div>
           )}
         </div>


### PR DESCRIPTION
## What changed
- upgrades Admin → Email Audit from an email-only lookup to a full **Identity lookup**
- accepts an email address, mobile number or exact full player name
- checks squad memberships, User accounts, team/player prospects, PlayerPool profiles, leads, team contacts and notification recipients
- shows recent `PlayerDuplicateAttempt` records for matching email, phone or player name
- links squad matches directly to the relevant team player/prospect admin page
- labels name-only matches as clues that must be verified against contact details

## Why
The current case for Adesina Arije only appears as a lead when searched by email. The duplicate guard can also block on an existing squad name or mobile number, so the admin lookup needs to surface those identities too.

## Safety
- admin-only and read-only
- exact email and exact full-name matching
- mobile numbers are normalised using the same SIXFL phone normalisation used by player creation
- no records are changed, merged or moved by this lookup