### PR TITLE
Fix matchday autopay fee-cap query grouping

### DIFF
--- a/scripts/apply-team-autopay-fee-authority.cjs
+++ b/scripts/apply-team-autopay-fee-authority.cjs
@@ -28,6 +28,18 @@ source = replaceRequired(
   "saved-card query fee authority",
 );
 
+// The verified fee cap is selected alongside SUM(tx.amountPence), so every
+// Team/Fixture column referenced by that expression must be part of GROUP BY.
+// Without this PostgreSQL rejects the entire matchday-autopay query before any
+// card can be considered, which in turn makes the notification cron report a
+// matchday-autopay failure.
+source = replaceRequired(
+  source,
+  `      t."autoPaySetupCheckoutSessionId",\n      pc."fixtureId",`,
+  `      t."autoPaySetupCheckoutSessionId",\n      t."standardMatchFeePence",\n      f."homeTeamId",\n      f."awayTeamId",\n      f."homeMatchFeePence",\n      f."awayMatchFeePence",\n      f."matchFeePence",\n      pc."fixtureId",`,
+  "saved-card query fee authority grouping",
+);
+
 source = replaceRequired(
   source,
   `  for (const row of rows) {\n    const outstandingPence = row.amountPence - row.paidPence;\n\n    if (outstandingPence <= 0) {`,

--- a/scripts/apply-team-specific-fixture-fee-final-guard.cjs
+++ b/scripts/apply-team-specific-fixture-fee-final-guard.cjs
@@ -106,6 +106,11 @@ mustContain(
 );
 mustContain(
   autoPay,
+  `      t."standardMatchFeePence",\n      f."homeTeamId",\n      f."awayTeamId",\n      f."homeMatchFeePence",\n      f."awayMatchFeePence",\n      f."matchFeePence",\n      pc."fixtureId",`,
+  "saved-card autopay must GROUP BY every Team/Fixture field used to derive the verified fee cap.",
+);
+mustContain(
+  autoPay,
   "if (chargeAmountPence > autoPayCapPence)",
   "saved-card autopay must block/correct a stored charge above the verified fee.",
 );


### PR DESCRIPTION
Fix the exact PostgreSQL error now identified by the notifications cron: `column t.standardMatchFeePence must appear in the GROUP BY clause or be used in an aggregate function`.

What changes:
- keeps the saved-card safety cap introduced after the SWAZ £40/£36 overcharge
- adds every Team/Fixture field used by the verified fee-cap expression to the `GROUP BY` of the matchday autopay query
- extends the final payment-safety guard so a future source-preparation change cannot remove that required grouping without failing the build

Why:
The notification cron now correctly isolates steps and showed that message delivery itself is healthy, but the `matchday-autopay` step was failing before it could evaluate any saved-card charges. The fee-cap patch selected team/fixture fee fields alongside `SUM(PaymentTransaction.amountPence)` without grouping those fields. PostgreSQL rejected the query with 42803.

This does not weaken the £36-v-£40 protection. It only makes the protected query valid PostgreSQL.