### PR TITLE
Add automatic PlayerPool SMS profile nudges

### DIFF
--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -12,6 +12,7 @@ import { backfillUpcomingFixtureConfirmationWarningEmails } from "@/lib/fixtures
 import { reconcilePendingLastMinuteReplacements } from "@/lib/fixtures/last-minute-replacement-resolution";
 import { processNotificationQueue } from "@/lib/notifications/processor";
 import { chargeDueMatchdayAutoPayments } from "@/lib/payments/team-autopay";
+import { runPlayerPoolProfileSmsReminderJob } from "@/lib/player-pool/profile-sms-reminders";
 import { queueDueRefereeNightConfirmationChasers } from "@/lib/referee-night-confirmations";
 import { queueDueRefereeNightReminderEmails } from "@/lib/referee-night-emails";
 import { syncPublishedFixtureRefereeNightAssignmentsAndRecalculate } from "@/lib/referee-night-assignment-sync";
@@ -131,6 +132,11 @@ export async function GET(request: NextRequest) {
     failures,
     runCaptainRulesOnboardingEmailJob,
   );
+  const playerPoolProfileSmsReminders = await runCronStep(
+    "player-pool-profile-sms-reminders",
+    failures,
+    runPlayerPoolProfileSmsReminderJob,
+  );
   const fixtureConfirmations = await runCronStep(
     "fixture-confirmation-reminders",
     failures,
@@ -209,6 +215,7 @@ export async function GET(request: NextRequest) {
     existingQueue,
     onboarding,
     rulesOnboarding,
+    playerPoolProfileSmsReminders,
     fixtureConfirmations,
     fixtureConfirmationEmails,
     fixtureConfirmationWarnings,

--- a/src/components/admin/player-pool/BulkPlayerPoolProfileReminderButton.tsx
+++ b/src/components/admin/player-pool/BulkPlayerPoolProfileReminderButton.tsx
@@ -37,7 +37,7 @@ export default function BulkPlayerPoolProfileReminderButton({
 
   async function sendBulkReminder() {
     const confirmed = window.confirm(
-      `Email all ${awaitingCount} players still awaiting their PlayerPool profile?\n\nEach player will receive the full PlayerPool explanation and their own secure profile link.`,
+      `Email all ${awaitingCount} players still awaiting their PlayerPool profile?\n\nEach player will receive the full PlayerPool explanation and their own secure profile link. Eligible players who still have not completed it will then receive an automatic SMS nudge 48 hours after the email is delivered.`,
     );
 
     if (!confirmed) return;
@@ -85,15 +85,16 @@ export default function BulkPlayerPoolProfileReminderButton({
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="max-w-3xl">
           <p className="text-[11px] font-black uppercase tracking-[0.18em] text-amber-300">
-            Profile reminder email
+            Email &amp; SMS profile reminders
           </p>
           <h3 className="mt-2 text-lg font-black text-white">
             Email everyone who is still awaiting their profile
           </h3>
           <p className="mt-2 text-sm leading-6 text-white/60">
-            This sends a friendly explanation of PlayerPool, how SIXFL leagues work,
-            privacy and introductions, plus each player&apos;s own secure form link.
-            Players without a usable email or profile link are safely skipped.
+            This sends the full PlayerPool explanation and each player&apos;s own secure
+            form link. If they still have not completed it, SIXFL automatically sends
+            one SMS 48 hours after the email is delivered and a final SMS five days
+            later. Completed profiles and players without a usable mobile are skipped.
           </p>
         </div>
 
@@ -117,7 +118,7 @@ export default function BulkPlayerPoolProfileReminderButton({
           {result.skipped > 0 ? ` ${result.skipped} skipped.` : ""}
           {result.failed > 0 ? ` ${result.failed} failed.` : ""}
           <div className="mt-1 text-xs text-emerald-100/65">
-            The latest queued or sent date is now shown on each player card below.
+            SMS follow-up starts automatically only after the email is actually sent. The latest email date is shown on each player card below.
           </div>
           {result.errors.length > 0 ? (
             <details className="mt-3 text-xs text-amber-100/80">

--- a/src/lib/player-pool/profile-sms-reminders.ts
+++ b/src/lib/player-pool/profile-sms-reminders.ts
@@ -1,0 +1,237 @@
+import {
+  NotificationAudience,
+  NotificationChannel,
+  NotificationRecipientSourceType,
+  Prisma,
+} from "@prisma/client";
+
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { queueDirectNotification } from "@/lib/notifications/service";
+import {
+  PLAYER_POOL_PROFILE_STATUSES,
+  getPlayerPoolBaseUrl,
+} from "@/lib/player-pool/storage";
+import { prisma } from "@/lib/prisma";
+import { PLAYER_POOL_PROFILE_REMINDER_SOURCE_TYPE } from "./profile-reminders";
+
+export const PLAYER_POOL_PROFILE_SMS_FIRST_SOURCE_TYPE =
+  "PLAYER_POOL_PROFILE_SMS_NUDGE_1";
+export const PLAYER_POOL_PROFILE_SMS_FINAL_SOURCE_TYPE =
+  "PLAYER_POOL_PROFILE_SMS_NUDGE_FINAL";
+
+const FIRST_SMS_DELAY_MS = 48 * 60 * 60 * 1000;
+const FINAL_SMS_DELAY_MS = 5 * 24 * 60 * 60 * 1000;
+
+type AwaitingProfileRow = {
+  id: string;
+  prospectId: string;
+  profileToken: string;
+  publicCode: string;
+  status: string;
+  profileSubmittedAt: Date | null;
+  leagueId: string | null;
+  firstName: string;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  emailSentAt: Date | null;
+  firstSmsCreatedAt: Date | null;
+  firstSmsSentAt: Date | null;
+  finalSmsCreatedAt: Date | null;
+};
+
+export type PlayerPoolProfileSmsReminderSummary = {
+  scanned: number;
+  firstSmsQueued: number;
+  finalSmsQueued: number;
+  skippedNoPhone: number;
+  skippedNotDue: number;
+  errors: string[];
+};
+
+function fullName(firstName: string, lastName: string | null) {
+  return [firstName, lastName].filter(Boolean).join(" ").trim();
+}
+
+function isDue(reference: Date | null, delayMs: number, now: Date) {
+  return Boolean(reference && now.getTime() >= reference.getTime() + delayMs);
+}
+
+async function getAwaitingProfiles() {
+  return prisma.$queryRaw<AwaitingProfileRow[]>(Prisma.sql`
+    SELECT
+      profile."id",
+      profile."prospectId",
+      profile."profileToken",
+      profile."publicCode",
+      profile."status",
+      profile."profileSubmittedAt",
+      profile."leagueId",
+      prospect."firstName",
+      prospect."lastName",
+      prospect."email",
+      prospect."phone",
+      (
+        SELECT MAX(dispatch."sentAt")
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${PLAYER_POOL_PROFILE_REMINDER_SOURCE_TYPE}
+          AND dispatch."sourceId" = profile."id"
+          AND dispatch."channel" = 'EMAIL'::"NotificationChannel"
+          AND dispatch."status" = 'SENT'::"NotificationDispatchStatus"
+      ) AS "emailSentAt",
+      (
+        SELECT MAX(dispatch."createdAt")
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${PLAYER_POOL_PROFILE_SMS_FIRST_SOURCE_TYPE}
+          AND dispatch."sourceId" = profile."id"
+          AND dispatch."channel" = 'SMS'::"NotificationChannel"
+          AND dispatch."status" <> 'CANCELLED'::"NotificationDispatchStatus"
+      ) AS "firstSmsCreatedAt",
+      (
+        SELECT MAX(dispatch."sentAt")
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${PLAYER_POOL_PROFILE_SMS_FIRST_SOURCE_TYPE}
+          AND dispatch."sourceId" = profile."id"
+          AND dispatch."channel" = 'SMS'::"NotificationChannel"
+          AND dispatch."status" = 'SENT'::"NotificationDispatchStatus"
+      ) AS "firstSmsSentAt",
+      (
+        SELECT MAX(dispatch."createdAt")
+        FROM "NotificationDispatch" dispatch
+        WHERE dispatch."sourceType" = ${PLAYER_POOL_PROFILE_SMS_FINAL_SOURCE_TYPE}
+          AND dispatch."sourceId" = profile."id"
+          AND dispatch."channel" = 'SMS'::"NotificationChannel"
+          AND dispatch."status" <> 'CANCELLED'::"NotificationDispatchStatus"
+      ) AS "finalSmsCreatedAt"
+    FROM "PlayerPoolProfile" profile
+    JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"
+    WHERE profile."status" = ${PLAYER_POOL_PROFILE_STATUSES.INVITED}
+      AND profile."profileSubmittedAt" IS NULL
+      AND profile."profileToken" IS NOT NULL
+      AND TRIM(profile."profileToken") <> ''
+    ORDER BY profile."invitedAt" ASC NULLS LAST
+  `);
+}
+
+async function queueSms(input: {
+  profile: AwaitingProfileRow;
+  stage: "first" | "final";
+}) {
+  const { profile } = input;
+  const profileUrl = `${getPlayerPoolBaseUrl()}/player-pool/profile/${profile.profileToken}`;
+  const displayName =
+    fullName(profile.firstName, profile.lastName) || profile.email || "Player";
+  const firstName = profile.firstName.trim() || "there";
+
+  const recipient = await upsertNotificationRecipient({
+    sourceType: NotificationRecipientSourceType.GENERAL,
+    sourceId: `player-pool-profile:${profile.id}`,
+    audience: NotificationAudience.PLAYER,
+    displayName,
+    email: profile.email,
+    phone: profile.phone,
+    transactionalEmailOptIn: true,
+    transactionalSmsOptIn: true,
+    marketingEmailOptIn: false,
+    marketingSmsOptIn: false,
+    metadata: {
+      entityType: "PLAYER_POOL_PROFILE",
+      profileId: profile.id,
+      prospectId: profile.prospectId,
+      publicCode: profile.publicCode,
+      leagueId: profile.leagueId,
+    },
+  });
+
+  const isFinal = input.stage === "final";
+  const body = isFinal
+    ? `Hi ${firstName}, just a final reminder from SIXFL about your PlayerPool profile. If you'd still like us to help find you a team, please complete it here: ${profileUrl} If you're no longer looking, you can ignore this message.`
+    : `Hi ${firstName}, it's SIXFL. We emailed you your PlayerPool profile link but it looks like you haven't completed it yet. It only takes a couple of minutes and helps us match you with the right local teams: ${profileUrl}`;
+
+  const dispatch = await queueDirectNotification({
+    recipientId: recipient.id,
+    channel: NotificationChannel.SMS,
+    audience: NotificationAudience.PLAYER,
+    body,
+    isTransactional: true,
+    sourceType: isFinal
+      ? PLAYER_POOL_PROFILE_SMS_FINAL_SOURCE_TYPE
+      : PLAYER_POOL_PROFILE_SMS_FIRST_SOURCE_TYPE,
+    sourceId: profile.id,
+    variables: {
+      firstName,
+      profileUrl,
+      publicCode: profile.publicCode,
+    },
+    metadata: {
+      type: "player_pool_profile_sms_reminder",
+      stage: input.stage,
+      profileId: profile.id,
+      prospectId: profile.prospectId,
+      publicCode: profile.publicCode,
+      ctaUrl: profileUrl,
+      automatic: true,
+    },
+  });
+
+  await logNotificationDispatchToThread({ dispatch, recipient });
+  return dispatch;
+}
+
+export async function runPlayerPoolProfileSmsReminderJob(): Promise<PlayerPoolProfileSmsReminderSummary> {
+  const summary: PlayerPoolProfileSmsReminderSummary = {
+    scanned: 0,
+    firstSmsQueued: 0,
+    finalSmsQueued: 0,
+    skippedNoPhone: 0,
+    skippedNotDue: 0,
+    errors: [],
+  };
+
+  const profiles = await getAwaitingProfiles();
+  summary.scanned = profiles.length;
+  const now = new Date();
+
+  for (const profile of profiles) {
+    if (!profile.phone?.trim()) {
+      summary.skippedNoPhone += 1;
+      continue;
+    }
+
+    try {
+      // We deliberately wait for the email to be SENT, not merely queued.
+      // This prevents an SMS overtaking a delayed or failed email.
+      if (
+        !profile.firstSmsCreatedAt &&
+        isDue(profile.emailSentAt, FIRST_SMS_DELAY_MS, now)
+      ) {
+        await queueSms({ profile, stage: "first" });
+        summary.firstSmsQueued += 1;
+        continue;
+      }
+
+      // The final reminder is only queued after the first SMS itself has been
+      // successfully sent, and only once. There are never more than two SMS nudges.
+      if (
+        profile.firstSmsSentAt &&
+        !profile.finalSmsCreatedAt &&
+        isDue(profile.firstSmsSentAt, FINAL_SMS_DELAY_MS, now)
+      ) {
+        await queueSms({ profile, stage: "final" });
+        summary.finalSmsQueued += 1;
+        continue;
+      }
+
+      summary.skippedNotDue += 1;
+    } catch (error) {
+      if (summary.errors.length < 20) {
+        summary.errors.push(
+          `${profile.id}:${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  return summary;
+}


### PR DESCRIPTION
Adds automatic SMS follow-up for PlayerPool profiles after the existing profile reminder email.

- waits until the profile reminder EMAIL is actually SENT, not merely queued
- first SMS is due 48 hours later if the profile is still INVITED/incomplete
- final SMS is due 5 days after the first SMS is successfully sent
- stops after two SMS reminders
- skips completed/changed-status profiles, missing secure links and players without a mobile number
- dedupes by dedicated NotificationDispatch source types so repeated cron runs cannot send the same stage twice
- uses each player's existing secure profile link and existing SMS quiet-hours/short-link handling
- logs SMS messages into the existing communications history
- runs as an independent notifications-cron step so another job failure does not suppress it
- updates the Awaiting profile panel to explain the automatic email → SMS sequence