### PR TITLE
Trace and quarantine unresolved shared-email metadata

### DIFF
--- a/src/app/(admin)/admin/users/identity-audit/actions.ts
+++ b/src/app/(admin)/admin/users/identity-audit/actions.ts
@@ -74,10 +74,11 @@ export async function quarantineUnresolvedSharedEmailAction(formData: FormData) 
   const { session, user } = await requireAdmin();
   const { sharedEmail, separateName, params } = buildParams(formData);
   const confirmed = text(formData, "quarantineConfirmed") === "on";
+  const target = "/admin/users/identity-audit/unresolved";
 
   if (!confirmed) {
     params.set("cleanupError", "Tick the confirmation box before quarantining the stale metadata.");
-    redirect(`/admin/users/identity-audit?${params.toString()}`);
+    redirect(`${target}?${params.toString()}`);
   }
 
   try {
@@ -89,15 +90,16 @@ export async function quarantineUnresolvedSharedEmailAction(formData: FormData) 
     });
 
     revalidatePath("/admin/users/identity-audit");
+    revalidatePath("/admin/users/identity-audit/unresolved");
     revalidatePath("/admin/email-audit");
     revalidatePath("/admin/messaging");
 
     params.set("cleanupDone", "1");
     params.set("quarantined", String(result.quarantined));
-    redirect(`/admin/users/identity-audit?${params.toString()}`);
+    redirect(`${target}?${params.toString()}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : "The stale metadata cleanup failed safely.";
     params.set("cleanupError", message);
-    redirect(`/admin/users/identity-audit?${params.toString()}`);
+    redirect(`${target}?${params.toString()}`);
   }
 }

--- a/src/app/(admin)/admin/users/identity-audit/actions.ts
+++ b/src/app/(admin)/admin/users/identity-audit/actions.ts
@@ -4,27 +4,37 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { applySharedEmailRepair } from "@/lib/players/shared-email-repair";
+import { quarantineUnresolvedSharedEmailPlayerRecipients } from "@/lib/players/shared-email-unresolved";
 import { requireAdmin } from "@/lib/requireAdmin";
 
 function text(formData: FormData, key: string) {
   return String(formData.get(key) ?? "").trim();
 }
 
-export async function applySharedEmailRepairAction(formData: FormData) {
-  const { session, user } = await requireAdmin();
-
+function buildParams(formData: FormData) {
   const sharedEmail = text(formData, "sharedEmail");
   const separateName = text(formData, "separateName");
   const newEmail = text(formData, "newEmail");
   const newPhone = text(formData, "newPhone") || null;
-  const confirmed = text(formData, "confirmed") === "on";
 
-  const params = new URLSearchParams({
+  return {
     sharedEmail,
     separateName,
     newEmail,
-    ...(newPhone ? { newPhone } : {}),
-  });
+    newPhone,
+    params: new URLSearchParams({
+      sharedEmail,
+      separateName,
+      ...(newEmail ? { newEmail } : {}),
+      ...(newPhone ? { newPhone } : {}),
+    }),
+  };
+}
+
+export async function applySharedEmailRepairAction(formData: FormData) {
+  const { session, user } = await requireAdmin();
+  const { sharedEmail, separateName, newEmail, newPhone, params } = buildParams(formData);
+  const confirmed = text(formData, "confirmed") === "on";
 
   if (!confirmed) {
     params.set("repairError", "Tick the confirmation box before applying the repair.");
@@ -58,4 +68,36 @@ export async function applySharedEmailRepairAction(formData: FormData) {
   params.set("recipientsResynced", String(result.playerSourceRecipientsResynced));
   params.set("unresolvedRecipients", String(result.unresolvedRecipientsLeft));
   redirect(`/admin/users/identity-audit?${params.toString()}`);
+}
+
+export async function quarantineUnresolvedSharedEmailAction(formData: FormData) {
+  const { session, user } = await requireAdmin();
+  const { sharedEmail, separateName, params } = buildParams(formData);
+  const confirmed = text(formData, "quarantineConfirmed") === "on";
+
+  if (!confirmed) {
+    params.set("cleanupError", "Tick the confirmation box before quarantining the stale metadata.");
+    redirect(`/admin/users/identity-audit?${params.toString()}`);
+  }
+
+  try {
+    const result = await quarantineUnresolvedSharedEmailPlayerRecipients({
+      sharedEmail,
+      separateName,
+      actorUserId: user?.id ?? null,
+      actorEmail: user?.email ?? session?.user?.email ?? null,
+    });
+
+    revalidatePath("/admin/users/identity-audit");
+    revalidatePath("/admin/email-audit");
+    revalidatePath("/admin/messaging");
+
+    params.set("cleanupDone", "1");
+    params.set("quarantined", String(result.quarantined));
+    redirect(`/admin/users/identity-audit?${params.toString()}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "The stale metadata cleanup failed safely.";
+    params.set("cleanupError", message);
+    redirect(`/admin/users/identity-audit?${params.toString()}`);
+  }
 }

