### PR TITLE
Clarify emails when a team is removed from a fixture

### DIFF
--- a/.github/workflows/night-board-fixture-change.yml
+++ b/.github/workflows/night-board-fixture-change.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "src/app/api/admin/night-board/update-match/route.ts"
+      - "src/app/api/admin/fixtures/change-notice/route.ts"
+      - "src/app/(admin)/admin/fixtures/[id]/edit/actions.ts"
       - "src/lib/fixtures/night-board-change-notifications.ts"
       - "src/lib/night-board/next-night-issues.ts"
       - "src/components/admin/AdminSidebar.tsx"
@@ -11,7 +13,9 @@ on:
       - "src/app/(admin)/admin/layout.tsx"
       - "scripts/apply-admin-team-kickoff-summary.cjs"
       - "scripts/apply-night-board-confirmation-reset-hardening.cjs"
+      - "scripts/apply-clear-removed-team-fixture-notices.cjs"
       - "scripts/check-night-board-fixture-notifications.mjs"
+      - "scripts/check-fixture-team-change-notifications.mjs"
       - "scripts/check-night-board-sidebar-alert.mjs"
       - "prisma/migrations/20260829214500_reset_stale_units_microwave_confirmations/migration.sql"
       - ".github/workflows/night-board-fixture-change.yml"
@@ -43,6 +47,9 @@ jobs:
 
       - name: Check Night Board notification contract
         run: node scripts/check-night-board-fixture-notifications.mjs
+
+      - name: Check fixture team-change notification contract
+        run: node scripts/check-fixture-team-change-notifications.mjs
 
       - name: Check Night Board sidebar alert contract
         run: node scripts/check-night-board-sidebar-alert.mjs

--- a/scripts/apply-admin-team-kickoff-summary.cjs
+++ b/scripts/apply-admin-team-kickoff-summary.cjs
@@ -64,3 +64,4 @@ if (changed) {
 // being overwritten by an earlier compatibility step.
 require("./apply-admin-lead-prospective-league-filter.cjs");
 require("./apply-night-board-confirmation-reset-hardening.cjs");
+require("./apply-clear-removed-team-fixture-notices.cjs");

--- a/scripts/apply-clear-removed-team-fixture-notices.cjs
+++ b/scripts/apply-clear-removed-team-fixture-notices.cjs
@@ -58,7 +58,7 @@ function applyPatch() {
       );
     }
 
