### PR TITLE
Resolve player records behind identity notification history

### DIFF
--- a/src/app/api/admin/identity-source-resolve/route.ts
+++ b/src/app/api/admin/identity-source-resolve/route.ts
@@ -1,0 +1,272 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { normalizePhoneNumber } from "@/lib/messaging/phone";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RecipientRow = {
+  id: string;
+  sourceId: string | null;
+  displayName: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+type FeeRow = {
+  id: string;
+  status: string;
+  amountPence: number;
+  teamId: string;
+  teamName: string;
+  kickoffAt: Date;
+  userName: string | null;
+  userEmail: string | null;
+  prospectId: string | null;
+  prospectName: string | null;
+  prospectEmail: string | null;
+};
+
+type ProspectRow = {
+  id: string;
+  firstName: string;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  status: string;
+  teamId: string | null;
+  teamName: string | null;
+};
+
+type SelectionRow = {
+  fixtureId: string;
+  teamMemberId: string;
+  selectionStatus: string;
+  kickoffAt: Date;
+  teamId: string;
+  teamName: string;
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+};
+
+type ResolvedSource = {
+  kind: "player-match-fee" | "team-prospect" | "fixture-selection" | "historic-reference";
+  title: string;
+  detail: string;
+  effect: string;
+  href: string | null;
+  recordId: string;
+};
+
+function normaliseEmail(value: string) {
+  const email = value.trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+$/.test(email) ? email : null;
+}
+
+function normalisePhoneDigits(value: string) {
+  return normalizePhoneNumber(value)?.replace(/^\+/, "") ?? null;
+}
+
+function normaliseName(value: string) {
+  const name = value.trim().replace(/\s+/g, " ").toLowerCase();
+  return name.length >= 2 ? name : null;
+}
+
+function formatDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Europe/London",
+  }).format(value);
+}
+
+export async function GET(request: Request) {
+  await requireAdmin();
+
+  const url = new URL(request.url);
+  const rawQuery = (url.searchParams.get("q") ?? "").trim();
+  if (!rawQuery) {
+    return NextResponse.json({ ok: false, error: "Enter an identity to resolve." }, { status: 400 });
+  }
+
+  const email = normaliseEmail(rawQuery);
+  const phoneDigits = email ? null : normalisePhoneDigits(rawQuery);
+  const name = email || phoneDigits ? null : normaliseName(rawQuery);
+
+  let recipients: RecipientRow[] = [];
+  if (email) {
+    recipients = await prisma.$queryRaw<RecipientRow[]>(Prisma.sql`
+      SELECT "id", "sourceId", "displayName",
+        COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email",
+        COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')) AS "phone"
+      FROM "NotificationRecipient"
+      WHERE LOWER(COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), ''))) = ${email}
+      ORDER BY "updatedAt" DESC
+      LIMIT 50
+    `);
+  } else if (phoneDigits) {
+    recipients = await prisma.$queryRaw<RecipientRow[]>(Prisma.sql`
+      SELECT "id", "sourceId", "displayName",
+        COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email",
+        COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')) AS "phone"
+      FROM "NotificationRecipient"
+      WHERE REGEXP_REPLACE(COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')), '[^0-9]', '', 'g') = ${phoneDigits}
+      ORDER BY "updatedAt" DESC
+      LIMIT 50
+    `);
+  } else if (name) {
+    recipients = await prisma.$queryRaw<RecipientRow[]>(Prisma.sql`
+      SELECT "id", "sourceId", "displayName",
+        COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')) AS "email",
+        COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')) AS "phone"
+      FROM "NotificationRecipient"
+      WHERE LOWER(REGEXP_REPLACE(BTRIM(COALESCE("displayName", '')), '[[:space:]]+', ' ', 'g')) = ${name}
+      ORDER BY "updatedAt" DESC
+      LIMIT 50
+    `);
+  }
+
+  const sourceIds = Array.from(new Set(recipients.map((row) => row.sourceId).filter((value): value is string => Boolean(value))));
+  const feeIds: string[] = [];
+  const prospectIds: string[] = [];
+  const selectionPairs: Array<{ fixtureId: string; teamMemberId: string; sourceId: string }> = [];
+
+  for (const sourceId of sourceIds) {
+    if (sourceId.startsWith("player-match-fee:")) {
+      const id = sourceId.slice("player-match-fee:".length);
+      if (id) feeIds.push(id);
+      continue;
+    }
+    if (sourceId.startsWith("team-prospect:")) {
+      const id = sourceId.slice("team-prospect:".length);
+      if (id) prospectIds.push(id);
+      continue;
+    }
+    if (sourceId.startsWith("fixture-selection:")) {
+      const [, fixtureId, teamMemberId] = sourceId.split(":");
+      if (fixtureId && teamMemberId) selectionPairs.push({ fixtureId, teamMemberId, sourceId });
+    }
+  }
+
+  const [fees, prospects, selections] = await Promise.all([
+    feeIds.length
+      ? prisma.$queryRaw<FeeRow[]>(Prisma.sql`
+          SELECT
+            fee."id",
+            fee."status"::text AS "status",
+            fee."amountPence",
+            team."id" AS "teamId",
+            team."name" AS "teamName",
+            fixture."kickoffAt",
+            player_user."name" AS "userName",
+            player_user."email" AS "userEmail",
+            prospect."id" AS "prospectId",
+            NULLIF(BTRIM(CONCAT_WS(' ', prospect."firstName", prospect."lastName")), '') AS "prospectName",
+            prospect."email" AS "prospectEmail"
+          FROM "PlayerMatchFee" fee
+          JOIN "Team" team ON team."id" = fee."teamId"
+          JOIN "Fixture" fixture ON fixture."id" = fee."fixtureId"
+          LEFT JOIN "TeamMember" member ON member."id" = fee."teamMemberId"
+          LEFT JOIN "User" player_user ON player_user."id" = member."userId"
+          LEFT JOIN "TeamPlayerProspect" prospect ON prospect."id" = fee."prospectId"
+          WHERE fee."id" IN (${Prisma.join(feeIds)})
+          ORDER BY fixture."kickoffAt" DESC
+        `)
+      : Promise.resolve([] as FeeRow[]),
+    prospectIds.length
+      ? prisma.$queryRaw<ProspectRow[]>(Prisma.sql`
+          SELECT
+            prospect."id", prospect."firstName", prospect."lastName", prospect."email", prospect."phone", prospect."status",
+            team."id" AS "teamId", team."name" AS "teamName"
+          FROM "TeamPlayerProspect" prospect
+          LEFT JOIN "Team" team ON team."id" = prospect."teamId"
+          WHERE prospect."id" IN (${Prisma.join(prospectIds)})
+        `)
+      : Promise.resolve([] as ProspectRow[]),
+    selectionPairs.length
+      ? prisma.$queryRaw<SelectionRow[]>(Prisma.sql`
+          SELECT
+            selection."fixtureId", selection."teamMemberId", selection."selectionStatus",
+            fixture."kickoffAt",
+            team."id" AS "teamId", team."name" AS "teamName",
+            player_user."id" AS "userId", player_user."name" AS "userName", player_user."email" AS "userEmail"
+          FROM "FixtureSelection" selection
+          JOIN "Fixture" fixture ON fixture."id" = selection."fixtureId"
+          JOIN "TeamMember" member ON member."id" = selection."teamMemberId"
+          JOIN "Team" team ON team."id" = member."teamId"
+          JOIN "User" player_user ON player_user."id" = member."userId"
+          WHERE selection."fixtureId" IN (${Prisma.join(Array.from(new Set(selectionPairs.map((pair) => pair.fixtureId))))})
+            AND selection."teamMemberId" IN (${Prisma.join(Array.from(new Set(selectionPairs.map((pair) => pair.teamMemberId))))})
+        `)
+      : Promise.resolve([] as SelectionRow[]),
+  ]);
+
+  const resolved: ResolvedSource[] = [];
+  const resolvedIds = new Set<string>();
+
+  for (const fee of fees) {
+    resolvedIds.add(`player-match-fee:${fee.id}`);
+    const playerName = fee.userName || fee.prospectName || "Player identity no longer attached";
+    const playerEmail = fee.userEmail || fee.prospectEmail;
+    resolved.push({
+      kind: "player-match-fee",
+      title: `${playerName} · ${fee.teamName}`,
+      detail: `${fee.status} · £${(fee.amountPence / 100).toFixed(2)} · fixture ${formatDate(fee.kickoffAt)}${playerEmail ? ` · ${playerEmail}` : ""}`,
+      effect: "This notification came from a real player match-fee record. It is strong evidence that this identity previously existed as a squad player or team prospect.",
+      href: `/admin/teams/${fee.teamId}`,
+      recordId: fee.id,
+    });
+  }
+
+  for (const prospect of prospects) {
+    resolvedIds.add(`team-prospect:${prospect.id}`);
+    const playerName = [prospect.firstName, prospect.lastName].filter(Boolean).join(" ");
+    resolved.push({
+      kind: "team-prospect",
+      title: `${playerName}${prospect.teamName ? ` · ${prospect.teamName}` : ""}`,
+      detail: `${prospect.status}${prospect.email ? ` · ${prospect.email}` : ""}${prospect.phone ? ` · ${prospect.phone}` : ""}`,
+      effect: "This source points directly to a TeamPlayerProspect record. If it is still active, this is the record to reuse or resolve rather than creating another player.",
+      href: prospect.teamId ? `/admin/teams/${prospect.teamId}/prospects` : "/admin/player-pool",
+      recordId: prospect.id,
+    });
+  }
+
+  for (const pair of selectionPairs) {
+    const selection = selections.find((row) => row.fixtureId === pair.fixtureId && row.teamMemberId === pair.teamMemberId);
+    if (!selection) continue;
+    resolvedIds.add(pair.sourceId);
+    resolved.push({
+      kind: "fixture-selection",
+      title: `${selection.userName || "Unnamed squad player"} · ${selection.teamName}`,
+      detail: `${selection.selectionStatus} · fixture ${formatDate(selection.kickoffAt)}${selection.userEmail ? ` · ${selection.userEmail}` : ""}`,
+      effect: "This source comes from a real fixture-selection row, which means this TeamMember existed on a squad and was available for matchday selection.",
+      href: `/admin/teams/${selection.teamId}/players`,
+      recordId: selection.teamMemberId,
+    });
+  }
+
+  for (const sourceId of sourceIds) {
+    if (resolvedIds.has(sourceId)) continue;
+    if (!sourceId.startsWith("player-match-fee:") && !sourceId.startsWith("team-prospect:") && !sourceId.startsWith("fixture-selection:")) continue;
+    resolved.push({
+      kind: "historic-reference",
+      title: "Historic player source reference",
+      detail: sourceId,
+      effect: "The notification still points at this player-related source, but the underlying record no longer resolves. That usually means the original player/prospect record was moved, merged or deleted after communications were created.",
+      href: null,
+      recordId: sourceId,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    notificationCount: recipients.length,
+    sourceCount: sourceIds.length,
+    resolvedCount: resolved.length,
+    resolved,
+  });
+}

--- a/src/components/admin/email-audit/EmailRecordLookup.tsx
+++ b/src/components/admin/email-audit/EmailRecordLookup.tsx
@@ -24,6 +24,24 @@ type LookupResponse = {
   error?: string;
 };
 
+type ResolvedSource = {
+  kind: "player-match-fee" | "team-prospect" | "fixture-selection" | "historic-reference";
+  title: string;
+  detail: string;
+  effect: string;
+  href: string | null;
+  recordId: string;
+};
+
+type SourceResponse = {
+  ok: boolean;
+  notificationCount?: number;
+  sourceCount?: number;
+  resolvedCount?: number;
+  resolved?: ResolvedSource[];
+  error?: string;
+};
+
 function toneClasses(tone: LookupMatch["tone"]) {
   if (tone === "amber") return "border-amber-400/25 bg-amber-500/[0.08]";
   if (tone === "emerald") return "border-emerald-400/25 bg-emerald-500/[0.08]";
@@ -38,13 +56,28 @@ function queryTypeLabel(type: LookupResponse["queryType"]) {
   return "Identity match";
 }
 
+function resolvedSourceLabel(kind: ResolvedSource["kind"]) {
+  if (kind === "player-match-fee") return "Resolved player match fee";
+  if (kind === "team-prospect") return "Resolved team prospect";
+  if (kind === "fixture-selection") return "Resolved fixture selection";
+  return "Historic player reference";
+}
+
 export default function EmailRecordLookup() {
   const pathname = usePathname();
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<LookupResponse | null>(null);
+  const [sourceResult, setSourceResult] = useState<SourceResponse | null>(null);
 
   const matches = useMemo(() => result?.matches ?? [], [result]);
+  const meaningfulMatches = useMemo(
+    () => matches.filter((match) => match.source !== "Notification recipient"),
+    [matches],
+  );
+  const notificationMetadataCount = matches.length - meaningfulMatches.length;
+  const resolvedSources = sourceResult?.resolved ?? [];
+  const meaningfulCount = meaningfulMatches.length + resolvedSources.length;
 
   if (pathname !== "/admin/email-audit") return null;
 
@@ -55,13 +88,20 @@ export default function EmailRecordLookup() {
 
     setLoading(true);
     setResult(null);
+    setSourceResult(null);
     try {
-      const response = await fetch(
-        `/api/admin/email-lookup?q=${encodeURIComponent(value)}`,
-        { cache: "no-store" },
-      );
-      const payload = (await response.json()) as LookupResponse;
-      setResult(payload);
+      const [identityResponse, sourceResponse] = await Promise.all([
+        fetch(`/api/admin/email-lookup?q=${encodeURIComponent(value)}`, { cache: "no-store" }),
+        fetch(`/api/admin/identity-source-resolve?q=${encodeURIComponent(value)}`, { cache: "no-store" }),
+      ]);
+
+      const [identityPayload, sourcePayload] = (await Promise.all([
+        identityResponse.json(),
+        sourceResponse.json(),
+      ])) as [LookupResponse, SourceResponse];
+
+      setResult(identityPayload);
+      setSourceResult(sourcePayload);
     } catch (error) {
       console.error("Identity record lookup failed", error);
       setResult({ ok: false, error: "Could not complete the lookup. Please try again." });
@@ -79,7 +119,7 @@ export default function EmailRecordLookup() {
           </p>
           <h2 className="mt-2 text-2xl font-semibold text-white">Identity lookup</h2>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-            Search by email address, mobile number or full player name. This checks squad memberships, Users, prospects, PlayerPool, leads, team contacts and recent blocked player-creation attempts.
+            Search by email address, mobile number or full player name. This checks current identities and also follows historic notification sources back to match fees, fixture selections and team prospects.
           </p>
         </div>
 
@@ -120,7 +160,7 @@ export default function EmailRecordLookup() {
       ) : null}
 
       {result?.ok ? (
-        <div className="mt-6 space-y-4">
+        <div className="mt-6 space-y-5">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <div className="flex flex-wrap items-center gap-2">
@@ -130,32 +170,62 @@ export default function EmailRecordLookup() {
                 </span>
               </div>
               <p className="mt-1 text-xs text-white/45">
-                {result.matchCount === 1 ? "1 matching record" : `${result.matchCount ?? 0} matching records`}
+                {meaningfulCount === 1 ? "1 useful identity/source result" : `${meaningfulCount} useful identity/source results`}
               </p>
             </div>
             <p className="max-w-2xl text-xs leading-5 text-white/40 sm:text-right">
-              Lead and notification records are shown for completeness. They do not by themselves block player creation. Name matches are clues only until the contact details agree.
+              Raw notification-recipient rows are collapsed below because they are communication metadata. Their source IDs are resolved into the real player-related records wherever possible.
             </p>
           </div>
 
-          {matches.length ? (
+          {resolvedSources.length ? (
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-amber-300/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-50/90">
+                <span className="font-bold">Historic player trail found.</span> These records are the important part of the notification history and may reveal where the player previously existed.
+              </div>
+              <div className="grid gap-3 xl:grid-cols-2">
+                {resolvedSources.map((source) => (
+                  <article key={`${source.kind}-${source.recordId}`} className="rounded-2xl border border-amber-400/25 bg-amber-500/[0.08] p-4">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <p className="text-[10px] font-bold uppercase tracking-[0.17em] text-amber-100/45">
+                          {resolvedSourceLabel(source.kind)}
+                        </p>
+                        <h3 className="mt-2 break-words text-base font-semibold text-white">{source.title}</h3>
+                        <p className="mt-1 break-words text-sm leading-6 text-white/65">{source.detail}</p>
+                      </div>
+                      {source.href ? (
+                        <Link
+                          href={source.href}
+                          className="shrink-0 rounded-xl border border-amber-200/20 bg-amber-400/10 px-3 py-2 text-xs font-bold text-amber-50 transition hover:bg-amber-400/20"
+                        >
+                          Open source
+                        </Link>
+                      ) : null}
+                    </div>
+                    <div className="mt-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs leading-5 text-white/60">
+                      {source.effect}
+                    </div>
+                    <p className="mt-2 break-all text-[10px] text-white/25">Record: {source.recordId}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {meaningfulMatches.length ? (
             <div className="grid gap-3 xl:grid-cols-2">
-              {matches.map((match, index) => (
+              {meaningfulMatches.map((match, index) => (
                 <article
                   key={`${match.source}-${match.recordId ?? index}-${index}`}
                   className={`rounded-2xl border p-4 ${toneClasses(match.tone)}`}
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0">
-                      <p className="text-[10px] font-bold uppercase tracking-[0.17em] text-white/40">
-                        {match.source}
-                      </p>
-                      <h3 className="mt-2 break-words text-base font-semibold text-white">
-                        {match.title}
-                      </h3>
+                      <p className="text-[10px] font-bold uppercase tracking-[0.17em] text-white/40">{match.source}</p>
+                      <h3 className="mt-2 break-words text-base font-semibold text-white">{match.title}</h3>
                       <p className="mt-1 break-words text-sm leading-6 text-white/60">{match.detail}</p>
                     </div>
-
                     {match.href ? (
                       <Link
                         href={match.href}
@@ -165,22 +235,24 @@ export default function EmailRecordLookup() {
                       </Link>
                     ) : null}
                   </div>
-
-                  <div className="mt-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs leading-5 text-white/55">
-                    {match.effect}
-                  </div>
-
-                  {match.recordId ? (
-                    <p className="mt-2 break-all text-[10px] text-white/25">Record: {match.recordId}</p>
-                  ) : null}
+                  <div className="mt-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs leading-5 text-white/55">{match.effect}</div>
+                  {match.recordId ? <p className="mt-2 break-all text-[10px] text-white/25">Record: {match.recordId}</p> : null}
                 </article>
               ))}
             </div>
-          ) : (
-            <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-6 text-center text-sm text-white/50">
-              No current SIXFL record was found for this exact identity search.
+          ) : null}
+
+          {notificationMetadataCount > 0 || (sourceResult?.notificationCount ?? 0) > 0 ? (
+            <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/45">
+              Collapsed {Math.max(notificationMetadataCount, sourceResult?.notificationCount ?? 0)} raw notification-recipient record{Math.max(notificationMetadataCount, sourceResult?.notificationCount ?? 0) === 1 ? "" : "s"}. They do not block player creation; the resolved player sources above are what matter.
             </div>
-          )}
+          ) : null}
+
+          {meaningfulCount === 0 ? (
+            <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-6 text-center text-sm text-white/50">
+              No current or resolvable historic SIXFL player record was found for this exact identity search.
+            </div>
+          ) : null}
         </div>
       ) : null}
     </section>


### PR DESCRIPTION
## What changed
- follows identity-search notification source IDs back to the underlying player records
- resolves `player-match-fee`, `fixture-selection` and `team-prospect` sources
- shows the actual team/player/prospect, fixture date, status and contact details where available
- collapses repetitive NotificationRecipient cards so the useful player trail is prominent
- links directly to the relevant team/prospect/player admin area

## Why
The Adesina Arije lookup exposed many notification records from player match fees, fixture selection and a team prospect, but the old UI only displayed opaque source IDs. Those source IDs are now traced to the actual records so we can identify where the player existed.

## Safety
Read-only admin diagnostics only. No player, prospect, payment, selection or notification record is changed.