### PR TITLE
Ensure admin email replies stay in SIXFL threads

### DIFF
--- a/src/app/(admin)/admin/messages/email-reply-actions.ts
+++ b/src/app/(admin)/admin/messages/email-reply-actions.ts
@@ -7,6 +7,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
+import { buildThreadReplyAddress } from "@/lib/email/reply-address";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { getMessageThreadById } from "@/lib/messaging/service";
@@ -170,7 +171,16 @@ export async function sendAdminEmailReplyAction(formData: FormData) {
   try {
     const now = new Date();
     const subject = getReplySubject(thread);
-    const replyTo = thread.replyAddress?.trim() || "hello@sixfl.co.uk";
+    let replyTo = thread.replyAddress?.trim() || null;
+
+    if (!replyTo) {
+      replyTo = buildThreadReplyAddress(thread.id);
+      await prisma.messageThread.update({
+        where: { id: thread.id },
+        data: { replyAddress: replyTo },
+      });
+    }
+
     const html = buildManualReplyHtml({
       body,
       teamName: thread.team?.name ?? thread.contactName ?? null,


### PR DESCRIPTION
## What changed

- removes the `hello@sixfl.co.uk` fallback from Admin Messages email replies
- if an older email thread does not yet have a reply address, creates the normal `thread-<id>@...` SIXFL reply address and saves it to the thread before sending
- if the configured reply domain is unavailable, the send fails visibly instead of silently routing customer replies to the ordinary mailbox

## Why

Captain support threads can be created without a `replyAddress`. A manual admin reply from Messages was therefore able to fall back to `hello@sixfl.co.uk`, which meant the captain's reply went to Outlook rather than back into the SIXFL conversation.

## Scope

One server action only. No schema or migration changes.