--- a/src/app/(admin)/admin/users/identity-audit/unresolved/page.tsx
+++ b/src/app/(admin)/admin/users/identity-audit/unresolved/page.tsx
@@ -1,0 +1,166 @@
+import Link from "next/link";
+
+import { getUnresolvedSharedEmailPlayerRecipients } from "@/lib/players/shared-email-unresolved";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+import { quarantineUnresolvedSharedEmailAction } from "../actions";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export const metadata = {
+  title: "Unresolved Shared Email Metadata | SIXFL Admin",
+};
+
+function searchValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] ?? "" : value ?? "";
+}
+
+export default async function UnresolvedSharedEmailPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  await requireAdmin();
+
+  const sp = (await searchParams) ?? {};
+  const sharedEmail = searchValue(sp.sharedEmail).trim();
+  const separateName = searchValue(sp.separateName).trim();
+  const cleanupDone = searchValue(sp.cleanupDone) === "1";
+  const cleanupError = searchValue(sp.cleanupError).trim();
+  const quarantined = searchValue(sp.quarantined).trim();
+
+  const unresolved =
+    sharedEmail && separateName
+      ? await getUnresolvedSharedEmailPlayerRecipients({ sharedEmail, separateName })
+      : [];
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6">
+      <section className="rounded-3xl border border-amber-400/25 bg-amber-500/[0.07] p-6 lg:p-8">
+        <p className="text-[11px] font-black uppercase tracking-[0.2em] text-amber-200/70">
+          Identity audit · stale metadata
+        </p>
+        <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-black text-white">Unresolved shared-email notification metadata</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-white/65">
+              This screen only finds player-related NotificationRecipient rows whose original player source no longer exists. It never edits Users, teams, fixtures, selections, payments, match fees or football history.
+            </p>
+          </div>
+          <Link
+            href="/admin/users/identity-audit"
+            className="inline-flex min-h-11 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-semibold text-white/75 hover:bg-white/10"
+          >
+            Back to Identity Audit
+          </Link>
+        </div>
+      </section>
+
+      {cleanupDone ? (
+        <div className="rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+          Cleanup completed. Quarantined stale notification records: {quarantined || "0"}.
+        </div>
+      ) : null}
+
+      {cleanupError ? (
+        <div className="rounded-2xl border border-red-400/25 bg-red-500/10 p-4 text-sm text-red-100">
+          {cleanupError}
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-white/10 bg-white/[0.035] p-6">
+        <form method="get" className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2">
+            <span className="text-sm font-semibold text-white/70">Shared / old email</span>
+            <input
+              type="email"
+              name="sharedEmail"
+              required
+              defaultValue={sharedEmail}
+              className="h-12 w-full rounded-xl border border-white/10 bg-black/30 px-4 text-white outline-none focus:border-amber-400/50"
+            />
+          </label>
+          <label className="space-y-2">
+            <span className="text-sm font-semibold text-white/70">Person name shown on stale record</span>
+            <input
+              name="separateName"
+              required
+              defaultValue={separateName}
+              className="h-12 w-full rounded-xl border border-white/10 bg-black/30 px-4 text-white outline-none focus:border-amber-400/50"
+            />
+          </label>
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="inline-flex min-h-11 items-center justify-center rounded-xl border border-amber-300/25 bg-amber-500/15 px-5 py-2.5 text-sm font-bold text-amber-50 hover:bg-amber-500/25"
+            >
+              Trace unresolved record
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {sharedEmail && separateName ? (
+        <section className="rounded-3xl border border-white/10 bg-white/[0.035] p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-white/40">Verified stale records</p>
+              <h2 className="mt-2 text-2xl font-black text-white">{unresolved.length}</h2>
+            </div>
+            <div className="text-xs text-white/45">
+              Only rows with a missing underlying player source appear here.
+            </div>
+          </div>
+
+          {unresolved.length === 0 ? (
+            <div className="mt-5 rounded-2xl border border-emerald-400/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+              No unresolved player-source metadata remains for this name and shared email.
+            </div>
+          ) : (
+            <>
+              <div className="mt-5 space-y-3">
+                {unresolved.map((row) => (
+                  <div key={row.id} className="rounded-2xl border border-amber-400/20 bg-amber-500/[0.06] p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-amber-300/20 bg-amber-500/10 px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.12em] text-amber-100">
+                        {row.sourceKind}
+                      </span>
+                      <span className="text-sm font-semibold text-white">{row.displayName || "Unnamed historic recipient"}</span>
+                    </div>
+                    <div className="mt-3 grid gap-1 text-xs text-white/55">
+                      <div><span className="text-white/35">Source ID:</span> {row.sourceId || "None"}</div>
+                      <div><span className="text-white/35">Recipient ID:</span> {row.id}</div>
+                      <div><span className="text-white/35">Stored email:</span> {row.email || "None"}</div>
+                      <div><span className="text-white/35">Stored phone:</span> {row.phone || "None"}</div>
+                    </div>
+                    <p className="mt-3 text-xs leading-5 text-amber-50/65">
+                      The referenced player source cannot be found. Because there is no live source to establish ownership, this row must not be reassigned to either player.
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <form action={quarantineUnresolvedSharedEmailAction} className="mt-5 rounded-2xl border border-red-400/20 bg-red-500/[0.06] p-5">
+                <input type="hidden" name="sharedEmail" value={sharedEmail} />
+                <input type="hidden" name="separateName" value={separateName} />
+                <label className="flex items-start gap-3 text-sm leading-6 text-white/70">
+                  <input type="checkbox" name="quarantineConfirmed" required className="mt-1 h-4 w-4" />
+                  <span>
+                    I have checked the stale source IDs above. Remove the old shared email/phone only from these dead notification records and preserve the original values in quarantine audit metadata. Do not alter any football record.
+                  </span>
+                </label>
+                <button
+                  type="submit"
+                  className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl border border-red-300/25 bg-red-500/15 px-5 py-2.5 text-sm font-black text-red-50 hover:bg-red-500/25"
+                >
+                  Quarantine stale metadata
+                </button>
+              </form>
+            </>
+          )}
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/src/lib/players/shared-email-unresolved.ts
+++ b/src/lib/players/shared-email-unresolved.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+export type UnresolvedSharedEmailRecipient = {
+  id: string;
+  sourceType: string;
+  sourceId: string | null;
+  displayName: string | null;
+  email: string | null;
+  phone: string | null;
+  sourceKind: "player-match-fee" | "fixture-selection" | "team-prospect";
+};
+
+function normaliseEmail(value: string) {
+  const email = value.trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+$/.test(email) ? email : null;
+}
+
+function normaliseName(value: string) {
+  const name = value.trim().replace(/\s+/g, " ").toLowerCase();
+  return name || null;
+}
+
+export async function getUnresolvedSharedEmailPlayerRecipients(input: {
+  sharedEmail: string;
+  separateName: string;
+}): Promise<UnresolvedSharedEmailRecipient[]> {
+  const sharedEmail = normaliseEmail(input.sharedEmail);
+  const separateName = normaliseName(input.separateName);
+  if (!sharedEmail || !separateName) return [];
+
+  return prisma.$queryRaw<UnresolvedSharedEmailRecipient[]>(Prisma.sql`
+    SELECT
+      recipient."id",
+      recipient."sourceType"::text AS "sourceType",
+      recipient."sourceId",
+      recipient."displayName",
+      COALESCE(NULLIF(BTRIM(recipient."emailNormalized"), ''), NULLIF(BTRIM(recipient."email"), '')) AS "email",
+      COALESCE(NULLIF(BTRIM(recipient."phoneNormalized"), ''), NULLIF(BTRIM(recipient."phone"), '')) AS "phone",
+      CASE
+        WHEN recipient."sourceId" LIKE 'player-match-fee:%' THEN 'player-match-fee'
+        WHEN recipient."sourceId" LIKE 'fixture-selection:%' THEN 'fixture-selection'
+        ELSE 'team-prospect'
+      END AS "sourceKind"
+    FROM "NotificationRecipient" recipient
+    WHERE LOWER(COALESCE(NULLIF(BTRIM(recipient."emailNormalized"), ''), NULLIF(BTRIM(recipient."email"), ''))) = ${sharedEmail}
+      AND LOWER(REGEXP_REPLACE(BTRIM(COALESCE(recipient."displayName", '')), '[[:space:]]+', ' ', 'g')) = ${separateName}
+      AND (
+        (
+          recipient."sourceId" LIKE 'player-match-fee:%'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "PlayerMatchFee" fee
+            WHERE recipient."sourceId" = 'player-match-fee:' || fee."id"
+          )
+        )
+        OR (
+          recipient."sourceId" LIKE 'fixture-selection:%'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "FixtureSelection" selection
+            WHERE recipient."sourceId" = 'fixture-selection:' || selection."fixtureId" || ':' || selection."teamMemberId"
+          )
+        )
+        OR (
+          recipient."sourceId" LIKE 'team-prospect:%'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM "TeamPlayerProspect" prospect
+            WHERE recipient."sourceId" = 'team-prospect:' || prospect."id"
+          )
+        )
+      )
+    ORDER BY recipient."updatedAt" DESC
+  `);
+}
+
+export async function quarantineUnresolvedSharedEmailPlayerRecipients(input: {
+  sharedEmail: string;
+  separateName: string;
+  actorUserId?: string | null;
+  actorEmail?: string | null;
+}) {
+  const sharedEmail = normaliseEmail(input.sharedEmail);
+  const separateName = normaliseName(input.separateName);
+  if (!sharedEmail || !separateName) {
+    throw new Error("Enter a valid shared email and player name before quarantining metadata.");
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const rows = await tx.$queryRaw<UnresolvedSharedEmailRecipient[]>(Prisma.sql`
+      SELECT
+        recipient."id",
+        recipient."sourceType"::text AS "sourceType",
+        recipient."sourceId",
+        recipient."displayName",
+        COALESCE(NULLIF(BTRIM(recipient."emailNormalized"), ''), NULLIF(BTRIM(recipient."email"), '')) AS "email",
+        COALESCE(NULLIF(BTRIM(recipient."phoneNormalized"), ''), NULLIF(BTRIM(recipient."phone"), '')) AS "phone",
+        CASE
+          WHEN recipient."sourceId" LIKE 'player-match-fee:%' THEN 'player-match-fee'
+          WHEN recipient."sourceId" LIKE 'fixture-selection:%' THEN 'fixture-selection'
+          ELSE 'team-prospect'
+        END AS "sourceKind"
+      FROM "NotificationRecipient" recipient
+      WHERE LOWER(COALESCE(NULLIF(BTRIM(recipient."emailNormalized"), ''), NULLIF(BTRIM(recipient."email"), ''))) = ${sharedEmail}
+        AND LOWER(REGEXP_REPLACE(BTRIM(COALESCE(recipient."displayName", '')), '[[:space:]]+', ' ', 'g')) = ${separateName}
+        AND (
+          (
+            recipient."sourceId" LIKE 'player-match-fee:%'
+            AND NOT EXISTS (
+              SELECT 1 FROM "PlayerMatchFee" fee
+              WHERE recipient."sourceId" = 'player-match-fee:' || fee."id"
+            )
+          )
+          OR (
+            recipient."sourceId" LIKE 'fixture-selection:%'
+            AND NOT EXISTS (
+              SELECT 1 FROM "FixtureSelection" selection
+              WHERE recipient."sourceId" = 'fixture-selection:' || selection."fixtureId" || ':' || selection."teamMemberId"
+            )
+          )
+          OR (
+            recipient."sourceId" LIKE 'team-prospect:%'
+            AND NOT EXISTS (
+              SELECT 1 FROM "TeamPlayerProspect" prospect
+              WHERE recipient."sourceId" = 'team-prospect:' || prospect."id"
+            )
+          )
+        )
+      FOR UPDATE
+    `);
+
+    if (rows.length === 0) {
+      return { quarantined: 0, rows: [] as UnresolvedSharedEmailRecipient[] };
+    }
+
+    const ids = rows.map((row) => row.id);
+
+    await tx.$executeRaw(Prisma.sql`
+      UPDATE "NotificationRecipient"
+      SET
+        "metadata" = COALESCE("metadata", '{}'::jsonb) || jsonb_build_object(
+          'identityQuarantinedAt', NOW()::text,
+          'identityQuarantineReason', 'Shared email repair: underlying player source no longer exists',
+          'identityQuarantinePreviousEmail', COALESCE(NULLIF(BTRIM("emailNormalized"), ''), NULLIF(BTRIM("email"), '')),
+          'identityQuarantinePreviousPhone', COALESCE(NULLIF(BTRIM("phoneNormalized"), ''), NULLIF(BTRIM("phone"), '')),
+          'identityQuarantineSourceId', "sourceId"
+        ),
+        "email" = NULL,
+        "emailNormalized" = NULL,
+        "phone" = NULL,
+        "phoneNormalized" = NULL,
+        "lastSyncedAt" = NOW(),
+        "updatedAt" = NOW()
+      WHERE "id" IN (${Prisma.join(ids)})
+    `);
+
+    await tx.$executeRawUnsafe(`
+      CREATE TABLE IF NOT EXISTS "SharedEmailRecipientQuarantineAudit" (
+        "id" TEXT PRIMARY KEY,
+        "sharedEmail" TEXT NOT NULL,
+        "separateName" TEXT NOT NULL,
+        "recipientIds" JSONB NOT NULL,
+        "actorUserId" TEXT,
+        "actorEmail" TEXT,
+        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "SharedEmailRecipientQuarantineAudit" (
+        "id", "sharedEmail", "separateName", "recipientIds", "actorUserId", "actorEmail", "createdAt"
+      ) VALUES (
+        ${randomUUID()}, ${sharedEmail}, ${input.separateName.trim()}, ${JSON.stringify(ids)}::jsonb,
+        ${input.actorUserId ?? null}, ${input.actorEmail ?? null}, NOW()
+      )
+    `);
+
+    return { quarantined: rows.length, rows };
+  });
+}


### PR DESCRIPTION
## What changed
- adds a dedicated unresolved shared-email metadata trace screen under User Identity Audit
- shows the exact stale NotificationRecipient source ID, recipient ID and stored contact details
- only lists player-related notification rows whose underlying `PlayerMatchFee`, `FixtureSelection` or `TeamPlayerProspect` source genuinely no longer exists
- adds an explicit quarantine action that removes the stale shared email/phone from those dead communication records only
- preserves the original contact values and source ID in JSON audit metadata and a separate quarantine audit table

## Safety
- admin-only
- explicit confirmation required
- does not update, merge, delete or reassign Users, teams, fixtures, fixture selections, PlayerMatchFee records, prospects, payments or football history
- re-checks source absence inside the transaction before changing anything

This handles the final unresolved Adesina Arije shared-email notification record left after the 13 live player-source records were successfully re-synchronised.