### PR TITLE
Clarify captain team-unavailable responses

### DIFF
--- a/prisma/migrations/20260830125000_clarify_team_unavailable_online_response/migration.sql
+++ b/prisma/migrations/20260830125000_clarify_team_unavailable_online_response/migration.sql
@@ -1,0 +1,9 @@
+-- Older captain responses stored a hard-coded note that sounded as though the
+-- captain had contacted SIXFL directly. They had actually selected the online
+-- No option, and the old form did not collect a reason.
+UPDATE "FixtureCaptainConfirmation"
+SET
+  "note" = 'Team unavailable: the captain selected “No — our team cannot play” on the SIXFL fixture page. This was an online response; the previous form did not collect a reason.',
+  "updatedAt" = NOW()
+WHERE "status"::text = 'ISSUE_RAISED'
+  AND BTRIM(COALESCE("note", '')) = 'Team unavailable: captain has told SIXFL they cannot fulfil this fixture.';

--- a/scripts/apply-issue-raised-confirmation-chase-fix.cjs
+++ b/scripts/apply-issue-raised-confirmation-chase-fix.cjs
@@ -75,4 +75,6 @@ replaceOnce(
   '            {inboundOnly\n              ? "No inbound messages have been logged for this team yet."\n              : "No communications have been logged for this team yet."}',
 );
 
+require("./apply-team-unavailability-response-copy.cjs");
+
 console.log("Applied fixture confirmation chase and inbound communications filter.");

