### PR TITLE
Deploy newest-first fixture cards without legacy prebuild mutation

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Check last-minute replacement resolution
         run: node scripts/check-last-minute-replacement-resolution.mjs
 
+      - name: Check fixture card ordering
+        run: node scripts/check-fixture-card-ordering.mjs
+
       - name: Check sign-in link activity
         run: node scripts/check-sign-in-link-activity-contract.mjs
 
@@ -117,6 +120,7 @@ jobs:
           node scripts/check-night-board-fixture-notifications.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
+          node scripts/check-fixture-card-ordering.mjs
           node scripts/check-sign-in-link-activity-contract.mjs
           node scripts/check-ai-prediction-matchup-integrity.mjs
           node scripts/check-ai-prediction-text-team-integrity.mjs

--- a/scripts/apply-fixture-week-scroll-return.cjs
+++ b/scripts/apply-fixture-week-scroll-return.cjs
@@ -2,99 +2,105 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = process.cwd();
+const failures = [];
 
-function patchFile(relativePath, transform, label) {
+function read(relativePath) {
   const filePath = path.join(root, relativePath);
   if (!fs.existsSync(filePath)) {
-    throw new Error(`[fixture-week-scroll] Missing ${label}: ${relativePath}`);
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
   }
-  const before = fs.readFileSync(filePath, "utf8");
-  const after = transform(before);
-  if (after === before) {
-    const alreadyPatched =
-      before.includes("fixture-week-unassigned") ||
-      before.includes('startsWith("/admin/fixtures#")');
-    if (alreadyPatched) {
-      console.log(`[fixture-week-scroll] ${label} already patched.`);
-      return;
-    }
-    throw new Error(`[fixture-week-scroll] Could not patch ${label}: source anchor changed.`);
-  }
-  fs.writeFileSync(filePath, after, "utf8");
-  console.log(`[fixture-week-scroll] Patched ${label}.`);
+  return fs.readFileSync(filePath, "utf8");
 }
 
-patchFile(
-  "src/components/admin/fixtures/FixtureMatchupGrid.tsx",
-  (source) => {
-    if (!source.includes("function getWeekAnchor(")) {
-      source = source.replace(
-        `function getWeekLabel(round: number | null) {\n  return round === null ? \"Unassigned week\" : \`Week \${round}\`;\n}\n`,
-        `function getWeekLabel(round: number | null) {\n  return round === null ? \"Unassigned week\" : \`Week \${round}\`;\n}\n\nfunction getWeekAnchor(round: number | null) {\n  return round === null ? \"fixture-week-unassigned\" : \`fixture-week-\${round}\`;\n}\n`,
-      );
-    }
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
 
-    source = source.replace(
-      `  status: StatusFilter;\n}) {\n  const returnTo = buildGridHref(input.leagueId, input.divisionId || null, input.visibility, input.status);\n  const params = new URLSearchParams({ returnTo });`,
-      `  status: StatusFilter;\n  round: number | null;\n}) {\n  const returnTo = buildGridHref(input.leagueId, input.divisionId || null, input.visibility, input.status);\n  const returnToWeek = \`${"${returnTo}"}#${"${getWeekAnchor(input.round)}"}\`;\n  const params = new URLSearchParams({ returnTo: returnToWeek });`,
-    );
+function reject(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
 
-    source = source.replace(
-      `<div key={roundLabel} className="space-y-3">`,
-      `<div\n                      key={roundLabel}\n                      id={getWeekAnchor(roundFixtures[0]?.round ?? null)}\n                      className="scroll-mt-6 space-y-3"\n                    >`,
-    );
+const grid = read("src/components/admin/fixtures/FixtureMatchupGrid.tsx");
+const action = read("src/app/(admin)/admin/fixtures/[id]/edit/actions.ts");
+const page = read("src/app/(admin)/admin/fixtures/[id]/edit/page.tsx");
 
-    source = source.replace(
-      `status: selectedStatus })}`,
-      `status: selectedStatus, round: fixture.round })}`,
-    );
-
-    return source;
-  },
-  "fixture matchup grid",
+// Fixture-card return handling is now owned natively by FixtureMatchupGrid.
+// This compatibility entry remains in the historic prebuild chain only as a
+// guard. It must never rewrite source again.
+expect(
+  grid,
+  'const FIXTURE_CARD_SCROLL_KEY = "sixfl:admin-fixtures:card-scroll";',
+  "FixtureMatchupGrid must retain its native session-scroll key.",
+);
+expect(
+  grid,
+  'if (focusFixtureId) params.set("focusFixture", focusFixtureId);',
+  "Fixture list return links must retain the focused fixture id.",
+);
+expect(
+  grid,
+  'const focusFixtureId = searchParams.get("focusFixture") ?? "";',
+  "FixtureMatchupGrid must read the focused fixture from the URL.",
+);
+expect(
+  grid,
+  "onClick={rememberFixtureCardScrollPosition}",
+  "Edit fixture must remember the current card-list scroll position.",
+);
+expect(
+  grid,
+  "focusedFixtureRef.current?.scrollIntoView({",
+  "Fixture return must retain its React-ref fallback.",
+);
+expect(
+  grid,
+  "if (!sameMatchDay) return bKickoff - aKickoff;",
+  "Fixture cards must keep newer match dates first within a week.",
+);
+expect(
+  grid,
+  "if (aKickoff !== bKickoff) return aKickoff - bKickoff;",
+  "Fixtures on one match night must stay in chronological kick-off order.",
+);
+expect(
+  grid,
+  "if (Number.isFinite(aNumber) && Number.isFinite(bNumber)) return bNumber - aNumber;",
+  "Fixture week groups must remain newest first.",
+);
+expect(
+  action,
+  'parsed.startsWith("/admin/fixtures?")',
+  "The fixture edit action must accept the native filtered fixture-list return URL.",
+);
+expect(
+  page,
+  'value.startsWith("/admin/fixtures?")',
+  "The fixture edit page must accept the native filtered fixture-list return URL.",
 );
 
-patchFile(
-  "src/app/(admin)/admin/fixtures/[id]/edit/actions.ts",
-  (source) => {
-    source = source.replace(
-      `function safeFixturesReturnTo(value: FormDataEntryValue | null) {\n  const parsed = String(value ?? \"\").trim();\n  return parsed === \"/admin/fixtures\" || parsed.startsWith(\"/admin/fixtures?\")\n    ? parsed\n    : \"/admin/fixtures\";\n}\n`,
-      `function safeFixturesReturnTo(value: FormDataEntryValue | null) {\n  const parsed = String(value ?? \"\").trim();\n  return (\n    parsed === \"/admin/fixtures\" ||\n    parsed.startsWith(\"/admin/fixtures?\") ||\n    parsed.startsWith(\"/admin/fixtures#\")\n  )\n    ? parsed\n    : \"/admin/fixtures\";\n}\n\nfunction stripHash(value: string) {\n  return value.split(\"#\", 1)[0] || \"/admin/fixtures\";\n}\n\nfunction withWeekAnchor(value: string, round: number | null) {\n  const base = stripHash(value);\n  const anchor = round === null ? \"fixture-week-unassigned\" : \`fixture-week-\${round}\`;\n  return \`${"${base}"}#${"${anchor}"}\`;\n}\n`,
-    );
-
-    source = source.replace(
-      `  const requestId = randomUUID().slice(0, 8);\n\n  try {`,
-      `  const requestId = randomUUID().slice(0, 8);\n  let successReturnTo = returnTo;\n\n  try {`,
-    );
-
-    source = source.replace(
-      `    const round = parseOptionalInt(formData.get(\"round\"), \"Week\");\n`,
-      `    const round = parseOptionalInt(formData.get(\"round\"), \"Week\");\n    successReturnTo = withWeekAnchor(returnTo, round);\n`,
-    );
-
-    source = source.replace(
-      `    revalidatePath(returnTo);`,
-      `    revalidatePath(stripHash(successReturnTo));`,
-    );
-
-    source = source.replace(
-      `  redirect(returnTo);\n}`,
-      `  redirect(successReturnTo);\n}`,
-    );
-
-    return source;
-  },
-  "fixture edit action",
+reject(
+  grid,
+  "round: fixture.round })}",
+  "The retired week-hash patch must not add an unsupported round property to the edit-link helper.",
+);
+reject(
+  action,
+  'startsWith("/admin/fixtures#")',
+  "The edit action must not restore the retired hash-based return path.",
+);
+reject(
+  page,
+  'startsWith("/admin/fixtures#")',
+  "The edit page must not restore the retired hash-based return path.",
 );
 
-patchFile(
-  "src/app/(admin)/admin/fixtures/[id]/edit/page.tsx",
-  (source) => {
-    source = source.replace(
-      `function safeReturnTo(value: string) {\n  return value === \"/admin/fixtures\" || value.startsWith(\"/admin/fixtures?\")\n    ? value\n    : \"/admin/fixtures\";\n}\n`,
-      `function safeReturnTo(value: string) {\n  return (\n    value === \"/admin/fixtures\" ||\n    value.startsWith(\"/admin/fixtures?\") ||\n    value.startsWith(\"/admin/fixtures#\")\n  )\n    ? value\n    : \"/admin/fixtures\";\n}\n`,
-    );
-    return source;
-  },
-  "fixture edit page",
+if (failures.length > 0) {
+  throw new Error(
+    `[fixture-week-scroll] Native fixture-card return contract failed:\n - ${failures.join("\n - ")}`,
+  );
+}
+
+console.log(
+  "[fixture-week-scroll] Native fixture-card focus return verified; no source patch required.",
 );

--- a/scripts/check-fixture-card-ordering.mjs
+++ b/scripts/check-fixture-card-ordering.mjs
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const filePath = path.join(root, relativePath);
+  if (!fs.existsSync(filePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function expect(source, marker, message) {
+  if (!source.includes(marker)) failures.push(message);
+}
+
+function reject(source, marker, message) {
+  if (source.includes(marker)) failures.push(message);
+}
+
+const grid = read("src/components/admin/fixtures/FixtureMatchupGrid.tsx");
+const compatibilityGuard = read("scripts/apply-fixture-week-scroll-return.cjs");
+const preparationChain = read("scripts/check-central-standings-usage.cjs");
+
+expect(
+  grid,
+  'const fixtureDayFormatter = new Intl.DateTimeFormat("en-GB", {',
+  "Fixture cards must compare match days in the displayed timezone.",
+);
+expect(
+  grid,
+  'timeZone: "Europe/London"',
+  "Fixture-card match-day grouping must retain the Europe/London timezone.",
+);
+expect(
+  grid,
+  "if (!sameMatchDay) return bKickoff - aKickoff;",
+  "Within a week, newer fixture dates must be displayed first.",
+);
+expect(
+  grid,
+  "if (aKickoff !== bKickoff) return aKickoff - bKickoff;",
+  "Fixtures on the same match night must remain earliest-to-latest by kick-off.",
+);
+expect(
+  grid,
+  "if (Number.isFinite(aNumber) && Number.isFinite(bNumber)) return bNumber - aNumber;",
+  "Numbered week groups must be displayed newest first.",
+);
+expect(
+  grid,
+  "if (Number.isFinite(aNumber)) return -1;",
+  "Numbered weeks must remain above unassigned fixtures.",
+);
+expect(
+  grid,
+  "if (Number.isFinite(bNumber)) return 1;",
+  "Unassigned fixtures must remain below numbered weeks.",
+);
+expect(
+  grid,
+  'if (focusFixtureId) params.set("focusFixture", focusFixtureId);',
+  "The edit return URL must retain the selected fixture id.",
+);
+expect(
+  grid,
+  "onClick={rememberFixtureCardScrollPosition}",
+  "Editing a fixture must remember the current list position.",
+);
+expect(
+  grid,
+  "focusedFixtureRef.current?.scrollIntoView({",
+  "Fixture return must retain its native React-ref fallback.",
+);
+reject(
+  grid,
+  "if (Number.isFinite(aNumber) && Number.isFinite(bNumber)) return aNumber - bNumber;",
+  "The retired oldest-week-first comparator must not return.",
+);
+reject(
+  grid,
+  "round: fixture.round })}",
+  "The retired week-hash patch must not add an unsupported round property.",
+);
+
+expect(
+  compatibilityGuard,
+  "Native fixture-card focus return verified; no source patch required.",
+  "The legacy fixture-week script must remain an inert native-source guard.",
+);
+reject(
+  compatibilityGuard,
+  "writeFileSync(",
+  "The retired fixture-week compatibility script must not rewrite application source.",
+);
+reject(
+  compatibilityGuard,
+  "source.replace(",
+  "The retired fixture-week compatibility script must not patch source anchors.",
+);
+expect(
+  preparationChain,
+  'require("./apply-fixture-week-scroll-return.cjs")',
+  "The production preparation chain must continue to verify the native fixture return contract.",
+);
+
+if (failures.length > 0) {
+  console.error("\nFIXTURE CARD ORDERING CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Fixture card ordering contract passed: newest weeks and dates appear first, same-night kick-offs remain chronological and edit-return handling stays native.",
+);


### PR DESCRIPTION
## What this fixes

The newest-first fixture-card change is already present in the native `FixtureMatchupGrid` component, but production preparation was still running an older source-rewriting script. That legacy script partially injected its previous hash-based return implementation, adding `round: fixture.round` without updating the newer helper type, so TypeScript failed and the merged change could not deploy.

## Changes

- retires `apply-fixture-week-scroll-return.cjs` as a source writer;
- keeps it in the historic preparation chain as a read-only guard for the current native focus/scroll implementation;
- preserves newest week first, newest fixture date first and chronological kick-offs on the same match night;
- adds a permanent fixture-card ordering contract;
- runs that contract after the complete production prebuild and again during the final critical-feature re-check.

## Scope

No fixture records, payments, results, filters or editing actions are changed. The owning React component remains the source of truth; this PR removes the legacy prebuild mutation that prevented it from building.