### PR TITLE
Add AI Predictor V3 laboratory and promotion gate

### DIFF
--- a/.github/workflows/ai-predictor-v3-laboratory.yml
+++ b/.github/workflows/ai-predictor-v3-laboratory.yml
@@ -1,0 +1,50 @@
+name: AI Predictor V3 laboratory
+
+on:
+  pull_request:
+    paths:
+      - "src/lib/fixtures/predictorV3Candidate.ts"
+      - "src/lib/fixtures/predictorBacktest.ts"
+      - "src/app/(admin)/admin/ai-predictor/backtest/page.tsx"
+      - "scripts/check-ai-predictor-v3-backtest.ts"
+      - ".github/workflows/ai-predictor-v3-laboratory.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/lib/fixtures/predictorV3Candidate.ts"
+      - "src/lib/fixtures/predictorBacktest.ts"
+      - "src/app/(admin)/admin/ai-predictor/backtest/page.tsx"
+      - "scripts/check-ai-predictor-v3-backtest.ts"
+      - ".github/workflows/ai-predictor-v3-laboratory.yml"
+  workflow_dispatch:
+
+jobs:
+  laboratory:
+    name: Keep V3 read-only and measurable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply production source preparation
+        run: npm run prebuild
+
+      - name: Check V3 laboratory contract
+        run: npx tsx scripts/check-ai-predictor-v3-backtest.ts
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Type-check application source
+        run: npx tsc --noEmit

--- a/scripts/check-ai-predictor-v3-backtest.ts
+++ b/scripts/check-ai-predictor-v3-backtest.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import {
+  calculatePredictorV3Candidates,
+  type PredictorV3Prediction,
+} from "../src/lib/fixtures/predictorV3Candidate";
+import {
+  runPredictorBacktest,
+  type PredictorBacktestRow,
+} from "../src/lib/fixtures/predictorBacktest";
+import type { WinChanceFixture } from "../src/lib/fixtures/winChance";
+
+function game(
+  homeTeamId: string,
+  awayTeamId: string,
+  homeScore: number,
+  awayScore: number,
+  day: number,
+): WinChanceFixture {
+  return {
+    kickoffAt: new Date(Date.UTC(2026, 0, day, 20, 0, 0)),
+    status: "COMPLETED",
+    homeTeam: { id: homeTeamId },
+    awayTeam: { id: awayTeamId },
+    result: { homeScore, awayScore },
+  };
+}
+
+function predictionOutcome(prediction: PredictorV3Prediction) {
+  if (prediction.score.home > prediction.score.away) return "HOME";
+  if (prediction.score.away > prediction.score.home) return "AWAY";
+  return "DRAW";
+}
+
+function strongestOutcome(prediction: PredictorV3Prediction) {
+  if (
+    prediction.probabilities.draw >= prediction.probabilities.home &&
+    prediction.probabilities.draw >= prediction.probabilities.away
+  ) {
+    return "DRAW";
+  }
+  return prediction.probabilities.home >= prediction.probabilities.away ? "HOME" : "AWAY";
+}
+
+const currentProbabilities = { home: 0.52, draw: 0.13, away: 0.35 };
+const lowScoringHistory: WinChanceFixture[] = [
+  game("A", "C", 1, 0, 1),
+  game("D", "A", 1, 1, 2),
+  game("B", "C", 0, 1, 3),
+  game("D", "B", 1, 0, 4),
+  game("A", "D", 2, 1, 5),
+  game("C", "B", 0, 0, 6),
+];
+const highScoringHistory: WinChanceFixture[] = [
+  game("A", "C", 8, 5, 1),
+  game("D", "A", 5, 7, 2),
+  game("B", "C", 6, 6, 3),
+  game("D", "B", 7, 5, 4),
+  game("A", "D", 9, 4, 5),
+  game("C", "B", 4, 8, 6),
+];
+
+const lowScoring = calculatePredictorV3Candidates({
+  homeTeamId: "A",
+  awayTeamId: "B",
+  history: lowScoringHistory,
+  currentProbabilities,
+});
+const highScoring = calculatePredictorV3Candidates({
+  homeTeamId: "A",
+  awayTeamId: "B",
+  history: highScoringHistory,
+  currentProbabilities,
+});
+const highScoringRepeat = calculatePredictorV3Candidates({
+  homeTeamId: "A",
+  awayTeamId: "B",
+  history: highScoringHistory,
+  currentProbabilities,
+});
+
+assert.deepEqual(
+  lowScoring.scoreOnly.probabilities,
+  currentProbabilities,
+  "The score-only candidate must preserve the live result probabilities exactly.",
+);
+assert.equal(
+  predictionOutcome(lowScoring.scoreOnly),
+  strongestOutcome(lowScoring.scoreOnly),
+  "The V3 score must agree with its result call.",
+);
+assert.equal(
+  predictionOutcome(highScoring.full),
+  strongestOutcome(highScoring.full),
+  "The full V3 score must agree with its result call.",
+);
+assert.ok(
+  highScoring.scoreOnly.score.home + highScoring.scoreOnly.score.away >
+    lowScoring.scoreOnly.score.home + lowScoring.scoreOnly.score.away,
+  "High- and low-scoring environments must not collapse to the same central score family.",
+);
+assert.notDeepEqual(
+  highScoring.scoreOnly.score,
+  lowScoring.scoreOnly.score,
+  "Different scoring environments must produce different V3 scorelines.",
+);
+assert.deepEqual(
+  highScoring,
+  highScoringRepeat,
+  "The V3 candidate must be deterministic and must not add cosmetic randomness.",
+);
+assert.ok(
+  Math.abs(
+    highScoring.full.probabilities.home +
+      highScoring.full.probabilities.draw +
+      highScoring.full.probabilities.away -
+      1,
+  ) < 1e-9,
+  "V3 outcome probabilities must sum to one.",
+);
+
+const scorePattern = [
+  [6, 2],
+  [2, 5],
+  [4, 4],
+  [7, 3],
+  [5, 1],
+  [2, 6],
+  [3, 2],
+  [1, 4],
+  [8, 5],
+  [0, 2],
+  [5, 5],
+  [6, 3],
+] as const;
+const pairPattern = [
+  ["A", "B"],
+  ["C", "D"],
+  ["A", "C"],
+  ["B", "D"],
+  ["A", "D"],
+  ["B", "C"],
+] as const;
+
+const rows: PredictorBacktestRow[] = Array.from({ length: 36 }, (_, index) => {
+  const pair = pairPattern[index % pairPattern.length];
+  const score = scorePattern[index % scorePattern.length];
+  const kickoffAt = new Date(Date.UTC(2026, 1, index + 1, 20, 0, 0));
+  return {
+    fixtureId: `fixture-${index + 1}`,
+    leagueId: "league-test",
+    leagueName: "Test League",
+    kickoffAt,
+    resultEnteredAt: new Date(kickoffAt.getTime() + 60 * 60 * 1000),
+    homeTeamId: pair[0],
+    homeTeamName: `Team ${pair[0]}`,
+    awayTeamId: pair[1],
+    awayTeamName: `Team ${pair[1]}`,
+    actualHomeScore: score[0],
+    actualAwayScore: score[1],
+  };
+});
+
+const backtest = runPredictorBacktest(rows);
+const current = backtest.methods.find((method) => method.key === "sixfl");
+const v3Score = backtest.methods.find((method) => method.key === "v3-score");
+const v3Full = backtest.methods.find((method) => method.key === "v3-full");
+
+if (!current || !v3Score || !v3Full) {
+  throw new Error("Both V3 candidates must be present in the back-test.");
+}
+assert.equal(v3Score.calls, current.calls);
+assert.equal(
+  v3Score.correct,
+  current.correct,
+  "The score-only candidate must isolate score changes by preserving every current result call.",
+);
+assert.ok(
+  current.brierScore !== null &&
+    v3Score.brierScore !== null &&
+    Math.abs(v3Score.brierScore - current.brierScore) < 1e-12,
+  "The score-only candidate must preserve current probability quality exactly.",
+);
+assert.ok(v3Score.averagePredictedGoals !== null);
+assert.ok(v3Score.averageActualGoals !== null);
+assert.ok(v3Score.distinctScorelines !== null);
+assert.ok(v3Score.topFourScorelineShare !== null);
+assert.ok(v3Score.calibrationError !== null);
+assert.equal(
+  v3Full.calibrationBins.reduce((total, bin) => total + bin.calls, 0),
+  v3Full.calls,
+  "Every probabilistic V3 call must be included in calibration monitoring.",
+);
+assert.equal(
+  Object.values(v3Full.confusionMatrix).reduce(
+    (total, row) => total + Object.values(row).reduce((sum, value) => sum + value, 0),
+    0,
+  ),
+  v3Full.calls,
+  "The V3 confusion matrix must account for every call.",
+);
+assert.deepEqual(
+  backtest.promotionAssessments.map((assessment) => assessment.candidateKey).sort(),
+  ["v3-full", "v3-score"],
+  "Both V3 candidates must be assessed against the live control before promotion.",
+);
+assert.ok(backtest.examples.every((example) => example.v3Score && example.v3Full));
+
+const integritySource = fs.readFileSync("src/lib/fixtures/aiPredictionIntegrity.ts", "utf8");
+const storedPredictionSource = fs.readFileSync(
+  "src/lib/fixtures/storedAiPredictions.ts",
+  "utf8",
+);
+const pageSource = fs.readFileSync(
+  "src/app/(admin)/admin/ai-predictor/backtest/page.tsx",
+  "utf8",
+);
+
+assert.match(integritySource, /opponent-adjusted-poisson-v2/);
+assert.doesNotMatch(
+  storedPredictionSource,
+  /predictorV3Candidate/,
+  "The laboratory candidate must not silently replace live stored predictions.",
+);
+assert.match(pageSource, /Laboratory only:/);
+assert.match(pageSource, /does not rewrite stored predictions/);
+
+console.log("AI Predictor V3 laboratory contract passed.");

--- a/src/app/(admin)/admin/ai-predictor/backtest/page.tsx
+++ b/src/app/(admin)/admin/ai-predictor/backtest/page.tsx
@@ -3,7 +3,9 @@ import { Prisma } from "@prisma/client";
 
 import {
   runPredictorBacktest,
+  type PredictorBacktestMethod,
   type PredictorBacktestRow,
+  type PredictorPromotionCheck,
 } from "@/lib/fixtures/predictorBacktest";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
