### PR TITLE
Upload team badges directly through the admin website

### DIFF
--- a/.github/workflows/team-badge-upload.yml
+++ b/.github/workflows/team-badge-upload.yml
@@ -1,0 +1,31 @@
+name: Team badge upload
+on:
+  pull_request:
+    paths:
+      - 'src/lib/images/**'
+      - 'src/lib/team-badges.ts'
+      - 'src/app/api/admin/teams/**'
+      - 'src/app/api/team-badges/**'
+      - 'src/app/(admin)/admin/teams/**'
+      - 'src/components/admin/teams/**'
+      - 'prisma/migrations/**'
+      - 'scripts/check-team-badge-upload.ts'
+      - '.github/workflows/team-badge-upload.yml'
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  image-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Exercise real image processing and multipart limits
+        run: npx tsx scripts/check-team-badge-upload.ts
+      - name: Audit all existing badge consumers for compatibility
+        run: git grep -n -E 'logoUrl|team-logos/' -- src scripts || true

--- a/prisma/migrations/20260905223000_team_badge_images/migration.sql
+++ b/prisma/migrations/20260905223000_team_badge_images/migration.sql
@@ -1,0 +1,11 @@
+-- Database-backed, immutable badge images, using the same BYTEA approach as KitDesign.
+-- Kept outside the generated Prisma models, like the existing kit image tables.
+CREATE TABLE IF NOT EXISTS "TeamBadgeImage" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "teamId" TEXT NOT NULL REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  "createdByUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "imageData" BYTEA NOT NULL,
+  "thumbnailData" BYTEA NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS "TeamBadgeImage_teamId_idx" ON "TeamBadgeImage"("teamId");

