### PR TITLE
Fix first-time invited-player login and record early sign-in failures

### DIFF
--- a/.github/workflows/auth-login-regression.yml
+++ b/.github/workflows/auth-login-regression.yml
@@ -1,0 +1,29 @@
+name: SIXFL sign-in lifecycle regression
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  login:
+    name: Verify login lifecycle after production preparation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Prepare exactly the source used in production
+        run: npm run prebuild
+      - name: Test first-time players, verification timing and failure tracking
+        run: node --test tests/auth-sign-in-lifecycle.test.cjs
+      - name: Verify legacy preparation cannot reinsert request-stage verification
+        run: |
+          cp src/auth.ts /tmp/auth-before.ts
+          node scripts/apply-player-email-verification-v2.cjs
+          diff -u /tmp/auth-before.ts src/auth.ts
+          node --test tests/auth-sign-in-lifecycle.test.cjs

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
+import { loginErrorNotice, type LoginNotice } from "@/lib/auth/login-notice";
 
 function isSafeCallbackUrl(value: string | null) {
   if (!value) return false;
@@ -30,7 +31,7 @@ function LoginForm() {
   const { status } = useSession();
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
-  const [notice, setNotice] = useState<string | null>(null);
+  const [notice, setNotice] = useState<LoginNotice | null>(null);
 
   const callbackUrlFromQuery = useMemo(() => {
     const value = searchParams.get("callbackUrl");
@@ -40,82 +41,78 @@ function LoginForm() {
 
   useEffect(() => {
     const emailFromQuery = searchParams.get("email")?.trim() ?? "";
-
-    if (emailFromQuery) {
-      setEmail(emailFromQuery);
-    }
+    if (emailFromQuery) setEmail(emailFromQuery);
+    const error = searchParams.get("error");
+    if (error) setNotice(loginErrorNotice(error));
   }, [searchParams]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-
+    if (loading) return;
     setLoading(true);
     setNotice(null);
 
-    const res = await fetch("/api/auth/check-email", {
-      method: "POST",
-      body: JSON.stringify({ email }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    try {
+      const normalizedEmail = email.trim().toLowerCase();
+      const res = await fetch("/api/auth/check-email", {
+        method: "POST",
+        body: JSON.stringify({ email: normalizedEmail }),
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!res.ok) throw new Error("Email eligibility check failed.");
+      const data = await res.json();
 
-    const data = await res.json();
+      if (data.canLogin === false) {
+        setNotice({
+          message: "This email isn’t currently registered with SIXFL.",
+          showRegistration: true,
+        });
+        return;
+      }
+      if (data.canLogin !== true) throw new Error("Invalid email eligibility response.");
 
-    if (!data.canLogin) {
-      setLoading(false);
-      setNotice("This email isn’t currently registered with SIXFL.");
-      return;
-    }
+      const callbackUrl = callbackUrlFromQuery
+        ? callbackUrlFromQuery
+        : data.pendingCaptain
+          ? data.claimCode
+            ? `/claim?code=${encodeURIComponent(data.claimCode)}`
+            : "/claim"
+          : data.canChooseLoginArea
+            ? "/dashboard"
+            : data.isReferee
+              ? "/referee"
+              : "/dashboard";
 
-    const callbackUrl = callbackUrlFromQuery
-      ? callbackUrlFromQuery
-      : data.pendingCaptain
-        ? data.claimCode
-          ? `/claim?code=${encodeURIComponent(data.claimCode)}`
-          : "/claim"
-        : data.canChooseLoginArea
-          ? "/dashboard"
-          : data.isReferee
-            ? "/referee"
-            : "/dashboard";
+      const result = await signIn("email", {
+        email: normalizedEmail,
+        callbackUrl,
+        redirect: false,
+      });
+      if (!result || result.error || !result.ok) {
+        setNotice(loginErrorNotice(result?.error));
+        return;
+      }
+      // NextAuth's CSRF rejection can return a 200 URL with ?csrf=true,
+      // rather than result.error. Do not report that as a successful send.
+      if (result.url && new URL(result.url, window.location.origin).searchParams.has("csrf")) {
+        setNotice(loginErrorNotice("CSRF"));
+        return;
+      }
 
-    const result = await signIn("email", {
-      email,
-      callbackUrl,
-      redirect: false,
-    });
-
-    if (result?.error) {
-      setLoading(false);
-      setNotice("We couldn’t send your sign-in link. Please try again.");
-      return;
-    }
-
-    const nextUrl = new URL("/login/check-email", window.location.origin);
-    nextUrl.searchParams.set("email", email);
-
-    if (data.pendingCaptain) {
-      nextUrl.searchParams.set("pendingCaptain", "1");
-
-      if (data.teamName) {
+      const nextUrl = new URL("/login/check-email", window.location.origin);
+      nextUrl.searchParams.set("email", normalizedEmail);
+      if (data.pendingCaptain) nextUrl.searchParams.set("pendingCaptain", "1");
+      if (data.pendingSquadActivation) nextUrl.searchParams.set("pendingSquadActivation", "1");
+      if ((data.pendingCaptain || data.pendingSquadActivation) && data.teamName) {
         nextUrl.searchParams.set("teamName", data.teamName);
       }
+      if (data.canChooseLoginArea) nextUrl.searchParams.set("choose", "1");
+      window.location.href = nextUrl.toString();
+    } catch {
+      setNotice(loginErrorNotice(null));
+    } finally {
+      setLoading(false);
     }
-
-    if (data.pendingSquadActivation) {
-      nextUrl.searchParams.set("pendingSquadActivation", "1");
-
-      if (data.teamName) {
-        nextUrl.searchParams.set("teamName", data.teamName);
-      }
-    }
-
-    if (data.canChooseLoginArea) {
-      nextUrl.searchParams.set("choose", "1");
-    }
-
-    window.location.href = nextUrl.toString();
   }
 
   if (status === "loading") {
@@ -157,24 +154,25 @@ function LoginForm() {
     <div className="flex min-h-screen items-center justify-center bg-black px-4 text-white">
       <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 shadow-2xl">
         <h1 className="text-xl font-semibold">Login</h1>
-
         <p className="mt-1 text-sm text-white/70">
           Enter your email to receive a SIXFL login link.
         </p>
 
         {notice && (
-          <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
-            <p>{notice}</p>
-            <p className="mt-2 text-amber-100/90">
-              If you’d like to play, enter a team or referee, please{" "}
-              <Link
-                href="/register-interest"
-                className="font-semibold text-emerald-300 underline underline-offset-4 transition hover:text-emerald-200"
-              >
-                register your interest here
-              </Link>
-              .
-            </p>
+          <div role="alert" className="mt-4 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+            <p>{notice.message}</p>
+            {notice.showRegistration && (
+              <p className="mt-2 text-amber-100/90">
+                If you’d like to play, enter a team or referee, please{" "}
+                <Link
+                  href="/register-interest"
+                  className="font-semibold text-emerald-300 underline underline-offset-4 transition hover:text-emerald-200"
+                >
+                  register your interest here
+                </Link>
+                .
+              </p>
+            )}
           </div>
         )}
 
@@ -187,7 +185,6 @@ function LoginForm() {
             placeholder="player@email.com"
             className="w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none placeholder:text-white/35 focus:border-emerald-400"
           />
-
           <button
             type="submit"
             disabled={loading}
@@ -196,7 +193,6 @@ function LoginForm() {
             {loading ? "Sending link..." : "Send magic link"}
           </button>
         </form>
-
         <p className="mt-4 text-xs text-white/50">
           Registered SIXFL users, referees, pending captains and invited squad players can log in here using the email address connected to their invite.
         </p>

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,10 +3,18 @@
 // ========================================
 
 import NextAuth from "next-auth";
+import type { NextRequest } from "next/server";
 import { authOptions } from "@/auth";
+import { withTrackedSignInRequest } from "@/lib/auth/track-sign-in-request";
 
 export const runtime = "nodejs";
 
 const handler = NextAuth(authOptions);
 
-export { handler as GET, handler as POST };
+type AuthRouteContext = { params: Promise<{ nextauth: string[] }> };
+
+export { handler as GET };
+
+export async function POST(request: NextRequest, context: AuthRouteContext) {
+  return withTrackedSignInRequest(request, () => handler(request, context));
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -22,6 +22,7 @@ import {
   markSignInLinkSent,
   startSignInLinkActivity,
 } from "@/lib/auth/sign-in-link-activity";
+import { setSignInRequestStage } from "@/lib/auth/sign-in-request-context";
 
 const LOGIN_CTA_LABEL = "Sign in to SIXFL";
 const CTA_PLACEHOLDER = "{{cta}}";
@@ -242,6 +243,7 @@ export const authOptions: NextAuthOptions = {
     EmailProvider({
       async sendVerificationRequest({ identifier, url, provider }) {
         const email = identifier.toLowerCase().trim();
+        setSignInRequestStage("email preparation");
 
         const [
           existingUser,
@@ -271,7 +273,7 @@ export const authOptions: NextAuthOptions = {
         ]);
 
         if (!existingUser && !pendingCaptain && !captainLoginContext && !pendingSquadActivation) {
-          return;
+          throw new Error("Sign-in access is no longer available. Contact SIXFL.");
         }
 
         const resend = new Resend(process.env.RESEND_API_KEY);
@@ -295,6 +297,7 @@ export const authOptions: NextAuthOptions = {
         });
 
         try {
+          setSignInRequestStage("email delivery");
           const result = await resend.emails.send({
             from,
             to,
@@ -311,6 +314,7 @@ export const authOptions: NextAuthOptions = {
             activityId,
             providerMessageId: result.data?.id ?? null,
           });
+          setSignInRequestStage("verification token");
         } catch (error) {
           await markSignInLinkFailed({ activityId, error });
           throw error;
@@ -329,7 +333,16 @@ export const authOptions: NextAuthOptions = {
   debug: process.env.NEXTAUTH_DEBUG === "true",
 
   events: {
-    async signIn({ user }) {
+    async signIn({ user, account }) {
+      // This event runs only AFTER a valid link is consumed and the adapter
+      // has persisted the real user. Never verify in callbacks.signIn: that
+      // also runs on the unauthenticated request, with a prototype user ID.
+      if (account?.provider === "email" && user.id) {
+        await prisma.user.updateMany({
+          where: { id: user.id, emailVerified: null },
+          data: { emailVerified: new Date() },
+        });
+      }
       await Promise.all([
         recordSuccessfulLogin({
           userId: user.id,
@@ -346,6 +359,7 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async signIn({ user, account }) {
       if (account?.provider === "email") {
+        setSignInRequestStage("account checks");
         const email = user.email?.toLowerCase().trim();
 
         if (!email) {

--- a/src/lib/auth/login-notice.ts
+++ b/src/lib/auth/login-notice.ts
@@ -1,0 +1,20 @@
+export type LoginNotice = { message: string; showRegistration: boolean };
+
+export function loginErrorNotice(error: string | null | undefined): LoginNotice {
+  if (error === "Verification") {
+    return {
+      message: "This sign-in link has expired or has already been used. Please request a new link below.",
+      showRegistration: false,
+    };
+  }
+  if (error === "AccessDenied") {
+    return {
+      message: "We couldn’t confirm your sign-in access. Please contact your team captain or SIXFL rather than registering again.",
+      showRegistration: false,
+    };
+  }
+  return {
+    message: "We couldn’t complete your sign-in request. Please try again shortly. If it still fails, contact SIXFL; you do not need to register again.",
+    showRegistration: false,
+  };
+}

--- a/src/lib/auth/sign-in-link-activity.ts
+++ b/src/lib/auth/sign-in-link-activity.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { prisma } from "@/lib/prisma";
+import { signInRequestContext } from "@/lib/auth/sign-in-request-context";
 
 let ensureTablePromise: Promise<void> | null = null;
 
@@ -17,13 +18,20 @@ function trimOptional(value: string | null | undefined, maximumLength = 500) {
 }
 
 function describeError(error: unknown) {
-  if (error instanceof Error) return error.message.slice(0, 1_000);
-
-  try {
-    return JSON.stringify(error).slice(0, 1_000);
-  } catch {
-    return String(error).slice(0, 1_000);
+  let message: string;
+  if (error instanceof Error) message = error.message;
+  else {
+    try {
+      message = JSON.stringify(error) ?? String(error);
+    } catch {
+      message = String(error);
+    }
   }
+  const safe = message
+    .replace(/\b(?:https?|postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi, "[URL redacted]")
+    .replace(/((?:token|secret|password|api[_-]?key|authorization|cookie|credential|signature)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi, "$1[redacted]");
+  const stage = signInRequestContext.getStore()?.stage;
+  return `${stage && !safe.startsWith("[") ? `[${stage}] ` : ""}${safe}`.slice(0, 1_000);
 }
 
 function sanitiseCallbackUrl(value: string | null) {
@@ -125,11 +133,31 @@ export async function startSignInLinkActivity(
   const email = normaliseEmail(input.email);
   if (!email) return null;
 
-  const id = randomUUID();
+  const request = signInRequestContext.getStore();
+  const id = request ? request.activityId : randomUUID();
+  if (!id) return null;
   const linkContext = readMagicLinkContext(input.magicLinkUrl);
 
   try {
     await ensureSignInLinkActivityTable();
+    if (request) {
+      // The route recorded this request before authentication began. Enrich
+      // that same row rather than counting a second request when sending starts.
+      await prisma.$executeRaw`
+        UPDATE "SignInLinkActivity"
+        SET
+          "userId" = ${trimOptional(input.userId, 255)},
+          "userNameSnapshot" = ${trimOptional(input.userName, 255)},
+          "accountTypeSnapshot" = ${trimOptional(input.accountType, 100)},
+          "teamIdSnapshot" = ${trimOptional(input.teamId, 255)},
+          "teamNameSnapshot" = ${trimOptional(input.teamName, 255)},
+          "callbackUrl" = ${linkContext.callbackUrl},
+          "linkHost" = ${linkContext.linkHost},
+          "updatedAt" = NOW()
+        WHERE "id" = ${id} AND "emailNormalized" = ${email}
+      `;
+      return id;
+    }
     await prisma.$executeRaw`
       INSERT INTO "SignInLinkActivity" (
         "id",
@@ -163,7 +191,8 @@ export async function startSignInLinkActivity(
     return id;
   } catch (error) {
     console.warn("Could not start sign-in link activity record", error);
-    return null;
+    // An enrichment failure must not orphan the request's existing audit row.
+    return request?.activityId ?? null;
   }
 }
 
@@ -202,7 +231,7 @@ export async function markSignInLinkFailed(input: {
       UPDATE "SignInLinkActivity"
       SET
         "failedAt" = NOW(),
-        "failureReason" = ${describeError(input.error)},
+        "failureReason" = COALESCE("failureReason", ${describeError(input.error)}),
         "updatedAt" = NOW()
       WHERE "id" = ${input.activityId}
     `;

--- a/src/lib/auth/sign-in-link-activity.ts
+++ b/src/lib/auth/sign-in-link-activity.ts
@@ -204,13 +204,13 @@ export async function markSignInLinkSent(input: {
 
   try {
     await ensureSignInLinkActivityTable();
+    // NextAuth sends the email and stores its token concurrently. The token
+    // write can fail before email acceptance returns: never clear that failure.
     await prisma.$executeRaw`
       UPDATE "SignInLinkActivity"
       SET
         "sentAt" = NOW(),
         "providerMessageId" = ${trimOptional(input.providerMessageId, 255)},
-        "failureReason" = NULL,
-        "failedAt" = NULL,
         "updatedAt" = NOW()
       WHERE "id" = ${input.activityId}
     `;

--- a/src/lib/auth/sign-in-request-context.ts
+++ b/src/lib/auth/sign-in-request-context.ts
@@ -1,0 +1,22 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type SignInRequestStage =
+  | "authentication"
+  | "account checks"
+  | "email preparation"
+  | "email delivery"
+  | "verification token";
+
+export type SignInRequestContext = {
+  activityId: string | null;
+  stage: SignInRequestStage;
+};
+
+// Server-owned, request-local state: never correlate by a client-supplied ID
+// or by the latest request for an email (concurrent requests must stay separate).
+export const signInRequestContext = new AsyncLocalStorage<SignInRequestContext>();
+
+export function setSignInRequestStage(stage: SignInRequestStage) {
+  const context = signInRequestContext.getStore();
+  if (context) context.stage = stage;
+}

--- a/src/lib/auth/track-sign-in-request.ts
+++ b/src/lib/auth/track-sign-in-request.ts
@@ -1,0 +1,88 @@
+import {
+  markSignInLinkFailed,
+  startSignInLinkActivity,
+} from "@/lib/auth/sign-in-link-activity";
+import { signInRequestContext } from "@/lib/auth/sign-in-request-context";
+
+const FAILURE_MESSAGES: Record<string, string> = {
+  AccessDenied: "The account or invitation did not pass the access check.",
+  EmailSignin: "The sign-in email or verification token could not be prepared.",
+  Configuration: "The sign-in service could not complete its configuration checks.",
+  CSRF: "The browser security check failed. Reload the login page and try again.",
+  HTTP_ERROR: "The authentication endpoint returned an unsuccessful response.",
+  AUTH_ERROR: "The authentication request failed before completion.",
+};
+
+async function responseFailure(response: Response): Promise<string | null> {
+  if (!response.ok && response.status >= 400) return "HTTP_ERROR";
+
+  let destination = response.headers.get("location");
+  if (response.headers.get("content-type")?.includes("application/json")) {
+    const body: unknown = await response.clone().json();
+    if (body && typeof body === "object" && "url" in body && typeof body.url === "string") {
+      destination = body.url;
+    }
+  }
+  if (!destination) return null;
+
+  const url = new URL(destination, "https://sixfl.invalid");
+  if (url.searchParams.has("csrf")) return "CSRF";
+  const error = url.searchParams.get("error");
+  if (!error) return null;
+  // NextAuth can put a thrown exception in this parameter. Never persist that
+  // raw URL, exception text, credentials, cookies, or verification token.
+  return Object.hasOwn(FAILURE_MESSAGES, error) ? error : "AUTH_ERROR";
+}
+
+export async function withTrackedSignInRequest(
+  request: Request,
+  handle: () => Promise<Response>,
+): Promise<Response> {
+  let email = "";
+  try {
+    if (request.method !== "POST" || new URL(request.url).pathname !== "/api/auth/signin/email") {
+      return handle();
+    }
+    const form = await request.clone().formData();
+    const value = form.get("email");
+    if (typeof value === "string") email = value.trim().toLowerCase();
+  } catch {
+    // Leave validation and CSRF enforcement to NextAuth. Tracking must not
+    // change an authentication response or consume its original request body.
+    return handle();
+  }
+  if (!email || email.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return handle();
+  }
+
+  // Record before NextAuth's normalizer, adapter lookup, CSRF and access checks.
+  // This is a request record, not evidence that an email was sent or verified.
+  const activityId = await startSignInLinkActivity({ email, magicLinkUrl: "" });
+  return signInRequestContext.run({ activityId, stage: "authentication" }, async () => {
+    const recordFailure = async (code: string) => {
+      const stage = signInRequestContext.getStore()?.stage ?? "authentication";
+      await markSignInLinkFailed({
+        activityId,
+        error: new Error(`[${stage}] ${FAILURE_MESSAGES[code] ?? FAILURE_MESSAGES.AUTH_ERROR}`),
+      });
+      // Also leave a safe fallback when the database itself cannot record it.
+      console.warn("SIXFL sign-in request failed", { activityId, email, stage, code });
+    };
+
+    let response: Response;
+    try {
+      response = await handle();
+    } catch (error) {
+      await recordFailure("AUTH_ERROR");
+      throw error;
+    }
+
+    try {
+      const failure = await responseFailure(response);
+      if (failure) await recordFailure(failure);
+    } catch {
+      console.warn("Could not inspect sign-in response for activity tracking", { activityId });
+    }
+    return response;
+  });
+}

--- a/tests/auth-sign-in-lifecycle.test.cjs
+++ b/tests/auth-sign-in-lifecycle.test.cjs
@@ -1,0 +1,283 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const ts = require("typescript");
+
+// Execute the real, prepared TypeScript with fake database/email boundaries.
+// No live credentials, network, users or emails are used by these tests.
+const root = path.resolve(__dirname, "..");
+function harness(options = {}) {
+  const queries = [], rows = new Map(), updates = [], sent = [];
+  const cache = new Map();
+  const state = { ...options };
+  const prisma = {
+    user: {
+      findUnique: async () => {
+        if (state.lookupError) throw new Error("Account lookup unavailable");
+        return state.user ?? null;
+      },
+      update: async (data) => { updates.push(data); throw new Error("Forbidden request-stage user update"); },
+      updateMany: async (data) => { updates.push(data); return { count: 1 }; },
+    },
+    teamPlayerProspect: { findFirst: async () => state.prospect ?? null },
+    notificationTemplate: { findUnique: async () => {
+      if (state.templateError) throw new Error("Template unavailable");
+      return null;
+    } },
+    $executeRaw: async (parts, ...values) => {
+      const query = parts.join("?");
+      queries.push({ query, values });
+      if (state.trackingError && query.includes('"SignInLinkActivity"')) throw new Error("Tracking unavailable");
+      if (query.includes('INSERT INTO "SignInLinkActivity"')) {
+        rows.set(values[0], { id: values[0], email: values[2] });
+      } else if (query.includes('UPDATE "SignInLinkActivity"') && !query.includes("WITH candidate")) {
+        const enrich = query.includes('"userNameSnapshot" =');
+        const row = rows.get(values[values.length - (enrich ? 2 : 1)]);
+        if (row && enrich) { row.team = values[4]; row.host = values[6]; }
+        else if (row && query.includes('"sentAt" = NOW()')) row.sent = true;
+        else if (row && query.includes('"failedAt" = NOW()')) row.failure ??= values[0];
+      }
+      return 1;
+    },
+  };
+  const mocks = {
+    "@/lib/prisma": { prisma },
+    "@auth/prisma-adapter": { PrismaAdapter: () => ({}) },
+    "next-auth/providers/email": { default: (config) => config },
+    resend: { Resend: class {
+      emails = { send: async (mail) => {
+        sent.push(mail);
+        if (state.sendError) return { error: { message: state.sendError } };
+        return { data: { id: "mock-provider-id" }, error: null };
+      } };
+    } },
+    "@/lib/email/buildEmail": {
+      appendSIXFLTextSignature: (text) => text,
+      buildSIXFLEmailHtml: ({ body }) => body,
+    },
+    "@/lib/notifications/renderer": { renderNotificationText: (text) => text },
+    "@/lib/auth/pendingCaptain": {
+      getPendingCaptainContext: async () => state.pendingCaptain ?? null,
+      getCaptainLoginContext: async () => state.captain ?? null,
+    },
+  };
+  function load(relative) {
+    const filename = path.join(root, relative);
+    if (cache.has(filename)) return cache.get(filename).exports;
+    const module = { exports: {} };
+    cache.set(filename, module);
+    const source = fs.readFileSync(filename, "utf8");
+    const compiled = ts.transpileModule(source, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+      fileName: filename,
+      reportDiagnostics: true,
+    });
+    assert.equal((compiled.diagnostics ?? []).filter(d => d.category === ts.DiagnosticCategory.Error).length, 0);
+    const localRequire = (id) => {
+      if (Object.hasOwn(mocks, id)) return mocks[id];
+      if (id.startsWith("@/")) return load(`src/${id.slice(2)}.ts`);
+      return require(id);
+    };
+    new Function("require", "module", "exports", compiled.outputText)(localRequire, module, module.exports);
+    return module.exports;
+  }
+  const auth = load("src/auth.ts").authOptions;
+  const tracker = load("src/lib/auth/track-sign-in-request.ts");
+  const activity = load("src/lib/auth/sign-in-link-activity.ts");
+  const context = load("src/lib/auth/sign-in-request-context.ts");
+  return { auth, tracker, activity, context, queries, rows, updates, sent, state, load };
+}
+
+const email = "invited.player@example.com";
+const prototypeUser = { id: email, email, emailVerified: null };
+const emailAccount = { provider: "email", type: "email" };
+const prospect = { id: "prospect-1", firstName: "Player", team: { id: "team-1", name: "Example United" } };
+const existingUser = { id: "persisted-user-1", email, emailVerified: null, name: "Player", role: "USER", teamMembers: [] };
+const request = (address = email) => new Request("https://sixfl.co.uk/api/auth/signin/email", {
+  method: "POST", body: new URLSearchParams({ email: address, csrfToken: "test-csrf" }),
+});
+const failedResponse = (error) => Response.json({ url: `https://sixfl.co.uk/api/auth/error?error=${encodeURIComponent(error)}` });
+async function flow(h, address = email) {
+  return h.tracker.withTrackedSignInRequest(request(address), async () => {
+    const allowed = await h.auth.callbacks.signIn({
+      user: h.state.user ?? { ...prototypeUser, id: address, email: address },
+      account: emailAccount, email: { verificationRequest: true },
+    });
+    if (!allowed) return failedResponse("AccessDenied");
+    try {
+      await h.auth.providers[0].sendVerificationRequest({
+        identifier: address,
+        url: `https://www.sixfl.co.uk/api/auth/callback/email?token=DO_NOT_STORE&email=${encodeURIComponent(address)}&callbackUrl=${encodeURIComponent("https://www.sixfl.co.uk/dashboard")}`,
+        provider: { from: "test@example.com" },
+      });
+      if (h.state.tokenError) throw new Error("Token persistence failed");
+      return Response.json({ url: "https://sixfl.co.uk/api/auth/verify-request?provider=email&type=email" });
+    } catch { return failedResponse("EmailSignin"); }
+  });
+}
+
+test("first-time invited player can request a link without updating a prototype ID", async () => {
+  const h = harness({ prospect });
+  await flow(h);
+  assert.equal(h.sent.length, 1);
+  assert.equal(h.updates.length, 0);
+  assert.equal(h.rows.size, 1);
+  const row = [...h.rows.values()][0];
+  assert.equal(row.sent, true);
+  assert.equal(row.team, "Example United");
+  assert.equal(row.failure, undefined);
+  assert.equal(JSON.stringify(h.queries).includes("DO_NOT_STORE"), false);
+});
+
+test("existing unverified user's request does not verify their email", async () => {
+  const h = harness({ user: existingUser });
+  await flow(h);
+  assert.equal(h.updates.length, 0);
+  assert.equal(h.sent.length, 1);
+});
+
+test("pending captain without a User row retains sign-in eligibility", async () => {
+  const h = harness({ pendingCaptain: { teamId: "team-1", teamName: "Example United", claimCode: "private-claim" } });
+  await flow(h);
+  assert.equal(h.sent.length, 1);
+  assert.equal(h.updates.length, 0);
+});
+
+test("access rejection is recorded before email preparation, without sending", async () => {
+  const h = harness();
+  const result = await flow(h);
+  assert.equal(result.status, 200); // NextAuth errors may be JSON URLs with HTTP 200.
+  assert.match([...h.rows.values()][0].failure, /account checks.*access check/);
+  assert.equal(h.sent.length, 0);
+});
+
+test("successful sign-in event verifies only the persisted account and records use", async () => {
+  const h = harness({ user: existingUser });
+  await h.auth.events.signIn({ user: existingUser, account: emailAccount });
+  assert.equal(h.updates.length, 1);
+  assert.deepEqual(h.updates[0].where, { id: existingUser.id, emailVerified: null });
+  assert.ok(h.updates[0].data.emailVerified instanceof Date);
+  assert.ok(h.queries.some(({ query }) => query.includes('"usedAt" = NOW()')));
+});
+
+test("non-email sign-in never verifies an email address", async () => {
+  const h = harness();
+  await h.auth.events.signIn({ user: existingUser, account: { provider: "other" } });
+  assert.equal(h.updates.length, 0);
+});
+
+test("callback-stage authorization never writes verification even after token click", async () => {
+  const h = harness({ prospect });
+  assert.equal(await h.auth.callbacks.signIn({ user: prototypeUser, account: emailAccount }), true);
+  assert.equal(h.updates.length, 0);
+});
+
+test("adapter/authorization exception leaves a safe failure record and still throws", async () => {
+  const h = harness({ lookupError: true });
+  await assert.rejects(flow(h), /Account lookup unavailable/);
+  assert.equal(h.rows.size, 1);
+  assert.match([...h.rows.values()][0].failure, /account checks/);
+});
+
+test("early NextAuth adapter failure is recorded before any provider callback", async () => {
+  const h = harness();
+  const exception = new Error("postgres://user:secret@database/private");
+  await assert.rejects(h.tracker.withTrackedSignInRequest(request(), async () => { throw exception; }), error => error === exception);
+  assert.match([...h.rows.values()][0].failure, /authentication/);
+  assert.equal(JSON.stringify(h.queries).includes("postgres://"), false);
+});
+
+test("email-template failures are visible even before provider send tracking starts", async () => {
+  const h = harness({ prospect, templateError: true });
+  await flow(h);
+  assert.equal(h.rows.size, 1);
+  assert.equal(h.sent.length, 0);
+  assert.match([...h.rows.values()][0].failure, /email preparation/);
+});
+
+test("provider rejection preserves its safe reason, not a later generic error", async () => {
+  const h = harness({ prospect, sendError: "Rate limit exceeded" });
+  await flow(h);
+  assert.equal(h.rows.size, 1);
+  assert.match([...h.rows.values()][0].failure, /email delivery.*Rate limit exceeded/);
+  assert.equal([...h.rows.values()][0].sent, undefined);
+});
+
+test("sent email with a subsequent token failure is distinguishable from success", async () => {
+  const h = harness({ prospect, tokenError: true });
+  await flow(h);
+  const row = [...h.rows.values()][0];
+  assert.equal(row.sent, true);
+  assert.match(row.failure, /verification token/);
+});
+
+test("CSRF rejection is recorded without weakening enforcement or changing response", async () => {
+  const h = harness();
+  const response = Response.json({ url: "https://sixfl.co.uk/api/auth/signin?csrf=true" }, { headers: { "x-test": "preserved" } });
+  const result = await h.tracker.withTrackedSignInRequest(request(), async () => response);
+  assert.equal(result, response);
+  assert.equal(result.headers.get("x-test"), "preserved");
+  assert.match([...h.rows.values()][0].failure, /browser security check/);
+  assert.ok((await result.json()).url.endsWith("csrf=true"));
+});
+
+test("unknown error URL cannot persist credentials or raw exception content", async () => {
+  const h = harness();
+  await h.tracker.withTrackedSignInRequest(request(), async () => failedResponse("secret=PRIVATE_TOKEN database failure"));
+  assert.match([...h.rows.values()][0].failure, /authentication/);
+  assert.equal(JSON.stringify(h.queries).includes("PRIVATE_TOKEN"), false);
+});
+
+test("concurrent requests for the same email have separate records and request contexts", async () => {
+  const h = harness({ prospect });
+  await Promise.all([flow(h), flow(h)]);
+  assert.equal(h.rows.size, 2);
+  assert.equal(h.sent.length, 2);
+  assert.ok([...h.rows.values()].every(row => row.sent && row.team === "Example United"));
+  assert.equal(h.context.signInRequestContext.getStore(), undefined);
+});
+
+test("logging outage cannot block the email request or create a false verification", async () => {
+  const h = harness({ prospect, trackingError: true });
+  const response = await flow(h);
+  assert.equal(h.sent.length, 1);
+  assert.equal(h.updates.length, 0);
+  assert.ok((await response.json()).url.includes("verify-request"));
+});
+
+test("non-sign-in POST routes and sign-out are passed through without a sign-in row", async () => {
+  const h = harness();
+  const response = new Response("unchanged");
+  assert.equal(await h.tracker.withTrackedSignInRequest(new Request("https://sixfl.co.uk/api/auth/signout", { method: "POST" }), async () => response), response);
+  assert.equal(h.rows.size, 0);
+});
+
+test("tracking preserves the original request body for NextAuth's CSRF validation", async () => {
+  const h = harness();
+  const req = request("  Player@Example.com ");
+  await h.tracker.withTrackedSignInRequest(req, async () => {
+    const form = await req.formData();
+    assert.equal(form.get("csrfToken"), "test-csrf");
+    assert.equal(form.get("email"), "  Player@Example.com ");
+    return new Response("ok");
+  });
+  assert.equal([...h.rows.values()][0].email, "player@example.com");
+});
+
+test("technical warnings never recommend registration or expose raw errors", () => {
+  const h = harness();
+  const { loginErrorNotice } = h.load("src/lib/auth/login-notice.ts");
+  for (const error of ["AccessDenied", "EmailSignin", "CSRF", "Verification", "secret=PRIVATE", null]) {
+    const notice = loginErrorNotice(error);
+    assert.equal(notice.showRegistration, false);
+    assert.equal(notice.message.includes("PRIVATE"), false);
+  }
+  assert.match(loginErrorNotice("Verification").message, /expired or has already been used/);
+  const page = fs.readFileSync(path.join(root, "src/app/(public)/login/page.tsx"), "utf8");
+  assert.ok(page.includes("notice.showRegistration &&"));
+  assert.ok(page.includes("finally"));
+  assert.ok(page.includes('data.canLogin === false'));
+  const route = fs.readFileSync(path.join(root, "src/app/api/auth/[...nextauth]/route.ts"), "utf8");
+  assert.ok(route.includes("withTrackedSignInRequest(request, () => handler(request, context))"));
+});

--- a/tests/auth-sign-in-lifecycle.test.cjs
+++ b/tests/auth-sign-in-lifecycle.test.cjs
@@ -35,7 +35,10 @@ function harness(options = {}) {
         const enrich = query.includes('"userNameSnapshot" =');
         const row = rows.get(values[values.length - (enrich ? 2 : 1)]);
         if (row && enrich) { row.team = values[4]; row.host = values[6]; }
-        else if (row && query.includes('"sentAt" = NOW()')) row.sent = true;
+        else if (row && query.includes('"sentAt" = NOW()')) {
+          row.sent = true;
+          if (query.includes('"failureReason" = NULL')) delete row.failure;
+        }
         else if (row && query.includes('"failedAt" = NOW()')) row.failure ??= values[0];
       }
       return 1;
@@ -48,6 +51,7 @@ function harness(options = {}) {
     resend: { Resend: class {
       emails = { send: async (mail) => {
         sent.push(mail);
+        if (state.sendWait) await state.sendWait;
         if (state.sendError) return { error: { message: state.sendError } };
         return { data: { id: "mock-provider-id" }, error: null };
       } };
@@ -280,4 +284,34 @@ test("technical warnings never recommend registration or expose raw errors", () 
   assert.ok(page.includes('data.canLogin === false'));
   const route = fs.readFileSync(path.join(root, "src/app/api/auth/[...nextauth]/route.ts"), "utf8");
   assert.ok(route.includes("withTrackedSignInRequest(request, () => handler(request, context))"));
+});
+
+// NextAuth v4 uses Promise.all for delivery and token persistence, not a
+// sequential send-then-token flow. A late provider success must not erase an
+// earlier failure returned to the browser.
+test("parallel token failure survives a later email-provider success", async () => {
+  let release;
+  const sendWait = new Promise(resolve => { release = resolve; });
+  const h = harness({ prospect, sendWait });
+  let sender;
+  await h.tracker.withTrackedSignInRequest(request(), async () => {
+    await h.auth.callbacks.signIn({ user: prototypeUser, account: emailAccount, email: { verificationRequest: true } });
+    sender = h.auth.providers[0].sendVerificationRequest({
+      identifier: email,
+      url: "https://sixfl.co.uk/api/auth/callback/email?token=DO_NOT_STORE",
+      provider: { from: "test@example.com" },
+    });
+    try {
+      await Promise.all([sender, new Promise((_, reject) => setImmediate(() => reject(new Error("Token persistence failed"))))]);
+      return new Response("unexpected success");
+    } catch { return failedResponse("EmailSignin"); }
+  });
+  const row = [...h.rows.values()][0];
+  assert.ok(row.failure);
+  const originalFailure = row.failure;
+  assert.equal(row.sent, undefined);
+  release();
+  await sender;
+  assert.equal(row.sent, true);
+  assert.equal(row.failure, originalFailure);
 });


### PR DESCRIPTION
## Problem
The production preparation script `apply-player-email-verification-v2.cjs` inserted an email-verification write into `callbacks.signIn`, which also runs when someone requests a link. That could update an invited player's temporary email-as-ID before a User row exists, or mark an existing user verified before they proved mailbox ownership. Failures before email preparation were absent from SignInLinkActivity.

## Changes
- Verification completion is now native in `src/auth.ts`'s successful `events.signIn` hook, never in the access callback. Existing verification timestamps are preserved. Legacy preparation detects this native block and cannot insert the request-stage write.
- The NextAuth POST entry point records valid-email sign-in requests before authentication checks. Server-owned request-local context enriches the same row at sending time without duplicating requests or mixing concurrent requests for an email.
- Early exceptions, HTTP-200 error URLs and CSRF failures record safe stage-specific diagnostics without changing NextAuth responses or weakening security. An email accepted after a parallel token-write failure cannot erase that failure.
- The public Login page handles network/expired-link errors and displays registration advice only for an explicit unregistered-email result. Existing-session handling, captain/referee destinations, templates and canonical-link preparation remain intact.
- Twenty executable regression tests protect the prepared production source, including first-time invited players, verification timing, safe errors, concurrency and the parallel token-write race.

## Verified before merge
All eight PR workflows passed on head `6d2b3c35c64979ce1dcf58e75398c6c66c6684c8`: DOM bridge policy, sign-in lifecycle regression, sign-in activity contract, critical feature contracts, critical pages/browser check, inactive player status, email template create completion and PlayerPool reminders. This included the complete production prebuild, Prisma generation/schema validation, TypeScript checks and production builds. All 20 lifecycle tests passed both after full prebuild and after rerunning the legacy verification preparation; that rerun left auth.ts unchanged.

Local tests also passed. A negative mutation restoring the old request-stage verification write caused 11 of the initial 19 tests to fail. A source recheck confirmed the native access callback contains no user-verification write and the old generic send-failure wording is absent from the modified native login files.

## Merge and deployment
Merged as `c33c4af5691b51df0812cceded3ace18fb5d1735`. Railway picked up this exact commit for website deployment `1c869bf0-7c47-432f-8a61-41491bed7e9b`; deployment completion is being checked separately.

## Scope and remaining live verification
Shared auth configuration, NextAuth POST entry point, SignInLinkActivity writer and public Login UI. No new schema, customer message template, email-provider integration or customer account repair was introduced. No real customer email was sent and no customer account was changed during testing. Historical missing activity cannot be reconstructed. The affected player's fresh request, mailbox receipt and successful sign-in remain the final end-to-end confirmation; their individual database state was not independently inspected.