### PR TITLE
Reuse valid sessions instead of sending repeat magic links

### DIFF
--- a/.github/workflows/sign-in-link-activity.yml
+++ b/.github/workflows/sign-in-link-activity.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     paths:
       - "src/auth.ts"
+      - "src/middleware.ts"
+      - "src/app/(public)/login/**"
       - "src/lib/auth/sign-in-link-activity.ts"
       - "src/app/(admin)/admin/sign-in-activity/**"
       - "src/components/admin/AdminSidebar.tsx"
       - "prisma/migrations/**"
+      - "scripts/apply-login-session-retention-guard.cjs"
+      - "scripts/apply-admin-team-kickoff-summary.cjs"
       - "scripts/check-sign-in-link-activity-contract.mjs"
       - ".github/workflows/sign-in-link-activity.yml"
   push:
@@ -15,10 +19,14 @@ on:
       - main
     paths:
       - "src/auth.ts"
+      - "src/middleware.ts"
+      - "src/app/(public)/login/**"
       - "src/lib/auth/sign-in-link-activity.ts"
       - "src/app/(admin)/admin/sign-in-activity/**"
       - "src/components/admin/AdminSidebar.tsx"
       - "prisma/migrations/**"
+      - "scripts/apply-login-session-retention-guard.cjs"
+      - "scripts/apply-admin-team-kickoff-summary.cjs"
       - "scripts/check-sign-in-link-activity-contract.mjs"
       - ".github/workflows/sign-in-link-activity.yml"
   workflow_dispatch:

--- a/scripts/apply-admin-team-kickoff-summary.cjs
+++ b/scripts/apply-admin-team-kickoff-summary.cjs
@@ -66,3 +66,4 @@ require("./apply-admin-lead-prospective-league-filter.cjs");
 require("./apply-night-board-confirmation-reset-hardening.cjs");
 require("./apply-clear-removed-team-fixture-notices.cjs");
 require("./apply-referee-dashboard-click-affordances.cjs");
+require("./apply-login-session-retention-guard.cjs");

