### PR TITLE
Prevent team-specific match fee regressions

### DIFF
--- a/scripts/apply-admin-team-kickoff-summary.cjs
+++ b/scripts/apply-admin-team-kickoff-summary.cjs
@@ -67,7 +67,7 @@ require("./apply-night-board-confirmation-reset-hardening.cjs");
 require("./apply-clear-removed-team-fixture-notices.cjs");
 require("./apply-referee-dashboard-click-affordances.cjs");
 
-// Payment safety must remain absolutely last. It re-applies the asymmetric
-// team-fee patch after every compatibility script and aborts the build if a
-// £36/£40 fixture could ever be collapsed back to £40/£40.
+// Payment safety must remain absolutely last. It checks the final generated
+// fixture-fee source and adds a saved-card cap so a stale £40 charge can never
+// debit a team whose agreed automatic match fee is £36.
 require("./apply-team-specific-fixture-fee-final-guard.cjs");

--- a/scripts/apply-admin-team-kickoff-summary.cjs
+++ b/scripts/apply-admin-team-kickoff-summary.cjs
@@ -66,3 +66,8 @@ require("./apply-admin-lead-prospective-league-filter.cjs");
 require("./apply-night-board-confirmation-reset-hardening.cjs");
 require("./apply-clear-removed-team-fixture-notices.cjs");
 require("./apply-referee-dashboard-click-affordances.cjs");
+
+// Payment safety must remain absolutely last. It re-applies the asymmetric
+// team-fee patch after every compatibility script and aborts the build if a
+// £36/£40 fixture could ever be collapsed back to £40/£40.
+require("./apply-team-specific-fixture-fee-final-guard.cjs");