--- a/scripts/apply-team-unavailability-response-copy.cjs
+++ b/scripts/apply-team-unavailability-response-copy.cjs
@@ -1,0 +1,220 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+
+function replaceOnce(filePath, before, after) {
+  const absolutePath = path.join(root, filePath);
+  const source = fs.readFileSync(absolutePath, "utf8");
+
+  if (source.includes(after)) return;
+  if (!source.includes(before)) {
+    throw new Error(`Expected team-unavailability source was not found in ${filePath}`);
+  }
+
+  fs.writeFileSync(absolutePath, source.replace(before, after), "utf8");
+}
+
+const captainFixturePage = "src/app/captain/team/[teamid]/fixtures/page.tsx";
+
+replaceOnce(
+  captainFixturePage,
+  `const TEAM_UNAVAILABLE_NOTE =
+  "Team unavailable: captain has told SIXFL they cannot fulfil this fixture.";`,
+  `const TEAM_UNAVAILABLE_NOTE_PREFIX =
+  "Team unavailable: the captain selected “No — our team cannot play” on the SIXFL fixture page.";`,
+);
+
+replaceOnce(
+  captainFixturePage,
+  `    if (error.message.includes("Issue note must be at least")) {
+      return "Please add a short note so SIXFL knows what the issue is.";
+    }`,
+  `    if (error.message.includes("Unavailability reason must be at least")) {
+      return "Please briefly tell SIXFL why the whole team cannot play.";
+    }
+    if (error.message.includes("Issue note must be at least")) {
+      return "Please add a short note so SIXFL knows what the issue is.";
+    }`,
+);
+
+replaceOnce(
+  captainFixturePage,
+  `async function markFixtureUnavailableAction(formData: FormData) {
+  "use server";
+
+  const teamid = String(formData.get("teamid") ?? "").trim();
+  const fixtureId = String(formData.get("fixtureId") ?? "").trim();
+  const access = await requireCaptain(teamid);
+
+  try {
+    await getConfirmableFixture(fixtureId, teamid);
+
+    await prisma.fixtureCaptainConfirmation.upsert({
+      where: { fixtureId_teamId: { fixtureId, teamId: teamid } },
+      update: {
+        status: "ISSUE_RAISED",
+        note: TEAM_UNAVAILABLE_NOTE,
+        issueRaisedAt: new Date(),
+        confirmedAt: null,
+        confirmedByUserId: access.user?.id ?? null,
+      },
+      create: {
+        fixtureId,
+        teamId: teamid,
+        status: "ISSUE_RAISED",
+        note: TEAM_UNAVAILABLE_NOTE,
+        issueRaisedAt: new Date(),
+        confirmedByUserId: access.user?.id ?? null,
+      },
+    });
+
+    revalidateFixtureConfirmationPaths(teamid);
+  } catch (error) {
+    console.error("Captain fixture unavailable submission failed", error);
+    redirect(buildFixtureRedirect(teamid, { fixtureId, error: getFriendlyErrorMessage(error) }));
+  }
+
+  redirect(buildFixtureRedirect(teamid, { fixtureId, saved: "unavailable" }));
+}`,
+  `async function markFixtureUnavailableAction(formData: FormData) {
+  "use server";
+
+  const teamid = String(formData.get("teamid") ?? "").trim();
+  const fixtureId = String(formData.get("fixtureId") ?? "").trim();
+  const unavailableReason = String(
+    formData.get("unavailableReason") ?? "",
+  )
+    .trim()
+    .slice(0, 500);
+  const access = await requireCaptain(teamid);
+
+  try {
+    if (unavailableReason.length < 5) {
+      throw new Error("Unavailability reason must be at least 5 characters.");
+    }
+
+    await getConfirmableFixture(fixtureId, teamid);
+    const note =
+      TEAM_UNAVAILABLE_NOTE_PREFIX + " Reason given: " + unavailableReason;
+
+    await prisma.fixtureCaptainConfirmation.upsert({
+      where: { fixtureId_teamId: { fixtureId, teamId: teamid } },
+      update: {
+        status: "ISSUE_RAISED",
+        note,
+        issueRaisedAt: new Date(),
+        confirmedAt: null,
+        confirmedByUserId: access.user?.id ?? null,
+      },
+      create: {
+        fixtureId,
+        teamId: teamid,
+        status: "ISSUE_RAISED",
+        note,
+        issueRaisedAt: new Date(),
+        confirmedByUserId: access.user?.id ?? null,
+      },
+    });
+
+    revalidateFixtureConfirmationPaths(teamid);
+  } catch (error) {
+    console.error("Captain fixture unavailable submission failed", error);
+    redirect(buildFixtureRedirect(teamid, { fixtureId, error: getFriendlyErrorMessage(error) }));
+  }
+
+  redirect(buildFixtureRedirect(teamid, { fixtureId, saved: "unavailable" }));
+}`,
+);
+
+replaceOnce(
+  captainFixturePage,
+  `SIXFL has been told that your team cannot play this fixture. The fixture is now flagged for review.`,
+  `Your online response has been sent to SIXFL. The fixture is now flagged for review.`,
+);
+
+replaceOnce(
+  captainFixturePage,
+  `You can confirm yes at any time before kick-off. If you need to say no, change a response or raise an issue, use the online options until {FIXTURE_RESPONSE_LOCK_HOURS} hours before kick-off; after that, contact SIXFL directly.`,
+  `Choose Yes when the whole team can fulfil the fixture. Choose No only when the whole team cannot fulfil it: a brief reason is required and SIXFL will be alerted immediately. You can use the online options until {FIXTURE_RESPONSE_LOCK_HOURS} hours before kick-off; after that, contact SIXFL directly.`,
+);
+
+replaceOnce(
+  captainFixturePage,
+  `                      <form action={markFixtureUnavailableAction}>
+                        <input type="hidden" name="teamid" value={team.id} />
+                        <input type="hidden" name="fixtureId" value={selectedFixture.id} />
+                        <button`,
+  `                      <form
+                        action={markFixtureUnavailableAction}
+                        className="space-y-3 rounded-2xl border border-red-400/20 bg-red-500/[0.04] p-3"
+                      >
+                        <input type="hidden" name="teamid" value={team.id} />
+                        <input type="hidden" name="fixtureId" value={selectedFixture.id} />
+                        <div>
+                          <p className="text-sm font-semibold text-red-50">
+                            Whole team cannot play?
+                          </p>
+                          <p className="mt-1 text-xs leading-5 text-red-100/65">
+                            Only use this when the whole team cannot fulfil the fixture. Sending it immediately raises an issue for SIXFL to review.
+                          </p>
+                        </div>
+                        <textarea
+                          name="unavailableReason"
+                          required
+                          minLength={5}
+                          maxLength={500}
+                          rows={3}
+                          disabled={isSelectedFixtureUnavailable}
+                          placeholder="Briefly tell SIXFL why the whole team cannot play."
+                          className="w-full rounded-xl border border-red-400/20 bg-black/25 px-3 py-2.5 text-sm text-white outline-none placeholder:text-white/30 focus:border-red-300/45 disabled:cursor-not-allowed disabled:opacity-50"
+                        />
+                        <button`,
+);
+
+replaceOnce(
+  captainFixturePage,
+  `{isSelectedFixtureUnavailable ? "✓ Team marked unavailable" : "No — we cannot play"}`,
+  `{isSelectedFixtureUnavailable ? "✓ Team marked unavailable" : "Send — our team cannot play"}`,
+);
+
+replaceOnce(
+  "src/lib/fixtures/confirmation-emails.ts",
+  `Open the fixture and select either ‘Yes — we can play’ or ‘No — we cannot play’. This is the whole-team response; individual player availability is separate.`,
+  `Open the fixture and select either ‘Yes — we can play’ or ‘No — our team cannot play’. Choose No only if the whole team cannot fulfil the fixture. You will be asked for a brief reason and SIXFL will be alerted immediately. Individual player availability is separate.`,
+);
+
+const reminderPath = "src/lib/fixtures/confirmation-reminders.ts";
+const oldDefaultSms =
+  "SIXFL: Confirm {{teamName}} v {{opponentName}}, {{kickoffDateTime}} here: {{link}}. Do not reply YES/NO - SMS replies do not confirm the fixture.";
+const oldUrgentSms =
+  "SIXFL URGENT: Confirm {{teamName}} v {{opponentName}}, {{kickoffDateTime}} here now: {{link}}. Do not reply YES/NO - SMS replies do not confirm the fixture.";
+const newDefaultSms =
+  "SIXFL: Confirm {{teamName}} v {{opponentName}}, {{kickoffDateTime}}: {{link}}. Use No only if the whole team cannot play; add a reason and SIXFL is alerted. Do not reply YES/NO.";
+const newUrgentSms =
+  "SIXFL URGENT: Confirm {{teamName}} v {{opponentName}}, {{kickoffDateTime}} now: {{link}}. Use No only if the whole team cannot play; it raises an issue for SIXFL. Do not reply YES/NO.";
+
+replaceOnce(reminderPath, oldDefaultSms, newDefaultSms);
+replaceOnce(reminderPath, oldUrgentSms, newUrgentSms);
+
+replaceOnce(
+  reminderPath,
+  `const PREVIOUS_DEFAULT_CONFIRMATION_SMS_BODY =`,
+  `const PREVIOUS_CLEAR_CONFIRMATION_SMS_BODY =
+  "${oldDefaultSms}";
+const PREVIOUS_CLEAR_URGENT_CONFIRMATION_SMS_BODY =
+  "${oldUrgentSms}";
+const PREVIOUS_DEFAULT_CONFIRMATION_SMS_BODY =`,
+);
+
+replaceOnce(
+  reminderPath,
+  `    body === PREVIOUS_DEFAULT_CONFIRMATION_SMS_BODY ||`,
+  `    body === PREVIOUS_CLEAR_CONFIRMATION_SMS_BODY ||
+    body === PREVIOUS_CLEAR_URGENT_CONFIRMATION_SMS_BODY ||
+    body === PREVIOUS_DEFAULT_CONFIRMATION_SMS_BODY ||`,
+);
+
+console.log(
+  "Applied clear online team-unavailability responses, required reasons and matching fixture confirmation copy.",
+);

