### PR TITLE
Show available PlayerPool players in captain nav

### DIFF
--- a/scripts/apply-captain-playerpool-availability-badge-v2.cjs
+++ b/scripts/apply-captain-playerpool-availability-badge-v2.cjs
@@ -1,0 +1,37 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const filePath = path.join(process.cwd(), "src/app/captain/team/[teamid]/layout.tsx");
+let source = fs.readFileSync(filePath, "utf8");
+function replaceOnce(oldText, newText, label) {
+  if (source.includes(newText)) return;
+  if (!source.includes(oldText)) throw new Error(`Could not find ${label}`);
+  source = source.replace(oldText, newText);
+}
+replaceOnce(
+  "  unreadCount?: number;\n};",
+  "  unreadCount?: number;\n  availabilityCount?: number;\n};",
+  "CaptainNavItem availabilityCount field",
+);
+replaceOnce(
+  "  const unreadMessageCount = await getCaptainUnreadMessageCount(teamid);",
+  `  const unreadMessageCount = await getCaptainUnreadMessageCount(teamid);\n  const playerPoolAvailableRows = team.league?.id\n    ? await prisma.$queryRaw<Array<{ count: bigint }>>\`\n        SELECT COUNT(*)::bigint AS "count"\n        FROM "PlayerPoolProfile" profile\n        JOIN "TeamPlayerProspect" prospect ON prospect."id" = profile."prospectId"\n        WHERE profile."leagueId" = \${team.league.id}\n          AND profile."status" = 'AVAILABLE'\n          AND profile."profileSubmittedAt" IS NOT NULL\n          AND profile."consentShareProfile" = true\n          AND profile."consentContact" = true\n          AND NOT EXISTS (\n            SELECT 1 FROM "TeamPlayerProspect" squad_prospect\n            WHERE squad_prospect."teamId" = \${teamid}\n              AND squad_prospect."email" IS NOT NULL\n              AND prospect."email" IS NOT NULL\n              AND LOWER(TRIM(squad_prospect."email")) = LOWER(TRIM(prospect."email"))\n          )\n          AND NOT EXISTS (\n            SELECT 1\n            FROM "TeamMember" squad_member\n            JOIN "User" squad_user ON squad_user."id" = squad_member."userId"\n            WHERE squad_member."teamId" = \${teamid}\n              AND squad_user."email" IS NOT NULL\n              AND prospect."email" IS NOT NULL\n              AND LOWER(TRIM(squad_user."email")) = LOWER(TRIM(prospect."email"))\n          )\n      \`\n    : [];\n  const playerPoolAvailableCount = Number(playerPoolAvailableRows[0]?.count ?? 0);`,
+  "PlayerPool availability count query",
+);
+replaceOnce(
+  '        { href: `/captain/team/${teamid}/player-pool`, label: "PlayerPool" },',
+  `        {\n          href: \`/captain/team/\${teamid}/player-pool\`,\n          label: "PlayerPool",\n          availabilityCount: playerPoolAvailableCount,\n        },`,
+  "PlayerPool nav item",
+);
+replaceOnce(
+  "                          : item.label\n                      }",
+  "                          : item.availabilityCount && item.availabilityCount > 0\n                            ? `${item.label}, ${item.availabilityCount} player${item.availabilityCount === 1 ? \"\" : \"s\"} available in your league`\n                            : item.label\n                      }",
+  "PlayerPool accessible availability label",
+);
+const badgeAnchor = `                      {item.unreadCount && item.unreadCount > 0 ? (\n                        <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-emerald-400 px-1.5 py-0.5 text-[11px] font-black text-black">\n                          {item.unreadCount}\n                        </span>\n                      ) : null}`;
+replaceOnce(
+  badgeAnchor,
+  `${badgeAnchor}\n                      {item.availabilityCount && item.availabilityCount > 0 ? (\n                        <span className="inline-flex items-center justify-center rounded-full border border-emerald-300/25 bg-emerald-400/15 px-2 py-0.5 text-[10px] font-black text-emerald-100">\n                          {item.availabilityCount} available\n                        </span>\n                      ) : null}`,
+  "PlayerPool availability badge",
+);
+fs.writeFileSync(filePath, source);
+console.log("Captain PlayerPool nav now shows available players in the team's league.");

