### PR TITLE
Make referee confirmations clear and handle stale links

### DIFF
--- a/src/app/(public)/referee/confirmation-actions.ts
+++ b/src/app/(public)/referee/confirmation-actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { Prisma } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requireReferee } from "@/lib/admin";
+import { ensureRefereeNightConfirmationColumns } from "@/lib/referee-night-confirmations";
+import { prisma } from "@/lib/prisma";
+
+export async function respondToRefereeNightAction(formData: FormData) {
+  const { user } = await requireReferee();
+  await ensureRefereeNightConfirmationColumns();
+
+  const refereeNightId = String(formData.get("refereeNightId") ?? "").trim();
+  const answer = String(formData.get("answer") ?? "").trim().toLowerCase();
+
+  if (!refereeNightId || (answer !== "yes" && answer !== "no")) {
+    redirect("/referee?confirmation=invalid");
+  }
+
+  const status = answer === "yes" ? "CONFIRMED" : "DECLINED";
+  const now = new Date();
+
+  const updated = await prisma.$executeRaw(Prisma.sql`
+    UPDATE "RefereeNight"
+    SET
+      "confirmationStatus" = ${status},
+      "confirmationConfirmedAt" = CASE WHEN ${status} = 'CONFIRMED' THEN ${now} ELSE "confirmationConfirmedAt" END,
+      "confirmationDeclinedAt" = CASE WHEN ${status} = 'DECLINED' THEN ${now} ELSE "confirmationDeclinedAt" END,
+      "confirmationResponseNote" = ${status === "CONFIRMED" ? "Referee confirmed they can attend from the referee dashboard." : "Referee said they cannot attend from the referee dashboard."},
+      "confirmationTokenHash" = NULL,
+      "updatedAt" = NOW()
+    WHERE id = ${refereeNightId}
+      AND "refereeId" = ${user.id}
+      AND status <> 'CANCELLED'
+      AND "nightDate" >= CURRENT_DATE
+  `);
+
+  revalidatePath("/referee");
+  revalidatePath(`/referee/night/${refereeNightId}`);
+
+  if (!updated) {
+    redirect("/referee?confirmation=stale");
+  }
+
+  redirect(`/referee?confirmation=${answer === "yes" ? "confirmed" : "declined"}`);
+}

