### PR TITLE
Allow squad payments on completed fixtures

### DIFF
--- a/scripts/apply-active-charge-squad-payment-authority.cjs
+++ b/scripts/apply-active-charge-squad-payment-authority.cjs
@@ -84,7 +84,12 @@ const after = [
   '    staleFixtureFeeRepair.awayMatchFeePence = existingAwayChargePence;',
   '  }',
   '',
-  '  if (Object.keys(staleFixtureFeeRepair).length > 0) {',
+  '  // Completed fixtures stay immutable. Their existing charge can still be used',
+  '  // for player-payment collection without repairing historical fixture fields.',
+  '  if (',
+  '    fixture.status !== "COMPLETED" &&',
+  '    Object.keys(staleFixtureFeeRepair).length > 0',
+  '  ) {',
   '    await prisma.fixture.update({',
   '      where: { id: fixture.id },',
   '      data: staleFixtureFeeRepair,',
@@ -122,6 +127,7 @@ for (const marker of [
   'existingChargeByTeamId.get(fixture.awayTeam.id) ?? storedAwayFeePence',
   'staleFixtureFeeRepair.homeMatchFeePence = existingHomeChargePence',
   'staleFixtureFeeRepair.awayMatchFeePence = existingAwayChargePence',
+  'fixture.status !== "COMPLETED"',
   'homeMatchFeePence: resolvedHomeFeePence',
   'awayMatchFeePence: resolvedAwayFeePence',
 ]) {
@@ -131,5 +137,5 @@ for (const marker of [
 }
 
 console.log(
-  "Captain squad payments now use an existing active fixture charge before stale raw fixture fee fields, and repair stale zero/null team-side fixture fees when safe.",
+  "Captain squad payments now use active fixture charges, keep completed fixtures immutable, and only repair stale fixture fee fields before completion.",
 );


### PR DESCRIPTION
Fixes the runtime error managers/captains hit when creating squad player-payment links for a completed fixture.

Root cause: the active-charge squad-payment compatibility patch tried to repair stale `homeMatchFeePence` / `awayMatchFeePence` fields with `prisma.fixture.update()`. Completed fixtures are intentionally locked globally, so that repair threw `This fixture has already been completed and is locked, so it cannot be changed.` (digest `3803008514`).

This change:
- keeps the completed-fixture lock intact;
- still allows completed/past fixtures to use their existing active match-fee charge for squad/player payments;
- skips only the historical fixture-field repair once a fixture is `COMPLETED`;
- continues to repair stale fee fields on non-completed fixtures;
- adds a build-time verification marker so the completed-fixture guard cannot silently disappear.

The captain player-payments page already intentionally includes both `SCHEDULED` and `COMPLETED` fixtures, so this restores the intended workflow rather than relaxing fixture-editing protection.