-    const helper = String.raw`
+    const helper = `
 async function queueRemovedTeamNotice(input: {
   fixtureId: string;
   teamId: string;

--- a/scripts/apply-clear-removed-team-fixture-notices.cjs
+++ b/scripts/apply-clear-removed-team-fixture-notices.cjs
@@ -1,0 +1,330 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const routePath = path.join(
+  process.cwd(),
+  "src",
+  "app",
+  "api",
+  "admin",
+  "fixtures",
+  "change-notice",
+  "route.ts",
+);
+
+function countOccurrences(source, value) {
+  return source.split(value).length - 1;
+}
+
+function applyPatch() {
+  if (!fs.existsSync(routePath)) {
+    throw new Error("Fixture change-notice route was not found.");
+  }
+
+  let source = fs.readFileSync(routePath, "utf8");
+  let changed = false;
+
+  function replaceOnce(before, after, label) {
+    if (source.includes(after)) return;
+    if (!source.includes(before)) {
+      throw new Error(`Removed-team fixture notice: ${label} anchor was not found.`);
+    }
+    source = source.replace(before, after);
+    changed = true;
+  }
+
+  replaceOnce(
+    [
+      "function buildCaptainFixturesUrl(teamId: string, fixtureId: string) {",
+      "  return `${getSiteUrl()}/captain/team/${teamId}/fixtures?fixtureId=${encodeURIComponent(fixtureId)}`;",
+      "}",
+    ].join("\n"),
+    [
+      "function buildCaptainFixturesUrl(teamId: string, fixtureId?: string) {",
+      "  const baseUrl = `${getSiteUrl()}/captain/team/${teamId}/fixtures`;",
+      "  return fixtureId",
+      "    ? `${baseUrl}?fixtureId=${encodeURIComponent(fixtureId)}`",
+      "    : baseUrl;",
+      "}",
+    ].join("\n"),
+    "captain fixtures URL helper",
+  );
+
+  if (!source.includes("async function queueRemovedTeamNotice(input: {")) {
+    const anchor = "\nexport async function POST(request: Request) {";
+    if (!source.includes(anchor)) {
+      throw new Error(
+        "Removed-team fixture notice: POST handler anchor was not found.",
+      );
+    }
+
+    const helper = String.raw`
+async function queueRemovedTeamNotice(input: {
+  fixtureId: string;
+  teamId: string;
+  previousFixtureLabel: string;
+  previousFixtureSummary: string;
+  previousKickoffAt: Date;
+  leagueId: string;
+  leagueLabel: string;
+  sourceType: string;
+  sourceId: string;
+}) {
+  const { recipient, snapshot } = await upsertTeamNotificationRecipient(
+    input.teamId,
+  );
+  const contactName = snapshot.primaryContact.name ?? snapshot.teamName;
+  const fixturesUrl = buildCaptainFixturesUrl(input.teamId);
+  const emailBody = [
+    \`Hi \${contactName},\`,
+    "",
+    "IMPORTANT: your team is no longer playing in the fixture below.",
+    "",
+    "Previous fixture — this no longer applies to your team:",
+    input.previousFixtureSummary,
+    "",
+    \`The revised fixture does not involve \${snapshot.teamName}. You do not need to attend it or confirm it.\`,
+    "",
+    "If SIXFL has arranged a replacement fixture for your team, you will receive the correct details and confirmation link separately. Your current published fixtures are also available using the button below.",
+    "",
+    "{{cta}}",
+    "",
+    "If you believe your team should still be in the original fixture, please contact SIXFL directly.",
+  ].join("\\n");
+
+  const emailDispatch = await queueDirectNotification({
+    recipientId: recipient.id,
+    channel: NotificationChannel.EMAIL,
+    audience: NotificationAudience.TEAM,
+    subject: \`SIXFL fixture change: \${snapshot.teamName} is no longer in \${input.previousFixtureLabel}\`,
+    body: emailBody,
+    isTransactional: true,
+    sourceType: input.sourceType,
+    sourceId: input.sourceId,
+    emailCta: { label: "View my fixtures", url: fixturesUrl },
+    metadata: {
+      fixtureId: input.fixtureId,
+      teamId: input.teamId,
+      leagueId: input.leagueId,
+      leagueLabel: input.leagueLabel,
+      notificationKind: "TEAM_REMOVED_FROM_FIXTURE",
+      previousFixtureLabel: input.previousFixtureLabel,
+    },
+  });
+
+  const smsDispatch = await queueDirectNotification({
+    recipientId: recipient.id,
+    channel: NotificationChannel.SMS,
+    audience: NotificationAudience.TEAM,
+    body: \`SIXFL: \${snapshot.teamName} is no longer playing \${input.previousFixtureLabel} (\${formatKickoff(input.previousKickoffAt)}). The revised fixture does not involve your team, so do not attend or confirm it. Check your fixtures: \${fixturesUrl}\`,
+    isTransactional: true,
+    sourceType: input.sourceType,
+    sourceId: input.sourceId,
+    metadata: {
+      fixtureId: input.fixtureId,
+      teamId: input.teamId,
+      leagueId: input.leagueId,
+      leagueLabel: input.leagueLabel,
+      notificationKind: "TEAM_REMOVED_FROM_FIXTURE",
+      previousFixtureLabel: input.previousFixtureLabel,
+    },
+  });
+
+  return (
+    Number(emailDispatch.status === NotificationDispatchStatus.QUEUED) +
+    Number(smsDispatch.status === NotificationDispatchStatus.QUEUED)
+  );
+}
+`;
+
+    source = source.replace(anchor, `${helper}${anchor}`);
+    changed = true;
+  }
+
+  replaceOnce(
+    "  const affectedTeamIds = Array.from(new Set([fixture.homeTeamId, fixture.awayTeamId, homeTeamId, awayTeamId]));",
+    [
+      "  const previousTeamIds = new Set([",
+      "    fixture.homeTeamId,",
+      "    fixture.awayTeamId,",
+      "  ]);",
+      "  const nextParticipantTeamIds = Array.from(",
+      "    new Set([homeTeamId, awayTeamId]),",
+      "  );",
+      "  const nextTeamIds = new Set(nextParticipantTeamIds);",
+      "  const removedTeamIds = new Set(",
+      "    Array.from(previousTeamIds).filter(",
+      "      (teamId) => !nextTeamIds.has(teamId),",
+      "    ),",
+      "  );",
+      "  const retainedTeamIds = Array.from(previousTeamIds).filter((teamId) =>",
+      "    nextTeamIds.has(teamId),",
+      "  );",
+      "  const scheduledNoticeTeamIds = [",
+      "    ...Array.from(removedTeamIds),",
+      "    ...retainedTeamIds,",
+      "  ];",
+      "  const affectedTeamIds = Array.from(",
+      "    new Set([",
+      "      ...Array.from(previousTeamIds),",
+      "      ...nextParticipantTeamIds,",
+      "    ]),",
+      "  );",
+    ].join("\n"),
+    "old/new team classification",
+  );
+
+  replaceOnce(
+    [
+      "  const leagueLabel = `${league.name}${league.season ? ` · ${league.season}` : \"\"}`;",
+      "  const newFixtureSummary = describeFixture({",
+    ].join("\n"),
+    [
+      "  const leagueLabel = `${league.name}${league.season ? ` · ${league.season}` : \"\"}`;",
+      "  const previousFixtureLabel = `${fixture.homeTeam.name} vs ${fixture.awayTeam.name}`;",
+      "  const previousFixtureSummary = describeFixture({",
+      "    homeTeamName: fixture.homeTeam.name,",
+      "    awayTeamName: fixture.awayTeam.name,",
+      "    kickoffAt: fixture.kickoffAt,",
+      "    venueName: fixture.venue?.name ?? null,",
+      "    pitch: fixture.pitch,",
+      "    status: fixture.status,",
+      "  });",
+      "  const newFixtureSummary = describeFixture({",
+    ].join("\n"),
+    "previous fixture summary",
+  );
+
+  const oldConfirmationTeamFilter =
+    "        teamId: { in: affectedTeamIds },";
+  const newConfirmationTeamFilter =
+    "        teamId: { in: nextParticipantTeamIds },";
+  const oldFilterCount = countOccurrences(source, oldConfirmationTeamFilter);
+  const newFilterCount = countOccurrences(source, newConfirmationTeamFilter);
+
+  if (oldFilterCount === 2) {
+    source = source.split(oldConfirmationTeamFilter).join(newConfirmationTeamFilter);
+    changed = true;
+  } else if (oldFilterCount !== 0 || newFilterCount !== 2) {
+    throw new Error(
+      `Removed-team fixture notice: expected two confirmation team filters, found old=${oldFilterCount}, new=${newFilterCount}.`,
+    );
+  }
+
+  replaceOnce(
+    [
+      "    for (const teamId of affectedTeamIds) {",
+      "      const { recipient, snapshot } = await upsertTeamNotificationRecipient(teamId);",
+    ].join("\n"),
+    [
+      "    for (const teamId of affectedTeamIds) {",
+      "      if (removedTeamIds.has(teamId)) {",
+      "        queued += await queueRemovedTeamNotice({",
+      "          fixtureId: fixture.id,",
+      "          teamId,",
+      "          previousFixtureLabel,",
+      "          previousFixtureSummary,",
+      "          previousKickoffAt: fixture.kickoffAt,",
+      "          leagueId,",
+      "          leagueLabel,",
+      "          sourceType: STATUS_SOURCE_TYPE,",
+      "          sourceId,",
+      "        });",
+      "        continue;",
+      "      }",
+      "",
+      "      const { recipient, snapshot } = await upsertTeamNotificationRecipient(teamId);",
+    ].join("\n"),
+    "removed team handling for cancelled or postponed fixtures",
+  );
+
+  replaceOnce(
+    [
+      "  for (const teamId of affectedTeamIds) {",
+      "    const { recipient, snapshot } = await upsertTeamNotificationRecipient(teamId);",
+    ].join("\n"),
+    [
+      "  for (const teamId of scheduledNoticeTeamIds) {",
+      "    if (removedTeamIds.has(teamId)) {",
+      "      queued += await queueRemovedTeamNotice({",
+      "        fixtureId: fixture.id,",
+      "        teamId,",
+      "        previousFixtureLabel,",
+      "        previousFixtureSummary,",
+      "        previousKickoffAt: fixture.kickoffAt,",
+      "        leagueId,",
+      "        leagueLabel,",
+      "        sourceType: RECONFIRM_SOURCE_TYPE,",
+      "        sourceId,",
+      "      });",
+      "      continue;",
+      "    }",
+      "",
+      "    const { recipient, snapshot } = await upsertTeamNotificationRecipient(teamId);",
+    ].join("\n"),
+    "removed team handling for scheduled fixture changes",
+  );
+
+  const required = [
+    "function buildCaptainFixturesUrl(teamId: string, fixtureId?: string)",
+    "async function queueRemovedTeamNotice(input: {",
+    "IMPORTANT: your team is no longer playing in the fixture below.",
+    "The revised fixture does not involve",
+    "You do not need to attend it or confirm it.",
+    'emailCta: { label: "View my fixtures", url: fixturesUrl }',
+    'notificationKind: "TEAM_REMOVED_FROM_FIXTURE"',
+    "const removedTeamIds = new Set(",
+    "const scheduledNoticeTeamIds = [",
+    "teamId: { in: nextParticipantTeamIds },",
+    "for (const teamId of scheduledNoticeTeamIds) {",
+    "sourceType: STATUS_SOURCE_TYPE,",
+    "sourceType: RECONFIRM_SOURCE_TYPE,",
+  ];
+
+  for (const token of required) {
+    if (!source.includes(token)) {
+      throw new Error(
+        `Removed-team fixture notice is missing required safeguard: ${token}`,
+      );
+    }
+  }
+
+  if (countOccurrences(source, "if (removedTeamIds.has(teamId)) {") !== 2) {
+    throw new Error(
+      "Removed-team fixture notice must protect both status and scheduled change emails.",
+    );
+  }
+
+  const scheduledBranchStart = source.indexOf(
+    "  if (!shouldSendReconfirmNoticeForStatus(status)) {",
+  );
+  const scheduledBranch =
+    scheduledBranchStart >= 0 ? source.slice(scheduledBranchStart) : "";
+  if (
+    !scheduledBranch ||
+    scheduledBranch.includes("for (const teamId of affectedTeamIds) {")
+  ) {
+    throw new Error(
+      "Newly added teams must not receive the pre-save generic update email; the saved fixture action sends their correct confirmation instead.",
+    );
+  }
+
+  if (changed) {
+    fs.writeFileSync(routePath, source, "utf8");
+  }
+
+  return changed;
+}
+
+const firstPassChanged = applyPatch();
+const secondPassChanged = applyPatch();
+
+if (secondPassChanged) {
+  throw new Error("Removed-team fixture notice patch is not idempotent.");
+}
+
+console.log(
+  firstPassChanged
+    ? "Added clear removed-team fixture notices and stopped irrelevant confirmation links."
+    : "Removed-team fixture notice safeguards already applied.",
+);

--- a/scripts/apply-clear-removed-team-fixture-notices.cjs
+++ b/scripts/apply-clear-removed-team-fixture-notices.cjs
@@ -202,12 +202,12 @@ async function queueRemovedTeamNotice(input: {
   const oldFilterCount = countOccurrences(source, oldConfirmationTeamFilter);
   const newFilterCount = countOccurrences(source, newConfirmationTeamFilter);
 
-  if (oldFilterCount === 2) {
+  if (oldFilterCount > 0) {
     source = source.split(oldConfirmationTeamFilter).join(newConfirmationTeamFilter);
     changed = true;
-  } else if (oldFilterCount !== 0 || newFilterCount !== 2) {
+  } else if (newFilterCount === 0) {
     throw new Error(
-      `Removed-team fixture notice: expected two confirmation team filters, found old=${oldFilterCount}, new=${newFilterCount}.`,
+      "Removed-team fixture notice could not find a confirmation-team filter to protect.",
     );
   }
 

--- a/scripts/check-fixture-team-change-notifications.mjs
+++ b/scripts/check-fixture-team-change-notifications.mjs
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Missing fixture team-change contract file: ${relativePath}`);
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function requireText(source, expected, message) {
+  if (!source.includes(expected)) {
+    throw new Error(message);
+  }
+}
+
+const changeNoticeRoute = read(
+  "src/app/api/admin/fixtures/change-notice/route.ts",
+);
+const editAction = read(
+  "src/app/(admin)/admin/fixtures/[id]/edit/actions.ts",
+);
+const sourcePreparation = read(
+  "scripts/apply-admin-team-kickoff-summary.cjs",
+);
+
+for (const expected of [
+  "async function queueRemovedTeamNotice(input: {",
+  "const removedTeamIds = new Set(",
+  "const scheduledNoticeTeamIds = [",
+  "teamId: { in: nextParticipantTeamIds },",
+  "if (removedTeamIds.has(teamId)) {",
+  "for (const teamId of scheduledNoticeTeamIds) {",
+  "IMPORTANT: your team is no longer playing in the fixture below.",
+  "The revised fixture does not involve",
+  "You do not need to attend it or confirm it.",
+  'emailCta: { label: "View my fixtures", url: fixturesUrl }',
+  'notificationKind: "TEAM_REMOVED_FROM_FIXTURE"',
+]) {
+  requireText(
+    changeNoticeRoute,
+    expected,
+    `Fixture change notices are missing the removed-team safeguard: ${expected}`,
+  );
+}
+
+const scheduledBranchStart = changeNoticeRoute.indexOf(
+  "  if (!shouldSendReconfirmNoticeForStatus(status)) {",
+);
+const scheduledBranch =
+  scheduledBranchStart >= 0
+    ? changeNoticeRoute.slice(scheduledBranchStart)
+    : "";
+
+if (
+  !scheduledBranch ||
+  scheduledBranch.includes("for (const teamId of affectedTeamIds) {")
+) {
+  throw new Error(
+    "Scheduled fixture changes must not send the pre-save generic update to newly added teams.",
+  );
+}
+
+for (const expected of [
+  "const addedTeamIds = [homeTeamId, awayTeamId].filter(",
+  "await queueInitialFixtureConfirmationEmailForTeam({",
+  "teamId: addedTeamId,",
+]) {
+  requireText(
+    editAction,
+    expected,
+    `The saved fixture action must send newly added teams their own correct fixture confirmation: ${expected}`,
+  );
+}
+
+requireText(
+  sourcePreparation,
+  'require("./apply-clear-removed-team-fixture-notices.cjs")',
+  "Production source preparation must apply the removed-team fixture notice safeguard.",
+);
+
+console.log(
+  "Fixture team-change notification contract passed: removed teams receive a no-action notice linked to their own fixtures, retained teams receive the updated-fixture notice, and newly added teams receive their correct confirmation only after the fixture is saved.",
+);


### PR DESCRIPTION
Fixes the misleading fixture-change email sent to teams that have been removed from a published fixture. Removed teams now receive a clear no-action email and SMS explaining that the revised fixture does not involve them, with a link to their own fixtures rather than the unrelated revised match. Retained teams continue to receive the updated-fixture/reconfirmation message. Newly added teams are excluded from the pre-save generic email and continue to receive their correct confirmation only after the fixture has saved successfully. The build-time patch is idempotent and a dedicated contract plus TypeScript workflow protects the recipient split.