--- a/scripts/apply-captain-playerpool-availability-badge.cjs
+++ b/scripts/apply-captain-playerpool-availability-badge.cjs
@@ -1,0 +1,136 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const filePath = path.join(
+  process.cwd(),
+  "src/app/captain/team/[teamid]/layout.tsx",
+);
+
+let source = fs.readFileSync(filePath, "utf8");
+
+function replaceOnce(oldText, newText, label) {
+  if (source.includes(newText)) return;
+  if (!source.includes(oldText)) {
+    throw new Error(`Could not find ${label}`);
+  }
+  source = source.replace(oldText, newText);
+}
+
+replaceOnce(
+  [
+    "type CaptainNavItem = {",
+    "  href: string;",
+    "  label: string;",
+    "  logoSrc?: string;",
+    "  unreadCount?: number;",
+    "};",
+  ].join("\n"),
+  [
+    "type CaptainNavItem = {",
+    "  href: string;",
+    "  label: string;",
+    "  logoSrc?: string;",
+    "  unreadCount?: number;",
+    "  availabilityCount?: number;",
+    "};",
+  ].join("\n"),
+  "CaptainNavItem availabilityCount field",
+);
+
+replaceOnce(
+  "  const unreadMessageCount = await getCaptainUnreadMessageCount(teamid);",
+  [
+    "  const unreadMessageCount = await getCaptainUnreadMessageCount(teamid);",
+    "  const playerPoolAvailableRows = team.league?.id",
+    "    ? await prisma.$queryRaw<Array<{ count: bigint }>>`",
+    "        SELECT COUNT(*)::bigint AS \"count\"",
+    "        FROM \"PlayerPoolProfile\" profile",
+    "        JOIN \"TeamPlayerProspect\" prospect ON prospect.\"id\" = profile.\"prospectId\"",
+    "        WHERE profile.\"leagueId\" = ${team.league.id}",
+    "          AND profile.\"status\" = 'AVAILABLE'",
+    "          AND profile.\"profileSubmittedAt\" IS NOT NULL",
+    "          AND profile.\"consentShareProfile\" = true",
+    "          AND profile.\"consentContact\" = true",
+    "          AND NOT EXISTS (",
+    "            SELECT 1",
+    "            FROM \"TeamPlayerProspect\" squad_prospect",
+    "            WHERE squad_prospect.\"teamId\" = ${teamid}",
+    "              AND squad_prospect.\"email\" IS NOT NULL",
+    "              AND prospect.\"email\" IS NOT NULL",
+    "              AND LOWER(TRIM(squad_prospect.\"email\")) = LOWER(TRIM(prospect.\"email\"))",
+    "          )",
+    "          AND NOT EXISTS (",
+    "            SELECT 1",
+    "            FROM \"TeamMember\" squad_member",
+    "            JOIN \"User\" squad_user ON squad_user.\"id\" = squad_member.\"userId\"",
+    "            WHERE squad_member.\"teamId\" = ${teamid}",
+    "              AND squad_user.\"email\" IS NOT NULL",
+    "              AND prospect.\"email\" IS NOT NULL",
+    "              AND LOWER(TRIM(squad_user.\"email\")) = LOWER(TRIM(prospect.\"email\"))",
+    "          )",
+    "      `",
+    "    : [];",
+    "  const playerPoolAvailableCount = Number(playerPoolAvailableRows[0]?.count ?? 0);",
+  ].join("\n"),
+  "PlayerPool availability count query",
+);
+
+replaceOnce(
+  '        { href: `/captain/team/${teamid}/player-pool`, label: "PlayerPool" },',
+  [
+    "        {",
+    "          href: `/captain/team/${teamid}/player-pool`,",
+    '          label: "PlayerPool",',
+    "          availabilityCount: playerPoolAvailableCount,",
+    "        },",
+  ].join("\n"),
+  "PlayerPool nav item",
+);
+
+replaceOnce(
+  [
+    "                      aria-label={",
+    "                        item.unreadCount && item.unreadCount > 0",
+    "                          ? `${item.label}, ${item.unreadCount} unread`",
+    "                          : item.label",
+    "                      }",
+  ].join("\n"),
+  [
+    "                      aria-label={",
+    "                        item.unreadCount && item.unreadCount > 0",
+    "                          ? `${item.label}, ${item.unreadCount} unread`",
+    "                          : item.availabilityCount && item.availabilityCount > 0",
+    "                            ? `${item.label}, ${item.availabilityCount} player${item.availabilityCount === 1 ? \"\" : \"s\"} available in your league`",
+    "                            : item.label",
+    "                      }",
+  ].join("\n"),
+  "PlayerPool accessible availability label",
+);
+
+const unreadBadgeAnchor = [
+  "                      {item.unreadCount && item.unreadCount > 0 ? (",
+  '                        <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-emerald-400 px-1.5 py-0.5 text-[11px] font-black text-black">',
+  "                          {item.unreadCount}",
+  "                        </span>",
+  "                      ) : null}",
+].join("\n");
+
+if (!source.includes("player${item.availabilityCount === 1")) {
+  // aria label should already have been added above; this is only a defensive marker.
+}
+
+replaceOnce(
+  unreadBadgeAnchor,
+  [
+    unreadBadgeAnchor,
+    "                      {item.availabilityCount && item.availabilityCount > 0 ? (",
+    '                        <span className="inline-flex items-center justify-center rounded-full border border-emerald-300/25 bg-emerald-400/15 px-2 py-0.5 text-[10px] font-black text-emerald-100">',
+    "                          {item.availabilityCount} available",
+    "                        </span>",
+    "                      ) : null}",
+  ].join("\n"),
+  "PlayerPool availability badge",
+);
+
+fs.writeFileSync(filePath, source);
+console.log("Captain PlayerPool nav now shows available players in the team's league.");

