### PR TITLE
Resolve team-raised fixture issues from the Night Board

### DIFF
--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Check last-minute replacement resolution
         run: node scripts/check-last-minute-replacement-resolution.mjs
 
+      - name: Check fixture card ordering
+        run: node scripts/check-fixture-card-ordering.mjs
+
       - name: Check sign-in link activity
         run: node scripts/check-sign-in-link-activity-contract.mjs
 
@@ -121,6 +124,7 @@ jobs:
           node scripts/check-night-board-fixture-issue-resolution.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
+          node scripts/check-fixture-card-ordering.mjs
           node scripts/check-sign-in-link-activity-contract.mjs
           node scripts/check-ai-prediction-matchup-integrity.mjs
           node scripts/check-ai-prediction-text-team-integrity.mjs

--- a/.github/workflows/critical-feature-contracts.yml
+++ b/.github/workflows/critical-feature-contracts.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check Night Board fixture-change notifications
         run: node scripts/check-night-board-fixture-notifications.mjs
 
+      - name: Check Night Board fixture issue resolution
+        run: node scripts/check-night-board-fixture-issue-resolution.mjs
+
       - name: Check standard-team player payment links
         run: node scripts/check-standard-team-player-payment-links.mjs
 
@@ -115,6 +118,7 @@ jobs:
           node scripts/check-critical-feature-contracts.mjs
           node scripts/check-team-confirmation-contract.mjs
           node scripts/check-night-board-fixture-notifications.mjs
+          node scripts/check-night-board-fixture-issue-resolution.mjs
           node scripts/check-standard-team-player-payment-links.mjs
           node scripts/check-last-minute-replacement-resolution.mjs
           node scripts/check-sign-in-link-activity-contract.mjs