--- a/scripts/apply-team-autopay-fee-authority.cjs
+++ b/scripts/apply-team-autopay-fee-authority.cjs
@@ -1,0 +1,55 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const file = "src/lib/payments/team-autopay.ts";
+const absolute = path.join(process.cwd(), ...file.split("/"));
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(`Saved-card fee safety source missing: ${label}`);
+  }
+  return source.replace(before, after);
+}
+
+let source = fs.readFileSync(absolute, "utf8");
+
+source = replaceRequired(
+  source,
+  `  amountPence: number;\n  paidPence: number;\n  dueDate: Date | null;`,
+  `  amountPence: number;\n  paidPence: number;\n  autoPayCapPence: number | null;\n  dueDate: Date | null;`,
+  "DueAutoPayCharge safe cap field",
+);
+
+source = replaceRequired(
+  source,
+  `      pc."amountPence"::int AS "amountPence",\n      COALESCE(SUM(tx."amountPence"), 0)::int AS "paidPence",\n      pc."dueDate"`,
+  `      pc."amountPence"::int AS "amountPence",\n      COALESCE(SUM(tx."amountPence"), 0)::int AS "paidPence",\n      COALESCE(\n        t."standardMatchFeePence",\n        CASE\n          WHEN f."homeTeamId" = pc."teamId" THEN f."homeMatchFeePence"\n          WHEN f."awayTeamId" = pc."teamId" THEN f."awayMatchFeePence"\n          ELSE NULL\n        END,\n        f."matchFeePence"\n      )::int AS "autoPayCapPence",\n      pc."dueDate"`,
+  "saved-card query fee authority",
+);
+
+source = replaceRequired(
+  source,
+  `  for (const row of rows) {\n    const outstandingPence = row.amountPence - row.paidPence;\n\n    if (outstandingPence <= 0) {`,
+  `  for (const row of rows) {\n    const autoPayCapPence = row.autoPayCapPence;\n\n    if (autoPayCapPence === null) {\n      const message =\n        "Automatic payment blocked because SIXFL could not verify this team's agreed match fee.";\n      await db.$executeRaw(Prisma.sql\`\n        UPDATE "Team"\n        SET\n          "autoPayLastFailureAt" = NOW(),\n          "autoPayLastFailureReason" = \${message}\n        WHERE "id" = \${row.teamId}\n      \`);\n      results.push({\n        chargeId: row.chargeId,\n        teamId: row.teamId,\n        status: "skipped",\n        amountPence: 0,\n        message,\n      });\n      continue;\n    }\n\n    let chargeAmountPence = row.amountPence;\n\n    if (chargeAmountPence > autoPayCapPence) {\n      if (row.paidPence > 0) {\n        const message =\n          \`Automatic payment blocked: stored charge \${chargeAmountPence}p exceeds the verified team fee \${autoPayCapPence}p and money is already recorded against the charge. Admin review is required.\`;\n        await db.$executeRaw(Prisma.sql\`\n          UPDATE "Team"\n          SET\n            "autoPayLastFailureAt" = NOW(),\n            "autoPayLastFailureReason" = \${message}\n          WHERE "id" = \${row.teamId}\n        \`);\n        results.push({\n          chargeId: row.chargeId,\n          teamId: row.teamId,\n          status: "skipped",\n          amountPence: 0,\n          message,\n        });\n        continue;\n      }\n\n      if (autoPayCapPence <= 0) {\n        await db.$executeRaw(Prisma.sql\`\n          UPDATE "PaymentCharge"\n          SET "status" = 'VOID'::"PaymentChargeStatus"\n          WHERE "id" = \${row.chargeId}\n            AND "status" <> 'VOID'::"PaymentChargeStatus"\n        \`);\n        results.push({\n          chargeId: row.chargeId,\n          teamId: row.teamId,\n          status: "skipped",\n          amountPence: 0,\n          message: "Automatic payment blocked because the verified team match fee is £0.00.",\n        });\n        continue;\n      }\n\n      await db.$executeRaw(Prisma.sql\`\n        UPDATE "PaymentCharge"\n        SET\n          "amountPence" = \${autoPayCapPence},\n          "status" = 'OPEN'::"PaymentChargeStatus"\n        WHERE "id" = \${row.chargeId}\n          AND "status" <> 'VOID'::"PaymentChargeStatus"\n      \`);\n\n      console.warn("Corrected saved-card charge down to verified team fee before Stripe debit", {\n        chargeId: row.chargeId,\n        teamId: row.teamId,\n        storedAmountPence: row.amountPence,\n        verifiedFeePence: autoPayCapPence,\n      });\n      chargeAmountPence = autoPayCapPence;\n    }\n\n    const outstandingPence = chargeAmountPence - row.paidPence;\n\n    if (outstandingPence <= 0) {`,
+  "saved-card charge cap",
+);
+
+source = replaceRequired(
+  source,
+  `          metadata: {\n            type: "team_matchday_auto_payment",\n            teamId: row.teamId,\n            chargeId: row.chargeId,\n            fixtureId: row.fixtureId,\n          },`,
+  `          metadata: {\n            type: "team_matchday_auto_payment",\n            teamId: row.teamId,\n            chargeId: row.chargeId,\n            fixtureId: row.fixtureId,\n            verifiedTeamFeePence: String(autoPayCapPence),\n            storedChargePence: String(row.amountPence),\n          },`,
+  "saved-card Stripe audit metadata",
+);
+
+source = replaceRequired(
+  source,
+  `          idempotencyKey: \`sixfl_matchday_autopay_\${row.chargeId}\`,`,
+  `          idempotencyKey: \`sixfl_matchday_autopay_\${row.chargeId}_\${chargeAmountPence}\`,`,
+  "saved-card amount-aware idempotency key",
+);
+
+fs.writeFileSync(absolute, source, "utf8");
+console.log(
+  "Saved-card autopay now verifies the team's agreed fee and cannot debit above it.",
+);

