### PR TITLE
Add captain SMS details and admin edit/remove controls

### DIFF
--- a/scripts/apply-admin-captain-management-visibility.cjs
+++ b/scripts/apply-admin-captain-management-visibility.cjs
@@ -18,15 +18,13 @@ let changed = false;
 
 const oldRoute = '  return /^\\/captain\\/team\\/([^/]+)\\/captain-squad\\/?$/.exec(pathname)?.[1] ?? null;';
 const newRoute = '  return /^\\/captain\\/team\\/([^/]+)\\/(?:captain-squad|squad)\\/?$/.exec(pathname)?.[1] ?? null;';
-
 if (source.includes(oldRoute)) {
   source = source.replace(oldRoute, newRoute);
   changed = true;
 }
 
 const oldAnchor = `  const addPlayerHeading = findHeading("Add a player to your squad");\n  const addPlayerSection = addPlayerHeading?.closest<HTMLElement>("section");`;
-const newAnchor = `  const addPlayerHeading =\n    findHeading("Add a player to your squad") ??\n    findHeading("Attach an existing user");\n  const addPlayerSection = addPlayerHeading?.closest<HTMLElement>("section");`;
-
+const newAnchor = `  const addPlayerHeading =\n    findHeading(["Add a player to your squad", "Attach an existing user"]);\n  const addPlayerSection = addPlayerHeading?.closest<HTMLElement>("section");`;
 if (source.includes(oldAnchor)) {
   source = source.replace(oldAnchor, newAnchor);
   changed = true;
@@ -35,8 +33,7 @@ if (source.includes(oldAnchor)) {
 if (!source.includes('(?:captain-squad|squad)')) {
   throw new Error("Could not enable captain management on the full admin Squad route.");
 }
-
-if (!source.includes('findHeading("Attach an existing user")')) {
+if (!source.includes("Attach an existing user")) {
   throw new Error("Could not add the full admin Squad insertion anchor.");
 }
 

--- a/src/app/api/captain/team/[teamid]/additional-captains/route.ts
+++ b/src/app/api/captain/team/[teamid]/additional-captains/route.ts
@@ -2,6 +2,7 @@
 // File: src/app/api/captain/team/[teamid]/additional-captains/route.ts
 // ========================================
 
+import { randomUUID } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import { TeamRole } from "@prisma/client";
 import { NextResponse } from "next/server";
@@ -9,6 +10,7 @@ import { NextResponse } from "next/server";
 import { sendDashboardLoginEmail } from "@/lib/auth/sendDashboardLoginEmail";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
+import { getTeamMemberProfilesByTeamMemberIds } from "@/lib/teamMemberProfiles";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -21,8 +23,43 @@ function cleanEmail(value: unknown) {
   return cleanText(value).toLowerCase();
 }
 
+function cleanPhone(value: unknown) {
+  return cleanText(value) || null;
+}
+
 function isPlausibleEmail(value: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+async function saveCaptainPhone(teamMemberId: string, phone: string | null) {
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS "TeamMemberProfile" (
+      "id" TEXT NOT NULL,
+      "teamMemberId" TEXT NOT NULL,
+      "phone" TEXT,
+      "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "TeamMemberProfile_pkey" PRIMARY KEY ("id")
+    );
+  `);
+  await prisma.$executeRawUnsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS "TeamMemberProfile_teamMemberId_key"
+    ON "TeamMemberProfile"("teamMemberId");
+  `);
+  await prisma.$executeRaw`
+    INSERT INTO "TeamMemberProfile" ("id", "teamMemberId", "phone", "updatedAt")
+    VALUES (${randomUUID()}, ${teamMemberId}, ${phone}, NOW())
+    ON CONFLICT ("teamMemberId") DO UPDATE
+    SET "phone" = EXCLUDED."phone", "updatedAt" = NOW()
+  `;
+}
+
+function revalidateTeam(teamId: string) {
+  revalidatePath(`/captain/team/${teamId}`);
+  revalidatePath(`/captain/team/${teamId}/captain-squad`);
+  revalidatePath(`/captain/team/${teamId}/squad`);
+  revalidatePath(`/admin/teams/${teamId}`);
+  revalidatePath(`/admin/teams/${teamId}/squad`);
 }
 
 export async function GET(
@@ -30,7 +67,7 @@ export async function GET(
   { params }: { params: Promise<{ teamid: string }> },
 ) {
   const { teamid } = await params;
-  await requireCaptain(teamid);
+  const access = await requireCaptain(teamid);
 
   const team = await prisma.team.findUnique({
     where: { id: teamid },
@@ -53,15 +90,21 @@ export async function GET(
     return NextResponse.json({ error: "Team not found." }, { status: 404 });
   }
 
+  const profiles = await getTeamMemberProfilesByTeamMemberIds(
+    team.members.map((member) => member.id),
+  );
+
   return NextResponse.json({
     ok: true,
     teamName: team.name,
     managed: team.teamMode === "MANAGED",
+    canManage: access.isAdmin,
     captains: team.members.map((member) => ({
       membershipId: member.id,
       userId: member.user.id,
       name: member.user.name,
       email: member.user.email,
+      phone: profiles.get(member.id)?.phone ?? null,
     })),
   });
 }
@@ -76,48 +119,31 @@ export async function POST(
   const body = (await request.json().catch(() => null)) as {
     name?: string;
     email?: string;
+    phone?: string;
   } | null;
 
   const name = cleanText(body?.name);
   const email = cleanEmail(body?.email);
+  const phone = cleanPhone(body?.phone);
 
   if (!teamid?.trim()) {
     return NextResponse.json({ error: "Team not found." }, { status: 400 });
   }
-
   if (!name) {
-    return NextResponse.json(
-      { error: "Enter the new captain's name." },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Enter the new captain's name." }, { status: 400 });
   }
-
   if (!isPlausibleEmail(email)) {
-    return NextResponse.json(
-      { error: "Enter a valid email address for the new captain." },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Enter a valid email address for the new captain." }, { status: 400 });
   }
 
   const team = await prisma.team.findUnique({
     where: { id: teamid },
-    select: {
-      id: true,
-      name: true,
-      teamMode: true,
-      captainUserId: true,
-    },
+    select: { id: true, name: true, teamMode: true, captainUserId: true },
   });
 
-  if (!team) {
-    return NextResponse.json({ error: "Team not found." }, { status: 404 });
-  }
-
+  if (!team) return NextResponse.json({ error: "Team not found." }, { status: 404 });
   if (team.teamMode === "MANAGED") {
-    return NextResponse.json(
-      { error: "SIXFL manages captain access for this team." },
-      { status: 403 },
-    );
+    return NextResponse.json({ error: "SIXFL manages captain access for this team." }, { status: 403 });
   }
 
   const result = await prisma.$transaction(async (tx) => {
@@ -129,31 +155,21 @@ export async function POST(
     });
 
     const existingMembership = await tx.teamMember.findUnique({
-      where: {
-        userId_teamId: {
-          userId: user.id,
-          teamId: team.id,
-        },
-      },
+      where: { userId_teamId: { userId: user.id, teamId: team.id } },
       select: { id: true, role: true },
     });
 
     const wasAlreadyCaptain = existingMembership?.role === TeamRole.CAPTAIN;
-
-    if (existingMembership) {
-      await tx.teamMember.update({
-        where: { id: existingMembership.id },
-        data: { role: TeamRole.CAPTAIN },
-      });
-    } else {
-      await tx.teamMember.create({
-        data: {
-          userId: user.id,
-          teamId: team.id,
-          role: TeamRole.CAPTAIN,
-        },
-      });
-    }
+    const membership = existingMembership
+      ? await tx.teamMember.update({
+          where: { id: existingMembership.id },
+          data: { role: TeamRole.CAPTAIN },
+          select: { id: true },
+        })
+      : await tx.teamMember.create({
+          data: { userId: user.id, teamId: team.id, role: TeamRole.CAPTAIN },
+          select: { id: true },
+        });
 
     if (!team.captainUserId) {
       await tx.team.update({
@@ -166,11 +182,12 @@ export async function POST(
       });
     }
 
-    return { user, wasAlreadyCaptain };
+    return { user, membershipId: membership.id, wasAlreadyCaptain };
   });
 
-  let emailSent = true;
+  await saveCaptainPhone(result.membershipId, phone);
 
+  let emailSent = true;
   try {
     await sendDashboardLoginEmail({
       email,
@@ -183,12 +200,7 @@ export async function POST(
     console.error("Failed to send additional captain login email", error);
   }
 
-  revalidatePath(`/captain/team/${team.id}`);
-  revalidatePath(`/captain/team/${team.id}/captain-squad`);
-  revalidatePath(`/captain/team/${team.id}/squad`);
-  revalidatePath(`/admin/teams/${team.id}`);
-  revalidatePath(`/admin/teams/${team.id}/squad`);
-
+  revalidateTeam(team.id);
   const accessMessage = result.wasAlreadyCaptain
     ? `${name} already had captain access.`
     : `${name} now has captain access.`;
@@ -200,4 +212,99 @@ export async function POST(
       ? `${accessMessage} A dashboard sign-in email has been sent to ${email}.`
       : `${accessMessage} The sign-in email could not be sent, but they can use the normal SIXFL sign-in page with ${email}.`,
   });
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  if (!access.isAdmin) {
+    return NextResponse.json({ error: "Only SIXFL admin can edit captain access." }, { status: 403 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    membershipId?: string;
+    name?: string;
+    email?: string;
+    phone?: string;
+  } | null;
+
+  const membershipId = cleanText(body?.membershipId);
+  const name = cleanText(body?.name);
+  const email = cleanEmail(body?.email);
+  const phone = cleanPhone(body?.phone);
+
+  if (!membershipId || !name || !isPlausibleEmail(email)) {
+    return NextResponse.json({ error: "Enter a captain name and valid email address." }, { status: 400 });
+  }
+
+  const membership = await prisma.teamMember.findFirst({
+    where: { id: membershipId, teamId: teamid, role: TeamRole.CAPTAIN },
+    select: { id: true, userId: true },
+  });
+  if (!membership) return NextResponse.json({ error: "Captain not found." }, { status: 404 });
+
+  const emailOwner = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+  if (emailOwner && emailOwner.id !== membership.userId) {
+    return NextResponse.json({ error: "That email address already belongs to another SIXFL user." }, { status: 409 });
+  }
+
+  await prisma.user.update({
+    where: { id: membership.userId },
+    data: { name, email },
+  });
+  await saveCaptainPhone(membership.id, phone);
+  revalidateTeam(teamid);
+
+  return NextResponse.json({ ok: true, message: "Captain details updated." });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ teamid: string }> },
+) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  if (!access.isAdmin) {
+    return NextResponse.json({ error: "Only SIXFL admin can remove captain access." }, { status: 403 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { membershipId?: string } | null;
+  const membershipId = cleanText(body?.membershipId);
+  if (!membershipId) return NextResponse.json({ error: "Captain not found." }, { status: 400 });
+
+  const captains = await prisma.teamMember.findMany({
+    where: { teamId: teamid, role: TeamRole.CAPTAIN },
+    select: { id: true, userId: true },
+  });
+  const target = captains.find((captain) => captain.id === membershipId);
+  if (!target) return NextResponse.json({ error: "Captain not found." }, { status: 404 });
+  if (captains.length <= 1) {
+    return NextResponse.json({ error: "Add another captain before removing the team's final captain." }, { status: 409 });
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.teamMember.update({
+      where: { id: membershipId },
+      data: { role: TeamRole.PLAYER },
+    });
+
+    const team = await tx.team.findUnique({ where: { id: teamid }, select: { captainUserId: true } });
+    if (team?.captainUserId === target.userId) {
+      const replacement = captains.find((captain) => captain.id !== membershipId);
+      await tx.team.update({
+        where: { id: teamid },
+        data: {
+          captainUserId: replacement?.userId ?? null,
+          captainLinkedAt: replacement ? new Date() : null,
+          captainLinkedSource: replacement ? "admin-captain-reassigned" : null,
+        },
+      });
+    }
+  });
+
+  revalidateTeam(teamid);
+  return NextResponse.json({ ok: true, message: "Captain access removed. They remain in the squad as a player." });
 }

--- a/src/app/api/captain/team/[teamid]/additional-captains/route.ts
+++ b/src/app/api/captain/team/[teamid]/additional-captains/route.ts
@@ -18,34 +18,19 @@ export const revalidate = 0;
 function cleanText(value: unknown) {
   return String(value ?? "").trim();
 }
-
 function cleanEmail(value: unknown) {
   return cleanText(value).toLowerCase();
 }
-
 function cleanPhone(value: unknown) {
   return cleanText(value) || null;
 }
-
 function isPlausibleEmail(value: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
 
 async function saveCaptainPhone(teamMemberId: string, phone: string | null) {
-  await prisma.$executeRawUnsafe(`
-    CREATE TABLE IF NOT EXISTS "TeamMemberProfile" (
-      "id" TEXT NOT NULL,
-      "teamMemberId" TEXT NOT NULL,
-      "phone" TEXT,
-      "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      CONSTRAINT "TeamMemberProfile_pkey" PRIMARY KEY ("id")
-    );
-  `);
-  await prisma.$executeRawUnsafe(`
-    CREATE UNIQUE INDEX IF NOT EXISTS "TeamMemberProfile_teamMemberId_key"
-    ON "TeamMemberProfile"("teamMemberId");
-  `);
+  // This helper ensures the full TeamMemberProfile table/columns exist.
+  await getTeamMemberProfilesByTeamMemberIds([teamMemberId]);
   await prisma.$executeRaw`
     INSERT INTO "TeamMemberProfile" ("id", "teamMemberId", "phone", "updatedAt")
     VALUES (${randomUUID()}, ${teamMemberId}, ${phone}, NOW())
@@ -68,7 +53,6 @@ export async function GET(
 ) {
   const { teamid } = await params;
   const access = await requireCaptain(teamid);
-
   const team = await prisma.team.findUnique({
     where: { id: teamid },
     select: {
@@ -85,10 +69,7 @@ export async function GET(
       },
     },
   });
-
-  if (!team) {
-    return NextResponse.json({ error: "Team not found." }, { status: 404 });
-  }
+  if (!team) return NextResponse.json({ error: "Team not found." }, { status: 404 });
 
   const profiles = await getTeamMemberProfilesByTeamMemberIds(
     team.members.map((member) => member.id),
@@ -115,23 +96,17 @@ export async function POST(
 ) {
   const { teamid } = await params;
   await requireCaptain(teamid);
-
   const body = (await request.json().catch(() => null)) as {
     name?: string;
     email?: string;
     phone?: string;
   } | null;
-
   const name = cleanText(body?.name);
   const email = cleanEmail(body?.email);
   const phone = cleanPhone(body?.phone);
 
-  if (!teamid?.trim()) {
-    return NextResponse.json({ error: "Team not found." }, { status: 400 });
-  }
-  if (!name) {
-    return NextResponse.json({ error: "Enter the new captain's name." }, { status: 400 });
-  }
+  if (!teamid?.trim()) return NextResponse.json({ error: "Team not found." }, { status: 400 });
+  if (!name) return NextResponse.json({ error: "Enter the new captain's name." }, { status: 400 });
   if (!isPlausibleEmail(email)) {
     return NextResponse.json({ error: "Enter a valid email address for the new captain." }, { status: 400 });
   }
@@ -140,7 +115,6 @@ export async function POST(
     where: { id: teamid },
     select: { id: true, name: true, teamMode: true, captainUserId: true },
   });
-
   if (!team) return NextResponse.json({ error: "Team not found." }, { status: 404 });
   if (team.teamMode === "MANAGED") {
     return NextResponse.json({ error: "SIXFL manages captain access for this team." }, { status: 403 });
@@ -153,12 +127,10 @@ export async function POST(
       create: { email, name },
       select: { id: true, name: true, email: true },
     });
-
     const existingMembership = await tx.teamMember.findUnique({
       where: { userId_teamId: { userId: user.id, teamId: team.id } },
       select: { id: true, role: true },
     });
-
     const wasAlreadyCaptain = existingMembership?.role === TeamRole.CAPTAIN;
     const membership = existingMembership
       ? await tx.teamMember.update({
@@ -181,7 +153,6 @@ export async function POST(
         },
       });
     }
-
     return { user, membershipId: membership.id, wasAlreadyCaptain };
   });
 
@@ -223,19 +194,16 @@ export async function PATCH(
   if (!access.isAdmin) {
     return NextResponse.json({ error: "Only SIXFL admin can edit captain access." }, { status: 403 });
   }
-
   const body = (await request.json().catch(() => null)) as {
     membershipId?: string;
     name?: string;
     email?: string;
     phone?: string;
   } | null;
-
   const membershipId = cleanText(body?.membershipId);
   const name = cleanText(body?.name);
   const email = cleanEmail(body?.email);
   const phone = cleanPhone(body?.phone);
-
   if (!membershipId || !name || !isPlausibleEmail(email)) {
     return NextResponse.json({ error: "Enter a captain name and valid email address." }, { status: 400 });
   }
@@ -251,13 +219,9 @@ export async function PATCH(
     return NextResponse.json({ error: "That email address already belongs to another SIXFL user." }, { status: 409 });
   }
 
-  await prisma.user.update({
-    where: { id: membership.userId },
-    data: { name, email },
-  });
+  await prisma.user.update({ where: { id: membership.userId }, data: { name, email } });
   await saveCaptainPhone(membership.id, phone);
   revalidateTeam(teamid);
-
   return NextResponse.json({ ok: true, message: "Captain details updated." });
 }
 
@@ -270,7 +234,6 @@ export async function DELETE(
   if (!access.isAdmin) {
     return NextResponse.json({ error: "Only SIXFL admin can remove captain access." }, { status: 403 });
   }
-
   const body = (await request.json().catch(() => null)) as { membershipId?: string } | null;
   const membershipId = cleanText(body?.membershipId);
   if (!membershipId) return NextResponse.json({ error: "Captain not found." }, { status: 400 });
@@ -286,11 +249,7 @@ export async function DELETE(
   }
 
   await prisma.$transaction(async (tx) => {
-    await tx.teamMember.update({
-      where: { id: membershipId },
-      data: { role: TeamRole.PLAYER },
-    });
-
+    await tx.teamMember.update({ where: { id: membershipId }, data: { role: TeamRole.PLAYER } });
     const team = await tx.team.findUnique({ where: { id: teamid }, select: { captainUserId: true } });
     if (team?.captainUserId === target.userId) {
       const replacement = captains.find((captain) => captain.id !== membershipId);
@@ -306,5 +265,8 @@ export async function DELETE(
   });
 
   revalidateTeam(teamid);
-  return NextResponse.json({ ok: true, message: "Captain access removed. They remain in the squad as a player." });
+  return NextResponse.json({
+    ok: true,
+    message: "Captain access removed. They remain in the squad as a player.",
+  });
 }

--- a/src/components/captain/CaptainAdditionalCaptainBridge.tsx
+++ b/src/components/captain/CaptainAdditionalCaptainBridge.tsx
@@ -7,13 +7,26 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 
+type CaptainRow = {
+  membershipId: string;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+type CaptainPayload = {
+  captains?: CaptainRow[];
+  canManage?: boolean;
+  error?: string;
+};
+
 function getCaptainSquadTeamId(pathname: string) {
-  return /^\/captain\/team\/([^/]+)\/captain-squad\/?$/.exec(pathname)?.[1] ?? null;
+  return /^\/captain\/team\/([^/]+)\/(?:captain-squad|squad)\/?$/.exec(pathname)?.[1] ?? null;
 }
 
-function findHeading(text: string) {
-  return Array.from(document.querySelectorAll<HTMLHeadingElement>("h2")).find(
-    (heading) => heading.textContent?.trim() === text,
+function findHeading(texts: string[]) {
+  return Array.from(document.querySelectorAll<HTMLHeadingElement>("h2")).find((heading) =>
+    texts.includes(heading.textContent?.trim() ?? ""),
   );
 }
 
@@ -26,34 +39,111 @@ function escapeHtml(value: string | null | undefined) {
     .replaceAll("'", "&#039;");
 }
 
-async function loadCaptains(teamId: string, target: HTMLElement) {
+async function fetchCaptains(teamId: string): Promise<CaptainPayload> {
+  const response = await fetch(
+    `/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`,
+    { cache: "no-store" },
+  );
+  const payload = (await response.json().catch(() => null)) as CaptainPayload | null;
+  if (!response.ok) throw new Error(payload?.error || "Could not load captains.");
+  return payload ?? {};
+}
+
+function captainCard(captain: CaptainRow, canManage: boolean) {
+  const name = escapeHtml(captain.name || captain.email || "Captain");
+  const email = escapeHtml(captain.email || "");
+  const phone = escapeHtml(captain.phone || "");
+
+  return `
+    <div class="rounded-xl border border-white/10 bg-black/20 px-4 py-3" data-captain-row="${escapeHtml(captain.membershipId)}">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div class="text-sm font-semibold text-white">${name}</div>
+          ${email ? `<div class="mt-1 text-xs text-white/50">${email}</div>` : ""}
+          ${phone ? `<div class="mt-1 text-xs text-emerald-200/70">SMS ${phone}</div>` : `<div class="mt-1 text-xs text-white/35">No SMS number saved</div>`}
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="inline-flex w-fit rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100">Captain access</span>
+          ${canManage ? `<button type="button" data-edit-captain class="rounded-lg border border-sky-400/25 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100">Edit</button><button type="button" data-remove-captain class="rounded-lg border border-red-400/25 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-100">Remove captain</button>` : ""}
+        </div>
+      </div>
+      ${canManage ? `
+        <form class="mt-4 hidden space-y-3 border-t border-white/10 pt-4" data-edit-captain-form>
+          <input type="hidden" name="membershipId" value="${escapeHtml(captain.membershipId)}" />
+          <div class="grid gap-3 sm:grid-cols-3">
+            <input name="name" required value="${escapeHtml(captain.name || "")}" placeholder="Captain name" class="rounded-xl border border-white/10 bg-black/25 px-3 py-2.5 text-sm text-white outline-none" />
+            <input name="email" type="email" required value="${email}" placeholder="Email" class="rounded-xl border border-white/10 bg-black/25 px-3 py-2.5 text-sm text-white outline-none" />
+            <input name="phone" value="${phone}" placeholder="SMS number" class="rounded-xl border border-white/10 bg-black/25 px-3 py-2.5 text-sm text-white outline-none" />
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button type="submit" class="rounded-lg bg-sky-300 px-3 py-2 text-xs font-semibold text-black">Save captain</button>
+            <button type="button" data-cancel-edit class="rounded-lg border border-white/10 px-3 py-2 text-xs font-semibold text-white/70">Cancel</button>
+          </div>
+        </form>` : ""}
+    </div>`;
+}
+
+async function renderCaptains(teamId: string, target: HTMLElement, status: HTMLElement) {
   try {
-    const response = await fetch(
-      `/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`,
-      { cache: "no-store" },
-    );
-    const payload = (await response.json().catch(() => null)) as {
-      captains?: Array<{ membershipId: string; name: string | null; email: string | null }>;
-      error?: string;
-    } | null;
-
-    if (!response.ok) throw new Error(payload?.error || "Could not load captains.");
-
-    const captains = payload?.captains ?? [];
+    const payload = await fetchCaptains(teamId);
+    const captains = payload.captains ?? [];
+    const canManage = Boolean(payload.canManage);
     target.innerHTML = captains.length
-      ? captains
-          .map(
-            (captain) => `
-              <div class="flex flex-col gap-1 rounded-xl border border-white/10 bg-black/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <div class="text-sm font-semibold text-white">${escapeHtml(captain.name || captain.email || "Captain")}</div>
-                  ${captain.email ? `<div class="mt-1 text-xs text-white/50">${escapeHtml(captain.email)}</div>` : ""}
-                </div>
-                <span class="mt-2 inline-flex w-fit rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100 sm:mt-0">Captain access</span>
-              </div>`,
-          )
-          .join("")
+      ? captains.map((captain) => captainCard(captain, canManage)).join("")
       : '<div class="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/55">No captain memberships found.</div>';
+
+    target.querySelectorAll<HTMLElement>("[data-captain-row]").forEach((row) => {
+      const editButton = row.querySelector<HTMLButtonElement>("[data-edit-captain]");
+      const removeButton = row.querySelector<HTMLButtonElement>("[data-remove-captain]");
+      const editForm = row.querySelector<HTMLFormElement>("[data-edit-captain-form]");
+      const cancelButton = row.querySelector<HTMLButtonElement>("[data-cancel-edit]");
+      const membershipId = row.dataset.captainRow || "";
+
+      editButton?.addEventListener("click", () => editForm?.classList.remove("hidden"));
+      cancelButton?.addEventListener("click", () => editForm?.classList.add("hidden"));
+
+      editForm?.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const data = new FormData(editForm);
+        const response = await fetch(`/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            membershipId,
+            name: String(data.get("name") ?? ""),
+            email: String(data.get("email") ?? ""),
+            phone: String(data.get("phone") ?? ""),
+          }),
+        });
+        const result = (await response.json().catch(() => null)) as { error?: string; message?: string } | null;
+        if (!response.ok) {
+          status.className = "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm text-red-100";
+          status.textContent = result?.error || "Captain could not be updated.";
+          return;
+        }
+        status.className = "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100";
+        status.textContent = result?.message || "Captain updated.";
+        await renderCaptains(teamId, target, status);
+      });
+
+      removeButton?.addEventListener("click", async () => {
+        const label = row.querySelector(".text-sm.font-semibold")?.textContent?.trim() || "this captain";
+        if (!window.confirm(`Remove captain access from ${label}? They will remain in the squad as a player.`)) return;
+        const response = await fetch(`/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ membershipId }),
+        });
+        const result = (await response.json().catch(() => null)) as { error?: string; message?: string } | null;
+        status.className = response.ok
+          ? "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100"
+          : "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm text-red-100";
+        status.textContent = response.ok
+          ? result?.message || "Captain access removed."
+          : result?.error || "Captain could not be removed.";
+        if (response.ok) await renderCaptains(teamId, target, status);
+      });
+    });
   } catch (error) {
     target.innerHTML = `<div class="rounded-xl border border-red-400/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">${escapeHtml(error instanceof Error ? error.message : "Could not load captains.")}</div>`;
   }
@@ -62,106 +152,65 @@ async function loadCaptains(teamId: string, target: HTMLElement) {
 function installAdditionalCaptainForm(teamId: string) {
   if (document.querySelector("[data-additional-captain-panel]")) return true;
 
-  const addPlayerHeading = findHeading("Add a player to your squad");
+  const addPlayerHeading = findHeading(["Add a player to your squad", "Attach an existing user"]);
   const addPlayerSection = addPlayerHeading?.closest<HTMLElement>("section");
-
-  if (!addPlayerSection) {
-    const managedHeading = findHeading("Player additions are managed by SIXFL");
-    return Boolean(managedHeading);
-  }
+  if (!addPlayerSection) return false;
 
   const panel = document.createElement("section");
   panel.dataset.additionalCaptainPanel = "true";
-  panel.className =
-    "rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.2)]";
-
+  panel.className = "rounded-3xl border border-amber-400/20 bg-amber-500/[0.07] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.2)]";
   panel.innerHTML = `
     <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">Team access</p>
     <h2 class="mt-2 text-xl font-semibold text-white">Captains</h2>
-    <p class="mt-2 text-sm leading-6 text-amber-50/70">
-      Every captain listed here can use the same captain dashboard. Important operational fixture messages are also sent to all captains who have contact details saved.
-    </p>
-
-    <div class="mt-4 space-y-2" data-current-captains>
-      <div class="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/55">Loading current captains…</div>
-    </div>
-
+    <p class="mt-2 text-sm leading-6 text-amber-50/70">Every captain listed here can use the captain dashboard. Save an SMS number so important operational messages can reach them by text as well as email.</p>
+    <div class="mt-4 space-y-2" data-current-captains><div class="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/55">Loading current captains…</div></div>
+    <div class="mt-4 hidden rounded-xl border px-4 py-3 text-sm" data-captain-status></div>
     <div class="mt-6 border-t border-white/10 pt-5">
       <h3 class="text-base font-semibold text-white">Add another captain</h3>
-      <p class="mt-2 text-sm leading-6 text-white/60">
-        Add someone you trust to share fixtures, availability, squad information and team payments.
-      </p>
-      <div class="mt-3 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-xs leading-5 text-white/55">
-        Captains cannot remove or demote another captain from this screen. SIXFL admin can correct captain access if needed.
-      </div>
-      <form class="mt-5 space-y-4" data-additional-captain-form>
-        <label class="block space-y-2 text-sm text-white/65">
-          <span>Captain name</span>
-          <input name="name" required autocomplete="name" placeholder="e.g. Alex Smith" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50" />
-        </label>
-        <label class="block space-y-2 text-sm text-white/65">
-          <span>Email</span>
-          <input name="email" type="email" required autocomplete="email" placeholder="captain@example.com" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none placeholder:text-white/30 focus:border-amber-400/50" />
-        </label>
-        <div class="hidden rounded-xl border px-4 py-3 text-sm" data-additional-captain-status></div>
-        <button type="submit" class="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-amber-300 px-5 text-sm font-semibold text-black transition hover:bg-amber-200 disabled:cursor-wait disabled:opacity-60">
-          Add captain and send login
-        </button>
+      <form class="mt-4 space-y-4" data-additional-captain-form>
+        <label class="block space-y-2 text-sm text-white/65"><span>Captain name</span><input name="name" required autocomplete="name" placeholder="e.g. Alex Smith" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none" /></label>
+        <label class="block space-y-2 text-sm text-white/65"><span>Email</span><input name="email" type="email" required autocomplete="email" placeholder="captain@example.com" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none" /></label>
+        <label class="block space-y-2 text-sm text-white/65"><span>SMS number</span><input name="phone" inputmode="tel" autocomplete="tel" placeholder="e.g. 07700 900123" class="w-full rounded-xl border border-white/10 bg-black/25 px-4 py-3 text-sm text-white outline-none" /></label>
+        <button type="submit" class="inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-amber-300 px-5 text-sm font-semibold text-black">Add captain and send login</button>
       </form>
-    </div>
-  `;
+    </div>`;
 
   addPlayerSection.insertAdjacentElement("beforebegin", panel);
-
   const currentCaptains = panel.querySelector<HTMLElement>("[data-current-captains]");
-  if (currentCaptains) void loadCaptains(teamId, currentCaptains);
-
+  const status = panel.querySelector<HTMLElement>("[data-captain-status]");
   const form = panel.querySelector<HTMLFormElement>("[data-additional-captain-form]");
-  const status = panel.querySelector<HTMLElement>("[data-additional-captain-status]");
   const button = form?.querySelector<HTMLButtonElement>('button[type="submit"]');
+  if (!currentCaptains || !status || !form || !button) return true;
 
-  if (!form || !status || !button) return true;
+  void renderCaptains(teamId, currentCaptains, status);
 
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
-
-    const formData = new FormData(form);
-    const name = String(formData.get("name") ?? "").trim();
-    const email = String(formData.get("email") ?? "").trim();
-
+    const data = new FormData(form);
     button.disabled = true;
     button.textContent = "Adding captain…";
-    status.className = "rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white/65";
-    status.textContent = "Creating captain access and sending the login email…";
-
-    try {
-      const response = await fetch(
-        `/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name, email }),
-        },
-      );
-
-      const payload = (await response.json().catch(() => null)) as { error?: string; message?: string } | null;
-      if (!response.ok) throw new Error(payload?.error || "The captain could not be added.");
-
-      status.className = "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm leading-6 text-emerald-100";
-      status.textContent = payload?.message || "Captain access has been added.";
-      button.textContent = "Captain added";
+    const response = await fetch(`/api/captain/team/${encodeURIComponent(teamId)}/additional-captains`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: String(data.get("name") ?? ""),
+        email: String(data.get("email") ?? ""),
+        phone: String(data.get("phone") ?? ""),
+      }),
+    });
+    const result = (await response.json().catch(() => null)) as { error?: string; message?: string } | null;
+    status.className = response.ok
+      ? "rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100"
+      : "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm text-red-100";
+    status.textContent = response.ok
+      ? result?.message || "Captain added."
+      : result?.error || "Captain could not be added.";
+    if (response.ok) {
       form.reset();
-      if (currentCaptains) await loadCaptains(teamId, currentCaptains);
-      window.setTimeout(() => {
-        button.disabled = false;
-        button.textContent = "Add captain and send login";
-      }, 800);
-    } catch (error) {
-      status.className = "rounded-xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm leading-6 text-red-100";
-      status.textContent = error instanceof Error ? error.message : "The captain could not be added.";
-      button.disabled = false;
-      button.textContent = "Add captain and send login";
+      await renderCaptains(teamId, currentCaptains, status);
     }
+    button.disabled = false;
+    button.textContent = "Add captain and send login";
   });
 
   return true;
@@ -177,14 +226,12 @@ export default function CaptainAdditionalCaptainBridge() {
     let frame = 0;
     let attempts = 0;
     let disposed = false;
-
     function install() {
       if (disposed) return;
       attempts += 1;
-      const installed = installAdditionalCaptainForm(teamId!);
-      if (!installed && attempts < 30) frame = window.requestAnimationFrame(install);
+      const installed = installAdditionalCaptainForm(teamId);
+      if (!installed && attempts < 60) frame = window.requestAnimationFrame(install);
     }
-
     frame = window.requestAnimationFrame(install);
 
     return () => {


### PR DESCRIPTION
Adds an SMS number when creating captains, shows saved captain phone numbers, and lets full SIXFL admin edit captain name/email/SMS or remove captain access. Removing captain access demotes the person to player rather than deleting them, and the final remaining captain cannot be removed until another captain is added. Keeps the captain-management panel available in both captain and full-admin Squad views.