### PR TITLE
Allow SIXFL TV full-match-only publishing

### DIFF
--- a/src/app/(admin)/admin/sixfl-tv/page.tsx
+++ b/src/app/(admin)/admin/sixfl-tv/page.tsx
@@ -6,6 +6,11 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { queueSixflTvFixtureUploadedEmailsOnce } from "@/lib/sixfl-tv/notifications";
+import {
+  buildSixflTvVideoValue,
+  getSixflTvVideos,
+  parseSixflTvVideoValue,
+} from "@/lib/sixfl-tv/videos";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -31,53 +36,6 @@ function formatKickoff(value: Date) {
     minute: "2-digit",
     timeZone: "Europe/London",
   }).format(value);
-}
-
-function normaliseVideoUrl(value: string) {
-  const raw = value.trim();
-  if (!raw) return null;
-
-  try {
-    const parsed = new URL(raw);
-    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
-
-function parseVideoLinks(value: unknown) {
-  const raw = String(value ?? "").trim();
-  if (!raw) return { ok: true as const, value: null, count: 0, links: [] as string[] };
-
-  const parts = raw
-    .split(/[\n,]+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  const normalised: string[] = [];
-  for (const part of parts) {
-    const url = normaliseVideoUrl(part);
-    if (!url) return { ok: false as const, value: null, count: 0, links: [] as string[] };
-    if (!normalised.includes(url)) normalised.push(url);
-  }
-
-  return {
-    ok: true as const,
-    value: normalised.length ? normalised.join("\n") : null,
-    count: normalised.length,
-    links: normalised,
-  };
-}
-
-function getSavedLinks(value: string | null) {
-  return parseVideoLinks(value).links;
-}
-
-function getVideoLinkLabel(index: number) {
-  if (index === 0) return "Open match highlights";
-  if (index === 1) return "Open full match";
-  return `Open extra clip ${index - 1}`;
 }
 
 async function getSixflTvFixtures() {
@@ -109,7 +67,9 @@ async function saveSixflTvFixtureAction(formData: FormData) {
   await requireAdmin();
 
   const fixtureId = String(formData.get("fixtureId") ?? "").trim();
-  const rawUrl = String(formData.get("sixflTvUrl") ?? "").trim();
+  const highlights = String(formData.get("highlightsUrl") ?? "");
+  const fullMatch = String(formData.get("fullMatchUrl") ?? "");
+  const extras = String(formData.get("extraUrls") ?? "");
   const markedRecorded = formData.get("sixflTvRecorded") === "on";
   const action = String(formData.get("action") ?? "save");
 
@@ -125,7 +85,7 @@ async function saveSixflTvFixtureAction(formData: FormData) {
       WHERE "id" = ${fixtureId}
     `);
   } else {
-    const parsed = parseVideoLinks(rawUrl);
+    const parsed = buildSixflTvVideoValue({ highlights, fullMatch, extras });
 
     if (!parsed.ok) {
       redirect("/admin/sixfl-tv?error=invalid-url");
@@ -163,7 +123,10 @@ export default async function AdminSixflTvPage({
 
   const sp = (await searchParams) ?? {};
   const fixtures = await getSixflTvFixtures();
-  const totalLinks = fixtures.reduce((sum, fixture) => sum + getSavedLinks(fixture.sixflTvUrl).length, 0);
+  const totalLinks = fixtures.reduce(
+    (sum, fixture) => sum + getSixflTvVideos(fixture.sixflTvUrl).length,
+    0,
+  );
 
   return (
     <div className="space-y-6">
@@ -173,7 +136,7 @@ export default async function AdminSixflTvPage({
         </p>
         <h1 className="mt-2 text-3xl font-black text-white">Recorded fixture dashboard</h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-fuchsia-50/75">
-          View, edit, open, or remove SIXFL TV/Veo links. Use one line per clip: line 1 is Match Highlights, line 2 is Full Match, and line 3 onwards are extra clips.
+          Add match highlights, a full match, or both. Either field can be left blank, so a match can be published as full-match-only when no highlights are available. Extra clips are optional.
         </p>
         <div className="mt-5 flex flex-wrap gap-3">
           <Link
@@ -193,7 +156,7 @@ export default async function AdminSixflTvPage({
 
       {sp.error === "invalid-url" ? (
         <div className="rounded-2xl border border-red-400/20 bg-red-500/10 px-5 py-4 text-sm text-red-100">
-          Enter valid http or https video links, one per line.
+          Enter valid http or https video links. Highlights and full match are separate optional fields; enter extra clips one per line.
         </div>
       ) : null}
 
@@ -213,12 +176,11 @@ export default async function AdminSixflTvPage({
           ) : (
             fixtures.map((fixture) => {
               const fixtureLabel = `${fixture.homeTeamName} vs ${fixture.awayTeamName}`;
-              const context = [
-                fixture.leagueName,
-                fixture.leagueSeason,
-                fixture.venueName,
-              ].filter(Boolean).join(" · ");
-              const links = getSavedLinks(fixture.sixflTvUrl);
+              const context = [fixture.leagueName, fixture.leagueSeason, fixture.venueName]
+                .filter(Boolean)
+                .join(" · ");
+              const saved = parseSixflTvVideoValue(fixture.sixflTvUrl);
+              const videos = getSixflTvVideos(fixture.sixflTvUrl);
 
               return (
                 <div key={fixture.id} className="px-6 py-5">
@@ -227,31 +189,33 @@ export default async function AdminSixflTvPage({
                       <div className="flex flex-wrap items-center gap-2">
                         <h3 className="text-lg font-semibold text-white">{fixtureLabel}</h3>
                         <span className="rounded-full border border-fuchsia-400/30 bg-fuchsia-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-fuchsia-100">
-                          {links.length} video{links.length === 1 ? "" : "s"}
+                          {videos.length} video{videos.length === 1 ? "" : "s"}
                         </span>
                       </div>
                       <p className="mt-1 text-sm text-white/55">{formatKickoff(fixture.kickoffAt)}</p>
                       <p className="mt-1 text-sm text-white/45">{context}</p>
-                      {links.length > 0 ? (
+                      {videos.length > 0 ? (
                         <div className="mt-3 flex flex-wrap gap-2">
-                          {links.map((link, index) => (
+                          {videos.map((video) => (
                             <a
-                              key={`${fixture.id}-${link}`}
-                              href={link}
+                              key={`${fixture.id}-${video.kind}-${video.url}`}
+                              href={video.url}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="inline-flex rounded-xl border border-fuchsia-300/30 bg-fuchsia-400/15 px-3 py-1.5 text-xs font-semibold text-fuchsia-50 transition hover:bg-fuchsia-400/20"
                             >
-                              {getVideoLinkLabel(index)}
+                              Open {video.label.toLowerCase()}
                             </a>
                           ))}
                         </div>
                       ) : (
-                        <p className="mt-3 text-sm text-amber-100/80">Marked as recorded, but no video link has been saved.</p>
+                        <p className="mt-3 text-sm text-amber-100/80">
+                          Marked as recorded, but no video link has been saved.
+                        </p>
                       )}
                     </div>
 
-                    <form action={saveSixflTvFixtureAction} className="w-full max-w-xl space-y-3 rounded-2xl border border-white/10 bg-black/20 p-4">
+                    <form action={saveSixflTvFixtureAction} className="w-full max-w-xl space-y-4 rounded-2xl border border-white/10 bg-black/20 p-4">
                       <input type="hidden" name="fixtureId" value={fixture.id} />
                       <label className="flex items-center justify-between gap-3 text-sm font-semibold text-white/80">
                         <span>Show as SIXFL TV recorded</span>
@@ -262,17 +226,45 @@ export default async function AdminSixflTvPage({
                           className="h-4 w-4 accent-fuchsia-500"
                         />
                       </label>
+
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <label className="block space-y-1.5 text-sm font-semibold text-white/80">
+                          <span>Match highlights <span className="font-normal text-white/40">(optional)</span></span>
+                          <input
+                            type="url"
+                            name="highlightsUrl"
+                            defaultValue={saved.highlights ?? ""}
+                            placeholder="Highlights link"
+                            className="w-full rounded-xl border border-white/10 bg-black/35 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-fuchsia-300/50"
+                          />
+                        </label>
+                        <label className="block space-y-1.5 text-sm font-semibold text-white/80">
+                          <span>Full match <span className="font-normal text-white/40">(optional)</span></span>
+                          <input
+                            type="url"
+                            name="fullMatchUrl"
+                            defaultValue={saved.fullMatch ?? ""}
+                            placeholder="Full match link"
+                            className="w-full rounded-xl border border-white/10 bg-black/35 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-fuchsia-300/50"
+                          />
+                        </label>
+                      </div>
+
                       <label className="block space-y-1.5 text-sm font-semibold text-white/80">
-                        <span>Veo / video links</span>
+                        <span>Extra clips <span className="font-normal text-white/40">(optional, one per line)</span></span>
                         <textarea
-                          name="sixflTvUrl"
-                          rows={4}
-                          defaultValue={fixture.sixflTvUrl ?? ""}
-                          placeholder="Line 1 highlights, line 2 full match, line 3+ extra clips…"
-                          className="min-h-[6.5rem] w-full resize-y rounded-xl border border-white/10 bg-black/35 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-fuchsia-300/50"
+                          name="extraUrls"
+                          rows={3}
+                          defaultValue={saved.extras.join("\n")}
+                          placeholder="Extra clip links, one per line…"
+                          className="min-h-[5rem] w-full resize-y rounded-xl border border-white/10 bg-black/35 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-fuchsia-300/50"
                         />
                       </label>
-                      <p className="text-xs leading-5 text-white/45">Line 1 = Match Highlights. Line 2 = Full Match. Line 3 onwards = extra clips.</p>
+
+                      <p className="rounded-xl border border-fuchsia-400/15 bg-fuchsia-500/[0.07] px-3 py-2 text-xs leading-5 text-fuchsia-50/70">
+                        Highlights-only, full-match-only, or both are all valid. Leave whichever one you do not have blank.
+                      </p>
+
                       <div className="flex flex-wrap gap-2">
                         <button
                           type="submit"

--- a/src/app/api/admin/fixtures/sixfl-tv/route.ts
+++ b/src/app/api/admin/fixtures/sixfl-tv/route.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { queueSixflTvFixtureUploadedEmailsOnce } from "@/lib/sixfl-tv/notifications";
+import { normaliseExistingSixflTvVideoValue } from "@/lib/sixfl-tv/videos";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -13,44 +14,6 @@ type FlagRow = {
   sixflTvRecorded: boolean;
   sixflTvUrl: string | null;
 };
-
-function normaliseVideoUrl(value: string) {
-  const raw = value.trim();
-  if (!raw) return null;
-
-  try {
-    const parsed = new URL(raw);
-    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
-    return parsed.toString();
-  } catch {
-    return null;
-  }
-}
-
-function parseVideoLinks(value: unknown) {
-  const raw = String(value ?? "").trim();
-  if (!raw) return { ok: true as const, value: null, count: 0 };
-
-  const parts = raw
-    .split(/[\n,]+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  const normalised: string[] = [];
-  for (const part of parts) {
-    const url = normaliseVideoUrl(part);
-    if (!url) {
-      return { ok: false as const, value: null, count: 0 };
-    }
-    if (!normalised.includes(url)) normalised.push(url);
-  }
-
-  return {
-    ok: true as const,
-    value: normalised.length ? normalised.join("\n") : null,
-    count: normalised.length,
-  };
-}
 
 export async function GET() {
   await requireAdmin();
@@ -86,17 +49,22 @@ export async function POST(request: Request) {
   }
 
   const suppliedUrl = typeof body?.sixflTvUrl === "string" ? body.sixflTvUrl : undefined;
-  const parsedLinks = suppliedUrl === undefined ? undefined : parseVideoLinks(suppliedUrl);
+  const parsedLinks =
+    suppliedUrl === undefined ? undefined : normaliseExistingSixflTvVideoValue(suppliedUrl);
 
   if (parsedLinks && !parsedLinks.ok) {
-    return NextResponse.json({ error: "Enter valid http or https video links, one per line." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Enter valid http or https video links." },
+      { status: 400 },
+    );
   }
 
   const storedLinks = parsedLinks?.value;
   const sixflTvRecorded = body?.sixflTvRecorded ?? Boolean(storedLinks);
-  const urlSql = parsedLinks === undefined
-    ? Prisma.empty
-    : Prisma.sql`, "sixflTvUrl" = ${storedLinks}`;
+  const urlSql =
+    parsedLinks === undefined
+      ? Prisma.empty
+      : Prisma.sql`, "sixflTvUrl" = ${storedLinks}`;
 
   const rows = await prisma.$queryRaw<FlagRow[]>(Prisma.sql`
     UPDATE "Fixture"

--- a/src/app/captain/team/[teamid]/tv/page.tsx
+++ b/src/app/captain/team/[teamid]/tv/page.tsx
@@ -9,6 +9,7 @@ import SixflTvFixtureMatchup from "@/components/sixfl-tv/SixflTvFixtureMatchup";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
 import { prisma } from "@/lib/prisma";
 import { requireCaptain } from "@/lib/requireCaptain";
+import { getSixflTvVideos } from "@/lib/sixfl-tv/videos";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -40,19 +41,6 @@ function formatDateTime(value: Date) {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function getVideoUrls(value: string | null | undefined) {
-  return (value ?? "")
-    .split(/\n+/)
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-function getVideoLabel(index: number) {
-  if (index === 0) return "Match highlights ▶";
-  if (index === 1) return "Full match ▶";
-  return `Extra clip ${index - 1} ▶`;
 }
 
 function getOpponent(row: TvFixtureRow, teamId: string) {
@@ -106,7 +94,7 @@ export default async function CaptainSixflTvPage({
   `);
 
   const totalVideos = fixtures.reduce(
-    (sum, fixture) => sum + getVideoUrls(fixture.sixflTvUrl).length,
+    (sum, fixture) => sum + getSixflTvVideos(fixture.sixflTvUrl).length,
     0,
   );
 
@@ -151,7 +139,7 @@ export default async function CaptainSixflTvPage({
             </div>
           ) : (
             fixtures.map((fixture) => {
-              const urls = getVideoUrls(fixture.sixflTvUrl);
+              const videos = getSixflTvVideos(fixture.sixflTvUrl);
               const accessibleTitle =
                 fixture.homeScore !== null && fixture.awayScore !== null
                   ? `${fixture.homeTeamName} ${fixture.homeScore}-${fixture.awayScore} ${fixture.awayTeamName}`
@@ -163,22 +151,14 @@ export default async function CaptainSixflTvPage({
                     <div className="min-w-0 flex-1">
                       <h3 className="sr-only">{accessibleTitle}</h3>
                       <SixflTvFixtureMatchup
-                        homeTeam={{
-                          name: fixture.homeTeamName,
-                          logoUrl: fixture.homeTeamLogoUrl,
-                        }}
-                        awayTeam={{
-                          name: fixture.awayTeamName,
-                          logoUrl: fixture.awayTeamLogoUrl,
-                        }}
+                        homeTeam={{ name: fixture.homeTeamName, logoUrl: fixture.homeTeamLogoUrl }}
+                        awayTeam={{ name: fixture.awayTeamName, logoUrl: fixture.awayTeamLogoUrl }}
                         homeScore={fixture.homeScore}
                         awayScore={fixture.awayScore}
                       />
 
                       <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
-                        <span className="text-white/60">
-                          Opponent: {getOpponent(fixture, team.id)}
-                        </span>
+                        <span className="text-white/60">Opponent: {getOpponent(fixture, team.id)}</span>
                         <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.12em] text-white/55">
                           {fixture.status.toLowerCase()}
                         </span>
@@ -189,15 +169,15 @@ export default async function CaptainSixflTvPage({
                     </div>
 
                     <div className="flex shrink-0 flex-wrap gap-2 lg:justify-end">
-                      {urls.map((url, index) => (
+                      {videos.map((video) => (
                         <a
-                          key={`${fixture.id}-${url}`}
-                          href={url}
+                          key={`${fixture.id}-${video.kind}-${video.url}`}
+                          href={video.url}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="inline-flex items-center justify-center rounded-full border border-fuchsia-300/35 bg-fuchsia-500/15 px-5 py-3 text-sm font-semibold text-fuchsia-50 transition hover:bg-fuchsia-500/25"
                         >
-                          {getVideoLabel(index)}
+                          {video.label} ▶
                         </a>
                       ))}
                     </div>

--- a/src/components/SixflTvFixtureBridge.tsx
+++ b/src/components/SixflTvFixtureBridge.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 
+import { getSixflTvVideos } from "@/lib/sixfl-tv/videos";
+
 type AdminTvFixture = {
   id: string;
   sixflTvRecorded: boolean;
@@ -21,10 +23,7 @@ function normalise(value: string | null | undefined) {
 }
 
 function getVideoUrls(value: string | null | undefined) {
-  return (value ?? "")
-    .split(/\n+/)
-    .map((item) => item.trim())
-    .filter(Boolean);
+  return getSixflTvVideos(value).map((video) => video.url);
 }
 
 async function loadAdminFixtures() {
@@ -103,13 +102,13 @@ function injectNightBoardControls(fixtures: Map<string, AdminTvFixture>) {
 
     const urlInput = document.createElement("textarea");
     urlInput.rows = 3;
-    urlInput.placeholder = "Paste one Veo/YouTube link per line…";
+    urlInput.placeholder = "Line 1 highlights, line 2 full match…";
     urlInput.value = savedFixture?.sixflTvUrl ?? "";
     urlInput.className = "min-h-[5.5rem] w-full resize-y rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-xs text-white outline-none placeholder:text-white/35 focus:border-fuchsia-300/60";
 
     const helper = document.createElement("div");
     helper.className = "text-[10px] leading-4 text-fuchsia-100/55";
-    helper.textContent = "Line 1 = match highlights. Line 2 = full match. Line 3+ = extra clips.";
+    helper.textContent = "Line 1 = match highlights. Line 2 = full match. Leave line 1 blank for full-match-only. Line 3+ = extra clips.";
 
     const actions = document.createElement("div");
     actions.className = "flex flex-wrap gap-2";
@@ -128,7 +127,7 @@ function injectNightBoardControls(fixtures: Map<string, AdminTvFixture>) {
     openLink.target = "_blank";
     openLink.rel = "noopener noreferrer";
     openLink.className = "rounded-lg border border-white/10 bg-black/20 px-3 py-1.5 text-[11px] font-semibold text-white/75 transition hover:bg-black/30";
-    openLink.textContent = "Open highlights";
+    openLink.textContent = "Open first video";
 
     function refreshStatus() {
       const urls = getVideoUrls(urlInput.value);
@@ -162,7 +161,7 @@ function injectNightBoardControls(fixtures: Map<string, AdminTvFixture>) {
       const ok = await saveAdminFixture({
         fixtureId,
         sixflTvRecorded: checkbox.checked || urls.length > 0,
-        sixflTvUrl: urls.join("\n"),
+        sixflTvUrl: urlInput.value,
       });
 
       setDisabled(false);

--- a/src/components/sixfl-tv/SixflTvFixtureBadge.tsx
+++ b/src/components/sixfl-tv/SixflTvFixtureBadge.tsx
@@ -1,11 +1,6 @@
 import Link from "next/link";
 
-function getFirstUrl(value: string | null | undefined) {
-  return (value ?? "")
-    .split(/\n+/)
-    .map((item) => item.trim())
-    .find(Boolean) ?? null;
-}
+import { getFirstSixflTvUrl } from "@/lib/sixfl-tv/videos";
 
 export default function SixflTvFixtureBadge({
   recorded,
@@ -14,7 +9,7 @@ export default function SixflTvFixtureBadge({
   recorded: boolean;
   url?: string | null;
 }) {
-  const firstUrl = getFirstUrl(url);
+  const firstUrl = getFirstSixflTvUrl(url);
   if (!recorded && !firstUrl) return null;
 
   const className =

--- a/src/lib/sixfl-tv/notifications.ts
+++ b/src/lib/sixfl-tv/notifications.ts
@@ -9,6 +9,7 @@ import { formatDateTimeInLondon } from "@/lib/datetime/london";
 import { queueDirectNotification } from "@/lib/notifications/service";
 import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
 import { prisma } from "@/lib/prisma";
+import { getSixflTvVideos } from "@/lib/sixfl-tv/videos";
 import { getPublicSiteUrl } from "@/lib/stripe/client";
 
 const SIXFL_TV_UPLOAD_SOURCE_TYPE = "FIXTURE_SIXFL_TV_UPLOAD";
@@ -29,13 +30,6 @@ type SixflTvFixtureEmailRow = {
   awayScore: number | null;
 };
 
-function getVideoUrls(value: string | null | undefined) {
-  return (value ?? "")
-    .split(/\n+/)
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
 function formatFixtureDate(value: Date) {
   return formatDateTimeInLondon(value, {
     weekday: "short",
@@ -51,7 +45,6 @@ function getFixtureTitle(fixture: SixflTvFixtureEmailRow) {
   if (fixture.homeScore !== null && fixture.awayScore !== null) {
     return `${fixture.homeTeamName} ${fixture.homeScore}-${fixture.awayScore} ${fixture.awayTeamName}`;
   }
-
   return `${fixture.homeTeamName} vs ${fixture.awayTeamName}`;
 }
 
@@ -59,10 +52,10 @@ function getCaptainTvUrl(teamId: string) {
   return new URL(`/captain/team/${teamId}/tv`, `${getPublicSiteUrl()}/`).toString();
 }
 
-function getVideoSummary(videoCount: number) {
-  if (videoCount <= 1) return "match highlights";
-  if (videoCount === 2) return "match highlights and the full match";
-  return `match highlights, the full match and ${videoCount - 2} extra clip${videoCount - 2 === 1 ? "" : "s"}`;
+function joinVideoLabels(labels: string[]) {
+  if (labels.length === 1) return labels[0].toLowerCase();
+  if (labels.length === 2) return `${labels[0].toLowerCase()} and ${labels[1].toLowerCase()}`;
+  return `${labels.slice(0, -1).map((label) => label.toLowerCase()).join(", ")} and ${labels.at(-1)?.toLowerCase()}`;
 }
 
 async function getFixtureEmailRow(fixtureId: string) {
@@ -90,7 +83,6 @@ async function getFixtureEmailRow(fixtureId: string) {
     WHERE f."id" = ${fixtureId}
     LIMIT 1
   `);
-
   return rows[0] ?? null;
 }
 
@@ -101,16 +93,13 @@ export async function queueSixflTvFixtureUploadedEmailsOnce(fixtureId: string) {
     return { queued: 0, skipped: true, reason: "fixture_not_published" };
   }
 
-  const videoUrls = getVideoUrls(fixture.sixflTvUrl);
-  if (videoUrls.length === 0) {
+  const videos = getSixflTvVideos(fixture.sixflTvUrl);
+  if (videos.length === 0) {
     return { queued: 0, skipped: true, reason: "no_video_links" };
   }
 
   const existing = await prisma.notificationDispatch.findFirst({
-    where: {
-      sourceType: SIXFL_TV_UPLOAD_SOURCE_TYPE,
-      sourceId: fixture.id,
-    },
+    where: { sourceType: SIXFL_TV_UPLOAD_SOURCE_TYPE, sourceId: fixture.id },
     select: { id: true },
   });
 
@@ -122,7 +111,7 @@ export async function queueSixflTvFixtureUploadedEmailsOnce(fixtureId: string) {
   const leagueLabel = [fixture.leagueName, fixture.leagueSeason].filter(Boolean).join(" · ");
   const fixtureDate = formatFixtureDate(fixture.kickoffAt);
   const venueLabel = fixture.venueName ?? "Venue TBC";
-  const videoSummary = getVideoSummary(videoUrls.length);
+  const videoSummary = joinVideoLabels(videos.map((video) => video.label));
   const teams = [
     { id: fixture.homeTeamId, name: fixture.homeTeamName },
     { id: fixture.awayTeamId, name: fixture.awayTeamName },
@@ -140,11 +129,8 @@ export async function queueSixflTvFixtureUploadedEmailsOnce(fixtureId: string) {
       audience: NotificationAudience.TEAM,
       isTransactional: true,
       subject: `SIXFL TV is ready: ${fixtureTitle}`,
-      body: `${SIXFL_TV_EMAIL_BRAND_MARKER}\n\nHi ${team.name},\n\nYour SIXFL TV ${videoSummary} for **${fixtureTitle}** is now available.\n\nMatch: **${fixtureTitle}**\nDate: ${fixtureDate}\nVenue: ${venueLabel}\nLeague: ${leagueLabel}\n\nOpen your SIXFL TV tab to watch the match highlights and any full-match/extra clip links.\n\n{{cta}}`,
-      emailCta: {
-        label: "Watch on SIXFL TV",
-        url: captainTvUrl,
-      },
+      body: `${SIXFL_TV_EMAIL_BRAND_MARKER}\n\nHi ${team.name},\n\nYour SIXFL TV ${videoSummary} for **${fixtureTitle}** is now available.\n\nMatch: **${fixtureTitle}**\nDate: ${fixtureDate}\nVenue: ${venueLabel}\nLeague: ${leagueLabel}\n\nOpen your SIXFL TV tab to watch the available videos.\n\n{{cta}}`,
+      emailCta: { label: "Watch on SIXFL TV", url: captainTvUrl },
       sourceType: SIXFL_TV_UPLOAD_SOURCE_TYPE,
       sourceId: fixture.id,
       metadata: {
@@ -152,10 +138,8 @@ export async function queueSixflTvFixtureUploadedEmailsOnce(fixtureId: string) {
         fixtureId: fixture.id,
         teamId: team.id,
         teamName: team.name,
-        videoCount: videoUrls.length,
-        videoLabels: videoUrls.map((_, index) =>
-          index === 0 ? "Match highlights" : index === 1 ? "Full match" : `Extra clip ${index - 1}`,
-        ),
+        videoCount: videos.length,
+        videoLabels: videos.map((video) => video.label),
       } satisfies Prisma.InputJsonValue,
     });
 

--- a/src/lib/sixfl-tv/videos.ts
+++ b/src/lib/sixfl-tv/videos.ts
@@ -48,8 +48,6 @@ export function parseSixflTvVideoValue(value: string | null | undefined): SixflT
   const trimmed = original.trim();
   if (!trimmed) return emptySixflTvVideoSet();
 
-  // Read the short-lived structured format too, so this remains safe if any
-  // value was saved while the richer editor was being developed.
   if (trimmed.startsWith("{")) {
     try {
       const parsed = JSON.parse(trimmed) as StoredVideoSetV2;
@@ -66,8 +64,8 @@ export function parseSixflTvVideoValue(value: string | null | undefined): SixflT
     }
   }
 
-  // Line positions are meaningful. In particular a leading blank line means
-  // there are no highlights and line 2 is a full-match-only video.
+  // Line positions are meaningful. A leading blank line means there are no
+  // highlights and line 2 is a full-match-only video.
   const rawLines = original.includes("\n")
     ? original.replace(/\r/g, "").split("\n")
     : original.split(",");
@@ -131,15 +129,25 @@ export function buildSixflTvVideoValue(input: {
   const storedValue = slots.join("\n");
   const videos = getSixflTvVideos(storedValue);
 
-  return {
-    ok: true as const,
-    value: storedValue,
-    count: videos.length,
-    videos,
-  };
+  return { ok: true as const, value: storedValue, count: videos.length, videos };
 }
 
 export function normaliseExistingSixflTvVideoValue(value: string | null | undefined) {
-  const parsed = parseSixflTvVideoValue(value);
-  return buildSixflTvVideoValue(parsed);
+  const original = value ?? "";
+  if (!original.trim()) return buildSixflTvVideoValue({});
+
+  const trimmed = original.trim();
+  if (!trimmed.startsWith("{")) {
+    const rawParts = original.includes("\n")
+      ? original.replace(/\r/g, "").split("\n")
+      : original.split(",");
+    const invalid = rawParts
+      .filter((part) => part.trim())
+      .some((part) => !normaliseSixflTvUrl(part));
+    if (invalid) {
+      return { ok: false as const, value: null, count: 0, videos: [] as SixflTvVideo[] };
+    }
+  }
+
+  return buildSixflTvVideoValue(parseSixflTvVideoValue(original));
 }

--- a/src/lib/sixfl-tv/videos.ts
+++ b/src/lib/sixfl-tv/videos.ts
@@ -1,0 +1,129 @@
+export type SixflTvVideoSet = {
+  highlights: string | null;
+  fullMatch: string | null;
+  extras: string[];
+};
+
+export type SixflTvVideo = {
+  kind: "HIGHLIGHTS" | "FULL_MATCH" | "EXTRA";
+  url: string;
+  label: string;
+};
+
+type StoredVideoSetV2 = {
+  v: 2;
+  highlights?: string | null;
+  fullMatch?: string | null;
+  extras?: string[];
+};
+
+export function normaliseSixflTvUrl(value: string | null | undefined) {
+  const raw = value?.trim();
+  if (!raw) return null;
+
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function unique(values: Array<string | null | undefined>) {
+  const result: string[] = [];
+  for (const value of values) {
+    const normalised = normaliseSixflTvUrl(value);
+    if (normalised && !result.includes(normalised)) result.push(normalised);
+  }
+  return result;
+}
+
+export function emptySixflTvVideoSet(): SixflTvVideoSet {
+  return { highlights: null, fullMatch: null, extras: [] };
+}
+
+export function parseSixflTvVideoValue(value: string | null | undefined): SixflTvVideoSet {
+  const raw = value?.trim();
+  if (!raw) return emptySixflTvVideoSet();
+
+  if (raw.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(raw) as StoredVideoSetV2;
+      if (parsed?.v === 2) {
+        const highlights = normaliseSixflTvUrl(parsed.highlights);
+        const fullMatch = normaliseSixflTvUrl(parsed.fullMatch);
+        const extras = unique(Array.isArray(parsed.extras) ? parsed.extras : []).filter(
+          (url) => url !== highlights && url !== fullMatch,
+        );
+        return { highlights, fullMatch, extras };
+      }
+    } catch {
+      // Fall through to the legacy newline format.
+    }
+  }
+
+  const legacy = unique(raw.split(/[\n,]+/));
+  return {
+    highlights: legacy[0] ?? null,
+    fullMatch: legacy[1] ?? null,
+    extras: legacy.slice(2),
+  };
+}
+
+export function getSixflTvVideos(value: string | null | undefined): SixflTvVideo[] {
+  const parsed = parseSixflTvVideoValue(value);
+  const videos: SixflTvVideo[] = [];
+
+  if (parsed.highlights) {
+    videos.push({ kind: "HIGHLIGHTS", url: parsed.highlights, label: "Match highlights" });
+  }
+  if (parsed.fullMatch) {
+    videos.push({ kind: "FULL_MATCH", url: parsed.fullMatch, label: "Full match" });
+  }
+  parsed.extras.forEach((url, index) => {
+    videos.push({ kind: "EXTRA", url, label: `Extra clip ${index + 1}` });
+  });
+
+  return videos;
+}
+
+export function getFirstSixflTvUrl(value: string | null | undefined) {
+  return getSixflTvVideos(value)[0]?.url ?? null;
+}
+
+export function buildSixflTvVideoValue(input: {
+  highlights?: string | null;
+  fullMatch?: string | null;
+  extras?: string | string[] | null;
+}) {
+  const rawExtras = Array.isArray(input.extras)
+    ? input.extras
+    : String(input.extras ?? "").split(/[\n,]+/);
+
+  const supplied = [input.highlights, input.fullMatch, ...rawExtras].filter(
+    (value): value is string => Boolean(value?.trim()),
+  );
+  const invalid = supplied.find((value) => !normaliseSixflTvUrl(value));
+  if (invalid) {
+    return { ok: false as const, value: null, count: 0, videos: [] as SixflTvVideo[] };
+  }
+
+  const highlights = normaliseSixflTvUrl(input.highlights);
+  const fullMatch = normaliseSixflTvUrl(input.fullMatch);
+  const extras = unique(rawExtras).filter((url) => url !== highlights && url !== fullMatch);
+  const videos = getSixflTvVideos(
+    JSON.stringify({ v: 2, highlights, fullMatch, extras } satisfies StoredVideoSetV2),
+  );
+
+  if (videos.length === 0) {
+    return { ok: true as const, value: null, count: 0, videos };
+  }
+
+  return {
+    ok: true as const,
+    value: JSON.stringify({ v: 2, highlights, fullMatch, extras } satisfies StoredVideoSetV2),
+    count: videos.length,
+    videos,
+  };
+}

--- a/src/lib/sixfl-tv/videos.ts
+++ b/src/lib/sixfl-tv/videos.ts
@@ -44,12 +44,15 @@ export function emptySixflTvVideoSet(): SixflTvVideoSet {
 }
 
 export function parseSixflTvVideoValue(value: string | null | undefined): SixflTvVideoSet {
-  const raw = value?.trim();
-  if (!raw) return emptySixflTvVideoSet();
+  const original = value ?? "";
+  const trimmed = original.trim();
+  if (!trimmed) return emptySixflTvVideoSet();
 
-  if (raw.startsWith("{")) {
+  // Read the short-lived structured format too, so this remains safe if any
+  // value was saved while the richer editor was being developed.
+  if (trimmed.startsWith("{")) {
     try {
-      const parsed = JSON.parse(raw) as StoredVideoSetV2;
+      const parsed = JSON.parse(trimmed) as StoredVideoSetV2;
       if (parsed?.v === 2) {
         const highlights = normaliseSixflTvUrl(parsed.highlights);
         const fullMatch = normaliseSixflTvUrl(parsed.fullMatch);
@@ -59,16 +62,23 @@ export function parseSixflTvVideoValue(value: string | null | undefined): SixflT
         return { highlights, fullMatch, extras };
       }
     } catch {
-      // Fall through to the legacy newline format.
+      // Fall through to the line-based format.
     }
   }
 
-  const legacy = unique(raw.split(/[\n,]+/));
-  return {
-    highlights: legacy[0] ?? null,
-    fullMatch: legacy[1] ?? null,
-    extras: legacy.slice(2),
-  };
+  // Line positions are meaningful. In particular a leading blank line means
+  // there are no highlights and line 2 is a full-match-only video.
+  const rawLines = original.includes("\n")
+    ? original.replace(/\r/g, "").split("\n")
+    : original.split(",");
+  const lines = rawLines.map((line) => normaliseSixflTvUrl(line));
+  const highlights = lines[0] ?? null;
+  const fullMatch = lines[1] ?? null;
+  const extras = unique(rawLines.slice(2)).filter(
+    (url) => url !== highlights && url !== fullMatch,
+  );
+
+  return { highlights, fullMatch, extras };
 }
 
 export function getSixflTvVideos(value: string | null | undefined): SixflTvVideo[] {
@@ -104,26 +114,32 @@ export function buildSixflTvVideoValue(input: {
   const supplied = [input.highlights, input.fullMatch, ...rawExtras].filter(
     (value): value is string => Boolean(value?.trim()),
   );
-  const invalid = supplied.find((value) => !normaliseSixflTvUrl(value));
-  if (invalid) {
+  if (supplied.some((value) => !normaliseSixflTvUrl(value))) {
     return { ok: false as const, value: null, count: 0, videos: [] as SixflTvVideo[] };
   }
 
   const highlights = normaliseSixflTvUrl(input.highlights);
   const fullMatch = normaliseSixflTvUrl(input.fullMatch);
   const extras = unique(rawExtras).filter((url) => url !== highlights && url !== fullMatch);
-  const videos = getSixflTvVideos(
-    JSON.stringify({ v: 2, highlights, fullMatch, extras } satisfies StoredVideoSetV2),
-  );
 
-  if (videos.length === 0) {
-    return { ok: true as const, value: null, count: 0, videos };
+  if (!highlights && !fullMatch && extras.length === 0) {
+    return { ok: true as const, value: null, count: 0, videos: [] as SixflTvVideo[] };
   }
+
+  const slots = [highlights ?? "", fullMatch ?? "", ...extras];
+  while (slots.length > 0 && !slots[slots.length - 1]) slots.pop();
+  const storedValue = slots.join("\n");
+  const videos = getSixflTvVideos(storedValue);
 
   return {
     ok: true as const,
-    value: JSON.stringify({ v: 2, highlights, fullMatch, extras } satisfies StoredVideoSetV2),
+    value: storedValue,
     count: videos.length,
     videos,
   };
+}
+
+export function normaliseExistingSixflTvVideoValue(value: string | null | undefined) {
+  const parsed = parseSixflTvVideoValue(value);
+  return buildSixflTvVideoValue(parsed);
 }


### PR DESCRIPTION
## What changed

- replaces the positional single textarea on Admin SIXFL TV with separate optional **Match highlights** and **Full match** fields plus optional extra clips
- allows highlights-only, full-match-only, both, or extras
- keeps existing stored one-line/two-line SIXFL TV data backwards compatible
- preserves a missing-highlights slot when a full match is the only video so it is labelled **Full match**, not **Match highlights**
- updates the captain SIXFL TV page, fixture badges and upload notification wording to use the actual available video types
- keeps the existing database fields; no migration is required

## Why

Some Veo recordings have no usable highlight reel (for example, no goals or missed goal detection) but the full match is still available. The old line-1/line-2 format made it impossible to publish only the full match without it being treated as highlights.