--- a/scripts/check-night-board-fixture-issue-resolution.mjs
+++ b/scripts/check-night-board-fixture-issue-resolution.mjs
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const panel = read(
+  "src/components/admin/night-board/NightBoardTeamIssuesPanel.tsx",
+);
+const issueCard = read(
+  "src/components/admin/night-board/NightBoardTeamIssueCard.tsx",
+);
+const resolveAction = read(
+  "src/app/(admin)/admin/fixtures/issue-actions.ts",
+);
+
+expect(
+  panel.includes("NightBoardTeamIssueCard") &&
+    panel.includes('case "issue_resolved"') &&
+    panel.includes('notice === "issue_resolved"'),
+  "the Night Board drawer must render native issue cards and show a successful resolution notice",
+);
+
+expect(
+  issueCard.includes("resolveFixtureConfirmationIssueAction") &&
+    issueCard.includes("action={resolveFixtureConfirmationIssueAction}") &&
+    issueCard.includes('name="returnTo"') &&
+    issueCard.includes("Resolve issue"),
+  "every Night Board issue card must expose the server-backed Resolve issue action and preserve the selected Night Board URL",
+);
+
+expect(
+  issueCard.includes("returns the team") &&
+    issueCard.includes("awaiting confirmation") &&
+    issueCard.includes("does not send an email"),
+  "the Night Board resolve control must explain that resolution returns confirmation to pending without emailing the team",
+);
+
+expect(
+  resolveAction.includes("await requireAdmin()") &&
+    resolveAction.includes('formData.get("returnTo")') &&
+    resolveAction.includes('url.pathname !== "/admin/night-board"') &&
+    resolveAction.includes('return "issue_resolved"'),
+  "fixture issue resolution must remain admin-only and use a validated Night Board return URL",
+);
+
+expect(
+  resolveAction.includes('status: "ISSUE_RAISED"') &&
+    resolveAction.includes('status: "PENDING"') &&
+    resolveAction.includes("note: null") &&
+    resolveAction.includes("issueRaisedAt: null"),
+  "resolution must close only an open raised issue and restore the team confirmation to a clean pending state",
+);
+
+expect(
+  resolveAction.includes('revalidatePath("/admin/night-board")') &&
+    resolveAction.includes('return `/admin/fixtures?${params.toString()}#fixture-issue-replies`'),
+  "resolution must refresh the Night Board while preserving the existing Admin Fixtures fallback flow",
+);
+
+if (failures.length) {
+  console.error("\nNIGHT BOARD FIXTURE ISSUE RESOLUTION CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  console.error("\nDo not merge until fixture issues can still be resolved safely from the Night Board drawer.\n");
+  process.exit(1);
+}
+
+console.log("Night Board fixture issue resolution contract passed.");

--- a/src/app/(admin)/admin/fixtures/issue-actions.ts
+++ b/src/app/(admin)/admin/fixtures/issue-actions.ts
@@ -10,15 +10,54 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
+type FixtureIssueResolutionResult = "resolved" | "unavailable" | "error";
+
 function getString(value: FormDataEntryValue | null) {
   return String(value ?? "").trim();
 }
 
+function getNightBoardNotice(result: FixtureIssueResolutionResult) {
+  if (result === "resolved") return "issue_resolved";
+  if (result === "error") return "issue_error";
+  return "issue_not_found";
+}
+
+function buildNightBoardRedirect(input: {
+  returnTo?: string | null;
+  result: FixtureIssueResolutionResult;
+  teamName?: string | null;
+}) {
+  const rawReturnTo = input.returnTo?.trim();
+  if (!rawReturnTo?.startsWith("/admin/night-board")) return null;
+
+  try {
+    const url = new URL(rawReturnTo, "https://sixfl.local");
+    if (url.pathname !== "/admin/night-board") return null;
+
+    url.searchParams.set("issueReply", getNightBoardNotice(input.result));
+
+    if (input.teamName?.trim()) {
+      url.searchParams.set("issueTeam", input.teamName.trim());
+    } else {
+      url.searchParams.delete("issueTeam");
+    }
+
+    const query = url.searchParams.toString();
+    return `${url.pathname}${query ? `?${query}` : ""}`;
+  } catch {
+    return null;
+  }
+}
+
 function getRedirectUrl(input: {
-  result: "resolved" | "unavailable" | "error";
+  result: FixtureIssueResolutionResult;
   teamName?: string | null;
   leagueId?: string | null;
+  returnTo?: string | null;
 }) {
+  const nightBoardRedirect = buildNightBoardRedirect(input);
+  if (nightBoardRedirect) return nightBoardRedirect;
+
   const params = new URLSearchParams();
   params.set("fixtureIssue", input.result);
 
@@ -38,11 +77,18 @@ export async function resolveFixtureConfirmationIssueAction(formData: FormData) 
 
   const fixtureId = getString(formData.get("fixtureId"));
   const teamId = getString(formData.get("teamId"));
+  const returnTo = getString(formData.get("returnTo"));
   let leagueId = getString(formData.get("leagueId")) || null;
   let teamName = "that team";
 
   if (!fixtureId || !teamId) {
-    redirect(getRedirectUrl({ result: "unavailable", leagueId }));
+    redirect(
+      getRedirectUrl({
+        result: "unavailable",
+        leagueId,
+        returnTo,
+      }),
+    );
   }
 
   const fixture = await prisma.fixture.findUnique({
@@ -56,7 +102,13 @@ export async function resolveFixtureConfirmationIssueAction(formData: FormData) 
   });
 
   if (!fixture) {
-    redirect(getRedirectUrl({ result: "unavailable", leagueId }));
+    redirect(
+      getRedirectUrl({
+        result: "unavailable",
+        leagueId,
+        returnTo,
+      }),
+    );
   }
 
   leagueId = fixture.leagueId ?? leagueId;
@@ -69,32 +121,60 @@ export async function resolveFixtureConfirmationIssueAction(formData: FormData) 
         : null;
 
   if (!team) {
-    redirect(getRedirectUrl({ result: "unavailable", leagueId }));
+    redirect(
+      getRedirectUrl({
+        result: "unavailable",
+        leagueId,
+        returnTo,
+      }),
+    );
   }
 
   teamName = team.name;
 
-  const result = await prisma.fixtureCaptainConfirmation.updateMany({
-    where: {
-      fixtureId,
-      teamId,
-      status: "ISSUE_RAISED",
-    },
-    data: {
-      status: "PENDING",
-      note: null,
-      issueRaisedAt: null,
-      confirmedAt: null,
-      confirmedByUserId: null,
-    },
-  });
+  let result;
+
+  try {
+    result = await prisma.fixtureCaptainConfirmation.updateMany({
+      where: {
+        fixtureId,
+        teamId,
+        status: "ISSUE_RAISED",
+      },
+      data: {
+        status: "PENDING",
+        note: null,
+        issueRaisedAt: null,
+        confirmedAt: null,
+        confirmedByUserId: null,
+      },
+    });
+  } catch {
+    redirect(
+      getRedirectUrl({
+        result: "error",
+        teamName,
+        leagueId,
+        returnTo,
+      }),
+    );
+  }
 
   if (result.count === 0) {
-    redirect(getRedirectUrl({ result: "unavailable", teamName, leagueId }));
+    redirect(
+      getRedirectUrl({
+        result: "unavailable",
+        teamName,
+        leagueId,
+        returnTo,
+      }),
+    );
   }
 
   revalidatePath("/admin");
   revalidatePath("/admin/fixtures");
+  revalidatePath("/admin/fixtures/issues");
+  revalidatePath("/admin/night-board");
   revalidatePath(`/captain/team/${teamId}`);
   revalidatePath(`/captain/team/${teamId}/fixtures`);
 
@@ -108,5 +188,12 @@ export async function resolveFixtureConfirmationIssueAction(formData: FormData) 
     revalidatePath(`/leagues/${fixture.league.slug}/fixtures`);
   }
 
-  redirect(getRedirectUrl({ result: "resolved", teamName, leagueId }));
+  redirect(
+    getRedirectUrl({
+      result: "resolved",
+      teamName,
+      leagueId,
+      returnTo,
+    }),
+  );
 }