--- a/scripts/apply-login-session-retention-guard.cjs
+++ b/scripts/apply-login-session-retention-guard.cjs
@@ -1,0 +1,135 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const authPath = path.join(process.cwd(), "src", "auth.ts");
+
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) {
+    throw new Error(`Login session retention: ${label} anchor was not found.`);
+  }
+  return source.replace(before, after);
+}
+
+function apply() {
+  let source = fs.readFileSync(authPath, "utf8");
+  const original = source;
+
+  source = replaceRequired(
+    source,
+    `const LOGIN_CTA_LABEL = "Sign in to SIXFL";
+const CTA_PLACEHOLDER = "{{cta}}";
+
+function getSiteUrl() {
+  return (
+    process.env.NEXTAUTH_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    "https://www.sixfl.co.uk"
+  ).replace(/\\/+$/, "");
+}`,
+    `const LOGIN_CTA_LABEL = "Sign in to SIXFL";
+const CTA_PLACEHOLDER = "{{cta}}";
+const CANONICAL_SITE_URL = "https://sixfl.co.uk";
+const CANONICAL_HOST = "sixfl.co.uk";
+const LEGACY_WWW_HOST = "www.sixfl.co.uk";
+
+function canonicaliseSIXFLUrl(value: string) {
+  try {
+    const parsed = new URL(value);
+    if (parsed.hostname.toLowerCase() === LEGACY_WWW_HOST) {
+      parsed.protocol = "https:";
+      parsed.hostname = CANONICAL_HOST;
+      parsed.port = "";
+    }
+    const callbackUrl = parsed.searchParams.get("callbackUrl");
+    if (callbackUrl) {
+      try {
+        const callback = new URL(callbackUrl);
+        if (callback.hostname.toLowerCase() === LEGACY_WWW_HOST) {
+          callback.protocol = "https:";
+          callback.hostname = CANONICAL_HOST;
+          callback.port = "";
+          parsed.searchParams.set("callbackUrl", callback.toString());
+        }
+      } catch {}
+    }
+    return parsed.toString();
+  } catch {
+    return value;
+  }
+}
+
+function getSiteUrl() {
+  const configured = (
+    process.env.NEXTAUTH_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    CANONICAL_SITE_URL
+  ).replace(/\\/+$/, "");
+  return canonicaliseSIXFLUrl(configured).replace(/\\/+$/, "");
+}`,
+    "canonical URL helper",
+  );
+
+  source = replaceRequired(
+    source,
+    `      async sendVerificationRequest({ identifier, url, provider }) {
+        const email = identifier.toLowerCase().trim();`,
+    `      async sendVerificationRequest({ identifier, url, provider }) {
+        const email = identifier.toLowerCase().trim();
+        const canonicalUrl = canonicaliseSIXFLUrl(url);`,
+    "canonical magic-link value",
+  );
+
+  source = replaceRequired(
+    source,
+    `        const emailContent = await buildLoginMagicLinkEmail({
+          email,
+          url,
+          pendingCaptain,
+        });`,
+    `        const emailContent = await buildLoginMagicLinkEmail({
+          email,
+          url: canonicalUrl,
+          pendingCaptain,
+        });`,
+    "login email URL",
+  );
+
+  source = replaceRequired(source, "          magicLinkUrl: url,", "          magicLinkUrl: canonicalUrl,", "activity URL");
+
+  if (!source.includes("    async redirect({ url, baseUrl }) {")) {
+    const anchor = "\n    async session({ session, user }) {";
+    if (!source.includes(anchor)) throw new Error("Session callback anchor was not found.");
+    const callback = `
+    async redirect({ url, baseUrl }) {
+      const canonicalBaseUrl = canonicaliseSIXFLUrl(baseUrl).replace(/\\/+$/, "");
+      if (url.startsWith("/")) return canonicalBaseUrl + url;
+      try {
+        const requestedUrl = new URL(canonicaliseSIXFLUrl(url));
+        const canonicalBase = new URL(canonicalBaseUrl);
+        if (requestedUrl.origin === canonicalBase.origin) return requestedUrl.toString();
+      } catch {}
+      return canonicalBaseUrl;
+    },
+`;
+    source = source.replace(anchor, callback + anchor);
+  }
+
+  for (const marker of [
+    'const CANONICAL_SITE_URL = "https://sixfl.co.uk";',
+    "const canonicalUrl = canonicaliseSIXFLUrl(url);",
+    "url: canonicalUrl,",
+    "magicLinkUrl: canonicalUrl,",
+    "async redirect({ url, baseUrl }) {",
+  ]) {
+    if (!source.includes(marker)) throw new Error(`Missing safeguard: ${marker}`);
+  }
+
+  if (source !== original) fs.writeFileSync(authPath, source, "utf8");
+  return source !== original;
+}
+
+const first = apply();
+const second = apply();
+if (second) throw new Error("Login session retention patch is not idempotent.");
+console.log(first ? "Canonical SIXFL session safeguards applied." : "Canonical SIXFL session safeguards already applied.");

--- a/scripts/check-sign-in-link-activity-contract.mjs
+++ b/scripts/check-sign-in-link-activity-contract.mjs
@@ -34,6 +34,9 @@ function expectOrder(source, markers, message) {
 }
 
 const auth = read("src/auth.ts");
+const loginPage = read("src/app/(public)/login/page.tsx");
+const checkEmailPage = read("src/app/(public)/login/check-email/page.tsx");
+const middleware = read("src/middleware.ts");
 const activityService = read("src/lib/auth/sign-in-link-activity.ts");
 const returnService = read("src/lib/auth/authenticated-return-visits.ts");
 const returnTracker = read("src/components/auth/AuthenticatedReturnVisitTracker.tsx");