@@ -24,9 +26,15 @@ const dateTimeFormatter = new Intl.DateTimeFormat("en-GB", {
   minute: "2-digit",
 });
 
-function percentage(value: number | null) {
+const outcomeLabels = {
+  HOME: "Team 1 win",
+  DRAW: "Draw",
+  AWAY: "Team 2 win",
+} as const;
+
+function percentage(value: number | null, digits = 0) {
   if (value === null || !Number.isFinite(value)) return "—";
-  return `${Math.round(value * 100)}%`;
+  return `${(value * 100).toFixed(digits)}%`;
 }
 
 function points(value: number) {
@@ -40,14 +48,162 @@ function accuracyClass(value: number, baseline: number) {
   return "text-red-300";
 }
 
+function decimal(value: number | null, digits = 1) {
+  if (value === null || !Number.isFinite(value)) return "—";
+  return value.toFixed(digits);
+}
+
+function signedDecimal(value: number | null, digits = 1) {
+  if (value === null || !Number.isFinite(value)) return "—";
+  return `${value > 0 ? "+" : ""}${value.toFixed(digits)}`;
+}
+
 function brier(value: number | null) {
   if (value === null) return "—";
   return value.toFixed(3);
 }
 
-function goalError(value: number | null) {
+function promotionMetricValue(check: PredictorPromotionCheck, value: number | null) {
   if (value === null) return "—";
-  return value.toFixed(1);
+  switch (check.key) {
+    case "accuracy":
+    case "top-four-share":
+      return percentage(value, 1);
+    case "brier":
+      return value.toFixed(3);
+    case "calibration":
+      return `${(value * 100).toFixed(1)} pts`;
+    case "goal-error":
+      return value.toFixed(2);
+    case "goal-bias":
+      return signedDecimal(value, 2);
+    case "distinct-scorelines":
+      return Math.round(value).toString();
+  }
+}
+
+function ScorelineCard({ method }: { method: PredictorBacktestMethod }) {
+  return (
+    <div className="rounded-3xl border border-violet-400/20 bg-violet-500/[0.06] p-5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-violet-100/60">
+        {method.label}
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-2xl border border-white/10 bg-black/20 p-3">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-white/35">Most common</div>
+          <div className="mt-2 text-2xl font-black text-emerald-300">
+            {method.mostCommonScoreline ?? "—"}
+          </div>
+          <div className="mt-1 text-xs text-white/45">
+            {method.mostCommonScorelineCount ?? 0} · {percentage(method.mostCommonScorelineShare)}
+          </div>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-black/20 p-3">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-white/35">Different scores</div>
+          <div className="mt-2 text-2xl font-black text-white">
+            {method.distinctScorelines ?? "—"}
+          </div>
+          <div className="mt-1 text-xs text-white/45">
+            Top four: {percentage(method.topFourScorelineShare)}
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white/65">
+        Predicted {decimal(method.averagePredictedGoals)} goals · actual {decimal(method.averageActualGoals)} · bias {signedDecimal(method.goalsBias)}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {method.commonScorelines.map((item) => (
+          <span
+            key={item.scoreline}
+            className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-xs text-white/65"
+          >
+            {item.scoreline} · {item.count}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ConfusionMatrix({ method }: { method: PredictorBacktestMethod }) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.035] p-5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+        {method.label}
+      </div>
+      <div className="mt-4 overflow-x-auto rounded-2xl border border-white/10">
+        <table className="min-w-full text-center text-sm">
+          <thead className="bg-white/[0.04] text-[10px] uppercase tracking-[0.12em] text-white/40">
+            <tr>
+              <th className="px-3 py-3 text-left">Actual ↓ / called →</th>
+              <th className="px-3 py-3">Team 1</th>
+              <th className="px-3 py-3">Draw</th>
+              <th className="px-3 py-3">Team 2</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10">
+            {(["HOME", "DRAW", "AWAY"] as const).map((actual) => (
+              <tr key={actual}>
+                <th className="px-3 py-3 text-left text-xs font-semibold text-white/60">
+                  {outcomeLabels[actual]}
+                </th>
+                {(["HOME", "DRAW", "AWAY"] as const).map((called) => (
+                  <td
+                    key={called}
+                    className={`px-3 py-3 font-semibold ${actual === called ? "text-emerald-300" : "text-white/55"}`}
+                  >
+                    {method.confusionMatrix[actual][called]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function CalibrationCard({ method }: { method: PredictorBacktestMethod }) {
+  return (
+    <div className="rounded-3xl border border-sky-400/20 bg-sky-500/[0.05] p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-100/60">
+            {method.label}
+          </div>
+          <div className="mt-2 text-sm text-white/55">
+            Average confidence {percentage(method.averageConfidence, 1)}
+          </div>
+        </div>
+        <div className="rounded-full border border-sky-300/20 bg-sky-400/10 px-3 py-1 text-xs font-semibold text-sky-100">
+          Calibration error {method.calibrationError === null ? "—" : `${(method.calibrationError * 100).toFixed(1)} pts`}
+        </div>
+      </div>
+      <div className="mt-4 overflow-x-auto rounded-2xl border border-white/10">
+        <table className="min-w-full text-left text-xs">
+          <thead className="bg-white/[0.04] uppercase tracking-[0.12em] text-white/35">
+            <tr>
+              <th className="px-3 py-2.5">Confidence band</th>
+              <th className="px-3 py-2.5">Calls</th>
+              <th className="px-3 py-2.5">Avg confidence</th>
+              <th className="px-3 py-2.5">Actual accuracy</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10">
+            {method.calibrationBins.map((bin) => (
+              <tr key={bin.label}>
+                <td className="px-3 py-2.5 font-semibold text-white/70">{bin.label}</td>
+                <td className="px-3 py-2.5 text-white/55">{bin.calls}</td>
+                <td className="px-3 py-2.5 text-white/55">{percentage(bin.averageConfidence, 1)}</td>
+                <td className="px-3 py-2.5 text-white/55">{percentage(bin.accuracy, 1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 }
 
 export default async function PredictorBacktestPage() {
@@ -79,9 +235,8 @@ export default async function PredictorBacktestPage() {
 
   const backtest = runPredictorBacktest(rows);
   const current = backtest.methods.find((method) => method.key === "sixfl") ?? null;
-  const candidate = backtest.methods.find((method) => method.key === "elo-goals") ?? null;
-  const candidateImprovement =
-    current && candidate ? candidate.accuracy - current.accuracy : null;
+  const v3Score = backtest.methods.find((method) => method.key === "v3-score") ?? null;
+  const v3Full = backtest.methods.find((method) => method.key === "v3-full") ?? null;
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
@@ -94,7 +249,7 @@ export default async function PredictorBacktestPage() {
             Historical predictor back-test
           </h1>
           <p className="mt-3 max-w-4xl text-sm leading-6 text-white/60">
-            Replays completed SIXFL fixtures in chronological order. For every match, the models can only see results whose kick-off and result-entry time were both before that match kicked off. The match being predicted and all future results are excluded.
+            Replays completed SIXFL fixtures in chronological order. Every model sees only results whose kick-off and result-entry time were both before the match being predicted. The target match and all future information remain excluded.
           </p>
         </div>
         <Link
@@ -103,6 +258,10 @@ export default async function PredictorBacktestPage() {
         >
           ← Live predictor monitoring
         </Link>
+      </div>
+
+      <div className="rounded-2xl border border-emerald-400/20 bg-emerald-500/[0.07] px-5 py-4 text-sm leading-6 text-emerald-50/80">
+        <span className="font-semibold text-emerald-200">Laboratory only:</span> the two V3 candidates below are calculated in memory. Opening this page does not rewrite stored predictions, alter completed matches or change the live model.
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
@@ -121,9 +280,11 @@ export default async function PredictorBacktestPage() {
         </div>
 
         <div className="rounded-3xl border border-amber-400/20 bg-amber-500/10 p-5">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/65">Blind two-team guess</p>
-          <p className="mt-3 text-4xl font-black text-amber-200">{percentage(backtest.twoTeamCoinExpectedAccuracy)}</p>
-          <p className="mt-2 text-xs text-white/45">Expected accuracy from a 50/50 team choice, with draws always missed</p>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/65">Live control model</p>
+          <p className="mt-3 text-4xl font-black text-amber-200">{percentage(current?.accuracy ?? null)}</p>
+          <p className="mt-2 text-xs text-white/45">
+            Blind two-team guess: {percentage(backtest.twoTeamCoinExpectedAccuracy)}
+          </p>
         </div>
 
         <div className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-5">
@@ -133,43 +294,88 @@ export default async function PredictorBacktestPage() {
         </div>
       </div>
 
-      {current && candidate ? (
-        <section className="rounded-3xl border border-sky-400/20 bg-sky-500/[0.07] p-6">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-100/60">Candidate check</p>
-              <h2 className="mt-2 text-xl font-semibold text-white">Does Elo + goals beat the live model?</h2>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">
-                Current SIXFL: {percentage(current.accuracy)} · Elo + goals: {percentage(candidate.accuracy)}. This is a historical test only; it does not rewrite any stored prediction or live result.
-              </p>
-            </div>
-            <div className={`text-4xl font-black ${candidateImprovement !== null && candidateImprovement > 0 ? "text-emerald-300" : "text-red-300"}`}>
-              {candidateImprovement === null ? "—" : points(candidateImprovement)}
-            </div>
+      <section className="rounded-3xl border border-white/10 bg-white/[0.035] p-6">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200/70">Promotion gate</p>
+            <h2 className="mt-2 text-xl font-semibold text-white">Is either V3 candidate safe enough for a live trial?</h2>
+            <p className="mt-2 max-w-4xl text-sm leading-6 text-white/55">
+              A candidate must preserve result accuracy and probability quality while reducing score error, total-goal bias and scoreline concentration. Passing here still requires a separate, explicit live-model change.
+            </p>
           </div>
-        </section>
-      ) : null}
+        </div>
+
+        <div className="mt-5 grid gap-4 xl:grid-cols-2">
+          {backtest.promotionAssessments.map((assessment) => (
+            <div
+              key={assessment.candidateKey}
+              className={`rounded-3xl border p-5 ${assessment.ready ? "border-emerald-400/30 bg-emerald-500/[0.08]" : "border-amber-400/20 bg-amber-500/[0.06]"}`}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h3 className="font-semibold text-white">{assessment.candidateLabel}</h3>
+                  <p className="mt-1 text-xs text-white/45">
+                    {assessment.passedChecks} of {assessment.totalChecks} safeguards passed
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold ${assessment.ready ? "border-emerald-300/25 bg-emerald-400/10 text-emerald-100" : "border-amber-300/25 bg-amber-400/10 text-amber-100"}`}
+                >
+                  {assessment.ready ? "Passes lab gate" : "Keep in laboratory"}
+                </span>
+              </div>
+
+              <div className="mt-4 space-y-2">
+                {assessment.checks.map((check) => (
+                  <div
+                    key={check.key}
+                    className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-black/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="flex items-center gap-2 text-sm text-white/70">
+                      <span className={check.passed ? "text-emerald-300" : "text-red-300"}>
+                        {check.passed ? "✓" : "×"}
+                      </span>
+                      <span>{check.label}</span>
+                    </div>
+                    <div className="shrink-0 text-xs font-semibold text-white/50">
+                      {promotionMetricValue(check, check.currentValue)} →{" "}
+                      <span className={check.passed ? "text-emerald-200" : "text-red-200"}>
+                        {promotionMetricValue(check, check.candidateValue)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
 
       <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
         <div>
           <h2 className="text-xl font-semibold text-white">Model comparison</h2>
-          <p className="mt-1 max-w-4xl text-sm leading-6 text-white/55">
-            Accuracy is the home/draw/away call. Exact score and goals-out are shown only for models that predict a score. Brier score measures probability quality — lower is better — so an overconfident wrong prediction is penalised more heavily.
+          <p className="mt-1 max-w-5xl text-sm leading-6 text-white/55">
+            Accuracy is the Team 1/draw/Team 2 call. Lower Brier, calibration error and goals-out are better. Predicted versus actual goals exposes systematic under- or over-scoring, while scoreline diversity shows whether the model is collapsing around 3–2 and 4–3.
           </p>
         </div>
 
         <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
-          <table className="min-w-full text-left text-sm">
-            <thead className="bg-white/[0.04] text-[11px] uppercase tracking-[0.16em] text-white/40">
+          <table className="min-w-[1500px] text-left text-sm">
+            <thead className="bg-white/[0.04] text-[10px] uppercase tracking-[0.14em] text-white/40">
               <tr>
                 <th className="px-4 py-3">Method</th>
                 <th className="px-4 py-3">Calls</th>
                 <th className="px-4 py-3">Correct</th>
                 <th className="px-4 py-3">Accuracy</th>
-                <th className="px-4 py-3">Vs blind guess</th>
+                <th className="px-4 py-3">Vs blind</th>
+                <th className="px-4 py-3">Brier</th>
+                <th className="px-4 py-3">Calibration</th>
                 <th className="px-4 py-3">Exact</th>
                 <th className="px-4 py-3">Avg goals out</th>
-                <th className="px-4 py-3">Brier</th>
+                <th className="px-4 py-3">Pred / actual goals</th>
+                <th className="px-4 py-3">Goal bias</th>
+                <th className="px-4 py-3">Different scores</th>
+                <th className="px-4 py-3">Top four share</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-white/10">
@@ -187,11 +393,22 @@ export default async function PredictorBacktestPage() {
                   <td className={`px-4 py-4 font-semibold ${method.accuracy > backtest.twoTeamCoinExpectedAccuracy ? "text-emerald-300" : "text-red-300"}`}>
                     {points(method.accuracy - backtest.twoTeamCoinExpectedAccuracy)}
                   </td>
+                  <td className="px-4 py-4 text-white/65">{brier(method.brierScore)}</td>
+                  <td className="px-4 py-4 text-white/65">
+                    {method.calibrationError === null ? "—" : `${(method.calibrationError * 100).toFixed(1)} pts`}
+                  </td>
                   <td className="px-4 py-4 text-sky-200">
                     {method.exact === null ? "—" : `${method.exact} (${percentage(method.exactAccuracy)})`}
                   </td>
-                  <td className="px-4 py-4 text-white/65">{goalError(method.averageGoalError)}</td>
-                  <td className="px-4 py-4 text-white/65">{brier(method.brierScore)}</td>
+                  <td className="px-4 py-4 text-white/65">{decimal(method.averageGoalError)}</td>
+                  <td className="px-4 py-4 text-white/65">
+                    {method.averagePredictedGoals === null
+                      ? "—"
+                      : `${decimal(method.averagePredictedGoals)} / ${decimal(method.averageActualGoals)}`}
+                  </td>
+                  <td className="px-4 py-4 text-white/65">{signedDecimal(method.goalsBias)}</td>
+                  <td className="px-4 py-4 text-white/65">{method.distinctScorelines ?? "—"}</td>
+                  <td className="px-4 py-4 text-white/65">{percentage(method.topFourScorelineShare)}</td>
                 </tr>
               ))}
             </tbody>
@@ -199,22 +416,70 @@ export default async function PredictorBacktestPage() {
         </div>
       </section>
 
+      {current && v3Score && v3Full ? (
+        <section className="rounded-3xl border border-violet-400/15 bg-violet-500/[0.04] p-6">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Scoreline concentration</h2>
+            <p className="mt-1 max-w-5xl text-sm leading-6 text-white/55">
+              V3 score-only keeps every current result call unchanged, so this isolates whether the new overdispersed pace model improves the exact scores without moving the winner prediction. V3 full also tests the new result layer.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-4 xl:grid-cols-3">
+            <ScorelineCard method={current} />
+            <ScorelineCard method={v3Score} />
+            <ScorelineCard method={v3Full} />
+          </div>
+        </section>
+      ) : null}
+
+      {current && v3Full ? (
+        <section className="rounded-3xl border border-white/10 bg-white/[0.035] p-6">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Outcome confusion</h2>
+            <p className="mt-1 max-w-4xl text-sm leading-6 text-white/55">
+              Rows are what happened; columns are what the model called. This makes missed draws and wrong-side calls visible rather than hiding them inside one accuracy number.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-4 xl:grid-cols-2">
+            <ConfusionMatrix method={current} />
+            <ConfusionMatrix method={v3Full} />
+          </div>
+        </section>
+      ) : null}
+
+      {current && v3Full ? (
+        <section className="rounded-3xl border border-sky-400/15 bg-sky-500/[0.035] p-6">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Confidence calibration</h2>
+            <p className="mt-1 max-w-4xl text-sm leading-6 text-white/55">
+              A well-calibrated 50% band should be right about half the time. Calibration error is the weighted gap between stated confidence and observed accuracy; lower is better.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-4 xl:grid-cols-2">
+            <CalibrationCard method={current} />
+            <CalibrationCard method={v3Full} />
+          </div>
+        </section>
+      ) : null}
+
       <section className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h2 className="text-xl font-semibold text-white">Recent replay examples</h2>
-            <p className="mt-1 text-sm text-white/55">Useful for spotting what each method is doing differently on real SIXFL fixtures.</p>
+            <p className="mt-1 text-sm text-white/55">Real SIXFL fixtures, replayed with only information available before kick-off.</p>
           </div>
           <div className="text-xs text-white/40">Latest {backtest.examples.length} eligible historical fixtures</div>
         </div>
 
         <div className="mt-5 overflow-x-auto rounded-2xl border border-white/10">
-          <table className="min-w-full text-left text-sm">
-            <thead className="bg-white/[0.04] text-[11px] uppercase tracking-[0.16em] text-white/40">
+          <table className="min-w-[1150px] text-left text-sm">
+            <thead className="bg-white/[0.04] text-[10px] uppercase tracking-[0.14em] text-white/40">
               <tr>
                 <th className="px-4 py-3">Fixture</th>
                 <th className="px-4 py-3">Actual</th>
                 <th className="px-4 py-3">Current SIXFL</th>
+                <th className="px-4 py-3">V3 score-only</th>
+                <th className="px-4 py-3">V3 full</th>
                 <th className="px-4 py-3">Elo + goals</th>
                 <th className="px-4 py-3">PPG</th>
                 <th className="px-4 py-3">Elo</th>
@@ -229,13 +494,15 @@ export default async function PredictorBacktestPage() {
                   </td>
                   <td className="px-4 py-3 text-lg font-black text-white">{row.actual}</td>
                   <td className="px-4 py-3 font-semibold text-sky-200">{row.sixfl}</td>
-                  <td className="px-4 py-3 font-semibold text-emerald-200">{row.eloGoals}</td>
+                  <td className="px-4 py-3 font-semibold text-violet-200">{row.v3Score}</td>
+                  <td className="px-4 py-3 font-semibold text-emerald-200">{row.v3Full}</td>
+                  <td className="px-4 py-3 text-white/65">{row.eloGoals}</td>
                   <td className="px-4 py-3 text-white/65">{row.ppg}</td>
                   <td className="px-4 py-3 text-white/65">{row.elo}</td>
                 </tr>
               ))}
               {backtest.examples.length === 0 ? (
-                <tr><td className="px-4 py-8 text-white/55" colSpan={6}>There is not enough historical data to run a fair replay yet.</td></tr>
+                <tr><td className="px-4 py-8 text-white/55" colSpan={8}>There is not enough historical data to run a fair replay yet.</td></tr>
               ) : null}
             </tbody>
           </table>
@@ -243,7 +510,7 @@ export default async function PredictorBacktestPage() {
       </section>
 
       <div className="rounded-2xl border border-amber-400/15 bg-amber-500/[0.06] px-4 py-3 text-xs leading-5 text-amber-50/65">
-        Back-testing is evidence, not proof. Once we choose a better model, future stored pre-match predictions remain the final test because they cannot benefit from retrospective tuning. No historical prediction rows are changed by this page.
+        Back-testing is evidence, not proof. Even a candidate that passes every retrospective gate should first be promoted under a new model version for future fixtures only. Completed historical prediction rows remain the audit record and are not rewritten by this page.
       </div>
     </div>
   );

--- a/src/lib/fixtures/predictorBacktest.ts
+++ b/src/lib/fixtures/predictorBacktest.ts
@@ -1,3 +1,8 @@
+import {
+  calculatePredictorV3Candidates,
+  type PredictorV3Outcome,
+  type PredictorV3Probabilities,
+} from "@/lib/fixtures/predictorV3Candidate";
 import { calculateFixtureWinChance, type WinChanceFixture } from "@/lib/fixtures/winChance";
 
 export type PredictorBacktestRow = {
@@ -14,13 +19,9 @@ export type PredictorBacktestRow = {
   actualAwayScore: number;
 };
 
-type Outcome = "HOME" | "DRAW" | "AWAY";
+type Outcome = PredictorV3Outcome;
 
-type Probabilities = {
-  home: number;
-  draw: number;
-  away: number;
-};
+type Probabilities = PredictorV3Probabilities;
 
 type TeamStats = {
   played: number;
@@ -37,6 +38,15 @@ type ModelPrediction = {
   score?: { home: number; away: number };
 };
 
+type MutableCalibrationBin = {
+  label: string;
+  calls: number;
+  confidenceTotal: number;
+  correct: number;
+};
+
+type OutcomeConfusionMatrix = Record<Outcome, Record<Outcome, number>>;
+
 type MutableMethod = {
   key: string;
   label: string;
@@ -46,8 +56,27 @@ type MutableMethod = {
   exact: number;
   scoredCalls: number;
   totalGoalError: number;
+  predictedGoalsTotal: number;
+  actualGoalsTotal: number;
+  scorelineCounts: Map<string, number>;
   brierTotal: number;
   brierCalls: number;
+  confidenceTotal: number;
+  calibrationBins: MutableCalibrationBin[];
+  confusionMatrix: OutcomeConfusionMatrix;
+};
+
+export type PredictorCalibrationBin = {
+  label: string;
+  calls: number;
+  averageConfidence: number | null;
+  accuracy: number | null;
+};
+
+export type PredictorCommonScoreline = {
+  scoreline: string;
+  count: number;
+  share: number;
 };
 
 export type PredictorBacktestMethod = {
@@ -60,7 +89,46 @@ export type PredictorBacktestMethod = {
   exact: number | null;
   exactAccuracy: number | null;
   averageGoalError: number | null;
+  averagePredictedGoals: number | null;
+  averageActualGoals: number | null;
+  goalsBias: number | null;
+  distinctScorelines: number | null;
+  mostCommonScoreline: string | null;
+  mostCommonScorelineCount: number | null;
+  mostCommonScorelineShare: number | null;
+  topFourScorelineShare: number | null;
+  commonScorelines: PredictorCommonScoreline[];
   brierScore: number | null;
+  averageConfidence: number | null;
+  calibrationError: number | null;
+  calibrationBins: PredictorCalibrationBin[];
+  confusionMatrix: OutcomeConfusionMatrix;
+};
+
+export type PredictorPromotionCheck = {
+  key:
+    | "accuracy"
+    | "brier"
+    | "goal-error"
+    | "goal-bias"
+    | "top-four-share"
+    | "distinct-scorelines"
+    | "calibration";
+  label: string;
+  passed: boolean;
+  currentValue: number | null;
+  candidateValue: number | null;
+  requiredValue: number | null;
+  direction: "higher" | "lower" | "closer-to-zero";
+};
+
+export type PredictorPromotionAssessment = {
+  candidateKey: string;
+  candidateLabel: string;
+  ready: boolean;
+  passedChecks: number;
+  totalChecks: number;
+  checks: PredictorPromotionCheck[];
 };
 
 export type PredictorBacktestExample = {
@@ -70,6 +138,8 @@ export type PredictorBacktestExample = {
   fixture: string;
   actual: string;
   sixfl: string;
+  v3Score: string;
+  v3Full: string;
   eloGoals: string;
   ppg: Outcome;
   elo: Outcome;
@@ -86,12 +156,21 @@ export type PredictorBacktestResult = {
   bestMethodKey: string | null;
   bestMethodLabel: string | null;
   bestAccuracy: number | null;
+  promotionAssessments: PredictorPromotionAssessment[];
   examples: PredictorBacktestExample[];
 };
 
 const MAX_SCORE = 12;
 const ELO_K = 30;
 const ELO_DRAW_THRESHOLD = 34;
+
+const CALIBRATION_BUCKETS = [
+  { label: "33–39%", min: 0, max: 0.4 },
+  { label: "40–49%", min: 0.4, max: 0.5 },
+  { label: "50–59%", min: 0.5, max: 0.6 },
+  { label: "60–69%", min: 0.6, max: 0.7 },
+  { label: "70%+", min: 0.7, max: Number.POSITIVE_INFINITY },
+] as const;
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
@@ -123,6 +202,17 @@ function outcome(home: number, away: number): Outcome {
 
 function percentageProbability(value: number) {
   return clamp(value / 100, 0, 1);
+}
+
+function normaliseProbabilities(input: Probabilities): Probabilities {
+  const home = Math.max(0, input.home);
+  const draw = Math.max(0, input.draw);
+  const away = Math.max(0, input.away);
+  const total = home + draw + away;
+  if (!Number.isFinite(total) || total <= 0) {
+    return { home: 1 / 3, draw: 1 / 3, away: 1 / 3 };
+  }
+  return { home: home / total, draw: draw / total, away: away / total };
 }
 
 function brierScore(probabilities: Probabilities, actual: Outcome) {
@@ -421,56 +511,72 @@ function eloGoalsPrediction(input: {
   return { outcome: predicted, probabilities, score };
 }
 
+function createConfusionMatrix(): OutcomeConfusionMatrix {
+  return {
+    HOME: { HOME: 0, DRAW: 0, AWAY: 0 },
+    DRAW: { HOME: 0, DRAW: 0, AWAY: 0 },
+    AWAY: { HOME: 0, DRAW: 0, AWAY: 0 },
+  };
+}
+
+function createMethod(key: string, label: string, description: string): MutableMethod {
+  return {
+    key,
+    label,
+    description,
+    calls: 0,
+    correct: 0,
+    exact: 0,
+    scoredCalls: 0,
+    totalGoalError: 0,
+    predictedGoalsTotal: 0,
+    actualGoalsTotal: 0,
+    scorelineCounts: new Map<string, number>(),
+    brierTotal: 0,
+    brierCalls: 0,
+    confidenceTotal: 0,
+    calibrationBins: CALIBRATION_BUCKETS.map((bucket) => ({
+      label: bucket.label,
+      calls: 0,
+      confidenceTotal: 0,
+      correct: 0,
+    })),
+    confusionMatrix: createConfusionMatrix(),
+  };
+}
+
 function initialiseMethods(): MutableMethod[] {
   return [
-    {
-      key: "sixfl",
-      label: "Current SIXFL model",
-      description: "The live hand-weighted strength model with the current goal model, replayed using only pre-kick-off history.",
-      calls: 0,
-      correct: 0,
-      exact: 0,
-      scoredCalls: 0,
-      totalGoalError: 0,
-      brierTotal: 0,
-      brierCalls: 0,
-    },
-    {
-      key: "elo-goals",
-      label: "Elo + goals candidate",
-      description: "A candidate model combining opponent-adjusted Elo strength with team scoring, conceding and recent goal rates.",
-      calls: 0,
-      correct: 0,
-      exact: 0,
-      scoredCalls: 0,
-      totalGoalError: 0,
-      brierTotal: 0,
-      brierCalls: 0,
-    },
-    {
-      key: "ppg",
-      label: "Better PPG baseline",
-      description: "A deliberately simple baseline that calls the team with the better points-per-game record, with a narrow draw band.",
-      calls: 0,
-      correct: 0,
-      exact: 0,
-      scoredCalls: 0,
-      totalGoalError: 0,
-      brierTotal: 0,
-      brierCalls: 0,
-    },
-    {
-      key: "elo",
-      label: "Elo-only baseline",
-      description: "A neutral-pitch Elo baseline updated after every available historical result, with a small draw band.",
-      calls: 0,
-      correct: 0,
-      exact: 0,
-      scoredCalls: 0,
-      totalGoalError: 0,
-      brierTotal: 0,
-      brierCalls: 0,
-    },
+    createMethod(
+      "sixfl",
+      "Current SIXFL model",
+      "The live opponent-adjusted Poisson model, replayed using only pre-kick-off history.",
+    ),
+    createMethod(
+      "v3-score",
+      "V3 score model · current result call",
+      "Keeps the current home/draw/away probabilities exactly, but replaces the conditional Poisson mode with an overdispersed, pace-aware score model.",
+    ),
+    createMethod(
+      "v3-full",
+      "V3 outcome + score candidate",
+      "Blends the current result probabilities with neutral-pitch Elo, points, goal difference, recent results and the observed SIXFL draw rate, then uses the V3 score model.",
+    ),
+    createMethod(
+      "elo-goals",
+      "Elo + goals candidate",
+      "The existing candidate combining opponent-adjusted Elo strength with team scoring, conceding and recent goal rates.",
+    ),
+    createMethod(
+      "ppg",
+      "Better PPG baseline",
+      "A deliberately simple baseline that calls the team with the better points-per-game record, with a narrow draw band.",
+    ),
+    createMethod(
+      "elo",
+      "Elo-only baseline",
+      "A neutral-pitch Elo baseline updated after every available historical result, with a small draw band.",
+    ),
   ];
 }
 
@@ -482,7 +588,9 @@ function recordPrediction(input: {
   actualAway: number;
 }) {
   input.method.calls += 1;
-  if (input.prediction.outcome === input.actualOutcome) input.method.correct += 1;
+  const correct = input.prediction.outcome === input.actualOutcome;
+  if (correct) input.method.correct += 1;
+  input.method.confusionMatrix[input.actualOutcome][input.prediction.outcome] += 1;
 
   if (input.prediction.score) {
     input.method.scoredCalls += 1;
@@ -495,15 +603,66 @@ function recordPrediction(input: {
     input.method.totalGoalError +=
       Math.abs(input.prediction.score.home - input.actualHome) +
       Math.abs(input.prediction.score.away - input.actualAway);
+    input.method.predictedGoalsTotal +=
+      input.prediction.score.home + input.prediction.score.away;
+    input.method.actualGoalsTotal += input.actualHome + input.actualAway;
+    const scoreline = `${input.prediction.score.home}–${input.prediction.score.away}`;
+    input.method.scorelineCounts.set(
+      scoreline,
+      (input.method.scorelineCounts.get(scoreline) ?? 0) + 1,
+    );
   }
 
   if (input.prediction.probabilities) {
+    const probabilities = normaliseProbabilities(input.prediction.probabilities);
     input.method.brierCalls += 1;
-    input.method.brierTotal += brierScore(input.prediction.probabilities, input.actualOutcome);
+    input.method.brierTotal += brierScore(probabilities, input.actualOutcome);
+    const confidence = Math.max(probabilities.home, probabilities.draw, probabilities.away);
+    input.method.confidenceTotal += confidence;
+    const bucketIndex = CALIBRATION_BUCKETS.findIndex(
+      (bucket) => confidence >= bucket.min && confidence < bucket.max,
+    );
+    const bucket = input.method.calibrationBins[
+      bucketIndex >= 0 ? bucketIndex : input.method.calibrationBins.length - 1
+    ];
+    bucket.calls += 1;
+    bucket.confidenceTotal += confidence;
+    if (correct) bucket.correct += 1;
   }
 }
 
 function toSummary(method: MutableMethod): PredictorBacktestMethod {
+  const rankedScorelines = [...method.scorelineCounts.entries()]
+    .map(([scoreline, count]) => ({
+      scoreline,
+      count,
+      share: method.scoredCalls > 0 ? count / method.scoredCalls : 0,
+    }))
+    .sort((first, second) => second.count - first.count || first.scoreline.localeCompare(second.scoreline));
+  const mostCommon = rankedScorelines[0] ?? null;
+  const calibrationBins = method.calibrationBins.map((bin) => ({
+    label: bin.label,
+    calls: bin.calls,
+    averageConfidence: bin.calls > 0 ? bin.confidenceTotal / bin.calls : null,
+    accuracy: bin.calls > 0 ? bin.correct / bin.calls : null,
+  }));
+  const calibrationError =
+    method.brierCalls > 0
+      ? calibrationBins.reduce((total, bin) => {
+          if (bin.calls === 0 || bin.averageConfidence === null || bin.accuracy === null) {
+            return total;
+          }
+          return (
+            total +
+            (bin.calls / method.brierCalls) * Math.abs(bin.averageConfidence - bin.accuracy)
+          );
+        }, 0)
+      : null;
+  const averagePredictedGoals =
+    method.scoredCalls > 0 ? method.predictedGoalsTotal / method.scoredCalls : null;
+  const averageActualGoals =
+    method.scoredCalls > 0 ? method.actualGoalsTotal / method.scoredCalls : null;
+
   return {
     key: method.key,
     label: method.label,
@@ -515,7 +674,144 @@ function toSummary(method: MutableMethod): PredictorBacktestMethod {
     exactAccuracy: method.scoredCalls > 0 ? method.exact / method.scoredCalls : null,
     averageGoalError:
       method.scoredCalls > 0 ? method.totalGoalError / method.scoredCalls : null,
+    averagePredictedGoals,
+    averageActualGoals,
+    goalsBias:
+      averagePredictedGoals !== null && averageActualGoals !== null
+        ? averagePredictedGoals - averageActualGoals
+        : null,
+    distinctScorelines: method.scoredCalls > 0 ? method.scorelineCounts.size : null,
+    mostCommonScoreline: mostCommon?.scoreline ?? null,
+    mostCommonScorelineCount: mostCommon?.count ?? null,
+    mostCommonScorelineShare: mostCommon?.share ?? null,
+    topFourScorelineShare:
+      method.scoredCalls > 0
+        ? rankedScorelines.slice(0, 4).reduce((sum, item) => sum + item.count, 0) /
+          method.scoredCalls
+        : null,
+    commonScorelines: rankedScorelines.slice(0, 8),
     brierScore: method.brierCalls > 0 ? method.brierTotal / method.brierCalls : null,
+    averageConfidence:
+      method.brierCalls > 0 ? method.confidenceTotal / method.brierCalls : null,
+    calibrationError,
+    calibrationBins,
+    confusionMatrix: {
+      HOME: { ...method.confusionMatrix.HOME },
+      DRAW: { ...method.confusionMatrix.DRAW },
+      AWAY: { ...method.confusionMatrix.AWAY },
+    },
+  };
+}
+
+function promotionAssessment(
+  current: PredictorBacktestMethod,
+  candidate: PredictorBacktestMethod,
+): PredictorPromotionAssessment {
+  const currentTopFourTarget =
+    current.topFourScorelineShare === null
+      ? null
+      : Math.min(0.55, Math.max(0, current.topFourScorelineShare - 0.05));
+  const distinctTarget =
+    current.distinctScorelines === null ? null : current.distinctScorelines + 2;
+  const goalErrorTarget =
+    current.averageGoalError === null ? null : Math.max(0, current.averageGoalError - 0.05);
+  const goalBiasTarget =
+    current.goalsBias === null ? null : Math.max(0.15, Math.abs(current.goalsBias) - 0.05);
+  const calibrationTarget =
+    current.calibrationError === null ? null : current.calibrationError + 0.005;
+
+  const checks: PredictorPromotionCheck[] = [
+    {
+      key: "accuracy",
+      label: "Result accuracy does not fall",
+      passed: candidate.accuracy + 1e-9 >= current.accuracy,
+      currentValue: current.accuracy,
+      candidateValue: candidate.accuracy,
+      requiredValue: current.accuracy,
+      direction: "higher",
+    },
+    {
+      key: "brier",
+      label: "Probability quality matches or improves",
+      passed:
+        candidate.brierScore !== null &&
+        current.brierScore !== null &&
+        candidate.brierScore <= current.brierScore + 0.0005,
+      currentValue: current.brierScore,
+      candidateValue: candidate.brierScore,
+      requiredValue: current.brierScore,
+      direction: "lower",
+    },
+    {
+      key: "goal-error",
+      label: "Average score error improves",
+      passed:
+        candidate.averageGoalError !== null &&
+        goalErrorTarget !== null &&
+        candidate.averageGoalError <= goalErrorTarget,
+      currentValue: current.averageGoalError,
+      candidateValue: candidate.averageGoalError,
+      requiredValue: goalErrorTarget,
+      direction: "lower",
+    },
+    {
+      key: "goal-bias",
+      label: "Average total-goals bias moves towards zero",
+      passed:
+        candidate.goalsBias !== null &&
+        goalBiasTarget !== null &&
+        Math.abs(candidate.goalsBias) <= goalBiasTarget,
+      currentValue: current.goalsBias,
+      candidateValue: candidate.goalsBias,
+      requiredValue: goalBiasTarget,
+      direction: "closer-to-zero",
+    },
+    {
+      key: "top-four-share",
+      label: "Top four scorelines stop dominating",
+      passed:
+        candidate.topFourScorelineShare !== null &&
+        currentTopFourTarget !== null &&
+        candidate.topFourScorelineShare <= currentTopFourTarget,
+      currentValue: current.topFourScorelineShare,
+      candidateValue: candidate.topFourScorelineShare,
+      requiredValue: currentTopFourTarget,
+      direction: "lower",
+    },
+    {
+      key: "distinct-scorelines",
+      label: "At least two more scorelines are used",
+      passed:
+        candidate.distinctScorelines !== null &&
+        distinctTarget !== null &&
+        candidate.distinctScorelines >= distinctTarget,
+      currentValue: current.distinctScorelines,
+      candidateValue: candidate.distinctScorelines,
+      requiredValue: distinctTarget,
+      direction: "higher",
+    },
+    {
+      key: "calibration",
+      label: "Confidence calibration does not materially worsen",
+      passed:
+        candidate.calibrationError !== null &&
+        calibrationTarget !== null &&
+        candidate.calibrationError <= calibrationTarget,
+      currentValue: current.calibrationError,
+      candidateValue: candidate.calibrationError,
+      requiredValue: calibrationTarget,
+      direction: "lower",
+    },
+  ];
+
+  const passedChecks = checks.filter((check) => check.passed).length;
+  return {
+    candidateKey: candidate.key,
+    candidateLabel: candidate.label,
+    ready: passedChecks === checks.length,
+    passedChecks,
+    totalChecks: checks.length,
+    checks,
   };
 }
 
@@ -587,28 +883,40 @@ export function runPredictorBacktest(rows: PredictorBacktestRow[]): PredictorBac
     const actual = outcome(target.actualHomeScore, target.actualAwayScore);
     if (actual === "DRAW") draws += 1;
 
-    const stats = buildStats(history);
-    const averages = leagueAverages(stats);
-    const ratings = buildEloRatings(history);
-
+    const currentProbabilities = normaliseProbabilities({
+      home: percentageProbability(current.home),
+      draw: percentageProbability(current.draw),
+      away: percentageProbability(current.away),
+    });
     const sixflPrediction: ModelPrediction = {
-      outcome: predictedOutcome({
-        home: percentageProbability(current.home),
-        draw: percentageProbability(current.draw),
-        away: percentageProbability(current.away),
-      }),
-      probabilities: {
-        home: percentageProbability(current.home),
-        draw: percentageProbability(current.draw),
-        away: percentageProbability(current.away),
-      },
+      outcome: predictedOutcome(currentProbabilities),
+      probabilities: currentProbabilities,
       score: {
         home: current.predictedResult.homeScore,
         away: current.predictedResult.awayScore,
       },
     };
+    const v3 = calculatePredictorV3Candidates({
+      homeTeamId,
+      awayTeamId,
+      history,
+      currentProbabilities,
+    });
+    const v3ScorePrediction: ModelPrediction = {
+      outcome: v3.scoreOnly.outcome,
+      probabilities: v3.scoreOnly.probabilities,
+      score: v3.scoreOnly.score,
+    };
+    const v3FullPrediction: ModelPrediction = {
+      outcome: v3.full.outcome,
+      probabilities: v3.full.probabilities,
+      score: v3.full.score,
+    };
 
-    const candidate = eloGoalsPrediction({ homeTeamId, awayTeamId, stats, ratings });
+    const stats = buildStats(history);
+    const averages = leagueAverages(stats);
+    const ratings = buildEloRatings(history);
+    const eloGoals = eloGoalsPrediction({ homeTeamId, awayTeamId, stats, ratings });
     const ppg = ppgPrediction({
       homeStats: stats.get(homeTeamId),
       awayStats: stats.get(awayTeamId),
@@ -616,34 +924,22 @@ export function runPredictorBacktest(rows: PredictorBacktestRow[]): PredictorBac
     });
     const elo = eloPrediction(ratings.get(homeTeamId) ?? 1500, ratings.get(awayTeamId) ?? 1500);
 
-    recordPrediction({
-      method: methodsByKey.get("sixfl")!,
-      prediction: sixflPrediction,
-      actualOutcome: actual,
-      actualHome: target.actualHomeScore,
-      actualAway: target.actualAwayScore,
-    });
-    recordPrediction({
-      method: methodsByKey.get("elo-goals")!,
-      prediction: candidate,
-      actualOutcome: actual,
-      actualHome: target.actualHomeScore,
-      actualAway: target.actualAwayScore,
-    });
-    recordPrediction({
-      method: methodsByKey.get("ppg")!,
-      prediction: ppg,
-      actualOutcome: actual,
-      actualHome: target.actualHomeScore,
-      actualAway: target.actualAwayScore,
-    });
-    recordPrediction({
-      method: methodsByKey.get("elo")!,
-      prediction: elo,
-      actualOutcome: actual,
-      actualHome: target.actualHomeScore,
-      actualAway: target.actualAwayScore,
-    });
+    for (const [key, prediction] of [
+      ["sixfl", sixflPrediction],
+      ["v3-score", v3ScorePrediction],
+      ["v3-full", v3FullPrediction],
+      ["elo-goals", eloGoals],
+      ["ppg", ppg],
+      ["elo", elo],
+    ] as const) {
+      recordPrediction({
+        method: methodsByKey.get(key)!,
+        prediction,
+        actualOutcome: actual,
+        actualHome: target.actualHomeScore,
+        actualAway: target.actualAwayScore,
+      });
+    }
 
     examples.push({
       fixtureId: target.fixtureId,
@@ -652,7 +948,9 @@ export function runPredictorBacktest(rows: PredictorBacktestRow[]): PredictorBac
       fixture: `${target.homeTeamName} v ${target.awayTeamName}`,
       actual: `${target.actualHomeScore}–${target.actualAwayScore}`,
       sixfl: scoreLabel(sixflPrediction),
-      eloGoals: scoreLabel(candidate),
+      v3Score: scoreLabel(v3ScorePrediction),
+      v3Full: scoreLabel(v3FullPrediction),
+      eloGoals: scoreLabel(eloGoals),
       ppg: ppg.outcome,
       elo: elo.outcome,
     });
@@ -661,7 +959,18 @@ export function runPredictorBacktest(rows: PredictorBacktestRow[]): PredictorBac
   const summaries = methods.map(toSummary);
   const best = summaries
     .filter((method) => method.calls > 0)
-    .sort((a, b) => b.accuracy - a.accuracy || (a.brierScore ?? 99) - (b.brierScore ?? 99))[0] ?? null;
+    .sort(
+      (a, b) =>
+        b.accuracy - a.accuracy ||
+        (a.brierScore ?? 99) - (b.brierScore ?? 99) ||
+        (a.averageGoalError ?? 99) - (b.averageGoalError ?? 99),
+    )[0] ?? null;
+  const currentSummary = summaries.find((method) => method.key === "sixfl") ?? null;
+  const promotionAssessments = currentSummary
+    ? summaries
+        .filter((method) => method.key === "v3-score" || method.key === "v3-full")
+        .map((candidate) => promotionAssessment(currentSummary, candidate))
+    : [];
   const nonDrawRate = eligibleFixtures > 0 ? (eligibleFixtures - draws) / eligibleFixtures : 0;
 
   return {
@@ -675,6 +984,7 @@ export function runPredictorBacktest(rows: PredictorBacktestRow[]): PredictorBac
     bestMethodKey: best?.key ?? null,
     bestMethodLabel: best?.label ?? null,
     bestAccuracy: best?.accuracy ?? null,
+    promotionAssessments,
     examples: examples.slice(-20).reverse(),
   };
 }

--- a/src/lib/fixtures/predictorV3Candidate.ts
+++ b/src/lib/fixtures/predictorV3Candidate.ts
@@ -1,0 +1,695 @@
+import type { WinChanceFixture } from "@/lib/fixtures/winChance";
+
+export type PredictorV3Outcome = "HOME" | "DRAW" | "AWAY";
+
+export type PredictorV3Probabilities = {
+  home: number;
+  draw: number;
+  away: number;
+};
+
+export type PredictorV3Score = {
+  home: number;
+  away: number;
+};
+
+export type PredictorV3Prediction = {
+  outcome: PredictorV3Outcome;
+  probabilities: PredictorV3Probabilities;
+  score: PredictorV3Score;
+  expectedHomeGoals: number;
+  expectedAwayGoals: number;
+};
+
+export type PredictorV3CandidateSet = {
+  scoreOnly: PredictorV3Prediction;
+  full: PredictorV3Prediction;
+};
+
+type TeamStats = {
+  played: number;
+  points: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  goalsForSamples: number[];
+  goalsAgainstSamples: number[];
+  resultPoints: number[];
+  matchTotals: number[];
+};
+
+type LeagueProfile = {
+  played: number;
+  drawRate: number;
+  pointsPerGame: number;
+  goalsPerTeamGame: number;
+  teamGoalSamples: number[];
+  matchTotalSamples: number[];
+};
+
+type JointScoreCell = {
+  home: number;
+  away: number;
+  probability: number;
+};
+
+const MAX_SCORE = 12;
+const ELO_K = 30;
+const SCORE_PRIOR_GAMES = 2.25;
+const RECENT_WINDOW = 5;
+const MIN_DISPERSION = 0.7;
+const MAX_DISPERSION = 24;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normaliseProbabilities(input: PredictorV3Probabilities): PredictorV3Probabilities {
+  const home = Math.max(0, input.home);
+  const draw = Math.max(0, input.draw);
+  const away = Math.max(0, input.away);
+  const total = home + draw + away;
+
+  if (!Number.isFinite(total) || total <= 0) {
+    return { home: 1 / 3, draw: 1 / 3, away: 1 / 3 };
+  }
+
+  return {
+    home: home / total,
+    draw: draw / total,
+    away: away / total,
+  };
+}
+
+function outcomeFromProbabilities(probabilities: PredictorV3Probabilities): PredictorV3Outcome {
+  if (probabilities.draw >= probabilities.home && probabilities.draw >= probabilities.away) {
+    return "DRAW";
+  }
+  return probabilities.home >= probabilities.away ? "HOME" : "AWAY";
+}
+
+function scoreOutcome(home: number, away: number): PredictorV3Outcome {
+  if (home > away) return "HOME";
+  if (away > home) return "AWAY";
+  return "DRAW";
+}
+
+function emptyStats(): TeamStats {
+  return {
+    played: 0,
+    points: 0,
+    goalsFor: 0,
+    goalsAgainst: 0,
+    goalsForSamples: [],
+    goalsAgainstSamples: [],
+    resultPoints: [],
+    matchTotals: [],
+  };
+}
+
+function buildStats(history: WinChanceFixture[]) {
+  const stats = new Map<string, TeamStats>();
+  const get = (teamId: string) => {
+    const existing = stats.get(teamId);
+    if (existing) return existing;
+    const created = emptyStats();
+    stats.set(teamId, created);
+    return created;
+  };
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.kickoffAt ?? 0).getTime() - new Date(b.kickoffAt ?? 0).getTime(),
+  );
+
+  for (const fixture of sorted) {
+    if (!fixture.result) continue;
+
+    const home = get(fixture.homeTeam.id);
+    const away = get(fixture.awayTeam.id);
+    const totalGoals = fixture.result.homeScore + fixture.result.awayScore;
+
+    home.played += 1;
+    away.played += 1;
+    home.goalsFor += fixture.result.homeScore;
+    home.goalsAgainst += fixture.result.awayScore;
+    away.goalsFor += fixture.result.awayScore;
+    away.goalsAgainst += fixture.result.homeScore;
+    home.goalsForSamples.push(fixture.result.homeScore);
+    home.goalsAgainstSamples.push(fixture.result.awayScore);
+    away.goalsForSamples.push(fixture.result.awayScore);
+    away.goalsAgainstSamples.push(fixture.result.homeScore);
+    home.matchTotals.push(totalGoals);
+    away.matchTotals.push(totalGoals);
+
+    if (fixture.result.homeScore > fixture.result.awayScore) {
+      home.points += 3;
+      home.resultPoints.push(3);
+      away.resultPoints.push(0);
+    } else if (fixture.result.awayScore > fixture.result.homeScore) {
+      away.points += 3;
+      home.resultPoints.push(0);
+      away.resultPoints.push(3);
+    } else {
+      home.points += 1;
+      away.points += 1;
+      home.resultPoints.push(1);
+      away.resultPoints.push(1);
+    }
+  }
+
+  return stats;
+}
+
+function buildLeagueProfile(stats: Map<string, TeamStats>, history: WinChanceFixture[]): LeagueProfile {
+  let teamGames = 0;
+  let points = 0;
+  let teamGoals = 0;
+  let played = 0;
+  let draws = 0;
+  const teamGoalSamples: number[] = [];
+  const matchTotalSamples: number[] = [];
+
+  for (const team of stats.values()) {
+    teamGames += team.played;
+    points += team.points;
+    teamGoals += team.goalsFor;
+    teamGoalSamples.push(...team.goalsForSamples);
+  }
+
+  for (const fixture of history) {
+    if (!fixture.result) continue;
+    played += 1;
+    if (fixture.result.homeScore === fixture.result.awayScore) draws += 1;
+    matchTotalSamples.push(fixture.result.homeScore + fixture.result.awayScore);
+  }
+
+  return {
+    played,
+    drawRate: (draws + 1.2) / (played + 12),
+    pointsPerGame: teamGames > 0 ? points / teamGames : 1.5,
+    goalsPerTeamGame: teamGames > 0 ? teamGoals / teamGames : 3.25,
+    teamGoalSamples,
+    matchTotalSamples,
+  };
+}
+
+function weightedRecent(values: number[], fallback: number) {
+  const recent = values.slice(-RECENT_WINDOW);
+  if (recent.length === 0) return fallback;
+
+  let total = 0;
+  let weightTotal = 0;
+  recent.forEach((value, index) => {
+    const weight = index + 1;
+    total += value * weight;
+    weightTotal += weight;
+  });
+
+  return weightTotal > 0 ? total / weightTotal : fallback;
+}
+
+function mean(values: number[], fallback: number) {
+  if (values.length === 0) return fallback;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sampleVariance(values: number[], fallback = 0) {
+  if (values.length < 2) return fallback;
+  const average = mean(values, 0);
+  const squared = values.reduce((sum, value) => sum + Math.pow(value - average, 2), 0);
+  return squared / (values.length - 1);
+}
+
+function smoothedRate(total: number, played: number, leagueAverage: number, priorGames = SCORE_PRIOR_GAMES) {
+  return (total + leagueAverage * priorGames) / (played + priorGames);
+}
+
+function blendedRate(input: {
+  total: number;
+  played: number;
+  recent: number[];
+  leagueAverage: number;
+}) {
+  const season = smoothedRate(input.total, input.played, input.leagueAverage);
+  const recent = weightedRecent(input.recent, season);
+  const recentWeight = Math.min(0.38, (input.played / (input.played + 4)) * 0.5);
+  return season * (1 - recentWeight) + recent * recentWeight;
+}
+
+function buildEloRatings(history: WinChanceFixture[]) {
+  const ratings = new Map<string, number>();
+  const get = (teamId: string) => ratings.get(teamId) ?? 1500;
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.kickoffAt ?? 0).getTime() - new Date(b.kickoffAt ?? 0).getTime(),
+  );
+
+  for (const fixture of sorted) {
+    if (!fixture.result) continue;
+
+    const homeRating = get(fixture.homeTeam.id);
+    const awayRating = get(fixture.awayTeam.id);
+    const expectedHome = 1 / (1 + Math.pow(10, (awayRating - homeRating) / 400));
+    const actualHome =
+      fixture.result.homeScore > fixture.result.awayScore
+        ? 1
+        : fixture.result.homeScore < fixture.result.awayScore
+          ? 0
+          : 0.5;
+    const margin = Math.abs(fixture.result.homeScore - fixture.result.awayScore);
+    const marginMultiplier = 1 + Math.log1p(margin) * 0.22;
+    const change = ELO_K * marginMultiplier * (actualHome - expectedHome);
+
+    ratings.set(fixture.homeTeam.id, homeRating + change);
+    ratings.set(fixture.awayTeam.id, awayRating - change);
+  }
+
+  return ratings;
+}
+
+function recentPointsPerGame(stats: TeamStats | undefined, fallback: number) {
+  if (!stats) return fallback;
+  return weightedRecent(stats.resultPoints, stats.played > 0 ? stats.points / stats.played : fallback);
+}
+
+function goalDifferencePerGame(stats: TeamStats | undefined) {
+  if (!stats?.played) return 0;
+  return (stats.goalsFor - stats.goalsAgainst) / stats.played;
+}
+
+function buildV3OutcomeProbabilities(input: {
+  homeTeamId: string;
+  awayTeamId: string;
+  stats: Map<string, TeamStats>;
+  profile: LeagueProfile;
+  ratings: Map<string, number>;
+  currentProbabilities: PredictorV3Probabilities;
+}) {
+  const current = normaliseProbabilities(input.currentProbabilities);
+  const home = input.stats.get(input.homeTeamId);
+  const away = input.stats.get(input.awayTeamId);
+
+  const homePpg = home?.played ? home.points / home.played : input.profile.pointsPerGame;
+  const awayPpg = away?.played ? away.points / away.played : input.profile.pointsPerGame;
+  const ppgSignal = clamp((homePpg - awayPpg) / 0.9, -2.2, 2.2);
+
+  const recentSignal = clamp(
+    (recentPointsPerGame(home, input.profile.pointsPerGame) -
+      recentPointsPerGame(away, input.profile.pointsPerGame)) /
+      1.05,
+    -2.2,
+    2.2,
+  );
+  const goalDifferenceSignal = clamp(
+    (goalDifferencePerGame(home) - goalDifferencePerGame(away)) / 3.2,
+    -2.2,
+    2.2,
+  );
+  const eloDifference = clamp(
+    (input.ratings.get(input.homeTeamId) ?? 1500) -
+      (input.ratings.get(input.awayTeamId) ?? 1500),
+    -400,
+    400,
+  );
+  const eloSignal = eloDifference / 190;
+
+  const strengthSignal = clamp(
+    ppgSignal * 0.28 + recentSignal * 0.18 + goalDifferenceSignal * 0.22 + eloSignal * 0.32,
+    -2.8,
+    2.8,
+  );
+  const structuralHomeShare = 1 / (1 + Math.exp(-strengthSignal));
+  const leastExperienced = Math.min(home?.played ?? 0, away?.played ?? 0);
+  const evidence = leastExperienced / (leastExperienced + 4);
+  const structuralWeight = 0.3 + evidence * 0.2;
+
+  const currentNoDrawTotal = Math.max(current.home + current.away, 0.0001);
+  const currentHomeShare = current.home / currentNoDrawTotal;
+  const homeShare = clamp(
+    currentHomeShare * (1 - structuralWeight) + structuralHomeShare * structuralWeight,
+    0.04,
+    0.96,
+  );
+
+  const empiricalDraw = clamp(input.profile.drawRate, 0.07, 0.18);
+  const structuralDraw = clamp(empiricalDraw * Math.exp(-Math.abs(strengthSignal) * 0.2), 0.055, 0.18);
+  const draw = clamp(current.draw * 0.35 + structuralDraw * 0.65, 0.055, 0.2);
+  const remaining = 1 - draw;
+
+  return normaliseProbabilities({
+    home: remaining * homeShare,
+    draw,
+    away: remaining * (1 - homeShare),
+  });
+}
+
+function estimateDispersion(expectedGoals: number, samples: number[]) {
+  if (samples.length < 4) return 5;
+  const variance = sampleVariance(samples, expectedGoals);
+  if (variance <= expectedGoals + 0.05) return MAX_DISPERSION;
+  return clamp(
+    Math.pow(expectedGoals, 2) / Math.max(variance - expectedGoals, 0.05),
+    MIN_DISPERSION,
+    MAX_DISPERSION,
+  );
+}
+
+function logFactorial(value: number) {
+  let total = 0;
+  for (let index = 2; index <= value; index += 1) total += Math.log(index);
+  return total;
+}
+
+function logGamma(value: number): number {
+  const coefficients = [
+    676.5203681218851,
+    -1259.1392167224028,
+    771.3234287776531,
+    -176.6150291621406,
+    12.507343278686905,
+    -0.13857109526572012,
+    9.984369578019572e-6,
+    1.5056327351493116e-7,
+  ];
+
+  if (value < 0.5) {
+    return Math.log(Math.PI) - Math.log(Math.sin(Math.PI * value)) - logGamma(1 - value);
+  }
+
+  const adjusted = value - 1;
+  let series = 0.9999999999998099;
+  coefficients.forEach((coefficient, index) => {
+    series += coefficient / (adjusted + index + 1);
+  });
+  const shifted = adjusted + coefficients.length - 0.5;
+
+  return (
+    0.5 * Math.log(2 * Math.PI) +
+    (adjusted + 0.5) * Math.log(shifted) -
+    shifted +
+    Math.log(series)
+  );
+}
+
+function negativeBinomialProbability(score: number, expectedGoals: number, dispersion: number) {
+  const meanGoals = Math.max(expectedGoals, 0.01);
+  const shape = clamp(dispersion, MIN_DISPERSION, MAX_DISPERSION);
+  const successProbability = shape / (shape + meanGoals);
+  const logProbability =
+    logGamma(score + shape) -
+    logGamma(shape) -
+    logFactorial(score) +
+    shape * Math.log(successProbability) +
+    score * Math.log(1 - successProbability);
+
+  return Math.exp(logProbability);
+}
+
+function buildScoreGrid(input: {
+  homeExpected: number;
+  awayExpected: number;
+  homeDispersion: number;
+  awayDispersion: number;
+  paceSpread: number;
+}) {
+  const spread = clamp(input.paceSpread, 0.12, 0.5);
+  const paceStates = [
+    { multiplier: clamp(1 - spread, 0.52, 0.9), weight: 0.24 },
+    { multiplier: 1, weight: 0.52 },
+    { multiplier: clamp(1 + spread, 1.1, 1.75), weight: 0.24 },
+  ];
+  const cells: JointScoreCell[] = [];
+  let total = 0;
+
+  for (let home = 0; home <= MAX_SCORE; home += 1) {
+    for (let away = 0; away <= MAX_SCORE; away += 1) {
+      let probability = 0;
+      for (const state of paceStates) {
+        probability +=
+          state.weight *
+          negativeBinomialProbability(
+            home,
+            input.homeExpected * state.multiplier,
+            input.homeDispersion,
+          ) *
+          negativeBinomialProbability(
+            away,
+            input.awayExpected * state.multiplier,
+            input.awayDispersion,
+          );
+      }
+      cells.push({ home, away, probability });
+      total += probability;
+    }
+  }
+
+  if (total <= 0) return cells;
+  return cells.map((cell) => ({ ...cell, probability: cell.probability / total }));
+}
+
+function enforceOutcome(score: PredictorV3Score, predictedOutcome: PredictorV3Outcome) {
+  let home = clamp(Math.round(score.home), 0, MAX_SCORE);
+  let away = clamp(Math.round(score.away), 0, MAX_SCORE);
+
+  if (predictedOutcome === "DRAW") {
+    const level = clamp(Math.round((home + away) / 2), 0, MAX_SCORE);
+    return { home: level, away: level };
+  }
+
+  if (predictedOutcome === "HOME" && home <= away) {
+    if (home < MAX_SCORE) home = away + 1;
+    else away = Math.max(0, home - 1);
+  }
+
+  if (predictedOutcome === "AWAY" && away <= home) {
+    if (away < MAX_SCORE) away = home + 1;
+    else home = Math.max(0, away - 1);
+  }
+
+  return { home, away };
+}
+
+function conditionalCentralScore(cells: JointScoreCell[], predictedOutcome: PredictorV3Outcome) {
+  const matching = cells.filter((cell) => scoreOutcome(cell.home, cell.away) === predictedOutcome);
+  const mass = matching.reduce((sum, cell) => sum + cell.probability, 0);
+
+  if (mass <= 0 || matching.length === 0) return null;
+
+  const expectedHome = matching.reduce(
+    (sum, cell) => sum + cell.home * cell.probability,
+    0,
+  ) / mass;
+  const expectedAway = matching.reduce(
+    (sum, cell) => sum + cell.away * cell.probability,
+    0,
+  ) / mass;
+  const expectedTotal = expectedHome + expectedAway;
+  const maxProbability = Math.max(...matching.map((cell) => cell.probability), 1e-12);
+
+  const best = [...matching].sort((first, second) => {
+    const cost = (cell: JointScoreCell) => {
+      const distance =
+        Math.pow(cell.home - expectedHome, 2) +
+        Math.pow(cell.away - expectedAway, 2) +
+        Math.pow(cell.home + cell.away - expectedTotal, 2) * 0.2;
+      const probabilityPenalty =
+        -Math.log(Math.max(cell.probability / maxProbability, 1e-12)) * 0.14;
+      return distance + probabilityPenalty;
+    };
+
+    return cost(first) - cost(second) || second.probability - first.probability;
+  })[0];
+
+  return best ? { home: best.home, away: best.away } : null;
+}
+
+function expectedGoalsAndGrid(input: {
+  homeTeamId: string;
+  awayTeamId: string;
+  stats: Map<string, TeamStats>;
+  profile: LeagueProfile;
+  probabilities: PredictorV3Probabilities;
+}) {
+  const home = input.stats.get(input.homeTeamId);
+  const away = input.stats.get(input.awayTeamId);
+  const leagueGoals = clamp(input.profile.goalsPerTeamGame, 0.75, 8.5);
+  const leagueTotal = leagueGoals * 2;
+
+  const homeAttack = blendedRate({
+    total: home?.goalsFor ?? 0,
+    played: home?.played ?? 0,
+    recent: home?.goalsForSamples ?? [],
+    leagueAverage: leagueGoals,
+  });
+  const awayAttack = blendedRate({
+    total: away?.goalsFor ?? 0,
+    played: away?.played ?? 0,
+    recent: away?.goalsForSamples ?? [],
+    leagueAverage: leagueGoals,
+  });
+  const homeConceding = blendedRate({
+    total: home?.goalsAgainst ?? 0,
+    played: home?.played ?? 0,
+    recent: home?.goalsAgainstSamples ?? [],
+    leagueAverage: leagueGoals,
+  });
+  const awayConceding = blendedRate({
+    total: away?.goalsAgainst ?? 0,
+    played: away?.played ?? 0,
+    recent: away?.goalsAgainstSamples ?? [],
+    leagueAverage: leagueGoals,
+  });
+
+  const rawHome =
+    leagueGoals *
+    Math.pow(clamp(homeAttack / leagueGoals, 0.25, 3.2), 0.6) *
+    Math.pow(clamp(awayConceding / leagueGoals, 0.25, 3.2), 0.4);
+  const rawAway =
+    leagueGoals *
+    Math.pow(clamp(awayAttack / leagueGoals, 0.25, 3.2), 0.6) *
+    Math.pow(clamp(homeConceding / leagueGoals, 0.25, 3.2), 0.4);
+
+  const homeSeasonPace = smoothedRate(
+    (home?.matchTotals ?? []).reduce((sum, value) => sum + value, 0),
+    home?.played ?? 0,
+    leagueTotal,
+    3,
+  );
+  const awaySeasonPace = smoothedRate(
+    (away?.matchTotals ?? []).reduce((sum, value) => sum + value, 0),
+    away?.played ?? 0,
+    leagueTotal,
+    3,
+  );
+  const homePace =
+    homeSeasonPace * 0.65 + weightedRecent(home?.matchTotals ?? [], homeSeasonPace) * 0.35;
+  const awayPace =
+    awaySeasonPace * 0.65 + weightedRecent(away?.matchTotals ?? [], awaySeasonPace) * 0.35;
+  const targetTotal = clamp(
+    leagueTotal * 0.34 + homePace * 0.33 + awayPace * 0.33,
+    1.4,
+    16,
+  );
+
+  const rawTotal = Math.max(rawHome + rawAway, 0.01);
+  let homeExpected = (rawHome / rawTotal) * targetTotal;
+  let awayExpected = (rawAway / rawTotal) * targetTotal;
+  const strengthShift = clamp(
+    (input.probabilities.home - input.probabilities.away) * 0.95,
+    -0.75,
+    0.75,
+  );
+  homeExpected = Math.max(0.25, homeExpected + strengthShift);
+  awayExpected = Math.max(0.25, awayExpected - strengthShift);
+
+  const adjustedTotal = homeExpected + awayExpected;
+  const totalScale = targetTotal / Math.max(adjustedTotal, 0.01);
+  homeExpected = clamp(homeExpected * totalScale, 0.25, 11.5);
+  awayExpected = clamp(awayExpected * totalScale, 0.25, 11.5);
+
+  const leagueDispersion = estimateDispersion(leagueGoals, input.profile.teamGoalSamples);
+  const homeSamples = [
+    ...(home?.goalsForSamples ?? []),
+    ...(away?.goalsAgainstSamples ?? []),
+  ];
+  const awaySamples = [
+    ...(away?.goalsForSamples ?? []),
+    ...(home?.goalsAgainstSamples ?? []),
+  ];
+  const homeDispersion = clamp(
+    estimateDispersion(homeExpected, homeSamples) * 0.65 + leagueDispersion * 0.35,
+    MIN_DISPERSION,
+    MAX_DISPERSION,
+  );
+  const awayDispersion = clamp(
+    estimateDispersion(awayExpected, awaySamples) * 0.65 + leagueDispersion * 0.35,
+    MIN_DISPERSION,
+    MAX_DISPERSION,
+  );
+  const totalMean = mean(input.profile.matchTotalSamples, targetTotal);
+  const totalVariance = sampleVariance(input.profile.matchTotalSamples, targetTotal);
+  const relativeSpread =
+    totalMean > 0 ? Math.sqrt(Math.max(totalVariance, 0)) / totalMean : 0.3;
+  const paceSpread = clamp(relativeSpread * 0.58, 0.14, 0.48);
+
+  return {
+    homeExpected,
+    awayExpected,
+    cells: buildScoreGrid({
+      homeExpected,
+      awayExpected,
+      homeDispersion,
+      awayDispersion,
+      paceSpread,
+    }),
+  };
+}
+
+function buildV3Prediction(input: {
+  homeTeamId: string;
+  awayTeamId: string;
+  stats: Map<string, TeamStats>;
+  profile: LeagueProfile;
+  probabilities: PredictorV3Probabilities;
+}) {
+  const probabilities = normaliseProbabilities(input.probabilities);
+  const predictedOutcome = outcomeFromProbabilities(probabilities);
+  const scoreModel = expectedGoalsAndGrid({
+    homeTeamId: input.homeTeamId,
+    awayTeamId: input.awayTeamId,
+    stats: input.stats,
+    profile: input.profile,
+    probabilities,
+  });
+  const score = enforceOutcome(
+    conditionalCentralScore(scoreModel.cells, predictedOutcome) ?? {
+      home: scoreModel.homeExpected,
+      away: scoreModel.awayExpected,
+    },
+    predictedOutcome,
+  );
+
+  return {
+    outcome: predictedOutcome,
+    probabilities,
+    score,
+    expectedHomeGoals: scoreModel.homeExpected,
+    expectedAwayGoals: scoreModel.awayExpected,
+  } satisfies PredictorV3Prediction;
+}
+
+export function calculatePredictorV3Candidates(input: {
+  homeTeamId: string;
+  awayTeamId: string;
+  history: WinChanceFixture[];
+  currentProbabilities: PredictorV3Probabilities;
+}): PredictorV3CandidateSet {
+  const stats = buildStats(input.history);
+  const profile = buildLeagueProfile(stats, input.history);
+  const ratings = buildEloRatings(input.history);
+  const currentProbabilities = normaliseProbabilities(input.currentProbabilities);
+  const fullProbabilities = buildV3OutcomeProbabilities({
+    homeTeamId: input.homeTeamId,
+    awayTeamId: input.awayTeamId,
+    stats,
+    profile,
+    ratings,
+    currentProbabilities,
+  });
+
+  return {
+    scoreOnly: buildV3Prediction({
+      homeTeamId: input.homeTeamId,
+      awayTeamId: input.awayTeamId,
+      stats,
+      profile,
+      probabilities: currentProbabilities,
+    }),
+    full: buildV3Prediction({
+      homeTeamId: input.homeTeamId,
+      awayTeamId: input.awayTeamId,
+      stats,
+      profile,
+      probabilities: fullProbabilities,
+    }),
+  };
+}


### PR DESCRIPTION
## What this adds

- adds two **read-only V3 predictor candidates** to the historical back-test:
  - **V3 score-only** keeps every current home/draw/away probability and result call unchanged, but replaces the conditional Poisson mode that keeps producing 3–2/4–3 with an overdispersed, pace-aware score model;
  - **V3 full** also tests a neutral-pitch outcome blend using current probabilities, Elo, points per game, goal difference, recent results and the observed SIXFL draw rate;
- models score variance with a negative-binomial distribution and shared high/normal/low pace states, then selects a central score conditional on the predicted result rather than the single Poisson mode;
- remains deterministic — no random scoreline variation is introduced;
- expands the back-test with predicted-versus-actual goals, goal bias, distinct scorelines, most-common and top-four concentration, Brier score, confidence calibration and a Team 1/draw/Team 2 confusion matrix;
- adds an explicit seven-part promotion gate comparing each V3 candidate with the current live control;
- shows V3 scores alongside current SIXFL and existing baselines in recent replay examples;
- adds a dedicated CI contract and workflow.

## Safety

This PR does **not** change `winChance.ts`, `storedAiPredictions.ts`, the current model version or any stored prediction. The V3 candidates run only inside the admin historical laboratory and are calculated in memory. Completed historical rows remain untouched, and passing the laboratory gate does not automatically promote a model.

## Promotion rule

A candidate must preserve result accuracy and Brier quality while improving score error, total-goal bias and scoreline concentration, use at least two additional scorelines, and avoid materially worse calibration. A separate explicit PR would still be required before any future-fixture predictions use V3.