--- a/src/components/admin/night-board/NightBoardTeamIssueCard.tsx
+++ b/src/components/admin/night-board/NightBoardTeamIssueCard.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+import { resolveFixtureConfirmationIssueAction } from "@/app/(admin)/admin/fixtures/issue-actions";
+import { replyToFixtureIssueAction } from "@/app/(admin)/admin/fixtures/issues/actions";
+
+export type NightBoardTeamIssue = {
+  id: string;
+  fixtureId: string;
+  teamId: string;
+  note: string | null;
+  issueRaisedAt: string | null;
+  lastChasedAt: string | null;
+  team: {
+    id: string;
+    name: string;
+    contactName: string | null;
+    contactEmail: string | null;
+    secondaryContactName: string | null;
+    secondaryContactEmail: string | null;
+  };
+  fixture: {
+    id: string;
+    leagueId: string;
+    kickoffAt: string;
+    pitch: string | null;
+    league: { name: string; season: string | null };
+    homeTeam: { id: string; name: string };
+    awayTeam: { id: string; name: string };
+  };
+  confirmedByUser: { name: string | null; email: string | null } | null;
+};
+
+function formatKickoff(value: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: "Europe/London",
+  }).format(new Date(value));
+}
+
+function formatStamp(value: string | null) {
+  if (!value) return null;
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: "Europe/London",
+  }).format(new Date(value));
+}
+
+function ResolveIssueButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl border border-sky-300/30 bg-sky-500/10 px-4 py-2.5 text-sm font-semibold text-sky-100 transition hover:border-sky-300/45 hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {pending ? "Resolving issue…" : "Resolve issue"}
+    </button>
+  );
+}
+
+export default function NightBoardTeamIssueCard({
+  issue,
+  returnTo,
+  emailReplyConfigured,
+}: {
+  issue: NightBoardTeamIssue;
+  returnTo: string;
+  emailReplyConfigured: boolean;
+}) {
+  const isHomeTeam = issue.fixture.homeTeam.id === issue.teamId;
+  const opponent = isHomeTeam
+    ? issue.fixture.awayTeam.name
+    : issue.fixture.homeTeam.name;
+  const raisedBy =
+    issue.confirmedByUser?.name || issue.confirmedByUser?.email || "Captain";
+  const raisedByEmail = issue.confirmedByUser?.email?.trim() || null;
+
+  return (
+    <div className="rounded-3xl border border-red-400/20 bg-red-500/[0.07] p-4 sm:p-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-red-200/75">
+            Issue raised
+          </div>
+          <h3 className="mt-2 text-lg font-semibold text-white">
+            {issue.team.name} v {opponent}
+          </h3>
+          <div className="mt-1 text-xs text-white/50">
+            {formatKickoff(issue.fixture.kickoffAt)}
+            {issue.fixture.pitch ? ` · ${issue.fixture.pitch}` : ""}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs sm:text-right">
+          <div className="font-semibold uppercase tracking-[0.12em] text-white/35">
+            Raised by
+          </div>
+          <div className="mt-1 font-semibold text-white/85">{raisedBy}</div>
+          {raisedByEmail && raisedByEmail !== raisedBy ? (
+            <div className="mt-0.5 text-white/40">{raisedByEmail}</div>
+          ) : null}
+          <div className="mt-1 text-white/40">
+            {formatStamp(issue.issueRaisedAt) ?? "Time not recorded"}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-2xl border border-red-400/20 bg-black/25 px-4 py-3 text-sm leading-6 text-red-50/90">
+        {issue.note || "No issue note was supplied."}
+      </div>
+
+      <div className="mt-3 text-xs text-white/45">
+        Contact: {issue.team.contactName || issue.team.name} ·{" "}
+        {issue.team.contactEmail || "No email on team record"}
+        {issue.lastChasedAt
+          ? ` · Last replied/chased ${formatStamp(issue.lastChasedAt)}`
+          : ""}
+      </div>
+
+      <form action={replyToFixtureIssueAction} className="mt-4 space-y-3">
+        <input type="hidden" name="fixtureId" value={issue.fixtureId} />
+        <input type="hidden" name="teamId" value={issue.teamId} />
+        <input type="hidden" name="leagueId" value={issue.fixture.leagueId} />
+        <input type="hidden" name="returnTo" value={returnTo} />
+        <textarea
+          name="reply"
+          rows={4}
+          required
+          minLength={5}
+          placeholder="Write your reply to the team…"
+          className="w-full rounded-2xl border border-white/10 bg-black/35 px-4 py-3 text-sm leading-6 text-white outline-none placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/15"
+        />
+        <button
+          type="submit"
+          disabled={!emailReplyConfigured}
+          className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-emerald-400 px-4 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Send reply to {issue.team.name}
+        </button>
+        {emailReplyConfigured ? (
+          <p className="text-xs leading-5 text-white/45">
+            If the team replies to this email, their response comes back into
+            SIXFL Messages on the same email conversation.
+          </p>
+        ) : null}
+      </form>
+
+      <div className="mt-4 border-t border-white/10 pt-4">
+        <form action={resolveFixtureConfirmationIssueAction} className="space-y-2">
+          <input type="hidden" name="fixtureId" value={issue.fixtureId} />
+          <input type="hidden" name="teamId" value={issue.teamId} />
+          <input type="hidden" name="leagueId" value={issue.fixture.leagueId} />
+          <input type="hidden" name="returnTo" value={returnTo} />
+          <ResolveIssueButton />
+          <p className="text-xs leading-5 text-white/45">
+            Removes this request from the open issues list and returns the team
+            to awaiting confirmation. Resolving it does not send an email.
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/night-board/NightBoardTeamIssuesPanel.tsx
+++ b/src/components/admin/night-board/NightBoardTeamIssuesPanel.tsx
@@ -8,65 +8,15 @@ import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
-import { replyToFixtureIssueAction } from "@/app/(admin)/admin/fixtures/issues/actions";
-
-type TeamIssue = {
-  id: string;
-  fixtureId: string;
-  teamId: string;
-  note: string | null;
-  issueRaisedAt: string | null;
-  lastChasedAt: string | null;
-  team: {
-    id: string;
-    name: string;
-    contactName: string | null;
-    contactEmail: string | null;
-    secondaryContactName: string | null;
-    secondaryContactEmail: string | null;
-  };
-  fixture: {
-    id: string;
-    leagueId: string;
-    kickoffAt: string;
-    pitch: string | null;
-    league: { name: string; season: string | null };
-    homeTeam: { id: string; name: string };
-    awayTeam: { id: string; name: string };
-  };
-  confirmedByUser: { name: string | null; email: string | null } | null;
-};
+import NightBoardTeamIssueCard, {
+  type NightBoardTeamIssue,
+} from "@/components/admin/night-board/NightBoardTeamIssueCard";
 
 type IssuesResponse = {
   selectedDate: string;
   emailReplyConfigured: boolean;
-  issues: TeamIssue[];
+  issues: NightBoardTeamIssue[];
 };
-
-function formatKickoff(value: string) {
-  return new Intl.DateTimeFormat("en-GB", {
-    weekday: "short",
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZone: "Europe/London",
-  }).format(new Date(value));
-}
-
-function formatStamp(value: string | null) {
-  if (!value) return null;
-
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZone: "Europe/London",
-  }).format(new Date(value));
-}
 
 function getNoticeMessage(notice: string, teamName: string) {
   switch (notice) {
@@ -76,10 +26,14 @@ function getNoticeMessage(notice: string, teamName: string) {
       return `Reply saved, but an email could not be queued for ${teamName || "the team"}. Check the team contact email and notification settings.`;
     case "reply_too_short":
       return "Please enter a longer reply.";
+    case "issue_resolved":
+      return `The open fixture issue for ${teamName || "the team"} has been resolved.`;
     case "issue_not_found":
       return "That issue could not be found or is no longer open.";
     case "missing_issue":
       return "The fixture issue details were missing.";
+    case "issue_error":
+      return `Something went wrong while resolving the issue for ${teamName || "the team"}.`;
     case "reply_error":
       return `Something went wrong while replying to ${teamName || "the team"}.`;
     default:
@@ -91,7 +45,10 @@ export default function NightBoardTeamIssuesPanel() {
   const pathname = usePathname();
   const rawSearchParams = useSearchParams();
   const searchKey = rawSearchParams.toString();
-  const parsedSearchParams = useMemo(() => new URLSearchParams(searchKey), [searchKey]);
+  const parsedSearchParams = useMemo(
+    () => new URLSearchParams(searchKey),
+    [searchKey],
+  );
   const [data, setData] = useState<IssuesResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -130,9 +87,15 @@ export default function NightBoardTeamIssuesPanel() {
       signal: controller.signal,
     })
       .then(async (response) => {
-        const payload = (await response.json().catch(() => null)) as IssuesResponse | { error?: string } | null;
+        const payload = (await response.json().catch(() => null)) as
+          | IssuesResponse
+          | { error?: string }
+          | null;
         if (!response.ok || !payload || !("issues" in payload)) {
-          throw new Error((payload && "error" in payload && payload.error) || "Team-raised fixture issues could not be loaded.");
+          throw new Error(
+            (payload && "error" in payload && payload.error) ||
+              "Team-raised fixture issues could not be loaded.",
+          );
         }
         return payload;
       })
@@ -142,7 +105,11 @@ export default function NightBoardTeamIssuesPanel() {
       })
       .catch((fetchError) => {
         if (controller.signal.aborted) return;
-        setError(fetchError instanceof Error ? fetchError.message : "Team-raised fixture issues could not be loaded.");
+        setError(
+          fetchError instanceof Error
+            ? fetchError.message
+            : "Team-raised fixture issues could not be loaded.",
+        );
       })
       .finally(() => {
         if (!controller.signal.aborted) setLoading(false);
@@ -155,6 +122,7 @@ export default function NightBoardTeamIssuesPanel() {
 
   const issueCount = data?.issues.length ?? 0;
   const hasIssues = issueCount > 0;
+  const successNotice = notice === "reply_queued" || notice === "issue_resolved";
 
   return (
     <>
@@ -167,13 +135,17 @@ export default function NightBoardTeamIssuesPanel() {
             ? "border-red-400/40 bg-red-500/90 text-white hover:bg-red-400"
             : "border-white/15 bg-[#111827]/95 text-white/85 hover:bg-[#182235]",
         ].join(" ")}
-        aria-label={`Open team-raised fixture issues${hasIssues ? ` (${issueCount})` : ""}`}
+        aria-label={`Open team-raised fixture issues${
+          hasIssues ? ` (${issueCount})` : ""
+        }`}
       >
         <span>{loading ? "Checking team issues…" : "Team fixture issues"}</span>
         <span
           className={[
             "inline-flex min-w-7 items-center justify-center rounded-full border px-2 py-0.5 text-xs font-black",
-            hasIssues ? "border-white/25 bg-black/20 text-white" : "border-white/10 bg-black/20 text-white/60",
+            hasIssues
+              ? "border-white/25 bg-black/20 text-white"
+              : "border-white/10 bg-black/20 text-white/60",
           ].join(" ")}
         >
           {loading ? "…" : issueCount}
@@ -181,16 +153,31 @@ export default function NightBoardTeamIssuesPanel() {
       </button>
 
       {open ? (
-        <div className="fixed inset-0 z-[100] flex justify-end bg-black/70 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Team-raised fixture issues">
-          <button type="button" className="absolute inset-0 cursor-default" aria-label="Close team issues" onClick={() => setOpen(false)} />
+        <div
+          className="fixed inset-0 z-[100] flex justify-end bg-black/70 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Team-raised fixture issues"
+        >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Close team issues"
+            onClick={() => setOpen(false)}
+          />
 
           <div className="relative flex h-full w-full max-w-2xl flex-col border-l border-white/10 bg-[#0b0f14] shadow-2xl">
             <div className="flex items-start justify-between gap-4 border-b border-white/10 px-5 py-5 sm:px-6">
               <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-red-300/80">Night Board</div>
-                <h2 className="mt-2 text-2xl font-semibold text-white">Team-raised fixture issues</h2>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-red-300/80">
+                  Night Board
+                </div>
+                <h2 className="mt-2 text-2xl font-semibold text-white">
+                  Team-raised fixture issues
+                </h2>
                 <p className="mt-1 text-sm text-white/50">
-                  {data?.selectedDate ?? "Selected night"} · {issueCount} open issue{issueCount === 1 ? "" : "s"}
+                  {data?.selectedDate ?? "Selected night"} · {issueCount} open issue
+                  {issueCount === 1 ? "" : "s"}
                 </p>
               </div>
               <button
@@ -208,7 +195,7 @@ export default function NightBoardTeamIssuesPanel() {
                 <div
                   className={[
                     "mb-4 rounded-2xl border px-4 py-3 text-sm",
-                    notice === "reply_queued"
+                    successNotice
                       ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"
                       : "border-amber-400/25 bg-amber-500/10 text-amber-100",
                   ].join(" ")}
@@ -218,94 +205,53 @@ export default function NightBoardTeamIssuesPanel() {
               ) : null}
 
               {error ? (
-                <div className="rounded-2xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm text-red-100">{error}</div>
+                <div className="rounded-2xl border border-red-400/25 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                  {error}
+                </div>
               ) : null}
 
               {!loading && !error && !data?.emailReplyConfigured ? (
                 <div className="mb-4 rounded-2xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-                  Reply-by-email is not configured. Add EMAIL_REPLY_DOMAIN in Railway before sending replies.
+                  Reply-by-email is not configured. Add EMAIL_REPLY_DOMAIN in
+                  Railway before sending replies. Issues can still be resolved.
                 </div>
               ) : null}
 
-              {loading ? <div className="py-10 text-center text-sm text-white/50">Loading team issues…</div> : null}
+              {loading ? (
+                <div className="py-10 text-center text-sm text-white/50">
+                  Loading team issues…
+                </div>
+              ) : null}
 
               {!loading && !error && issueCount === 0 ? (
                 <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.02] p-10 text-center">
-                  <div className="text-lg font-semibold text-white">No team-raised issues on this night</div>
-                  <p className="mt-2 text-sm leading-6 text-white/50">Any captain request or problem raised against a fixture will appear here.</p>
+                  <div className="text-lg font-semibold text-white">
+                    No team-raised issues on this night
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-white/50">
+                    Any captain request or problem raised against a fixture will
+                    appear here.
+                  </p>
                 </div>
               ) : null}
 
               <div className="space-y-4">
-                {data?.issues.map((issue) => {
-                  const isHomeTeam = issue.fixture.homeTeam.id === issue.teamId;
-                  const opponent = isHomeTeam ? issue.fixture.awayTeam.name : issue.fixture.homeTeam.name;
-                  const raisedBy = issue.confirmedByUser?.name || issue.confirmedByUser?.email || "Captain";
-                  const raisedByEmail = issue.confirmedByUser?.email?.trim() || null;
-
-                  return (
-                    <div key={issue.id} className="rounded-3xl border border-red-400/20 bg-red-500/[0.07] p-4 sm:p-5">
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                        <div>
-                          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-red-200/75">Issue raised</div>
-                          <h3 className="mt-2 text-lg font-semibold text-white">{issue.team.name} v {opponent}</h3>
-                          <div className="mt-1 text-xs text-white/50">
-                            {formatKickoff(issue.fixture.kickoffAt)}{issue.fixture.pitch ? ` · ${issue.fixture.pitch}` : ""}
-                          </div>
-                        </div>
-                        <div className="rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs sm:text-right">
-                          <div className="font-semibold uppercase tracking-[0.12em] text-white/35">Raised by</div>
-                          <div className="mt-1 font-semibold text-white/85">{raisedBy}</div>
-                          {raisedByEmail && raisedByEmail !== raisedBy ? (
-                            <div className="mt-0.5 text-white/40">{raisedByEmail}</div>
-                          ) : null}
-                          <div className="mt-1 text-white/40">{formatStamp(issue.issueRaisedAt) ?? "Time not recorded"}</div>
-                        </div>
-                      </div>
-
-                      <div className="mt-4 rounded-2xl border border-red-400/20 bg-black/25 px-4 py-3 text-sm leading-6 text-red-50/90">
-                        {issue.note || "No issue note was supplied."}
-                      </div>
-
-                      <div className="mt-3 text-xs text-white/45">
-                        Contact: {issue.team.contactName || issue.team.name} · {issue.team.contactEmail || "No email on team record"}
-                        {issue.lastChasedAt ? ` · Last replied/chased ${formatStamp(issue.lastChasedAt)}` : ""}
-                      </div>
-
-                      <form action={replyToFixtureIssueAction} className="mt-4 space-y-3">
-                        <input type="hidden" name="fixtureId" value={issue.fixtureId} />
-                        <input type="hidden" name="teamId" value={issue.teamId} />
-                        <input type="hidden" name="leagueId" value={issue.fixture.leagueId} />
-                        <input type="hidden" name="returnTo" value={returnTo} />
-                        <textarea
-                          name="reply"
-                          rows={4}
-                          required
-                          minLength={5}
-                          placeholder="Write your reply to the team…"
-                          className="w-full rounded-2xl border border-white/10 bg-black/35 px-4 py-3 text-sm leading-6 text-white outline-none placeholder:text-white/25 focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-400/15"
-                        />
-                        <button
-                          type="submit"
-                          disabled={!data.emailReplyConfigured}
-                          className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-emerald-400 px-4 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-40"
-                        >
-                          Send reply to {issue.team.name}
-                        </button>
-                        {data.emailReplyConfigured ? (
-                          <p className="text-xs leading-5 text-white/45">
-                            If the team replies to this email, their response comes back into SIXFL Messages on the same email conversation.
-                          </p>
-                        ) : null}
-                      </form>
-                    </div>
-                  );
-                })}
+                {data?.issues.map((issue) => (
+                  <NightBoardTeamIssueCard
+                    key={issue.id}
+                    issue={issue}
+                    returnTo={returnTo}
+                    emailReplyConfigured={data.emailReplyConfigured}
+                  />
+                ))}
               </div>
             </div>
 
             <div className="border-t border-white/10 px-5 py-4 sm:px-6">
-              <Link href="/admin/fixtures/issues" className="text-sm font-semibold text-sky-200 hover:text-sky-100">
+              <Link
+                href="/admin/fixtures/issues"
+                className="text-sm font-semibold text-sky-200 hover:text-sky-100"
+              >
                 Open all fixture issues and reply history
               </Link>
             </div>


### PR DESCRIPTION
## What this changes

- adds a clear **Resolve issue** button directly inside every team-raised fixture issue card in the Night Board drawer
- keeps resolution available even when reply-by-email is not configured
- resolves only confirmations currently in `ISSUE_RAISED`, clears the open issue note and returns that team to `PENDING` confirmation
- returns to the same Night Board date, league and venue filters after resolving
- automatically reopens the drawer with a success message and refreshes the open-issue count
- keeps the existing reply-by-email action unchanged
- preserves the existing Admin Fixtures **Mark handled** flow as a fallback

## Safety

- action remains admin-only
- the return URL is accepted only when it is exactly `/admin/night-board`; external or other admin redirects are rejected
- no email is sent by the resolve action
- fixture, teams, result, payments and schedule are not changed
- adds a permanent critical-feature contract covering the button, status transition, safe redirect and Night Board refresh

## UI note

The issue card explains that resolving removes the request from the open list and returns the team to awaiting confirmation, so it is distinct from sending a reply.