--- a/scripts/check-team-confirmation-contract.mjs
+++ b/scripts/check-team-confirmation-contract.mjs
@@ -24,12 +24,30 @@ const commitmentEmailActionPath =
 const reassuranceActionPath =
   "src/app/(admin)/admin/leads/reassurance-email-actions.ts";
 const reassuranceSeedPath = "scripts/seed-league-starter-email-template.cjs";
+const captainFixturePagePath =
+  "src/app/captain/team/[teamid]/fixtures/page.tsx";
+const fixtureConfirmationEmailPath =
+  "src/lib/fixtures/confirmation-emails.ts";
+const fixtureConfirmationReminderPath =
+  "src/lib/fixtures/confirmation-reminders.ts";
+const teamUnavailablePreparationPath =
+  "scripts/apply-team-unavailability-response-copy.cjs";
+const sourcePreparationPath =
+  "scripts/apply-issue-raised-confirmation-chase-fix.cjs";
+const teamUnavailableMigrationPath =
+  "prisma/migrations/20260830125000_clarify_team_unavailable_online_response/migration.sql";
 
 const page = read(pagePath);
 const confirmation = read(confirmationPath);
 const commitmentEmailAction = read(commitmentEmailActionPath);
 const reassuranceAction = read(reassuranceActionPath);
 const reassuranceSeed = read(reassuranceSeedPath);