@@ -105,6 +108,88 @@ expect(
   auth,
   "markLatestSignInLinkUsed({",
   "A successful email sign-in must update its activity record.",
+);
+expect(
+  auth,
+  'const CANONICAL_SITE_URL = "https://sixfl.co.uk";',
+  "Magic-link generation must use the apex SIXFL host.",
+);
+expect(
+  auth,
+  "const canonicalUrl = canonicaliseSIXFLUrl(url);",
+  "NextAuth-generated magic links must be canonicalised before they are emailed.",
+);
+expect(
+  auth,
+  "magicLinkUrl: canonicalUrl,",
+  "Sign-in diagnostics must record the same canonical URL that was emailed.",
+);
+expect(
+  auth,
+  "async redirect({ url, baseUrl }) {",
+  "Post-login redirects must remain on the canonical SIXFL host.",
+);
+
+expect(
+  loginPage,
+  "useSession",
+  "The login page must check whether this browser is already signed in.",
+);
+expect(
+  loginPage,
+  'status === "authenticated"',
+  "An existing browser session must bypass the magic-link form.",
+);
+expect(
+  loginPage,
+  "You’re already signed in",
+  "Logged-in users must be told they do not need another email link.",
+);
+expect(
+  loginPage,
+  "Open my SIXFL account",
+  "Logged-in users must have a direct route to their existing dashboard.",
+);
+expect(
+  loginPage,
+  'signOut({ callbackUrl: "/login" })',
+  "The login page must still allow an intentional account change.",
+);
+expect(
+  checkEmailPage,
+  "same normal browser",
+  "The check-email page must explain that the same browser retains the session.",
+);
+expect(
+  checkEmailPage,
+  "Open in browser",
+  "Users must be warned about email-app mini-browsers.",
+);
+
+expect(
+  middleware,
+  'const CANONICAL_HOST = "sixfl.co.uk";',
+  "Browser traffic must have one canonical SIXFL host.",
+);
+expect(
+  middleware,
+  'const LEGACY_WWW_HOST = "www.sixfl.co.uk";',
+  "The legacy www host must be recognised explicitly.",
+);
+expect(
+  middleware,
+  'request.method !== "GET" && request.method !== "HEAD"',
+  "Canonical redirects must not interfere with POST webhooks or form submissions.",
+);
+expect(
+  middleware,
+  "NextResponse.redirect(url, 308)",
+  "Legacy www visits must permanently preserve their path and query on the apex host.",
+);
+expect(
+  middleware,
+  'matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"]',
+  "The canonical-host safeguard must cover login, callback and dashboard routes.",
 );
 
 expect(

--- a/src/app/(public)/login/check-email/page.tsx
+++ b/src/app/(public)/login/check-email/page.tsx
@@ -41,8 +41,11 @@ export default async function CheckEmailPage({ searchParams }: PageProps) {
           </div>
         ) : null}
 
-        <div className="mt-6 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
-          Make sure you open the link on this device to complete sign-in.
+        <div className="mt-6 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm leading-6 text-emerald-200">
+          Open the email link on this device in the same normal browser you use
+          for SIXFL, such as Chrome or Safari. If your email app opens its own
+          mini-browser, choose <strong>Open in browser</strong>. This helps SIXFL
+          keep you signed in for your next visit.
         </div>
 
         <div className="mt-6">

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -6,7 +6,7 @@
 
 import Link from "next/link";
 import { Suspense, useEffect, useMemo, useState } from "react";