--- a/scripts/apply-team-specific-fixture-fee-final-guard.cjs
+++ b/scripts/apply-team-specific-fixture-fee-final-guard.cjs
@@ -1,11 +1,11 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-// Re-apply the team-specific fixture fee patch after every other compatibility
-// script has run. This must be the final payment-related source mutation before
-// Next.js builds, otherwise a later legacy patch can silently restore one shared
-// fixture fee and overcharge the cheaper team.
-require("./apply-fixture-team-fee-overrides.cjs");
+// This runs last in prebuild/predev. Do not re-run the old whole fixture patch
+// here because later compatibility steps intentionally evolve the publish code.
+// Instead, add the last-line saved-card safety and then verify the final source
+// that will actually be compiled/deployed.
+require("./apply-team-autopay-fee-authority.cjs");
 
 const root = path.resolve(__dirname, "..");
 
@@ -30,6 +30,7 @@ const publishOne = read("src/app/api/admin/fixtures/publish-one/route.ts");
 const singleFixture = read("src/app/(admin)/admin/fixtures/generate/single-fixture-action.ts");
 const editFixture = read("src/app/(admin)/admin/fixtures/[id]/edit/actions.ts");
 const chargeSync = read("src/lib/payments/fixture-match-fees.ts");
+const autoPay = read("src/lib/payments/team-autopay.ts");
 
 for (const [label, source] of [
   ["batch fixture publishing", publishBatch],
@@ -93,6 +94,32 @@ mustContain(
   "charge sync must use the supplied away-side amount.",
 );
 
+mustContain(
+  autoPay,
+  "autoPayCapPence: number | null;",
+  "saved-card autopay must carry a verified fee cap.",
+);
+mustContain(
+  autoPay,
+  't."standardMatchFeePence"',
+  "saved-card autopay must verify the team's configured standard fee before charging.",
+);
+mustContain(
+  autoPay,
+  "if (chargeAmountPence > autoPayCapPence)",
+  "saved-card autopay must block/correct a stored charge above the verified fee.",
+);
+mustContain(
+  autoPay,
+  "storedAmountPence: row.amountPence",
+  "saved-card corrections must be auditable.",
+);
+mustContain(
+  autoPay,
+  "sixfl_matchday_autopay_${row.chargeId}_${chargeAmountPence}",
+  "saved-card idempotency must include the verified charge amount.",
+);
+
 console.log(
-  "Final team-specific fixture fee guard passed: asymmetric team fees cannot be collapsed to one shared charge.",
+  "Final payment safety passed: asymmetric fixture fees stay separate and saved-card autopay cannot exceed the verified team fee.",
 );

--- a/scripts/apply-team-specific-fixture-fee-final-guard.cjs
+++ b/scripts/apply-team-specific-fixture-fee-final-guard.cjs
@@ -1,0 +1,98 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Re-apply the team-specific fixture fee patch after every other compatibility
+// script has run. This must be the final payment-related source mutation before
+// Next.js builds, otherwise a later legacy patch can silently restore one shared
+// fixture fee and overcharge the cheaper team.
+require("./apply-fixture-team-fee-overrides.cjs");
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, ...relativePath.split("/")), "utf8");
+}
+
+function mustContain(source, expected, message) {
+  if (!source.includes(expected)) {
+    throw new Error(`Team-specific fixture fee safety failed: ${message}`);
+  }
+}
+
+function mustNotMatch(source, pattern, message) {
+  if (pattern.test(source)) {
+    throw new Error(`Team-specific fixture fee safety failed: ${message}`);
+  }
+}
+
+const publishBatch = read("src/app/(admin)/admin/fixtures/publish-actions.ts");
+const publishOne = read("src/app/api/admin/fixtures/publish-one/route.ts");
+const singleFixture = read("src/app/(admin)/admin/fixtures/generate/single-fixture-action.ts");
+const editFixture = read("src/app/(admin)/admin/fixtures/[id]/edit/actions.ts");
+const chargeSync = read("src/lib/payments/fixture-match-fees.ts");
+
+for (const [label, source] of [
+  ["batch fixture publishing", publishBatch],
+  ["single fixture publishing", publishOne],
+]) {
+  mustContain(
+    source,
+    "homeMatchFeePence: number | null;",
+    `${label} must load the home team's own fixture fee.`,
+  );
+  mustContain(
+    source,
+    "awayMatchFeePence: number | null;",
+    `${label} must load the away team's own fixture fee.`,
+  );
+  mustContain(
+    source,
+    "fixture.homeMatchFeePence ?? fixture.matchFeePence ?? DEFAULT_MATCH_FEE_PENCE",
+    `${label} must resolve the home fee independently.`,
+  );
+  mustContain(
+    source,
+    "fixture.awayMatchFeePence ?? fixture.matchFeePence ?? DEFAULT_MATCH_FEE_PENCE",
+    `${label} must resolve the away fee independently.`,
+  );
+  mustNotMatch(
+    source,
+    /homeMatchFeePence:\s*matchFeePence,\s*awayMatchFeePence:\s*matchFeePence,/m,
+    `${label} must never copy one shared fixture fee to both teams. A £36 team playing a £40 team must remain £36.`,
+  );
+}
+
+mustContain(
+  singleFixture,
+  "homeMatchFeePence: homeStandardMatchFeePence,",
+  "new fixtures must snapshot the home team's standard fee.",
+);
+mustContain(
+  singleFixture,
+  "awayMatchFeePence: awayStandardMatchFeePence,",
+  "new fixtures must snapshot the away team's standard fee.",
+);
+mustContain(
+  editFixture,
+  "homeMatchFeePence,",
+  "fixture edits must persist the home-side fee.",
+);
+mustContain(
+  editFixture,
+  "awayMatchFeePence,",
+  "fixture edits must persist the away-side fee.",
+);
+mustContain(
+  chargeSync,
+  "amountPence: input.homeMatchFeePence",
+  "charge sync must use the supplied home-side amount.",
+);
+mustContain(
+  chargeSync,
+  "amountPence: input.awayMatchFeePence",
+  "charge sync must use the supplied away-side amount.",
+);
+
+console.log(
+  "Final team-specific fixture fee guard passed: asymmetric team fees cannot be collapsed to one shared charge.",
+);


