### PR TITLE
Make multi-captain access and communications clear

### DIFF
--- a/scripts/apply-admin-team-kickoff-summary.cjs
+++ b/scripts/apply-admin-team-kickoff-summary.cjs
@@ -126,6 +126,7 @@ require("./apply-clear-removed-team-fixture-notices.cjs");
 require("./apply-referee-dashboard-click-affordances.cjs");
 require("./apply-login-session-retention-guard.cjs");
 require("./apply-referee-settled-balance-summary-fix.cjs");
+require("./apply-multi-captain-operational-notifications.cjs");
 
 // Payment safety must remain absolutely last. It checks the final generated
 // fixture-fee source and adds a saved-card cap so a stale £40 charge can never

--- a/scripts/apply-multi-captain-operational-notifications.cjs
+++ b/scripts/apply-multi-captain-operational-notifications.cjs
@@ -1,0 +1,49 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const filePath = path.join(
+  process.cwd(),
+  "src",
+  "lib",
+  "fixtures",
+  "night-board-change-notifications.ts",
+);
+
+if (!fs.existsSync(filePath)) {
+  throw new Error("Night Board notification source not found for multi-captain patch.");
+}
+
+let source = fs.readFileSync(filePath, "utf8");
+let changed = false;
+
+const importAnchor = 'import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";';
+const importLine = 'import { upsertAdditionalCaptainOperationalRecipients } from "@/lib/notifications/team-operational-recipients";';
+if (!source.includes(importLine)) {
+  if (!source.includes(importAnchor)) throw new Error("Multi-captain notification import anchor not found.");
+  source = source.replace(importAnchor, `${importAnchor}\n${importLine}`);
+  changed = true;
+}
+
+const marker = "      const additionalCaptainRecipients = await upsertAdditionalCaptainOperationalRecipients({";
+if (!source.includes(marker)) {
+  const closingAnchor = `      );\n    }\n  }\n\n  const kickoffChanged =`;
+  if (!source.includes(closingAnchor)) {
+    throw new Error("Multi-captain notification team-loop anchor not found.");
+  }
+
+  const addition = `      );\n\n      const additionalCaptainRecipients = await upsertAdditionalCaptainOperationalRecipients({\n        teamId,\n        excludeEmail: recipient.email,\n        excludePhone: recipient.phone,\n      });\n\n      for (const captainRecipient of additionalCaptainRecipients) {\n        recordOutcome(\n          team,\n          NotificationChannel.EMAIL,\n          await queueOnce({\n            recipientId: captainRecipient.id,\n            channel: NotificationChannel.EMAIL,\n            audience: NotificationAudience.TEAM,\n            subject: emailCopy.subject,\n            body: emailCopy.body,\n            sourceType,\n            sourceId,\n            metadata: { ...metadata, operationalCaptainCopy: true },\n            emailBranding: {\n              teamName: currentTeam.name,\n              teamLogoUrl: currentTeam.logoUrl,\n              leagueName: brandingLeague,\n            },\n            emailCta: { label: emailCopy.ctaLabel, url: dashboardUrl },\n            createdByUserId: input.createdByUserId,\n          }),\n        );\n\n        recordOutcome(\n          team,\n          NotificationChannel.SMS,\n          await queueOnce({\n            recipientId: captainRecipient.id,\n            channel: NotificationChannel.SMS,\n            audience: NotificationAudience.TEAM,\n            body: teamSmsCopy({\n              status: input.after.status,\n              homeTeamName: input.homeTeam.name,\n              awayTeamName: input.awayTeam.name,\n              after: input.after,\n              dashboardUrl,\n            }),\n            sourceType,\n            sourceId,\n            metadata: { ...metadata, operationalCaptainCopy: true },\n            createdByUserId: input.createdByUserId,\n          }),\n        );\n      }\n    }\n  }\n\n  const kickoffChanged =`;
+
+  source = source.replace(closingAnchor, addition);
+  changed = true;
+}
+
+if (!source.includes(importLine) || !source.includes(marker)) {
+  throw new Error("Multi-captain operational notification patch did not apply completely.");
+}
+
+if (changed) {
+  fs.writeFileSync(filePath, source, "utf8");
+  console.log("Important Night Board fixture updates now fan out to all captains.");
+} else {
+  console.log("Multi-captain operational notifications already applied.");
+}