-import { signIn } from "next-auth/react";
+import { signIn, signOut, useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 
 function isSafeCallbackUrl(value: string | null) {
@@ -14,12 +14,12 @@ function isSafeCallbackUrl(value: string | null) {
   return value.startsWith("/") && !value.startsWith("//");
 }
 
-function LoginFallback() {
+function LoginFallback({ message = "Checking your existing sign-in..." }: { message?: string }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-black px-4 text-white">
       <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 shadow-2xl">
         <h1 className="text-xl font-semibold">Login</h1>
-        <p className="mt-2 text-sm text-white/60">Loading login form...</p>
+        <p className="mt-2 text-sm text-white/60">{message}</p>
       </div>
     </div>
   );
@@ -27,6 +27,7 @@ function LoginFallback() {
 
 function LoginForm() {
   const searchParams = useSearchParams();
+  const { status } = useSession();
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -35,6 +36,7 @@ function LoginForm() {
     const value = searchParams.get("callbackUrl");
     return isSafeCallbackUrl(value) ? value! : "";
   }, [searchParams]);
+  const signedInDestination = callbackUrlFromQuery || "/dashboard";
 
   useEffect(() => {
     const emailFromQuery = searchParams.get("email")?.trim() ?? "";
@@ -116,6 +118,41 @@ function LoginForm() {
     window.location.href = nextUrl.toString();
   }
 
+  if (status === "loading") {
+    return <LoginFallback />;
+  }
+
+  if (status === "authenticated") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-black px-4 text-white">
+        <div className="w-full max-w-md rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-6 shadow-2xl">
+          <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-emerald-200/70">
+            Existing sign-in found
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold">You’re already signed in</h1>
+          <p className="mt-3 text-sm leading-6 text-emerald-50/75">
+            This browser already has a valid SIXFL session. You do not need another email link.
+          </p>
+
+          <Link
+            href={signedInDestination}
+            className="mt-6 inline-flex w-full items-center justify-center rounded-xl bg-emerald-400 px-4 py-3 font-bold text-black transition hover:bg-emerald-300"
+          >
+            Open my SIXFL account
+          </Link>
+
+          <button
+            type="button"
+            onClick={() => void signOut({ callbackUrl: "/login" })}
+            className="mt-3 w-full rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm font-semibold text-white/70 transition hover:border-white/20 hover:bg-black/30 hover:text-white"
+          >
+            Sign out and use a different email
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-black px-4 text-white">
       <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 shadow-2xl">
@@ -170,7 +207,7 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<LoginFallback />}>
+    <Suspense fallback={<LoginFallback message="Loading login..." />}>
       <LoginForm />
     </Suspense>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,11 +4,42 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 
+const CANONICAL_HOST = "sixfl.co.uk";
+const LEGACY_WWW_HOST = "www.sixfl.co.uk";
+
 const WHATSAPP_LOGO_ALIASES = new Set([
   "/WhatsApp-Logo.png",
   "/WhatsApp-logo.png",
   "/whatsapp-logo.png",
 ]);
+
+function getRequestHostname(request: NextRequest) {
+  const forwardedHost = request.headers
+    .get("x-forwarded-host")
+    ?.split(",")[0]
+    ?.trim();
+  const host =
+    forwardedHost || request.headers.get("host") || request.nextUrl.hostname;
+
+  return host.toLowerCase().replace(/:\d+$/, "");
+}
+
+function redirectToCanonicalHost(request: NextRequest) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return null;
+  }
+
+  if (getRequestHostname(request) !== LEGACY_WWW_HOST) {
+    return null;
+  }
+
+  const url = request.nextUrl.clone();
+  url.protocol = "https:";
+  url.hostname = CANONICAL_HOST;
+  url.port = "";
+
+  return NextResponse.redirect(url, 308);
+}
 
 function preserveRegisterInterestContext(request: NextRequest) {
   const currentUrl = request.nextUrl;
@@ -67,6 +98,9 @@ function isHarrogateTuesdaySignup(request: NextRequest) {
 }
 
 export function middleware(request: NextRequest) {
+  const canonicalRedirect = redirectToCanonicalHost(request);
+  if (canonicalRedirect) return canonicalRedirect;
+
   const { pathname } = request.nextUrl;
 
   if (WHATSAPP_LOGO_ALIASES.has(pathname)) {
@@ -93,10 +127,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    "/register-interest",
-    "/WhatsApp-Logo.png",
-    "/WhatsApp-logo.png",
-    "/whatsapp-logo.png",
-  ],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };


### PR DESCRIPTION
## What changed
- checks the browser session before showing the login form
- when the browser is already signed in, shows **Open my SIXFL account** instead of sending another email link
- retains an explicit **Sign out and use a different email** option
- redirects legacy `www.sixfl.co.uk` GET/HEAD visits to the canonical `sixfl.co.uk` host while leaving POST requests untouched
- canonicalises NextAuth magic-link URLs, nested callbacks and post-login redirects to the same host
- explains on the check-email page that users should open the link in their normal browser rather than an email-app mini-browser
- extends the sign-in reliability contract and workflow paths

## Why
Finn's latest activity proves that another magic link was requested and used even though SIXFL still had valid database sessions for the account. That does not by itself prove his browser lost its cookie: the existing login page always offered another link, and mixed `www`/apex URLs could split host-scoped cookies. This change removes both avoidable causes while keeping the existing return-session diagnosis in place.

## Expected result
A user who visits `/login` in a browser that still has a valid SIXFL session is sent straight back to their account without requesting another magic link. A genuinely unsigned browser can still use the normal email flow.