--- a/src/app/(public)/referee/layout.tsx
+++ b/src/app/(public)/referee/layout.tsx
@@ -1,0 +1,120 @@
+import type { ReactNode } from "react";
+import { Prisma } from "@prisma/client";
+
+import { requireReferee } from "@/lib/admin";
+import { ensureRefereeNightConfirmationColumns } from "@/lib/referee-night-confirmations";
+import { formatNightDate } from "@/lib/referee-nights";
+import { prisma } from "@/lib/prisma";
+
+import { respondToRefereeNightAction } from "./confirmation-actions";
+
+type UpcomingConfirmation = {
+  id: string;
+  nightDate: Date | string;
+  confirmationStatus: string | null;
+  leagueName: string;
+  venueName: string | null;
+};
+
+export default async function RefereeLayout({ children }: { children: ReactNode }) {
+  const { user } = await requireReferee();
+  await ensureRefereeNightConfirmationColumns();
+
+  const rows = await prisma.$queryRaw<UpcomingConfirmation[]>(Prisma.sql`
+    SELECT
+      rn.id,
+      rn."nightDate",
+      rn."confirmationStatus",
+      l.name AS "leagueName",
+      v.name AS "venueName"
+    FROM "RefereeNight" rn
+    JOIN "League" l ON l.id = rn."leagueId"
+    LEFT JOIN "Venue" v ON v.id = rn."venueId"
+    WHERE rn."refereeId" = ${user.id}
+      AND rn.status <> 'CANCELLED'
+      AND rn."nightDate" >= CURRENT_DATE
+    ORDER BY rn."nightDate" ASC
+    LIMIT 1
+  `);
+
+  const night = rows[0] ?? null;
+  const confirmationStatus = String(night?.confirmationStatus ?? "PENDING").toUpperCase();
+  const isConfirmed = confirmationStatus === "CONFIRMED";
+  const isDeclined = confirmationStatus === "DECLINED";
+
+  return (
+    <>
+      {night ? (
+        <section className="mx-auto mb-5 max-w-[1180px] px-4 sm:px-6 lg:px-8">
+          <div
+            className={[
+              "rounded-3xl border p-5 shadow-[0_16px_50px_rgba(0,0,0,0.22)] sm:p-6",
+              isConfirmed
+                ? "border-emerald-400/35 bg-emerald-500/12"
+                : isDeclined
+                  ? "border-red-400/30 bg-red-500/10"
+                  : "border-amber-300/40 bg-amber-400/12",
+            ].join(" ")}
+          >
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/55">
+                  Referee night confirmation
+                </p>
+                <h2 className="mt-2 text-2xl font-bold text-white">
+                  {isConfirmed
+                    ? "✓ Night confirmed"
+                    : isDeclined
+                      ? "You have said you cannot referee this night"
+                      : "Please confirm your next referee night"}
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-white/70">
+                  <span className="font-semibold text-white">{formatNightDate(night.nightDate)}</span>
+                  {` · ${night.leagueName}`}
+                  {night.venueName ? ` · ${night.venueName}` : ""}
+                </p>
+                <p className="mt-2 text-sm text-white/60">
+                  {isConfirmed
+                    ? "SIXFL has your confirmation. If your availability changes, tell us here straight away."
+                    : isDeclined
+                      ? "SIXFL will arrange cover. If your availability has changed, you can confirm again below."
+                      : "Please respond now so SIXFL knows whether cover is needed."}
+                </p>
+              </div>
+
+              <div className="flex min-w-fit flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row">
+                {!isConfirmed ? (
+                  <form action={respondToRefereeNightAction}>
+                    <input type="hidden" name="refereeNightId" value={night.id} />
+                    <input type="hidden" name="answer" value="yes" />
+                    <button
+                      type="submit"
+                      className="inline-flex w-full items-center justify-center rounded-2xl bg-emerald-400 px-5 py-3.5 text-sm font-bold text-black transition hover:bg-emerald-300"
+                    >
+                      ✓ Yes, I can referee
+                    </button>
+                  </form>
+                ) : null}
+
+                {!isDeclined ? (
+                  <form action={respondToRefereeNightAction}>
+                    <input type="hidden" name="refereeNightId" value={night.id} />
+                    <input type="hidden" name="answer" value="no" />
+                    <button
+                      type="submit"
+                      className="inline-flex w-full items-center justify-center rounded-2xl border border-red-300/35 bg-red-500/15 px-5 py-3.5 text-sm font-bold text-red-50 transition hover:bg-red-500/25"
+                    >
+                      ✕ I can’t referee this night
+                    </button>
+                  </form>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {children}
+    </>
+  );
+}

--- a/src/app/referee-confirm/[answer]/page.tsx
+++ b/src/app/referee-confirm/[answer]/page.tsx
@@ -3,11 +3,9 @@
 // ========================================
 
 import Link from "next/link";
-import { notFound } from "next/navigation";
 
 import { recordRefereeNightConfirmationResponse } from "@/lib/referee-night-confirmation-response";
 import { formatNightDate } from "@/lib/referee-nights";
-import { getPublicSiteUrl } from "@/lib/stripe/client";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -24,16 +22,47 @@ function getAnswer(value: string) {
   return null;
 }
 
+function StaleConfirmationLink() {
+  return (
+    <main className="min-h-screen bg-[#07130f] px-4 py-10 text-white">
+      <div className="mx-auto max-w-2xl rounded-3xl border border-amber-300/30 bg-amber-400/[0.08] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)] sm:p-8">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-amber-200/80">
+          SIXFL referee confirmation
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          This confirmation link is no longer current
+        </h1>
+        <p className="mt-4 text-sm leading-6 text-white/70">
+          The referee night may have been changed since this message was sent, so we have not recorded a response from this old link.
+        </p>
+        <p className="mt-3 text-sm leading-6 text-white/60">
+          Open your referee dashboard to see the latest date, venue and fixtures, then confirm the current night there.
+        </p>
+        <Link
+          href="/referee"
+          className="mt-6 inline-flex rounded-2xl bg-emerald-400 px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-300"
+        >
+          Open my referee dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}
+
 export default async function RefereeNightConfirmationPage({ params, searchParams }: PageProps) {
   const { answer: rawAnswer } = await params;
   const sp = (await searchParams) ?? {};
   const answer = getAnswer(rawAnswer);
   const token = sp.token?.trim();
 
-  if (!answer || !token) notFound();
+  if (!answer || !token) {
+    return <StaleConfirmationLink />;
+  }
 
   const saved = await recordRefereeNightConfirmationResponse({ token, answer });
-  if (!saved) notFound();
+  if (!saved) {
+    return <StaleConfirmationLink />;
+  }
 
   const confirmed = answer === "yes";
 
@@ -52,13 +81,13 @@ export default async function RefereeNightConfirmationPage({ params, searchParam
             : `We’ve recorded that you cannot make ${formatNightDate(saved.nightDate)} for ${saved.leagueName}. SIXFL will arrange cover.`}
         </p>
         <p className="mt-3 text-sm leading-6 text-white/55">
-          If this is wrong, reply to the original message as soon as possible.
+          You can always check or update your current availability from the referee dashboard.
         </p>
         <Link
-          href={getPublicSiteUrl()}
+          href="/referee"
           className="mt-6 inline-flex rounded-2xl bg-emerald-400 px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-300"
         >
-          Back to SIXFL
+          Open my referee dashboard
         </Link>
       </div>
     </main>


### PR DESCRIPTION
## Changes
- adds a prominent confirmation panel across the referee dashboard and referee-night pages
- shows the next upcoming night with clear **Yes, I can referee** / **I can’t referee this night** controls
- shows a clear confirmed/declined state and lets the referee update availability
- records dashboard responses against the authenticated/previewed referee only
- replaces the 404 from an expired confirmation link with a useful explanation and a button to the live referee dashboard

## Reason
Referees currently have no obvious dashboard control for confirming a night. Old confirmation links are invalidated after a fixture/night change and currently lead to a confusing 404.