--- a/src/app/api/captain/team/[teamid]/additional-captains/route.ts
+++ b/src/app/api/captain/team/[teamid]/additional-captains/route.ts
@@ -25,6 +25,47 @@ function isPlausibleEmail(value: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
 
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+
+  const team = await prisma.team.findUnique({
+    where: { id: teamid },
+    select: {
+      id: true,
+      name: true,
+      teamMode: true,
+      members: {
+        where: { role: TeamRole.CAPTAIN },
+        orderBy: { createdAt: "asc" },
+        select: {
+          id: true,
+          user: { select: { id: true, name: true, email: true } },
+        },
+      },
+    },
+  });
+
+  if (!team) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    teamName: team.name,
+    managed: team.teamMode === "MANAGED",
+    captains: team.members.map((member) => ({
+      membershipId: member.id,
+      userId: member.user.id,
+      name: member.user.name,
+      email: member.user.email,
+    })),
+  });
+}
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ teamid: string }> },

--- a/src/components/captain/CaptainAdditionalCaptainBridge.tsx
+++ b/src/components/captain/CaptainAdditionalCaptainBridge.tsx
@@ -17,6 +17,48 @@ function findHeading(text: string) {
   );
 }
 
+function escapeHtml(value: string | null | undefined) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+async function loadCaptains(teamId: string, target: HTMLElement) {
+  try {
+    const response = await fetch(
+      `/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`,
+      { cache: "no-store" },
+    );
+    const payload = (await response.json().catch(() => null)) as {
+      captains?: Array<{ membershipId: string; name: string | null; email: string | null }>;
+      error?: string;
+    } | null;
+
+    if (!response.ok) throw new Error(payload?.error || "Could not load captains.");
+
+    const captains = payload?.captains ?? [];
+    target.innerHTML = captains.length
+      ? captains
+          .map(
+            (captain) => `
+              <div class="flex flex-col gap-1 rounded-xl border border-white/10 bg-black/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div class="text-sm font-semibold text-white">${escapeHtml(captain.name || captain.email || "Captain")}</div>
+                  ${captain.email ? `<div class="mt-1 text-xs text-white/50">${escapeHtml(captain.email)}</div>` : ""}
+                </div>
+                <span class="mt-2 inline-flex w-fit rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100 sm:mt-0">Captain access</span>
+              </div>`,
+          )
+          .join("")
+      : '<div class="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/55">No captain memberships found.</div>';
+  } catch (error) {
+    target.innerHTML = `<div class="rounded-xl border border-red-400/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">${escapeHtml(error instanceof Error ? error.message : "Could not load captains.")}</div>`;
+  }
+}
+
 function installAdditionalCaptainForm(teamId: string) {
   if (document.querySelector("[data-additional-captain-panel]")) return true;
 
@@ -34,49 +76,45 @@ function installAdditionalCaptainForm(teamId: string) {
     "rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.2)]";
 
   panel.innerHTML = `
-    <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">
-      Team access
-    </p>
-    <h2 class="mt-2 text-xl font-semibold text-white">Add another captain</h2>
+    <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">Team access</p>
+    <h2 class="mt-2 text-xl font-semibold text-white">Captains</h2>
     <p class="mt-2 text-sm leading-6 text-amber-50/70">
-      Add someone you trust to share the captain dashboard. They will be able to manage fixtures, availability, squad information and team payments just like you.
+      Every captain listed here can use the same captain dashboard. Important operational fixture messages are also sent to all captains who have contact details saved.
     </p>
-    <div class="mt-4 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/55">
-      Captains cannot remove or demote other captains from this screen, so the team cannot accidentally be left without a captain.
+
+    <div class="mt-4 space-y-2" data-current-captains>
+      <div class="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/55">Loading current captains…</div>
     </div>
-    <form class="mt-5 space-y-4" data-additional-captain-form>
-      <label class="block space-y-2 text-sm text-white/65">
-        <span>Captain name</span>
-        <input
-          name="name"
-          required
-          autocomplete="name"
-          placeholder="e.g. Alex Smith"
-          class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50"
-        />
-      </label>
-      <label class="block space-y-2 text-sm text-white/65">
-        <span>Email</span>
-        <input
-          name="email"
-          type="email"
-          required
-          autocomplete="email"
-          placeholder="captain@example.com"
-          class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50"
-        />
-      </label>
-      <div class="hidden rounded-xl border px-4 py-3 text-sm" data-additional-captain-status></div>
-      <button
-        type="submit"
-        class="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200 disabled:cursor-wait disabled:opacity-60"
-      >
-        Add captain and send login
-      </button>
-    </form>
+
+    <div class="mt-6 border-t border-white/10 pt-5">
+      <h3 class="text-base font-semibold text-white">Add another captain</h3>
+      <p class="mt-2 text-sm leading-6 text-white/60">
+        Add someone you trust to share fixtures, availability, squad information and team payments.
+      </p>
+      <div class="mt-3 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/55">
+        Captains cannot remove or demote another captain from this screen. SIXFL admin can correct captain access if needed.
+      </div>
+      <form class="mt-5 space-y-4" data-additional-captain-form>
+        <label class="block space-y-2 text-sm text-white/65">
+          <span>Captain name</span>
+          <input name="name" required autocomplete="name" placeholder="e.g. Alex Smith" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50" />
+        </label>
+        <label class="block space-y-2 text-sm text-white/65">
+          <span>Email</span>
+          <input name="email" type="email" required autocomplete="email" placeholder="captain@example.com" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50" />
+        </label>
+        <div class="hidden rounded-xl border px-4 py-3 text-sm" data-additional-captain-status></div>
+        <button type="submit" class="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200 disabled:cursor-wait disabled:opacity-60">
+          Add captain and send login
+        </button>
+      </form>
+    </div>
   `;
 
   addPlayerSection.insertAdjacentElement("beforebegin", panel);
+
+  const currentCaptains = panel.querySelector<HTMLElement>("[data-current-captains]");
+  if (currentCaptains) void loadCaptains(teamId, currentCaptains);
 
   const form = panel.querySelector<HTMLFormElement>("[data-additional-captain-form]");
   const status = panel.querySelector<HTMLElement>("[data-additional-captain-status]");
@@ -93,8 +131,7 @@ function installAdditionalCaptainForm(teamId: string) {
 
     button.disabled = true;
     button.textContent = "Adding captain…";
-    status.className =
-      "rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65";
+    status.className = "rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65";
     status.textContent = "Creating captain access and sending the login email…";
 
     try {
@@ -107,26 +144,21 @@ function installAdditionalCaptainForm(teamId: string) {
         },
       );
 
-      const payload = (await response.json().catch(() => null)) as {
-        error?: string;
-        message?: string;
-      } | null;
+      const payload = (await response.json().catch(() => null)) as { error?: string; message?: string } | null;
+      if (!response.ok) throw new Error(payload?.error || "The captain could not be added.");
 
-      if (!response.ok) {
-        throw new Error(payload?.error || "The captain could not be added.");
-      }
-
-      status.className =
-        "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm leading-6 text-emerald-100";
+      status.className = "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm leading-6 text-emerald-100";
       status.textContent = payload?.message || "Captain access has been added.";
       button.textContent = "Captain added";
-
-      window.setTimeout(() => window.location.reload(), 1200);
+      form.reset();
+      if (currentCaptains) await loadCaptains(teamId, currentCaptains);
+      window.setTimeout(() => {
+        button.disabled = false;
+        button.textContent = "Add captain and send login";
+      }, 800);
     } catch (error) {
-      status.className =
-        "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm leading-6 text-red-100";
-      status.textContent =
-        error instanceof Error ? error.message : "The captain could not be added.";
+      status.className = "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm leading-6 text-red-100";
+      status.textContent = error instanceof Error ? error.message : "The captain could not be added.";
       button.disabled = false;
       button.textContent = "Add captain and send login";
     }
@@ -142,7 +174,6 @@ export default function CaptainAdditionalCaptainBridge() {
     const teamId = getCaptainSquadTeamId(pathname);
     if (!teamId) return;
 
-    const confirmedTeamId = teamId;
     let frame = 0;
     let attempts = 0;
     let disposed = false;
@@ -150,11 +181,8 @@ export default function CaptainAdditionalCaptainBridge() {
     function install() {
       if (disposed) return;
       attempts += 1;
-
-      const installed = installAdditionalCaptainForm(confirmedTeamId);
-      if (!installed && attempts < 30) {
-        frame = window.requestAnimationFrame(install);
-      }
+      const installed = installAdditionalCaptainForm(teamId!);
+      if (!installed && attempts < 30) frame = window.requestAnimationFrame(install);
     }
 
     frame = window.requestAnimationFrame(install);
@@ -162,9 +190,7 @@ export default function CaptainAdditionalCaptainBridge() {
     return () => {
       disposed = true;
       window.cancelAnimationFrame(frame);
-      document
-        .querySelectorAll<HTMLElement>("[data-additional-captain-panel]")
-        .forEach((panel) => panel.remove());
+      document.querySelectorAll<HTMLElement>("[data-additional-captain-panel]").forEach((panel) => panel.remove());
     };
   }, [pathname]);
 

--- a/src/lib/notifications/team-operational-recipients.ts
+++ b/src/lib/notifications/team-operational-recipients.ts
@@ -1,0 +1,68 @@
+import {
+  NotificationAudience,
+  NotificationRecipientSourceType,
+  TeamRole,
+} from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { getTeamMemberProfilesByTeamMemberIds } from "@/lib/teamMemberProfiles";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+
+export async function upsertAdditionalCaptainOperationalRecipients(input: {
+  teamId: string;
+  excludeEmail?: string | null;
+  excludePhone?: string | null;
+}) {
+  const captains = await prisma.teamMember.findMany({
+    where: { teamId: input.teamId, role: TeamRole.CAPTAIN },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      userId: true,
+      user: { select: { name: true, email: true } },
+    },
+  });
+
+  const profiles = await getTeamMemberProfilesByTeamMemberIds(
+    captains.map((captain) => captain.id),
+  );
+  const excludedEmail = input.excludeEmail?.trim().toLowerCase() || null;
+  const excludedPhone = input.excludePhone?.replace(/\D/g, "") || null;
+  const recipients = [];
+  const seen = new Set<string>();
+
+  for (const captain of captains) {
+    const email = captain.user.email?.trim().toLowerCase() || null;
+    const phone = profiles.get(captain.id)?.phone?.trim() || null;
+    const phoneKey = phone?.replace(/\D/g, "") || null;
+
+    if ((!email || email === excludedEmail) && (!phoneKey || phoneKey === excludedPhone)) {
+      continue;
+    }
+
+    const key = `${email ?? ""}|${phoneKey ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    recipients.push(
+      await upsertNotificationRecipient({
+        sourceType: NotificationRecipientSourceType.USER,
+        sourceId: captain.userId,
+        audience: NotificationAudience.TEAM,
+        displayName: captain.user.name || email || "Team captain",
+        email,
+        phone,
+        transactionalEmailOptIn: true,
+        transactionalSmsOptIn: true,
+        metadata: {
+          teamId: input.teamId,
+          teamMemberId: captain.id,
+          role: "CAPTAIN",
+          operationalTeamCopy: true,
+        },
+      }),
+    );
+  }
+
+  return recipients;
+}


### PR DESCRIPTION
Adds a visible captain-management panel on Captain Squad that lists current captains and allows another captain to be added with a login email. Important Night Board fixture-change/cancellation/postponement notices are fanned out to all captain contacts (email/SMS where saved), while routine reminders remain unchanged.