--- a/scripts/check-team-badge-upload.ts
+++ b/scripts/check-team-badge-upload.ts
@@ -19,11 +19,11 @@ async function main() {
     (error: unknown) => error instanceof ImageUploadError && error.status === status);
 
   for (const format of ["png", "jpeg", "webp"] as const) {
-    await check(`${format} is decoded, resized without enlargement and re-encoded as WebP`, async () => {
+    await check(`${format} is decoded, resized without enlargement and re-encoded as PNG`, async () => {
       const result = await optimiseBadgeImage(file(await image(format), `image/${format}`));
       for (const bytes of [result.imageData, result.thumbnailData]) {
         const metadata = await sharp(bytes).metadata();
-        assert.equal(metadata.format, "webp");
+        assert.equal(metadata.format, "png");
         assert.equal(metadata.width, 160);
         assert.equal(metadata.height, 80);
         assert.equal(metadata.exif, undefined);
@@ -92,6 +92,8 @@ async function main() {
     assert.match(store, /team\.logoUrl \?\? ""/);
     assert.match(store, /tx\.team\.update\(/);
     assert.match(store, /data: \{ logoUrl \}/);
+    assert.match(store, /new URL\(`/);
+    assert.match(read("src/app/api/team-badges/[id]/route.ts"), /"Content-Type": "image\/png"/);
     assert.doesNotMatch(store, /writeFile|unlinkSync/);
   });
   console.log(`Team badge upload: ${checks} checks passed.`);

--- a/scripts/check-team-badge-upload.ts
+++ b/scripts/check-team-badge-upload.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import sharp from "sharp";
+import { ImageUploadError, optimiseBadgeImage, readImageUploadForm } from "../src/lib/images/upload";
+import { MAX_IMAGE_UPLOAD_BYTES } from "../src/lib/images/constants";
+
+async function main() {
+  let checks = 0;
+  const check = async (name: string, run: () => Promise<void> | void) => {
+    await run();
+    checks += 1;
+    console.log(`PASS ${name}`);
+  };
+  const image = async (format: "png" | "jpeg" | "webp", width = 160, height = 80) =>
+    sharp({ create: { width, height, channels: 4, background: { r: 0, g: 150, b: 80, alpha: 0.5 } } })
+      .toFormat(format).toBuffer();
+  const file = (data: Buffer, type: string) => new File([new Uint8Array(data)], "badge", { type });
+  const rejects = (run: () => Promise<unknown>, status = 400) => assert.rejects(run,
+    (error: unknown) => error instanceof ImageUploadError && error.status === status);
+
+  for (const format of ["png", "jpeg", "webp"] as const) {
+    await check(`${format} is decoded, resized without enlargement and re-encoded as WebP`, async () => {
+      const result = await optimiseBadgeImage(file(await image(format), `image/${format}`));
+      for (const bytes of [result.imageData, result.thumbnailData]) {
+        const metadata = await sharp(bytes).metadata();
+        assert.equal(metadata.format, "webp");
+        assert.equal(metadata.width, 160);
+        assert.equal(metadata.height, 80);
+        assert.equal(metadata.exif, undefined);
+        if (format !== "jpeg") assert.equal(metadata.hasAlpha, true);
+      }
+    });
+  }
+  await check("large badges fit within 900px; thumbnails fit within 240px", async () => {
+    const result = await optimiseBadgeImage(file(await image("png", 1800, 1200), "image/png"));
+    assert.equal((await sharp(result.imageData).metadata()).width, 900);
+    assert.equal((await sharp(result.thumbnailData).metadata()).width, 240);
+  });
+  await check("EXIF orientation is applied and metadata stripped", async () => {
+    const input = await sharp(await image("jpeg")).withMetadata({ orientation: 6 }).toBuffer();
+    const result = await optimiseBadgeImage(file(input, "image/jpeg"));
+    const metadata = await sharp(result.imageData).metadata();
+    assert.equal(metadata.width, 80);
+    assert.equal(metadata.height, 160);
+    assert.equal(metadata.orientation, undefined);
+  });
+  await check("SVG renamed as PNG is rejected before decoding", () =>
+    rejects(() => optimiseBadgeImage(file(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"/>'), "image/png"))));
+  await check("unsupported MIME types are rejected", () =>
+    rejects(() => optimiseBadgeImage(file(Buffer.from("GIF89a"), "image/gif"))));
+  await check("corrupt PNG data is rejected", () =>
+    rejects(() => optimiseBadgeImage(file(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]), "image/png"))));
+  await check("empty file is rejected", () =>
+    rejects(() => optimiseBadgeImage(file(Buffer.alloc(0), "image/png"))));
+  await check("file over 5 MB is rejected", () =>
+    rejects(() => optimiseBadgeImage(file(Buffer.alloc(MAX_IMAGE_UPLOAD_BYTES + 1), "image/png")), 413));
+  await check("valid multipart request retains file and action", async () => {
+    const body = new FormData();
+    body.set("action", "save");
+    body.set("expectedLogoUrl", "/team-logos/old.png");
+    body.set("file", file(await image("png"), "image/png"));
+    const result = await readImageUploadForm(new Request("https://example.test/upload", { method: "POST", body }));
+    assert.equal(result.get("action"), "save");
+    assert.equal(result.get("expectedLogoUrl"), "/team-logos/old.png");
+    assert.ok(result.get("file") instanceof File);
+  });
+  await check("non-multipart requests are rejected", () => rejects(() =>
+    readImageUploadForm(new Request("https://example.test/upload", { method: "POST", body: "bad" }))));
+  await check("multipart limit applies without a Content-Length header", async () => {
+    const body = new FormData();
+    body.set("file", file(Buffer.alloc(MAX_IMAGE_UPLOAD_BYTES + 65536), "image/png"));
+    const request = new Request("https://example.test/upload", { method: "POST", body });
+    assert.equal(request.headers.get("content-length"), null);
+    await rejects(() => readImageUploadForm(request), 413);
+  });
+  await check("declared oversized body is rejected", () => rejects(() =>
+    readImageUploadForm(new Request("https://example.test/upload", {
+      method: "POST", body: "bad", headers: {
+        "content-type": "multipart/form-data; boundary=test", "content-length": String(MAX_IMAGE_UPLOAD_BYTES * 2),
+      },
+    })), 413));
+  await check("native upload navigation and shared team field remain wired", () => {
+    const read = (path: string) => readFileSync(path, "utf8");
+    assert.match(read("src/app/(admin)/admin/teams/[id]/layout.tsx"), /href=\{`\/admin\/teams\/\$\{id\}\/badge`\}/);
+    const route = read("src/app/api/admin/teams/[id]/badge/route.ts");
+    assert.ok(route.indexOf("await requireAdmin()") < route.indexOf("await saveTeamBadge("));
+    assert.match(route, /isSameOriginUpload\(request\)/);
+    assert.match(route, /revalidatePath\("\/", "layout"\)/);
+    const store = read("src/lib/team-badges.ts");
+    assert.match(store, /prisma\.\$transaction/);
+    assert.match(store, /FOR UPDATE/);
+    assert.match(store, /team\.logoUrl \?\? ""/);
+    assert.match(store, /tx\.team\.update\(/);
+    assert.match(store, /data: \{ logoUrl \}/);
+    assert.doesNotMatch(store, /writeFile|unlinkSync/);
+  });
+  console.log(`Team badge upload: ${checks} checks passed.`);
+}
+
+main().catch((error: unknown) => { console.error(error); process.exitCode = 1; });

--- a/scripts/check-team-badge-upload.ts
+++ b/scripts/check-team-badge-upload.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import sharp from "sharp";
 import { ImageUploadError, optimiseBadgeImage, readImageUploadForm } from "../src/lib/images/upload";
 import { MAX_IMAGE_UPLOAD_BYTES } from "../src/lib/images/constants";
@@ -82,7 +82,7 @@ async function main() {
   await check("native upload navigation and shared team field remain wired", () => {
     const read = (path: string) => readFileSync(path, "utf8");
     assert.match(read("src/app/(admin)/admin/teams/[id]/layout.tsx"), /href=\{`\/admin\/teams\/\$\{id\}\/badge`\}/);
-    const route = read("src/app/api/admin/teams/[id]/badge/route.ts");
+    const route = read("src/app/api/admin/teams/[teamId]/badge/route.ts");
     assert.ok(route.indexOf("await requireAdmin()") < route.indexOf("await saveTeamBadge("));
     assert.match(route, /isSameOriginUpload\(request\)/);
     assert.match(route, /revalidatePath\("\/", "layout"\)/);
@@ -95,6 +95,13 @@ async function main() {
     assert.match(store, /new URL\(`/);
     assert.match(read("src/app/api/team-badges/[id]/route.ts"), /"Content-Type": "image\/png"/);
     assert.doesNotMatch(store, /writeFile|unlinkSync/);
+  });
+  await check("upload route uses the existing teamId dynamic segment without conflicts", () => {
+    const segments = readdirSync("src/app/api/admin/teams").filter((name) => name.startsWith("["));
+    assert.deepEqual(segments, ["[teamId]"]);
+    const route = readFileSync("src/app/api/admin/teams/[teamId]/badge/route.ts", "utf8");
+    assert.ok(route.includes("params: Promise<{ teamId: string }>"));
+    assert.ok(route.includes("const { teamId } = await context.params"));
   });
   console.log(`Team badge upload: ${checks} checks passed.`);
 }

--- a/src/app/(admin)/admin/teams/[id]/badge/page.tsx
+++ b/src/app/(admin)/admin/teams/[id]/badge/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/requireAdmin";
+import TeamBadgeUploader from "@/components/admin/teams/TeamBadgeUploader";
+
+export const dynamic = "force-dynamic";
+
+export default async function TeamBadgePage({ params }: { params: Promise<{ id: string }> }) {
+  await requireAdmin();
+  const { id } = await params;
+  const team = await prisma.team.findUnique({ where: { id }, select: { id: true, name: true, logoUrl: true } });
+  if (!team) notFound();
+  return (
+    <section className="mx-auto max-w-3xl rounded-3xl border border-white/10 bg-white/5 p-5 sm:p-8">
+      <Link href={`/admin/teams/${team.id}`} className="text-sm font-medium text-emerald-300 hover:text-emerald-200">
+        Back to {team.name}
+      </Link>
+      <h1 className="mt-4 text-2xl font-bold text-white">Team badge</h1>
+      <p className="mt-2 text-sm leading-6 text-white/60">
+        Choose an image, check the preview and save. No filenames, image links or GitHub changes needed.
+        Your other team details are not changed here.
+      </p>
+      <TeamBadgeUploader key={team.id} teamId={team.id} teamName={team.name} initialLogoUrl={team.logoUrl} />
+    </section>
+  );
+}

--- a/src/app/(admin)/admin/teams/[id]/layout.tsx
+++ b/src/app/(admin)/admin/teams/[id]/layout.tsx
@@ -294,6 +294,12 @@ export default async function AdminTeamDetailLayout({
               Team overview
             </Link>
             <Link
+              href={`/admin/teams/${id}/badge`}
+              className="inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
+            >
+              Upload badge
+            </Link>
+            <Link
               href={`/admin/teams/${id}/managed-squad`}
               className="inline-flex items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
             >

--- a/src/app/api/admin/teams/[id]/badge/route.ts
+++ b/src/app/api/admin/teams/[id]/badge/route.ts
@@ -1,0 +1,57 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { ImageUploadError, optimiseBadgeImage, readImageUploadForm } from "@/lib/images/upload";
+import { saveTeamBadge, TeamBadgeError } from "@/lib/team-badges";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function isSameOriginUpload(request: Request) {
+  // A custom header also prevents cross-site HTML forms from submitting uploads.
+  if (request.headers.get("x-sixfl-upload") !== "1") return false;
+  if (request.headers.get("sec-fetch-site") === "cross-site") return false;
+  try {
+    const origin = new URL(request.headers.get("origin") ?? "");
+    if (origin.protocol !== "https:" && origin.protocol !== "http:") return false;
+    const hosts = new Set([new URL(request.url).host, request.headers.get("host")]);
+    if (process.env.NEXTAUTH_URL) hosts.add(new URL(process.env.NEXTAUTH_URL).host);
+    return hosts.has(origin.host);
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  // Keep redirects outside the catch so an unauthorised session can never reach a write.
+  const { user } = await requireAdmin();
+  if (!isSameOriginUpload(request)) {
+    return NextResponse.json({ ok: false, error: "Please upload from the SIXFL website." }, { status: 403 });
+  }
+
+  try {
+    const { id: teamId } = await context.params;
+    const form = await readImageUploadForm(request);
+    const action = form.get("action");
+    const expectedLogoUrl = form.get("expectedLogoUrl");
+    if ((action !== "save" && action !== "remove") || typeof expectedLogoUrl !== "string") {
+      throw new ImageUploadError("Please use the team badge upload form.");
+    }
+    let image = null;
+    if (action === "save") {
+      const file = form.get("file");
+      if (!(file instanceof File)) throw new ImageUploadError("Choose an image first.");
+      image = await optimiseBadgeImage(file);
+    }
+    const logoUrl = await saveTeamBadge({ teamId, expectedLogoUrl, image, createdByUserId: user?.id ?? null });
+    // Badges are shared by admin, captain, player, fixture and public league pages.
+    revalidatePath("/", "layout");
+    return NextResponse.json({ ok: true, logoUrl }, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    if (error instanceof ImageUploadError || error instanceof TeamBadgeError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: error.status });
+    }
+    console.error("Team badge upload failed", error);
+    return NextResponse.json({ ok: false, error: "The badge could not be saved. Please try again." }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/teams/[teamId]/badge/route.ts
+++ b/src/app/api/admin/teams/[teamId]/badge/route.ts
@@ -22,7 +22,7 @@ function isSameOriginUpload(request: Request) {
   }
 }
 
-export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+export async function POST(request: Request, context: { params: Promise<{ teamId: string }> }) {
   // Keep redirects outside the catch so an unauthorised session can never reach a write.
   const { user } = await requireAdmin();
   if (!isSameOriginUpload(request)) {
@@ -30,7 +30,7 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
   }
 
   try {
-    const { id: teamId } = await context.params;
+    const { teamId } = await context.params;
     const form = await readImageUploadForm(request);
     const action = form.get("action");
     const expectedLogoUrl = form.get("expectedLogoUrl");

--- a/src/app/api/team-badges/[id]/route.ts
+++ b/src/app/api/team-badges/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
   if (!data) return new Response("Not found", { status: 404, headers: { "Cache-Control": "no-store" } });
   const etag = `"${id}-${thumbnail ? "thumbnail" : "full"}"`;
   const headers = {
-    "Content-Type": "image/webp",
+    "Content-Type": "image/png",
     "Cache-Control": "public, max-age=31536000, immutable",
     "X-Content-Type-Options": "nosniff",
     "Content-Disposition": "inline",

--- a/src/app/api/team-badges/[id]/route.ts
+++ b/src/app/api/team-badges/[id]/route.ts
@@ -1,0 +1,25 @@
+import { getTeamBadgeImage } from "@/lib/team-badges";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Public images, like the existing public/team-logos files; writes remain admin-only. */
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    return new Response("Not found", { status: 404, headers: { "Cache-Control": "no-store" } });
+  }
+  const thumbnail = new URL(request.url).searchParams.get("variant") === "thumbnail";
+  const data = await getTeamBadgeImage(id, thumbnail);
+  if (!data) return new Response("Not found", { status: 404, headers: { "Cache-Control": "no-store" } });
+  const etag = `"${id}-${thumbnail ? "thumbnail" : "full"}"`;
+  const headers = {
+    "Content-Type": "image/webp",
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "X-Content-Type-Options": "nosniff",
+    "Content-Disposition": "inline",
+    ETag: etag,
+  };
+  if (request.headers.get("if-none-match") === etag) return new Response(null, { status: 304, headers });
+  return new Response(new Uint8Array(data), { headers });
+}

--- a/src/components/admin/teams/TeamBadgeUploader.tsx
+++ b/src/components/admin/teams/TeamBadgeUploader.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { IMAGE_UPLOAD_ACCEPT, IMAGE_UPLOAD_TYPES, MAX_IMAGE_UPLOAD_BYTES } from "@/lib/images/constants";
+
+export default function TeamBadgeUploader({ teamId, teamName, initialLogoUrl }: {
+  teamId: string;
+  teamName: string;
+  initialLogoUrl: string | null;
+}) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const [savedLogoUrl, setSavedLogoUrl] = useState(initialLogoUrl);
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => () => {
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+  }, []);
+
+  function clearSelection() {
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    objectUrlRef.current = null;
+    setPreviewUrl(null);
+    setFile(null);
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  function chooseFile(nextFile: File | undefined) {
+    if (!nextFile) return;
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    objectUrlRef.current = null;
+    setFile(null);
+    setPreviewUrl(null);
+    setError("");
+    setMessage("");
+    setConfirmRemove(false);
+    if (!(IMAGE_UPLOAD_TYPES as readonly string[]).includes(nextFile.type)) {
+      setError("Use a PNG, JPEG or WebP image.");
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+    if (nextFile.size <= 0 || nextFile.size > MAX_IMAGE_UPLOAD_BYTES) {
+      setError("Choose an image no larger than 5 MB.");
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+    const url = URL.createObjectURL(nextFile);
+    objectUrlRef.current = url;
+    setPreviewUrl(url);
+    setFile(nextFile);
+  }
+
+  async function save(action: "save" | "remove") {
+    if (busy || (action === "save" && !file)) return;
+    setBusy(true);
+    setError("");
+    setMessage("");
+    try {
+      const form = new FormData();
+      form.set("action", action);
+      form.set("expectedLogoUrl", savedLogoUrl ?? "");
+      if (action === "save" && file) form.set("file", file);
+      const response = await fetch(`/api/admin/teams/${encodeURIComponent(teamId)}/badge`, {
+        method: "POST", headers: { "X-SIXFL-Upload": "1" }, body: form,
+      });
+      if (response.redirected || !response.headers.get("content-type")?.includes("application/json")) {
+        throw new Error("Your session may have expired. Sign in again, then retry the upload.");
+      }
+      const result = await response.json() as { ok?: boolean; logoUrl?: string | null; error?: string };
+      if (!response.ok || !result.ok || !(typeof result.logoUrl === "string" || result.logoUrl === null)) {
+        throw new Error(result.error || "The badge could not be saved.");
+      }
+      setSavedLogoUrl(result.logoUrl);
+      clearSelection();
+      setConfirmRemove(false);
+      setMessage(action === "remove" ? "Badge removed from this team." : "Badge saved. It is now used throughout the website.");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "The badge could not be saved.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const shownUrl = previewUrl || savedLogoUrl;
+  return (
+    <div className="mt-6 space-y-5" aria-busy={busy}>
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+        <div className="flex h-56 w-56 shrink-0 items-center justify-center rounded-2xl border border-white/15 bg-black/30 p-4">
+          {shownUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img key={shownUrl} src={shownUrl} alt={`${teamName} badge${file ? " preview" : ""}`} className="h-full w-full object-contain" />
+          ) : <span className="text-sm text-white/50">No badge set</span>}
+        </div>
+        <div className="min-w-0 space-y-3">
+          <label htmlFor="team-badge-file" className="block text-sm font-semibold text-white">
+            {savedLogoUrl ? "Replace badge" : "Upload badge"}
+          </label>
+          <input ref={inputRef} id="team-badge-file" type="file" accept={IMAGE_UPLOAD_ACCEPT}
+            disabled={busy} onChange={(event) => chooseFile(event.currentTarget.files?.[0])}
+            aria-describedby="team-badge-help" className="block w-full text-sm text-white/75 file:mr-3 file:rounded-xl file:border-0 file:bg-emerald-400 file:px-4 file:py-2.5 file:font-semibold file:text-black disabled:opacity-50" />
+          <p id="team-badge-help" className="text-xs leading-5 text-white/55">
+            PNG, JPEG or WebP, up to 5 MB. The whole badge is kept, including any transparent background.
+          </p>
+          {file ? <p className="break-words text-sm text-emerald-200">Preview: {file.name}. Not saved yet.</p> : null}
+        </div>
+      </div>
+
+      {error ? <p role="alert" className="rounded-xl border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-100">{error}</p> : null}
+      {message ? <p role="status" className="rounded-xl border border-emerald-400/30 bg-emerald-400/10 p-3 text-sm text-emerald-100">{message}</p> : null}
+
+      <div className="flex flex-wrap gap-3">
+        <button type="button" onClick={() => void save("save")} disabled={busy || !file}
+          className="rounded-xl bg-emerald-400 px-5 py-2.5 text-sm font-bold text-black disabled:cursor-not-allowed disabled:opacity-40">
+          {busy ? "Saving…" : "Save badge"}
+        </button>
+        {file ? <button type="button" onClick={clearSelection} disabled={busy} className="rounded-xl border border-white/15 px-4 py-2.5 text-sm text-white/80 disabled:opacity-40">Cancel selection</button> : null}
+        {savedLogoUrl && !confirmRemove ? <button type="button" onClick={() => { setConfirmRemove(true); setError(""); setMessage(""); }} disabled={busy}
+          className="rounded-xl border border-red-400/25 px-4 py-2.5 text-sm text-red-200 disabled:opacity-40">Remove badge</button> : null}
+      </div>
+      {confirmRemove ? (
+        <div className="space-y-3 rounded-xl border border-red-400/25 bg-red-400/5 p-4">
+          <p className="text-sm text-white/80">Remove the current badge from {teamName}? The team will use its default badge instead.</p>
+          <div className="flex flex-wrap gap-3">
+            <button type="button" disabled={busy} onClick={() => void save("remove")} className="rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40">Yes, remove badge</button>
+            <button type="button" disabled={busy} onClick={() => setConfirmRemove(false)} className="rounded-lg border border-white/15 px-4 py-2 text-sm text-white/80 disabled:opacity-40">Keep badge</button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/images/constants.ts
+++ b/src/lib/images/constants.ts
@@ -1,0 +1,4 @@
+/** Shared browser/server limits for website image uploads. */
+export const MAX_IMAGE_UPLOAD_BYTES = 5 * 1024 * 1024;
+export const IMAGE_UPLOAD_TYPES = ["image/png", "image/jpeg", "image/webp"] as const;
+export const IMAGE_UPLOAD_ACCEPT = IMAGE_UPLOAD_TYPES.join(",");

--- a/src/lib/images/upload.ts
+++ b/src/lib/images/upload.ts
@@ -1,0 +1,98 @@
+import sharp from "sharp";
+import { IMAGE_UPLOAD_TYPES, MAX_IMAGE_UPLOAD_BYTES } from "./constants";
+
+const MAX_FORM_BYTES = MAX_IMAGE_UPLOAD_BYTES + 64 * 1024;
+const MAX_INPUT_PIXELS = 25_000_000;
+const SUPPORTED_FORMATS = new Set(["png", "jpeg", "webp"]);
+
+export class ImageUploadError extends Error {
+  constructor(message: string, public readonly status = 400) {
+    super(message);
+    this.name = "ImageUploadError";
+  }
+}
+
+/** Bound the whole request, including chunked requests, before parsing multipart. */
+export async function readImageUploadForm(request: Request): Promise<FormData> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith("multipart/form-data;")) {
+    throw new ImageUploadError("Please choose an image using the upload form.");
+  }
+  const declaredSize = Number(request.headers.get("content-length") ?? 0);
+  if (declaredSize > MAX_FORM_BYTES) {
+    throw new ImageUploadError("Each image must be no larger than 5 MB.", 413);
+  }
+  if (!request.body) throw new ImageUploadError("No image was supplied.");
+
+  const reader = request.body.getReader();
+  const chunks: Buffer[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_FORM_BYTES) {
+        await reader.cancel();
+        throw new ImageUploadError("Each image must be no larger than 5 MB.", 413);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  try {
+    return await new Response(new Uint8Array(Buffer.concat(chunks)), {
+      headers: { "content-type": contentType },
+    }).formData();
+  } catch {
+    throw new ImageUploadError("The upload could not be read. Please choose the image again.");
+  }
+}
+
+export type OptimisedBadgeImage = {
+  imageData: Buffer;
+  thumbnailData: Buffer;
+};
+
+/** Decode, orient, resize and re-encode; never serve the original uploaded bytes. */
+export async function optimiseBadgeImage(file: File): Promise<OptimisedBadgeImage> {
+  if (!(IMAGE_UPLOAD_TYPES as readonly string[]).includes(file.type)) {
+    throw new ImageUploadError("Use a PNG, JPEG or WebP image.");
+  }
+  if (file.size <= 0) throw new ImageUploadError("The image file is empty.");
+  if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+    throw new ImageUploadError("Each image must be no larger than 5 MB.", 413);
+  }
+
+  try {
+    const source = Buffer.from(await file.arrayBuffer());
+    // Reject renamed SVG/GIF files before passing any input to the image decoder.
+    const isPng = source.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+    const isJpeg = source[0] === 0xff && source[1] === 0xd8 && source[2] === 0xff;
+    const isWebp = source.toString("ascii", 0, 4) === "RIFF" && source.toString("ascii", 8, 12) === "WEBP";
+    if (!isPng && !isJpeg && !isWebp) {
+      throw new ImageUploadError("Use a real PNG, JPEG or WebP image, not an SVG or renamed file.");
+    }
+    const pipeline = sharp(source, { failOn: "error", limitInputPixels: MAX_INPUT_PIXELS });
+    const metadata = await pipeline.metadata();
+    if (!metadata.format || !SUPPORTED_FORMATS.has(metadata.format)) {
+      throw new ImageUploadError("Use a real PNG, JPEG or WebP image, not an SVG or renamed file.");
+    }
+    if ((metadata.pages ?? 1) > 1) {
+      throw new ImageUploadError("Use a still image rather than an animated badge.");
+    }
+    const oriented = pipeline.rotate();
+    const [imageData, thumbnailData] = await Promise.all([
+      oriented.clone().resize({ width: 900, height: 900, fit: "inside", withoutEnlargement: true })
+        .webp({ quality: 88, effort: 4 }).toBuffer(),
+      oriented.clone().resize({ width: 240, height: 240, fit: "inside", withoutEnlargement: true })
+        .webp({ quality: 82, effort: 4 }).toBuffer(),
+    ]);
+    return { imageData, thumbnailData };
+  } catch (error) {
+    if (error instanceof ImageUploadError) throw error;
+    throw new ImageUploadError("This image could not be processed. Try a PNG, JPEG or WebP under 5 MB and 25 megapixels.");
+  }
+}

--- a/src/lib/images/upload.ts
+++ b/src/lib/images/upload.ts
@@ -83,12 +83,13 @@ export async function optimiseBadgeImage(file: File): Promise<OptimisedBadgeImag
     if ((metadata.pages ?? 1) > 1) {
       throw new ImageUploadError("Use a still image rather than an animated badge.");
     }
+    // PNG also works in the existing node-canvas PDFs and email clients.
     const oriented = pipeline.rotate();
     const [imageData, thumbnailData] = await Promise.all([
       oriented.clone().resize({ width: 900, height: 900, fit: "inside", withoutEnlargement: true })
-        .webp({ quality: 88, effort: 4 }).toBuffer(),
+        .png({ compressionLevel: 9 }).toBuffer(),
       oriented.clone().resize({ width: 240, height: 240, fit: "inside", withoutEnlargement: true })
-        .webp({ quality: 82, effort: 4 }).toBuffer(),
+        .png({ compressionLevel: 9 }).toBuffer(),
     ]);
     return { imageData, thumbnailData };
   } catch (error) {

--- a/src/lib/team-badges.ts
+++ b/src/lib/team-badges.ts
@@ -34,7 +34,10 @@ export async function saveTeamBadge(input: {
         INSERT INTO "TeamBadgeImage" ("id", "teamId", "createdByUserId", "imageData", "thumbnailData")
         VALUES (${id}, ${input.teamId}, ${input.createdByUserId}, ${input.image.imageData}, ${input.image.thumbnailData})
       `);
-      logoUrl = `/api/team-badges/${id}`;
+      // Existing server-side social/PDF renderers fetch absolute URLs, but read
+      // relative paths from public/. Keep uploaded badges compatible with both.
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXTAUTH_URL || "https://www.sixfl.co.uk";
+      logoUrl = new URL(`/api/team-badges/${id}`, siteUrl).toString();
     }
     // Retain old immutable images so previously shared image URLs do not break.
     // Removing a badge unlinks it from the team; deleting the team cascades its images.

--- a/src/lib/team-badges.ts
+++ b/src/lib/team-badges.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import type { OptimisedBadgeImage } from "@/lib/images/upload";
+
+export class TeamBadgeError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+    this.name = "TeamBadgeError";
+  }
+}
+
+/** Team.logoUrl remains the shared source of truth for every badge consumer. */
+export async function saveTeamBadge(input: {
+  teamId: string;
+  expectedLogoUrl: string;
+  createdByUserId: string | null;
+  image: OptimisedBadgeImage | null;
+}): Promise<string | null> {
+  return prisma.$transaction(async (tx) => {
+    const rows = await tx.$queryRaw<Array<{ id: string; logoUrl: string | null }>>(Prisma.sql`
+      SELECT "id", "logoUrl" FROM "Team" WHERE "id" = ${input.teamId} FOR UPDATE
+    `);
+    const team = rows[0];
+    if (!team) throw new TeamBadgeError("This team could not be found.", 404);
+    if ((team.logoUrl ?? "") !== input.expectedLogoUrl) {
+      throw new TeamBadgeError("This badge was changed in another session. Refresh the page before saving again.", 409);
+    }
+
+    let logoUrl: string | null = null;
+    if (input.image) {
+      const id = randomUUID();
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO "TeamBadgeImage" ("id", "teamId", "createdByUserId", "imageData", "thumbnailData")
+        VALUES (${id}, ${input.teamId}, ${input.createdByUserId}, ${input.image.imageData}, ${input.image.thumbnailData})
+      `);
+      logoUrl = `/api/team-badges/${id}`;
+    }
+    // Retain old immutable images so previously shared image URLs do not break.
+    // Removing a badge unlinks it from the team; deleting the team cascades its images.
+    await tx.team.update({ where: { id: input.teamId }, data: { logoUrl } });
+    return logoUrl;
+  });
+}
+
+export async function getTeamBadgeImage(id: string, thumbnail: boolean) {
+  const column = thumbnail ? Prisma.sql`"thumbnailData"` : Prisma.sql`"imageData"`;
+  const rows = await prisma.$queryRaw<Array<{ data: Uint8Array }>>(Prisma.sql`
+    SELECT ${column} AS "data" FROM "TeamBadgeImage" WHERE "id" = ${id} LIMIT 1
+  `);
+  return rows[0]?.data ?? null;
+}


### PR DESCRIPTION
## What this adds
- Native **Upload badge** navigation on each team's admin screen, opening an image preview/save/replace/remove page.
- Admin-only, same-origin upload API with real PNG/JPEG/WebP decoding, a 5 MB file limit and bounded multipart request, a 25 megapixel limit, rotation, PNG resizing and transparent-background preservation.
- Persistent PostgreSQL BYTEA image storage instead of ephemeral filesystem writes or GitHub uploads. An additive migration runs through the existing `prisma migrate deploy` startup.
- Existing `Team.logoUrl` remains the shared badge source. Existing static/remote image links continue working. Updates run transactionally with a row lock and expected-URL check to stop stale upload sessions overwriting newer badge changes.
- Public immutable PNG image URLs, saved as absolute URLs for compatibility with existing social-image, email and node-canvas fixture PDF consumers. Removed/replaced images remain available at previously shared URLs.
- No changes to player/payment/fixture rules or other team fields. The API uses the existing `[teamId]` segment, matching adjacent team routes.

## Scope
Team-badge uploads, not a general website media library. No extra storage provider or new environment variables are needed.

## Verification
- All 16 local image-processing/multipart/wiring checks pass using real Sharp decoding, including transparency, resizing, EXIF orientation, invalid/SVG/corrupt/empty/oversized inputs, multipart limits and a dynamic-route conflict regression check.
- Added a CI job to repeat these tests and list all existing logo URL consumers for compatibility review.
- Full application type-check and critical-feature contracts passed before the final route-name correction; the corrected head is now being checked again.
- A startup check caught the initial `[id]` versus existing `[teamId]` route conflict. This has been corrected before merge; the uploader now uses `[teamId]` throughout its API route.
- Live migration/deployment and an authenticated browser upload have not yet been verified. No production badge records have been modified.