+const captainFixturePage = read(captainFixturePagePath);
+const fixtureConfirmationEmail = read(fixtureConfirmationEmailPath);
+const fixtureConfirmationReminder = read(fixtureConfirmationReminderPath);
+const teamUnavailablePreparation = read(teamUnavailablePreparationPath);
+const sourcePreparation = read(sourcePreparationPath);
+const teamUnavailableMigration = read(teamUnavailableMigrationPath);
 
 expect(
   page.includes("getLeagueConfirmationDetails") && page.includes("const effectiveLeague ="),
@@ -154,6 +172,67 @@ expect(
     reassuranceAction.includes("leagueMode,") &&
     reassuranceAction.includes("liveLeagueDetection"),
   "the reassurance sender must automatically choose and record the correct league version",
+);
+
+expect(
+  sourcePreparation.includes(
+    'require("./apply-team-unavailability-response-copy.cjs")',
+  ) && teamUnavailablePreparation.includes(captainFixturePagePath),
+  "the complete development and production source-preparation chain must apply the team-unavailability correction",
+);
+expect(
+  captainFixturePage.includes('name="unavailableReason"') &&
+    captainFixturePage.includes("required") &&
+    captainFixturePage.includes("minLength={5}") &&
+    captainFixturePage.includes("maxLength={500}"),
+  "captains must provide a brief reason when saying the whole team cannot play",
+);
+expect(
+  captainFixturePage.includes("TEAM_UNAVAILABLE_NOTE_PREFIX") &&
+    captainFixturePage.includes("Reason given:") &&
+    captainFixturePage.includes("the captain selected “No — our team cannot play”"),
+  "stored team-unavailable notes must identify an online selection and retain the captain's reason",
+);
+expect(
+  !captainFixturePage.includes(
+    "captain has told SIXFL they cannot fulfil this fixture",
+  ),
+  "the captain fixture page must not falsely imply that the captain contacted SIXFL directly",
+);
+expect(
+  captainFixturePage.includes(
+    "Only use this when the whole team cannot fulfil the fixture",
+  ) &&
+    captainFixturePage.includes("SIXFL will be alerted immediately") &&
+    captainFixturePage.includes("Send — our team cannot play"),
+  "the No action must clearly explain what it means before the captain submits it",
+);
+expect(
+  fixtureConfirmationEmail.includes(
+    "Choose No only if the whole team cannot fulfil the fixture",
+  ) &&
+    fixtureConfirmationEmail.includes(
+      "You will be asked for a brief reason and SIXFL will be alerted immediately",
+    ),
+  "fixture confirmation emails must explain that No is a whole-team issue report",
+);
+expect(
+  fixtureConfirmationReminder.includes(
+    "Use No only if the whole team cannot play",
+  ) &&
+    fixtureConfirmationReminder.includes(
+      "PREVIOUS_CLEAR_CONFIRMATION_SMS_BODY",
+    ),
+  "fixture confirmation SMS reminders must explain the No action and upgrade the previous default wording",
+);
+expect(
+  teamUnavailableMigration.includes(
+    "Team unavailable: captain has told SIXFL they cannot fulfil this fixture.",
+  ) &&
+    teamUnavailableMigration.includes(
+      "This was an online response; the previous form did not collect a reason.",
+    ),
+  "the existing misleading stored notes must be corrected during deployment",
 );
 
 const confirmStart = confirmation.indexOf("export async function confirmTeamPlaceFromLead");


### PR DESCRIPTION
Corrects the misleading hard-coded fixture issue note that said a captain had already told SIXFL directly. The captain page now makes clear that No is only for whole-team unavailability, requires a short reason, and stores the response as an online selection with that reason. The initial fixture email and SMS reminder explain the same meaning before captains open the page. A targeted migration corrects existing legacy notes, including currently open issues, and the team confirmation contract protects the new wording and reason field.