### PR TITLE
Show automatic SMS status on team leads

### DIFF
--- a/src/app/api/admin/leads/team-confirmation-sms-status/route.ts
+++ b/src/app/api/admin/leads/team-confirmation-sms-status/route.ts
@@ -1,0 +1,392 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const FIRST_SMS_DELAY_MS = 48 * 60 * 60 * 1000;
+const FINAL_SMS_DELAY_MS = 5 * 24 * 60 * 60 * 1000;
+
+const FIRST_SMS_SOURCE_TYPE = "LEAD_TEAM_CONFIRMATION_SMS_NUDGE_1";
+const FINAL_SMS_SOURCE_TYPE = "LEAD_TEAM_CONFIRMATION_SMS_NUDGE_FINAL";
+
+const RELEVANT_EMAIL_SOURCE_TYPES = [
+  "LEAD_REASSURANCE_EMAIL",
+  "LEAD_LIVE_LEAGUE_REASSURANCE_EMAIL",
+  "LEAD_TEAM_CONFIRMATION",
+  "LEAD_TEAM_CONFIRMATION_CHASE",
+] as const;
+
+type StatusTone = "muted" | "info" | "success" | "warning" | "danger";
+
+type StatusLine = {
+  text: string;
+  tone: StatusTone;
+  title?: string | null;
+};
+
+type TeamLeadSmsStatus = {
+  lines: StatusLine[];
+};
+
+type TeamLeadSmsStatusRow = {
+  leadId: string;
+  phone: string | null;
+  leadStatus: string;
+  convertedTeamId: string | null;
+  confirmationStatus: string;
+  latestRelevantEmailSentAt: Date | null;
+  latestInboundAt: Date | null;
+  firstStatus: string | null;
+  firstCreatedAt: Date | null;
+  firstScheduledFor: Date | null;
+  firstProcessingAt: Date | null;
+  firstProcessedAt: Date | null;
+  firstSentAt: Date | null;
+  firstFailedAt: Date | null;
+  firstCancelledAt: Date | null;
+  firstErrorMessage: string | null;
+  finalStatus: string | null;
+  finalCreatedAt: Date | null;
+  finalScheduledFor: Date | null;
+  finalProcessingAt: Date | null;
+  finalProcessedAt: Date | null;
+  finalSentAt: Date | null;
+  finalFailedAt: Date | null;
+  finalCancelledAt: Date | null;
+  finalErrorMessage: string | null;
+};
+
+type DispatchSnapshot = {
+  status: string | null;
+  createdAt: Date | null;
+  scheduledFor: Date | null;
+  processingAt: Date | null;
+  processedAt: Date | null;
+  sentAt: Date | null;
+  failedAt: Date | null;
+  cancelledAt: Date | null;
+  errorMessage: string | null;
+};
+
+function formatDateTime(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: "Europe/London",
+  }).format(value);
+}
+
+function addMilliseconds(value: Date, milliseconds: number) {
+  return new Date(value.getTime() + milliseconds);
+}
+
+function latestDate(first: Date, second: Date | null) {
+  if (!second) return first;
+  return second.getTime() > first.getTime() ? second : first;
+}
+
+function dispatchStatusLine(
+  label: "First SMS" | "Final SMS",
+  dispatch: DispatchSnapshot,
+  now: Date,
+): StatusLine | null {
+  if (!dispatch.status) return null;
+
+  if (dispatch.status === "SENT") {
+    const sentAt = dispatch.sentAt ?? dispatch.processedAt ?? dispatch.createdAt;
+    return {
+      text: sentAt ? `${label} sent ${formatDateTime(sentAt)}` : `${label} sent`,
+      tone: "success",
+    };
+  }
+
+  if (dispatch.status === "FAILED") {
+    const failedAt = dispatch.failedAt ?? dispatch.processedAt ?? dispatch.createdAt;
+    return {
+      text: failedAt ? `${label} failed ${formatDateTime(failedAt)}` : `${label} failed`,
+      tone: "danger",
+      title: dispatch.errorMessage,
+    };
+  }
+
+  if (dispatch.status === "PROCESSING") {
+    const processingAt = dispatch.processingAt ?? dispatch.createdAt;
+    return {
+      text: processingAt
+        ? `${label} sending ${formatDateTime(processingAt)}`
+        : `${label} sending`,
+      tone: "info",
+    };
+  }
+
+  if (dispatch.status === "QUEUED") {
+    const scheduledFor = dispatch.scheduledFor ?? dispatch.createdAt;
+    const isFuture = Boolean(scheduledFor && scheduledFor.getTime() > now.getTime() + 60_000);
+    return {
+      text: scheduledFor
+        ? `${label} queued${isFuture ? " for" : ""} ${formatDateTime(scheduledFor)}`
+        : `${label} queued`,
+      tone: "info",
+    };
+  }
+
+  if (dispatch.status === "CANCELLED") {
+    const cancelledAt = dispatch.cancelledAt ?? dispatch.processedAt ?? dispatch.createdAt;
+    return {
+      text: cancelledAt
+        ? `${label} not sent ${formatDateTime(cancelledAt)}`
+        : `${label} not sent`,
+      tone: "warning",
+      title: dispatch.errorMessage,
+    };
+  }
+
+  return {
+    text: `${label}: ${dispatch.status.toLowerCase()}`,
+    tone: "muted",
+  };
+}
+
+function stopReason(row: TeamLeadSmsStatusRow) {
+  if (row.confirmationStatus === "CONFIRMED") return "team place confirmed";
+  if (row.confirmationStatus === "DECLINED") return "place released";
+  if (row.convertedTeamId) return "team created";
+  if (row.leadStatus === "QUALIFIED") return "lead qualified";
+  if (row.leadStatus === "CLOSED") return "lead closed";
+
+  if (
+    row.latestInboundAt &&
+    row.latestRelevantEmailSentAt &&
+    row.latestInboundAt.getTime() >= row.latestRelevantEmailSentAt.getTime()
+  ) {
+    return "reply received";
+  }
+
+  return null;
+}
+
+function buildStatus(row: TeamLeadSmsStatusRow, now: Date): TeamLeadSmsStatus {
+  const firstDispatch: DispatchSnapshot = {
+    status: row.firstStatus,
+    createdAt: row.firstCreatedAt,
+    scheduledFor: row.firstScheduledFor,
+    processingAt: row.firstProcessingAt,
+    processedAt: row.firstProcessedAt,
+    sentAt: row.firstSentAt,
+    failedAt: row.firstFailedAt,
+    cancelledAt: row.firstCancelledAt,
+    errorMessage: row.firstErrorMessage,
+  };
+  const finalDispatch: DispatchSnapshot = {
+    status: row.finalStatus,
+    createdAt: row.finalCreatedAt,
+    scheduledFor: row.finalScheduledFor,
+    processingAt: row.finalProcessingAt,
+    processedAt: row.finalProcessedAt,
+    sentAt: row.finalSentAt,
+    failedAt: row.finalFailedAt,
+    cancelledAt: row.finalCancelledAt,
+    errorMessage: row.finalErrorMessage,
+  };
+
+  const firstLine = dispatchStatusLine("First SMS", firstDispatch, now);
+  const finalLine = dispatchStatusLine("Final SMS", finalDispatch, now);
+  const stopped = stopReason(row);
+
+  if (!firstLine && !finalLine && stopped) {
+    return {
+      lines: [{ text: `Automatic SMS stopped — ${stopped}`, tone: "muted" }],
+    };
+  }
+
+  if (!firstLine && !finalLine && !row.phone?.trim()) {
+    return {
+      lines: [{ text: "Automatic SMS unavailable — no phone number", tone: "warning" }],
+    };
+  }
+
+  if (!firstLine && !finalLine && !row.latestRelevantEmailSentAt) {
+    return {
+      lines: [{ text: "Automatic SMS waiting for email delivery", tone: "muted" }],
+    };
+  }
+
+  const lines: StatusLine[] = [];
+
+  if (firstLine) {
+    lines.push(firstLine);
+  } else if (stopped) {
+    lines.push({ text: `First SMS stopped — ${stopped}`, tone: "muted" });
+  } else if (row.latestRelevantEmailSentAt) {
+    const firstDueAt = addMilliseconds(
+      row.latestRelevantEmailSentAt,
+      FIRST_SMS_DELAY_MS,
+    );
+    lines.push({
+      text:
+        firstDueAt.getTime() <= now.getTime()
+          ? "First SMS due now"
+          : `First SMS due ${formatDateTime(firstDueAt)}`,
+      tone: firstDueAt.getTime() <= now.getTime() ? "warning" : "info",
+    });
+  }
+
+  if (finalLine) {
+    lines.push(finalLine);
+  } else if (stopped) {
+    lines.push({ text: `Final SMS stopped — ${stopped}`, tone: "muted" });
+  } else if (row.firstSentAt) {
+    const fiveDaysAfterFirst = addMilliseconds(row.firstSentAt, FINAL_SMS_DELAY_MS);
+    const fortyEightHoursAfterLatestEmail = row.latestRelevantEmailSentAt
+      ? addMilliseconds(row.latestRelevantEmailSentAt, FIRST_SMS_DELAY_MS)
+      : null;
+    const finalDueAt = latestDate(
+      fiveDaysAfterFirst,
+      fortyEightHoursAfterLatestEmail,
+    );
+
+    lines.push({
+      text:
+        finalDueAt.getTime() <= now.getTime()
+          ? "Final SMS due now"
+          : `Final SMS due ${formatDateTime(finalDueAt)}`,
+      tone: finalDueAt.getTime() <= now.getTime() ? "warning" : "info",
+    });
+  } else if (row.firstStatus === "FAILED" || row.firstStatus === "CANCELLED") {
+    lines.push({
+      text: "Final SMS stopped — first SMS was not sent",
+      tone: "muted",
+    });
+  } else {
+    lines.push({ text: "Final SMS not due yet", tone: "muted" });
+  }
+
+  return { lines };
+}
+
+export async function GET() {
+  await requireAdmin();
+
+  const rows = await prisma.$queryRaw<TeamLeadSmsStatusRow[]>(Prisma.sql`
+    SELECT
+      lead."id" AS "leadId",
+      lead."phone",
+      lead."status"::text AS "leadStatus",
+      lead."convertedTeamId",
+      confirmation."status"::text AS "confirmationStatus",
+      latest_email."sentAt" AS "latestRelevantEmailSentAt",
+      (
+        SELECT MAX(thread."latestInboundAt")
+        FROM "MessageThread" thread
+        WHERE thread."latestInboundAt" IS NOT NULL
+          AND (
+            thread."sourceId" = lead."id"
+            OR thread."recipientId" IN (
+              SELECT recipient."id"
+              FROM "NotificationRecipient" recipient
+              WHERE recipient."sourceType"::text = 'LEAD'
+                AND recipient."sourceId" = lead."id"
+            )
+          )
+      ) AS "latestInboundAt",
+      first_sms."status"::text AS "firstStatus",
+      first_sms."createdAt" AS "firstCreatedAt",
+      first_sms."scheduledFor" AS "firstScheduledFor",
+      first_sms."processingAt" AS "firstProcessingAt",
+      first_sms."processedAt" AS "firstProcessedAt",
+      first_sms."sentAt" AS "firstSentAt",
+      first_sms."failedAt" AS "firstFailedAt",
+      first_sms."cancelledAt" AS "firstCancelledAt",
+      first_sms."errorMessage" AS "firstErrorMessage",
+      final_sms."status"::text AS "finalStatus",
+      final_sms."createdAt" AS "finalCreatedAt",
+      final_sms."scheduledFor" AS "finalScheduledFor",
+      final_sms."processingAt" AS "finalProcessingAt",
+      final_sms."processedAt" AS "finalProcessedAt",
+      final_sms."sentAt" AS "finalSentAt",
+      final_sms."failedAt" AS "finalFailedAt",
+      final_sms."cancelledAt" AS "finalCancelledAt",
+      final_sms."errorMessage" AS "finalErrorMessage"
+    FROM "InterestLead" lead
+    JOIN "LeadTeamConfirmation" confirmation
+      ON confirmation."leadId" = lead."id"
+    LEFT JOIN LATERAL (
+      SELECT dispatch."sentAt"
+      FROM "NotificationDispatch" dispatch
+      WHERE dispatch."sourceId" = lead."id"
+        AND dispatch."channel"::text = 'EMAIL'
+        AND dispatch."status"::text = 'SENT'
+        AND dispatch."sourceType" IN (${Prisma.join(RELEVANT_EMAIL_SOURCE_TYPES)})
+        AND dispatch."createdAt" >=
+          COALESCE(confirmation."sentAt", confirmation."createdAt") - INTERVAL '5 minutes'
+      ORDER BY dispatch."sentAt" DESC NULLS LAST, dispatch."createdAt" DESC
+      LIMIT 1
+    ) latest_email ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT
+        dispatch."status",
+        dispatch."createdAt",
+        dispatch."scheduledFor",
+        dispatch."processingAt",
+        dispatch."processedAt",
+        dispatch."sentAt",
+        dispatch."failedAt",
+        dispatch."cancelledAt",
+        dispatch."errorMessage"
+      FROM "NotificationDispatch" dispatch
+      WHERE dispatch."sourceId" = lead."id"
+        AND dispatch."sourceType" = ${FIRST_SMS_SOURCE_TYPE}
+        AND dispatch."channel"::text = 'SMS'
+      ORDER BY
+        (dispatch."status"::text = 'CANCELLED') ASC,
+        dispatch."createdAt" DESC
+      LIMIT 1
+    ) first_sms ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT
+        dispatch."status",
+        dispatch."createdAt",
+        dispatch."scheduledFor",
+        dispatch."processingAt",
+        dispatch."processedAt",
+        dispatch."sentAt",
+        dispatch."failedAt",
+        dispatch."cancelledAt",
+        dispatch."errorMessage"
+      FROM "NotificationDispatch" dispatch
+      WHERE dispatch."sourceId" = lead."id"
+        AND dispatch."sourceType" = ${FINAL_SMS_SOURCE_TYPE}
+        AND dispatch."channel"::text = 'SMS'
+      ORDER BY
+        (dispatch."status"::text = 'CANCELLED') ASC,
+        dispatch."createdAt" DESC
+      LIMIT 1
+    ) final_sms ON TRUE
+    WHERE lead."interestType"::text = 'TEAM'
+    ORDER BY lead."createdAt" DESC
+    LIMIT 1000
+  `);
+
+  const now = new Date();
+  const statuses: Record<string, TeamLeadSmsStatus> = {};
+
+  for (const row of rows) {
+    statuses[row.leadId] = buildStatus(row, now);
+  }
+
+  return NextResponse.json(
+    { ok: true, statuses },
+    {
+      headers: {
+        "Cache-Control": "private, no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
+++ b/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
@@ -4,11 +4,67 @@
 
 "use client";
 
-import { useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { sendTeamCommitmentEmailAction } from "@/app/(admin)/admin/leads/team-commitment-email-actions";
 import { sendLeadReassuranceEmailAction } from "@/app/(admin)/admin/leads/reassurance-email-actions";
+
+type SmsStatusTone = "muted" | "info" | "success" | "warning" | "danger";
+
+type SmsStatusLine = {
+  text: string;
+  tone: SmsStatusTone;
+  title?: string | null;
+};
+
+type TeamLeadSmsStatus = {
+  lines: SmsStatusLine[];
+};
+
+type TeamLeadSmsStatusResponse = {
+  ok: boolean;
+  statuses?: Record<string, TeamLeadSmsStatus>;
+};
+
+let sharedStatusRequest: Promise<Record<string, TeamLeadSmsStatus>> | null = null;
+
+async function loadTeamLeadSmsStatuses(force = false) {
+  if (force) sharedStatusRequest = null;
+
+  if (!sharedStatusRequest) {
+    sharedStatusRequest = fetch("/api/admin/leads/team-confirmation-sms-status", {
+      cache: "no-store",
+      credentials: "same-origin",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`SMS status request failed (${response.status}).`);
+        }
+
+        const payload = (await response.json()) as TeamLeadSmsStatusResponse;
+        if (!payload.ok || !payload.statuses) {
+          throw new Error("SMS status response was incomplete.");
+        }
+
+        return payload.statuses;
+      })
+      .catch((error) => {
+        sharedStatusRequest = null;
+        throw error;
+      });
+  }
+
+  return sharedStatusRequest;
+}
+
+function statusToneClass(tone: SmsStatusTone) {
+  if (tone === "success") return "text-emerald-200/90";
+  if (tone === "danger") return "text-rose-200/90";
+  if (tone === "warning") return "text-amber-200/90";
+  if (tone === "info") return "text-sky-200/85";
+  return "text-white/45";
+}
 
 export default function LeadConfirmationQuickSendButton({
   leadId,
@@ -22,7 +78,40 @@ export default function LeadConfirmationQuickSendButton({
   const router = useRouter();
   const [sendingReassurance, startReassuranceTransition] = useTransition();
   const [sendingDecision, startDecisionTransition] = useTransition();
+  const [smsStatus, setSmsStatus] = useState<TeamLeadSmsStatus | null>(null);
+  const [smsStatusFailed, setSmsStatusFailed] = useState(false);
   const pending = sendingReassurance || sendingDecision;
+
+  async function refreshSmsStatus(force = false) {
+    try {
+      const statuses = await loadTeamLeadSmsStatuses(force);
+      setSmsStatus(statuses[leadId] ?? null);
+      setSmsStatusFailed(false);
+    } catch (error) {
+      console.error("Team lead automatic SMS status could not be loaded", error);
+      setSmsStatusFailed(true);
+    }
+  }
+
+  useEffect(() => {
+    let active = true;
+
+    void loadTeamLeadSmsStatuses()
+      .then((statuses) => {
+        if (!active) return;
+        setSmsStatus(statuses[leadId] ?? null);
+        setSmsStatusFailed(false);
+      })
+      .catch((error) => {
+        if (!active) return;
+        console.error("Team lead automatic SMS status could not be loaded", error);
+        setSmsStatusFailed(true);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [leadId]);
 
   function handleReassuranceClick() {
     if (!canSend || pending) return;
@@ -39,7 +128,7 @@ export default function LeadConfirmationQuickSendButton({
       }
 
       const emailStatus = result.status ?? "UNKNOWN";
-      const smsStatus = result.smsStatus ?? "UNKNOWN";
+      const smsStatusValue = result.smsStatus ?? "UNKNOWN";
       const smsFailureReason = result.smsFailureReason ?? null;
       const emailVersion =
         result.leagueMode === "LIVE"
@@ -52,19 +141,20 @@ export default function LeadConfirmationQuickSendButton({
           : `The ${emailVersion.toLowerCase()} was ${emailStatus.toLowerCase()}.`;
 
       const smsMessage =
-        smsStatus === "QUEUED"
+        smsStatusValue === "QUEUED"
           ? "The inbox-check SMS was also queued automatically."
-          : smsStatus === "NO_PHONE"
+          : smsStatusValue === "NO_PHONE"
             ? "No SMS was sent because this lead has no phone number."
-            : smsStatus === "EMAIL_NOT_QUEUED"
+            : smsStatusValue === "EMAIL_NOT_QUEUED"
               ? "The SMS was not sent because the email was not queued."
-              : smsStatus === "FAILED_TO_QUEUE"
+              : smsStatusValue === "FAILED_TO_QUEUE"
                 ? "The email was queued, but the automatic SMS could not be queued."
-                : smsStatus === "SKIPPED"
+                : smsStatusValue === "SKIPPED"
                   ? `The email was queued, but the SMS was skipped${smsFailureReason ? `: ${smsFailureReason}` : "."}`
-                  : `SMS status: ${smsStatus.toLowerCase()}.`;
+                  : `SMS status: ${smsStatusValue.toLowerCase()}.`;
 
       alert(`${emailMessage} ${smsMessage}`);
+      await refreshSmsStatus(true);
       router.refresh();
     });
   }
@@ -88,6 +178,7 @@ export default function LeadConfirmationQuickSendButton({
           ? "Commitment link resent. It asks only for their decision, team name and approximate squad size."
           : "Commitment link sent. It asks only for their decision, team name and approximate squad size.",
       );
+      await refreshSmsStatus(true);
       router.refresh();
     });
   }
@@ -125,6 +216,32 @@ export default function LeadConfirmationQuickSendButton({
             ? "Resend decision link"
             : "Send decision link"}
       </button>
+
+      {smsStatus?.lines.length ? (
+        <div
+          className="mt-1 w-full max-w-[190px] rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-right"
+          aria-live="polite"
+        >
+          <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-white/35">
+            Automatic SMS
+          </div>
+          <div className="mt-1 space-y-0.5 text-[11px] leading-4">
+            {smsStatus.lines.map((line, index) => (
+              <div
+                key={`${line.text}-${index}`}
+                className={statusToneClass(line.tone)}
+                title={line.title || undefined}
+              >
+                {line.text}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : smsStatusFailed ? (
+        <div className="max-w-[190px] text-right text-[11px] leading-4 text-amber-200/70">
+          Automatic SMS status unavailable
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What this changes

- shows the first and final automatic team-lead SMS status directly beneath the lead actions
- displays the exact sent time when an SMS has been sent
- distinguishes queued, sending, failed, cancelled, due now, due later and stopped states
- shows why reminders have stopped, including a reply, team decision, conversion or closed lead
- shows when a phone number or delivered decision email is still missing
- uses one shared status request for the whole Leads page rather than one database request per row
- keeps the status endpoint admin-only and uncached

The existing decision-link timestamp remains visible below the buttons, with the new automatic SMS panel directly alongside it.