### PR TITLE
Fix referee-night cancellation for completed fixtures

### DIFF
--- a/src/app/(admin)/admin/referee-nights/[id]/correction-actions.ts
+++ b/src/app/(admin)/admin/referee-nights/[id]/correction-actions.ts
@@ -105,13 +105,15 @@ export async function cancelIncorrectRefereeNightAction(formData: FormData) {
     `);
 
     if (fixtureIds.length > 0) {
-      await tx.fixture.updateMany({
-        where: {
-          id: { in: fixtureIds },
-          refereeId: night.refereeId,
-        },
-        data: { refereeId: null },
-      });
+      // This is an explicit admin correction, not a match-data edit. Use a narrowly
+      // scoped SQL update so completed fixtures can release only this incorrect
+      // referee assignment without weakening the global completed-fixture lock.
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE "Fixture"
+        SET "refereeId" = NULL
+        WHERE id IN (${Prisma.join(fixtureIds)})
+          AND "refereeId" = ${night.refereeId}
+      `);
     }
 
     await tx.$executeRaw(Prisma.sql`


### PR DESCRIPTION
## Summary
- allow the explicit admin referee-night correction flow to release an incorrect referee assignment even when the fixture is already completed
- keep the global completed-fixture lock unchanged
- scope the bypass to `Fixture.refereeId = NULL` for only the fixtures attached to the cancelled referee night and only when they still reference that referee

## Why
Cancelling an incorrect referee night currently calls `fixture.updateMany`, which is blocked by the global completed-fixture guard and causes a production server error. This correction action is intentionally administrative and should be able to remove only the incorrect referee assignment without altering completed match data.