### PR DESCRIPTION
Urgent payment safety fix following the SWAZ £40/£36 saved-card overcharge.

What this does:
- Keeps the existing team-specific fixture fee patch in the normal prebuild chain, then verifies the FINAL generated publish source after all compatibility scripts have run.
- Adds a hard build guard that aborts deployment if batch publishing or single-fixture publishing ever copies one shared `matchFeePence` to both teams again.
- Explicitly protects the £36-v-£40 scenario by forbidding the legacy `homeMatchFeePence: matchFeePence` / `awayMatchFeePence: matchFeePence` pattern.
- Verifies new fixtures snapshot each team's own standard fee, fixture edits persist both side fees, and charge sync uses separate home/away amounts.
- Adds a second, runtime saved-card safety layer: immediately before Stripe autopay, SIXFL now resolves the team's configured standard match fee (falling back to the team-side fixture fee only where necessary) and will NEVER debit above that verified amount.
- If an unpaid stale PaymentCharge is higher than the verified saved-card fee, it is reduced to the safe amount before Stripe is called. If money is already recorded against a mismatched charge, autopay is blocked for admin review rather than taking more money.
- £0/unverifiable automatic charges are blocked, and Stripe metadata/idempotency records the verified amount for audit.

Why:
The publish-time team-specific fee logic exists, but SWAZ proved that an old/stale £40 PaymentCharge can still survive until matchday. Saved-card autopay previously trusted that stored row completely. This PR adds defence in depth: publish/source checks prevent new £36→£40 collapses, and the runtime autopay cap prevents any stale bad row from causing another over-debit.

No historical live payment data is modified by this PR.