--- a/scripts/apply-player-pool-league-matching.cjs
+++ b/scripts/apply-player-pool-league-matching.cjs
@@ -110,19 +110,13 @@ replaceOnce(
   "captain PlayerPool exact league matching",
 );
 
-// Copy is deliberately not a build contract. The PlayerPool page now explains
-// the full request lifecycle (requested -> approved -> joined), so an older
-// wording patch must not fail prebuild or overwrite newer native copy.
 const oldMatchingExplanation =
   "          These players are looking for a SIXFL team and match your league area or playing night. Profiles are anonymised: names, email addresses and mobile numbers stay private until the player agrees to an introduction.";
 const previousMatchingExplanation =
   "          These players have chosen your league, or are looking to play locally on the same night. Request an introduction and SIXFL will check with the player first. Their name and contact details stay private unless they agree.";
 let captainSource = read(captainPage);
 if (captainSource.includes(oldMatchingExplanation)) {
-  captainSource = captainSource.replace(
-    oldMatchingExplanation,
-    previousMatchingExplanation,
-  );
+  captainSource = captainSource.replace(oldMatchingExplanation, previousMatchingExplanation);
   write(captainPage, captainSource);
 }
 
@@ -148,10 +142,7 @@ replaceOnce(
 replaceOnce(
   adminPage,
   "  leagueName: string | null;",
-  [
-    "  leagueName: string | null;",
-    "  leagueNames: string[];",
-  ].join("\n"),
+  ["  leagueName: string | null;", "  leagueNames: string[];"].join("\n"),
   "admin PlayerPool league names type",
 );
 
@@ -236,3 +227,5 @@ for (const filePath of [captainPage, adminPage]) {
 console.log(
   "PlayerPool profiles now match captains by selected league IDs, while legacy profiles retain the previous area/night fallback. Display copy is not used as a build anchor.",
 );
+
+require("./apply-captain-playerpool-availability-badge.cjs");

--- a/scripts/check-captain-playerpool-availability-badge.mjs
+++ b/scripts/check-captain-playerpool-availability-badge.mjs
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const layout = fs.readFileSync(path.join(root, "src/app/captain/team/[teamid]/layout.tsx"), "utf8");
+
+const required = [
+  "availabilityCount?: number;",
+  "playerPoolAvailableCount",
+  "profile.\"status\" = 'AVAILABLE'",
+  "profile.\"leagueId\" = ${team.league.id}",
+  "{item.availabilityCount} available",
+  "available in your league",
+];
+
+const missing = required.filter((marker) => !layout.includes(marker));
+if (missing.length) {
+  console.error("Captain PlayerPool availability badge contract failed:");
+  for (const marker of missing) console.error(`- missing ${marker}`);
+  process.exit(1);
+}
+
+console.log("Captain PlayerPool availability badge contract passed.");


### PR DESCRIPTION
Shows captains when PlayerPool has available players in their league directly on the dashboard navigation.

- adds an `N available` badge beside PlayerPool only when matching players exist
- counts only completed, shareable, contactable AVAILABLE profiles linked to the team's league
- excludes players already on that team's squad/prospect list
- keeps the existing PlayerPool page as the detailed view
- adds an accessibility label describing the available-player count
- runs through the existing PlayerPool league-matching prebuild path so it survives production source preparation