### PR TITLE
Record SIXFL-approved guests directly on each fixture’s Matchday squad

### DIFF
--- a/.github/workflows/fixture-guest-approvals.yml
+++ b/.github/workflows/fixture-guest-approvals.yml
@@ -1,0 +1,36 @@
+name: Fixture guest approval contracts
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  guest-approvals:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sixfl_guest_test
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sixfl_guest_test"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_guest_test
+      GUEST_APPROVAL_TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_guest_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Apply complete production source preparation
+        run: npm run prebuild
+      - run: npx prisma generate
+      - name: Test permissions, real PostgreSQL transactions, races and native wiring
+        run: npx tsx --test tests/fixture-guest-approvals.test.ts
+      - name: Type-check application
+        run: npx tsc --noEmit

--- a/.github/workflows/fixture-guest-approvals.yml
+++ b/.github/workflows/fixture-guest-approvals.yml
@@ -32,5 +32,27 @@ jobs:
       - run: npx prisma generate
       - name: Test permissions, real PostgreSQL transactions, races and native wiring
         run: npx tsx --test tests/fixture-guest-approvals.test.ts
+      - name: Prove the tests detect a removed admin safeguard
+        shell: bash
+        run: |
+          target=src/lib/fixtures/guest-approvals.ts
+          original=$(mktemp)
+          cp "$target" "$original"
+          trap 'cp "$original" "$target"; rm -f "$original"' EXIT
+          node - <<'JS'
+          const fs = require("node:fs");
+          const path = "src/lib/fixtures/guest-approvals.ts";
+          const source = fs.readFileSync(path, "utf8");
+          const guard = 'if (actors[0]?.role !== "ADMIN")';
+          if (!source.includes(guard)) throw new Error("Admin safeguard marker not found");
+          fs.writeFileSync(path, source.replace(guard, "if (false)"));
+          JS
+          if npx tsx --test --test-name-pattern="storage layer independently" tests/fixture-guest-approvals.test.ts > guest-negative-control.log 2>&1; then
+            cat guest-negative-control.log
+            echo "ERROR: removing the admin guard did not fail its test"
+            exit 1
+          fi
+          grep -q "Missing expected rejection" guest-negative-control.log
+          echo "Negative control passed: the permission test rejected a removed admin guard."
       - name: Type-check application
         run: npx tsc --noEmit

--- a/docs/fixture-guest-approvals.md
+++ b/docs/fixture-guest-approvals.md
@@ -1,0 +1,36 @@
+# Fixture-specific guest permission
+
+In full admin captain view, open **Matchday squad**, select the fixture and open it.
+The native **Guest approvals** panel lets a SIXFL administrator search an existing
+player by name or email, confirm the correct player/team/fixture, add an optional
+internal note, and choose **Confirm guest approval**. No player pass is required
+to record permission. Captains have a read-only list for their own team/fixture.
+
+The badge is **Guest — SIXFL approved**. Approval records the admin, timestamp,
+player and fixture. It does not change permanent registration, select a player,
+create or waive a fee, or send notifications. The existing temporary-player and
+payment workflows are unchanged. Approval does not replace player consent, count
+as an appearance or override normal guest, squad-size or disciplinary rules.
+
+## Revocation and audit
+
+Before kick-off a full administrator may revoke permission with a reason. It is
+shown as **Revoked — not approved**; existing selection and fees must be reviewed
+separately. A later reapproval retains the previous decisions in the append-only
+`FixtureGuestApprovalEvent` table. Past and non-scheduled fixtures are read-only;
+this is not a retrospective permission/backdating tool.
+
+Permissions are restricted to the exact fixture and receiving team, not future
+fixtures. Writes recheck the admin role, fixture ownership, publication, status,
+kick-off and record revision inside a transaction. The fixture row lock prevents
+concurrent approvals from silently overwriting each other, including competing
+approvals for both sides. Actor and decision are recorded atomically. Private
+notes, player-search emails and admin identities are not exposed to captains.
+
+## Regression checks
+
+`fixture-guest-approvals.yml` runs the complete production prebuild followed by
+real PostgreSQL tests in a newly created, isolated schema. It checks permissions,
+preview restrictions, validation, atomic audit, concurrent/stale changes,
+fixture scoping, revocation, and unchanged registrations/payments. It also checks
+native layout/API wiring after prebuild and type-checks the application.

--- a/prisma/migrations/20260906010000_fixture_guest_approvals/migration.sql
+++ b/prisma/migrations/20260906010000_fixture_guest_approvals/migration.sql
@@ -1,0 +1,31 @@
+-- Permission is deliberately separate from attendance, permanent membership and money.
+CREATE TABLE "FixtureGuestApproval" (
+  "id" TEXT PRIMARY KEY,
+  "fixtureId" TEXT NOT NULL REFERENCES "Fixture"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  "teamId" TEXT NOT NULL REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  "playerUserId" TEXT NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "status" TEXT NOT NULL CHECK ("status" IN ('APPROVED', 'REVOKED')),
+  "revision" INTEGER NOT NULL DEFAULT 1 CHECK ("revision" > 0),
+  "approvedAt" TIMESTAMP(3) NOT NULL,
+  "approvedByUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "approvedByName" TEXT NOT NULL,
+  "reason" TEXT NOT NULL DEFAULT '',
+  "revokedAt" TIMESTAMP(3),
+  "revokedByUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "revokedByName" TEXT,
+  "revocationReason" TEXT,
+  UNIQUE ("fixtureId", "teamId", "playerUserId")
+);
+CREATE INDEX "FixtureGuestApproval_team_fixture_status_idx"
+  ON "FixtureGuestApproval" ("teamId", "fixtureId", "status");
+CREATE TABLE "FixtureGuestApprovalEvent" (
+  "id" TEXT PRIMARY KEY,
+  "approvalId" TEXT NOT NULL REFERENCES "FixtureGuestApproval"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  "decision" TEXT NOT NULL CHECK ("decision" IN ('APPROVED', 'REVOKED')),
+  "revision" INTEGER NOT NULL,
+  "actorUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "actorName" TEXT NOT NULL,
+  "reason" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE ("approvalId", "revision")
+);

--- a/src/app/api/captain/team/[teamid]/guest-approvals/route.ts
+++ b/src/app/api/captain/team/[teamid]/guest-approvals/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { getFixtureGuestApprovals, searchGuestCandidates, setFixtureGuestApproval } from "@/lib/fixtures/guest-approvals";
+import { assertGuestApprovalAccess, assertGuestApprovalOrigin, canManageGuestApprovals, GuestApprovalError, readGuestDecision } from "@/lib/fixtures/guest-approval-policy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+type Context = { params: Promise<{ teamid: string }> };
+const noStore = { "Cache-Control": "no-store" };
+function failure(error: unknown) {
+  if (error instanceof GuestApprovalError) return NextResponse.json({ error: error.message }, { status: error.status, headers: noStore });
+  console.error("Fixture guest approval failed", error);
+  return NextResponse.json({ error: "Guest approvals could not be saved or loaded. Please reload and try again." }, { status: 500, headers: noStore });
+}
+
+export async function GET(request: Request, { params }: Context) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  try {
+    assertGuestApprovalAccess(access);
+    const canManage = canManageGuestApprovals(access);
+    const url = new URL(request.url);
+    const fixtureId = url.searchParams.get("fixtureId") || "";
+    if (!/^[a-zA-Z0-9_-]{1,150}$/.test(fixtureId)) throw new GuestApprovalError("Select a fixture first.");
+    const data = await getFixtureGuestApprovals(teamid, fixtureId);
+    const query = url.searchParams.get("q");
+    if (query !== null && !canManage) throw new GuestApprovalError("Player search is available to SIXFL administrators only.", 403);
+    const candidates = query !== null && canManage ? await searchGuestCandidates(teamid, query) : [];
+    // Captains can see permission status, but not private notes, another player's email or administrator identity.
+    const approvals = data.approvals.map((row) => canManage ? row : {
+      id: row.id, playerUserId: row.playerUserId, playerName: row.playerName,
+      status: row.status, revision: row.revision, approvedAt: row.approvedAt, revokedAt: row.revokedAt,
+    });
+    return NextResponse.json({ fixture: data.fixture, approvals, candidates, canManage }, { headers: noStore });
+  } catch (error) { return failure(error); }
+}
+
+export async function POST(request: Request, { params }: Context) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  try {
+    assertGuestApprovalAccess(access, true);
+    assertGuestApprovalOrigin(request);
+    const input = await readGuestDecision(request);
+    const result = await setFixtureGuestApproval({ ...input, teamId: teamid, actorUserId: access.user!.id });
+    revalidatePath(`/captain/team/${teamid}/match-fees`);
+    return NextResponse.json({ ok: true, ...result }, { headers: noStore });
+  } catch (error) { return failure(error); }
+}

--- a/src/app/captain/team/[teamid]/match-fees/layout.tsx
+++ b/src/app/captain/team/[teamid]/match-fees/layout.tsx
@@ -1,0 +1,19 @@
+import { Suspense, type ReactNode } from "react";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { canManageGuestApprovals } from "@/lib/fixtures/guest-approval-policy";
+import FixtureGuestApprovals from "@/components/captain/FixtureGuestApprovals";
+
+export default async function MatchdaySquadLayout({ children, params }: {
+  children: ReactNode; params: Promise<{ teamid: string }>;
+}) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  return (
+    <div className="space-y-6">
+      <Suspense fallback={null}>
+        <FixtureGuestApprovals teamId={teamid} canManage={canManageGuestApprovals(access)} />
+      </Suspense>
+      {children}
+    </div>
+  );
+}

--- a/src/components/captain/FixtureGuestApprovals.tsx
+++ b/src/components/captain/FixtureGuestApprovals.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Approval = {
+  id: string; playerUserId: string; playerName: string; status: "APPROVED" | "REVOKED";
+  revision: number; approvedAt: string; approvedByName?: string; reason?: string;
+  revokedAt: string | null; revokedByName?: string | null; revocationReason?: string | null;
+};
+type Candidate = { id: string; name: string; email: string | null; teams: string };
+type Payload = {
+  canManage: boolean;
+  fixture: { id: string; teamName: string; opponentName: string; kickoffAt: string; status: string; editable: boolean };
+  approvals: Approval[]; candidates: Candidate[];
+};
+const inputStyle = "w-full rounded-xl border border-white/20 bg-black/30 px-3 py-2.5 text-sm text-white outline-none focus:border-emerald-400 disabled:opacity-50";
+const buttonStyle = "rounded-xl bg-emerald-400 px-4 py-2.5 text-sm font-semibold text-black hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-50";
+const dateTime = (value: string) => new Intl.DateTimeFormat("en-GB", {
+  day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: "Europe/London",
+}).format(new Date(value));
+
+async function readResponse(response: Response) {
+  if (response.redirected) throw new Error("Your session may have expired. Sign in again, then reload this fixture.");
+  const value = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(value?.error || "The guest approval request failed. Reload before trying again.");
+  if (!value) throw new Error("The server response could not be read. Reload before trying again.");
+  return value;
+}
+
+export default function FixtureGuestApprovals({ teamId, canManage }: { teamId: string; canManage: boolean }) {
+  const fixtureId = useSearchParams().get("fixtureId") || "";
+  if (!fixtureId) return canManage ? (
+    <section className="rounded-3xl border border-emerald-400/20 bg-emerald-500/[0.06] p-5">
+      <h2 className="text-lg font-semibold text-white">Guest approvals</h2>
+      <p className="mt-2 text-sm leading-6 text-white/70">Choose the match in the fixture selector below and open it to approve a guest. Approval applies to one named player and one fixture only.</p>
+    </section>
+  ) : null;
+  return <GuestApprovalPanel key={`${teamId}:${fixtureId}`} teamId={teamId} fixtureId={fixtureId} canManage={canManage} />;
+}
+
+function GuestApprovalPanel({ teamId, fixtureId, canManage }: { teamId: string; fixtureId: string; canManage: boolean }) {
+  const router = useRouter();
+  const [data, setData] = useState<Payload | null>(null);
+  const [query, setQuery] = useState("");
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [selected, setSelected] = useState<Candidate | null>(null);
+  const [reason, setReason] = useState("");
+  const [revoke, setRevoke] = useState<Approval | null>(null);
+  const [revokeReason, setRevokeReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [searching, setSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const endpoint = `/api/captain/team/${encodeURIComponent(teamId)}/guest-approvals`;
+  const readUrl = `${endpoint}?fixtureId=${encodeURIComponent(fixtureId)}`;
+  const editable = Boolean(canManage && data?.canManage && data.fixture.editable);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(readUrl, { cache: "no-store", signal: controller.signal })
+      .then(readResponse).then((value: Payload) => setData(value))
+      .catch((err: Error) => { if (!controller.signal.aborted) setError(err.message); })
+      .finally(() => { if (!controller.signal.aborted) setLoading(false); });
+    return () => controller.abort();
+  }, [readUrl]);
+
+  async function reload() {
+    setLoading(true);
+    try { setData(await readResponse(await fetch(readUrl, { cache: "no-store" })) as Payload); }
+    finally { setLoading(false); }
+  }
+
+  async function search(event: FormEvent) {
+    event.preventDefault();
+    if (query.trim().length < 2 || !editable) return;
+    setSearching(true); setError(""); setSelected(null); setCandidates([]); setSearched(false);
+    try {
+      const result = await readResponse(await fetch(`${readUrl}&q=${encodeURIComponent(query.trim())}`, { cache: "no-store" })) as Payload;
+      setData(result); setCandidates(result.candidates); setSearched(true);
+    } catch (err) { setError(err instanceof Error ? err.message : "Player search failed."); }
+    finally { setSearching(false); }
+  }
+
+  async function decide(playerUserId: string, decision: "approve" | "revoke", note: string) {
+    if (!data || !editable || busy) return;
+    const existing = data.approvals.find((row) => row.playerUserId === playerUserId);
+    setBusy(true); setError(""); setMessage("");
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fixtureId, playerUserId, decision, reason: note,
+          expectedRevision: existing?.revision ?? null, expectedKickoffAt: data.fixture.kickoffAt }),
+      });
+      await readResponse(response);
+      setMessage(decision === "approve"
+        ? "Guest approved for this fixture. Permanent registration and payments are unchanged."
+        : "Guest approval revoked for this fixture. Existing selection and payments have not been changed; review them separately if needed.");
+      setSelected(null); setCandidates([]); setSearched(false); setQuery(""); setReason("");
+      setRevoke(null); setRevokeReason(""); setShowForm(false);
+      await reload(); router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "The save could not be confirmed. Reload before trying again.");
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <section id="guest-approvals" className="rounded-3xl border border-emerald-400/25 bg-emerald-500/[0.06] p-5 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200/70">Fixture-specific permission</p>
+          <h2 className="mt-1 text-xl font-semibold text-white">Guest approvals</h2>
+          {data ? <p className="mt-2 text-sm text-white/75">For <strong>{data.fixture.teamName}</strong> vs {data.fixture.opponentName} · {dateTime(data.fixture.kickoffAt)} (UK)</p> : null}
+        </div>
+        {editable ? <button type="button" disabled={busy} className={buttonStyle} onClick={() => setShowForm(!showForm)}>Approve guest for this fixture</button> : null}
+      </div>
+      <p className="mt-3 text-sm leading-6 text-white/60">Permission only—not confirmation that the player has played. This does not add a permanent squad member, change selection, create a fee, waive payment or send a message. Normal guest and matchday squad limits still apply.</p>
+      {loading ? <p role="status" className="mt-3 text-sm text-white/70">Loading guest approvals…</p> : null}
+      {error ? <div role="alert" className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{error}<button type="button" disabled={busy || loading} className="ml-3 underline" onClick={() => { setError(""); void reload().catch((err: Error) => setError(err.message)); }}>Reload approvals</button></div> : null}
+      {message ? <p role="status" className="mt-4 rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-100">{message}</p> : null}
+      {data && !data.fixture.editable ? <p className="mt-3 text-sm text-amber-100">Read-only: approvals cannot be added, revoked or backdated after kick-off, or while a fixture is not scheduled.</p> : null}
+      {showForm && editable ? (
+        <div className="mt-5 space-y-4 rounded-2xl border border-white/15 bg-black/20 p-4">
+          <form onSubmit={search} className="flex flex-wrap items-end gap-3">
+            <label className="min-w-0 flex-1 text-sm text-white">Find an existing player by name or email
+              <input value={query} onChange={(e) => { setQuery(e.target.value); setSelected(null); setCandidates([]); setSearched(false); }} minLength={2} maxLength={80} required disabled={busy || searching} className={`mt-2 ${inputStyle}`} placeholder="Enter at least two characters" />
+            </label>
+            <button className={buttonStyle} disabled={busy || searching || query.trim().length < 2}>{searching ? "Searching…" : "Find player"}</button>
+          </form>
+          {searched && candidates.length === 0 ? <p className="text-sm text-white/65">No matching player found. Permanent members of this team are excluded.</p> : null}
+          {candidates.length > 0 ? <div className="max-h-64 space-y-2 overflow-y-auto">
+            {candidates.map((player) => {
+              const approved = data.approvals.some((a) => a.playerUserId === player.id && a.status === "APPROVED");
+              return <button key={player.id} type="button" disabled={approved || busy} aria-pressed={selected?.id === player.id} onClick={() => setSelected(player)} className={`block w-full rounded-xl border p-3 text-left text-sm disabled:opacity-50 ${selected?.id === player.id ? "border-emerald-300 bg-emerald-500/15" : "border-white/15 bg-white/[0.03]"}`}>
+                <span className="font-semibold text-white">{player.name}{approved ? " — already approved" : ""}</span>
+                <span className="mt-1 block break-all text-white/60">{player.email || "No email saved"}</span>
+                <span className="mt-1 block text-white/55">Permanent team: {player.teams}</span>
+              </button>;
+            })}
+          </div> : null}
+          {selected ? <form onSubmit={(e) => { e.preventDefault(); void decide(selected.id, "approve", reason); }} className="space-y-3 border-t border-white/10 pt-4">
+            <p className="text-sm text-emerald-100">Approve <strong>{selected.name}</strong> for <strong>{data.fixture.teamName}</strong> in this match only.</p>
+            <label className="block text-sm text-white/75">Optional internal approval note
+              <textarea value={reason} onChange={(e) => setReason(e.target.value)} maxLength={500} rows={2} disabled={busy} className={`mt-2 ${inputStyle}`} />
+            </label>
+            <button className={buttonStyle} disabled={busy}>{busy ? "Saving…" : "Confirm guest approval"}</button>
+          </form> : null}
+        </div>
+      ) : null}
+      {data && data.approvals.length === 0 && !loading ? <p className="mt-4 text-sm text-white/65">No SIXFL guest approvals recorded for this team in this fixture.</p> : null}
+      <div className="mt-4 space-y-3">
+        {data?.approvals.map((approval) => <article key={approval.id} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="font-semibold text-white">{approval.playerName}</h3>
+              <span className={`rounded-full px-3 py-1 text-xs font-semibold ${approval.status === "APPROVED" ? "bg-emerald-500/20 text-emerald-100" : "bg-red-500/15 text-red-100"}`}>{approval.status === "APPROVED" ? "Guest — SIXFL approved" : "Revoked — not approved"}</span>
+            </div>
+            {editable && approval.status === "APPROVED" ? <button type="button" disabled={busy} onClick={() => { setRevoke(approval); setRevokeReason(""); }} className="rounded-lg border border-red-400/30 px-3 py-2 text-xs font-semibold text-red-100 disabled:opacity-50">Revoke approval</button> : null}
+          </div>
+          <p className="mt-2 text-xs text-white/60">Approved {dateTime(approval.approvedAt)} (UK){approval.approvedByName ? ` by ${approval.approvedByName}` : " by SIXFL"}.</p>
+          {approval.reason ? <p className="mt-2 whitespace-pre-wrap text-sm text-white/65">Internal note: {approval.reason}</p> : null}
+          {approval.revokedAt ? <p className="mt-2 text-xs text-red-100/80">Revoked {dateTime(approval.revokedAt)} (UK){approval.revokedByName ? ` by ${approval.revokedByName}` : ""}.{approval.revocationReason ? ` ${approval.revocationReason}` : ""}</p> : null}
+          {revoke?.id === approval.id && editable ? <form onSubmit={(e) => { e.preventDefault(); void decide(approval.playerUserId, "revoke", revokeReason); }} className="mt-3 space-y-3">
+            <label className="block text-sm text-white">Reason for revoking
+              <input value={revokeReason} onChange={(e) => setRevokeReason(e.target.value)} minLength={3} maxLength={500} required disabled={busy} className={`mt-2 ${inputStyle}`} />
+            </label>
+            <p className="text-xs text-white/65">This removes permission only. Check any existing matchday selection or fee separately.</p>
+            <div className="flex gap-3"><button disabled={busy || revokeReason.trim().length < 3} className="rounded-xl border border-red-400/30 bg-red-500/15 px-4 py-2 text-sm text-red-100 disabled:opacity-50">Confirm revocation</button><button type="button" disabled={busy} onClick={() => setRevoke(null)} className="px-3 py-2 text-sm text-white/70">Cancel</button></div>
+          </form> : null}
+        </article>)}
+      </div>
+    </section>
+  );
+}

--- a/src/components/captain/FixtureGuestApprovals.tsx
+++ b/src/components/captain/FixtureGuestApprovals.tsx
@@ -122,7 +122,7 @@ function GuestApprovalPanel({ teamId, fixtureId, canManage }: { teamId: string; 
       {error ? <div role="alert" className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{error}<button type="button" disabled={busy || loading} className="ml-3 underline" onClick={() => { setError(""); void reload().catch((err: Error) => setError(err.message)); }}>Reload approvals</button></div> : null}
       {message ? <p role="status" className="mt-4 rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-100">{message}</p> : null}
       {data && !data.fixture.editable ? <p className="mt-3 text-sm text-amber-100">Read-only: approvals cannot be added, revoked or backdated after kick-off, or while a fixture is not scheduled.</p> : null}
-      {showForm && editable ? (
+      {showForm && editable && data ? (
         <div className="mt-5 space-y-4 rounded-2xl border border-white/15 bg-black/20 p-4">
           <form onSubmit={search} className="flex flex-wrap items-end gap-3">
             <label className="min-w-0 flex-1 text-sm text-white">Find an existing player by name or email

--- a/src/lib/fixtures/guest-approval-policy.ts
+++ b/src/lib/fixtures/guest-approval-policy.ts
@@ -1,0 +1,116 @@
+export class GuestApprovalError extends Error {
+  constructor(message: string, public readonly status = 400) {
+    super(message);
+    this.name = "GuestApprovalError";
+  }
+}
+
+export type GuestApprovalAccess = {
+  session: unknown;
+  user: { id: string; role: string } | null;
+  isAdmin: boolean;
+  isCaptain: boolean;
+  accessMode: string;
+};
+
+export function canManageGuestApprovals(access: GuestApprovalAccess) {
+  return Boolean(access.session && access.user?.id && access.user.role === "ADMIN" &&
+    access.isAdmin && access.accessMode === "captain");
+}
+
+export function assertGuestApprovalAccess(access: GuestApprovalAccess, write = false) {
+  if (!access.session || !access.user?.id || (!access.isAdmin && !access.isCaptain)) {
+    throw new GuestApprovalError("Sign in with access to this team.", 403);
+  }
+  if (write && !canManageGuestApprovals(access)) {
+    throw new GuestApprovalError("Only SIXFL administrators in full admin view can approve or revoke guests.", 403);
+  }
+}
+
+export type GuestDecisionInput = {
+  fixtureId: string;
+  playerUserId: string;
+  decision: "approve" | "revoke";
+  reason: string;
+  expectedRevision: number | null;
+  expectedKickoffAt: string;
+};
+
+export function parseGuestDecision(value: unknown): GuestDecisionInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new GuestApprovalError("Choose a player and fixture first.");
+  }
+  const data = value as Record<string, unknown>;
+  const id = (key: string) => {
+    const v = data[key];
+    if (typeof v !== "string" || !/^[a-zA-Z0-9_-]{1,150}$/.test(v)) {
+      throw new GuestApprovalError("Choose a valid player and fixture first.");
+    }
+    return v;
+  };
+  if (data.decision !== "approve" && data.decision !== "revoke") {
+    throw new GuestApprovalError("Choose approve or revoke.");
+  }
+  if (typeof data.reason !== "string" || data.reason.length > 500) {
+    throw new GuestApprovalError("Keep the approval note or reason within 500 characters.");
+  }
+  const reason = data.reason.trim();
+  if (data.decision === "revoke" && reason.length < 3) {
+    throw new GuestApprovalError("Give a short reason for revoking this approval.");
+  }
+  if (data.expectedRevision !== null &&
+      (typeof data.expectedRevision !== "number" || !Number.isInteger(data.expectedRevision) || data.expectedRevision < 1)) {
+    throw new GuestApprovalError("Reload the guest approvals before making a change.", 409);
+  }
+  if (typeof data.expectedKickoffAt !== "string" || !Number.isFinite(Date.parse(data.expectedKickoffAt))) {
+    throw new GuestApprovalError("Reload the fixture before making a change.", 409);
+  }
+  return {
+    fixtureId: id("fixtureId"), playerUserId: id("playerUserId"),
+    decision: data.decision, reason,
+    expectedRevision: data.expectedRevision as number | null,
+    expectedKickoffAt: data.expectedKickoffAt,
+  };
+}
+
+export function assertGuestApprovalOrigin(request: Request) {
+  const origin = request.headers.get("origin");
+  const allowed = [new URL(request.url).origin];
+  for (const value of [process.env.NEXTAUTH_URL, process.env.NEXT_PUBLIC_SITE_URL, process.env.NEXT_PUBLIC_APP_URL]) {
+    if (value) { try { allowed.push(new URL(value).origin); } catch { /* Ignore invalid deployment settings. */ } }
+  }
+  if (!origin || !allowed.includes(origin) || request.headers.get("sec-fetch-site") === "cross-site") {
+    throw new GuestApprovalError("Open this page on the SIXFL website before saving.", 403);
+  }
+}
+
+export async function readGuestDecision(request: Request) {
+  if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+    throw new GuestApprovalError("Send a JSON approval request.", 415);
+  }
+  const limit = 8192;
+  if (Number(request.headers.get("content-length")) > limit) {
+    throw new GuestApprovalError("The approval request is too large.", 413);
+  }
+  const reader = request.body?.getReader();
+  if (!reader) throw new GuestApprovalError("The approval request is empty.");
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      bytes += chunk.value.byteLength;
+      if (bytes > limit) {
+        await reader.cancel();
+        throw new GuestApprovalError("The approval request is too large.", 413);
+      }
+      text += decoder.decode(chunk.value, { stream: true });
+    }
+    text += decoder.decode();
+  } finally { reader.releaseLock(); }
+  let value: unknown;
+  try { value = JSON.parse(text); } catch { throw new GuestApprovalError("The approval request could not be read."); }
+  return parseGuestDecision(value);
+}

--- a/src/lib/fixtures/guest-approvals.ts
+++ b/src/lib/fixtures/guest-approvals.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { Prisma, type PrismaClient } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { GuestApprovalError, parseGuestDecision, type GuestDecisionInput } from "./guest-approval-policy";
+
+// Accept SIXFL's extended Prisma client and the isolated test client without requiring unrelated delegates.
+type GuestTransaction = Pick<Prisma.TransactionClient, "$queryRaw" | "$executeRaw">;
+type GuestDatabase = Pick<GuestTransaction, "$queryRaw"> & {
+  $transaction<T>(action: (tx: GuestTransaction) => Promise<T>): Promise<T>;
+};
 
 type FixtureRow = {
   id: string; homeTeamId: string; awayTeamId: string; kickoffAt: Date;
@@ -21,7 +27,7 @@ function assertTeamFixture(fixture: FixtureRow | undefined, teamId: string): ass
 }
 
 /** Reads only. Approval is not attendance, a second registration, a fee or a waiver. */
-export async function getFixtureGuestApprovals(teamId: string, fixtureId: string, db: PrismaClient = prisma) {
+export async function getFixtureGuestApprovals(teamId: string, fixtureId: string, db: GuestDatabase = prisma) {
   const fixtures = await db.$queryRaw<FixtureRow[]>(Prisma.sql`
     SELECT "id", "homeTeamId", "awayTeamId", "kickoffAt", "publishedAt", "status"::text
     FROM "Fixture" WHERE "id" = ${fixtureId}
@@ -51,7 +57,7 @@ export async function getFixtureGuestApprovals(teamId: string, fixtureId: string
 }
 
 /** Called only after full admin access has been checked by the API. */
-export async function searchGuestCandidates(teamId: string, query: string, db: PrismaClient = prisma) {
+export async function searchGuestCandidates(teamId: string, query: string, db: GuestDatabase = prisma) {
   const trimmed = query.trim();
   if (trimmed.length < 2) return [] as GuestCandidate[];
   if (trimmed.length > 80) throw new GuestApprovalError("Search using no more than 80 characters.");
@@ -69,7 +75,7 @@ export async function searchGuestCandidates(teamId: string, query: string, db: P
 
 /** Revalidate at write time and lock the fixture: two admin tabs cannot silently overwrite one another. */
 export async function setFixtureGuestApproval(
-  input: GuestDecisionInput & { teamId: string; actorUserId: string }, db: PrismaClient = prisma,
+  input: GuestDecisionInput & { teamId: string; actorUserId: string }, db: GuestDatabase = prisma,
 ) {
   const decision = parseGuestDecision(input);
   if (!input.teamId || !input.actorUserId) throw new GuestApprovalError("SIXFL admin access is required.", 403);

--- a/src/lib/fixtures/guest-approvals.ts
+++ b/src/lib/fixtures/guest-approvals.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { GuestApprovalError, parseGuestDecision, type GuestDecisionInput } from "./guest-approval-policy";
+
+type FixtureRow = {
+  id: string; homeTeamId: string; awayTeamId: string; kickoffAt: Date;
+  publishedAt: Date | null; status: string;
+};
+export type GuestApprovalRow = {
+  id: string; playerUserId: string; playerName: string; status: "APPROVED" | "REVOKED";
+  revision: number; approvedAt: Date; approvedByName: string; reason: string;
+  revokedAt: Date | null; revokedByName: string | null; revocationReason: string | null;
+};
+export type GuestCandidate = { id: string; name: string; email: string | null; teams: string };
+
+function assertTeamFixture(fixture: FixtureRow | undefined, teamId: string): asserts fixture is FixtureRow {
+  if (!fixture || !fixture.publishedAt || ![fixture.homeTeamId, fixture.awayTeamId].includes(teamId)) {
+    throw new GuestApprovalError("That published fixture does not belong to this team.", 404);
+  }
+}
+
+/** Reads only. Approval is not attendance, a second registration, a fee or a waiver. */
+export async function getFixtureGuestApprovals(teamId: string, fixtureId: string, db: PrismaClient = prisma) {
+  const fixtures = await db.$queryRaw<FixtureRow[]>(Prisma.sql`
+    SELECT "id", "homeTeamId", "awayTeamId", "kickoffAt", "publishedAt", "status"::text
+    FROM "Fixture" WHERE "id" = ${fixtureId}
+  `);
+  const fixture = fixtures[0];
+  assertTeamFixture(fixture, teamId);
+  const teams = await db.$queryRaw<Array<{ id: string; name: string }>>(Prisma.sql`
+    SELECT "id", "name" FROM "Team" WHERE "id" IN (${fixture.homeTeamId}, ${fixture.awayTeamId})
+  `);
+  const approvals = await db.$queryRaw<GuestApprovalRow[]>(Prisma.sql`
+    SELECT a."id", a."playerUserId", COALESCE(NULLIF(TRIM(u."name"), ''), 'Unnamed player') AS "playerName",
+      a."status", a."revision", a."approvedAt", a."approvedByName", a."reason",
+      a."revokedAt", a."revokedByName", a."revocationReason"
+    FROM "FixtureGuestApproval" a JOIN "User" u ON u."id" = a."playerUserId"
+    WHERE a."fixtureId" = ${fixtureId} AND a."teamId" = ${teamId}
+    ORDER BY a."approvedAt" DESC, a."id"
+  `);
+  return {
+    fixture: {
+      id: fixture.id, kickoffAt: fixture.kickoffAt.toISOString(), status: fixture.status,
+      teamName: teams.find((t) => t.id === teamId)?.name ?? "Team",
+      opponentName: teams.find((t) => t.id !== teamId)?.name ?? "Opponent",
+      editable: fixture.status === "SCHEDULED" && fixture.kickoffAt.getTime() > Date.now(),
+    },
+    approvals,
+  };
+}
+
+/** Called only after full admin access has been checked by the API. */
+export async function searchGuestCandidates(teamId: string, query: string, db: PrismaClient = prisma) {
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return [] as GuestCandidate[];
+  if (trimmed.length > 80) throw new GuestApprovalError("Search using no more than 80 characters.");
+  const term = `%${trimmed.replace(/[\\%_]/g, "\\$&")}%`;
+  return db.$queryRaw<GuestCandidate[]>(Prisma.sql`
+    SELECT u."id", COALESCE(NULLIF(TRIM(u."name"), ''), 'Unnamed player') AS "name", u."email",
+      COALESCE((SELECT STRING_AGG(t."name", ', ' ORDER BY t."name") FROM "TeamMember" m
+        JOIN "Team" t ON t."id" = m."teamId" WHERE m."userId" = u."id"), 'No permanent team') AS "teams"
+    FROM "User" u
+    WHERE (u."name" ILIKE ${term} OR u."email" ILIKE ${term})
+      AND NOT EXISTS (SELECT 1 FROM "TeamMember" own WHERE own."userId" = u."id" AND own."teamId" = ${teamId})
+    ORDER BY u."name" NULLS LAST, u."id" LIMIT 20
+  `);
+}
+
+/** Revalidate at write time and lock the fixture: two admin tabs cannot silently overwrite one another. */
+export async function setFixtureGuestApproval(
+  input: GuestDecisionInput & { teamId: string; actorUserId: string }, db: PrismaClient = prisma,
+) {
+  const decision = parseGuestDecision(input);
+  if (!input.teamId || !input.actorUserId) throw new GuestApprovalError("SIXFL admin access is required.", 403);
+  return db.$transaction(async (tx) => {
+    const actors = await tx.$queryRaw<Array<{ name: string | null; role: string }>>(Prisma.sql`
+      SELECT "name", "role"::text FROM "User" WHERE "id" = ${input.actorUserId} FOR SHARE
+    `);
+    if (actors[0]?.role !== "ADMIN") throw new GuestApprovalError("SIXFL admin access is required.", 403);
+    const actorName = actors[0].name?.trim() || "SIXFL administrator";
+    const fixtures = await tx.$queryRaw<FixtureRow[]>(Prisma.sql`
+      SELECT "id", "homeTeamId", "awayTeamId", "kickoffAt", "publishedAt", "status"::text
+      FROM "Fixture" WHERE "id" = ${decision.fixtureId} FOR UPDATE
+    `);
+    const fixture = fixtures[0];
+    assertTeamFixture(fixture, input.teamId);
+    const now = new Date();
+    if (fixture.status !== "SCHEDULED" || fixture.kickoffAt <= now) {
+      throw new GuestApprovalError("Guest permissions can only be changed before kick-off for a scheduled fixture.", 409);
+    }
+    if (fixture.kickoffAt.getTime() !== Date.parse(decision.expectedKickoffAt)) {
+      throw new GuestApprovalError("The fixture time has changed. Reload and check the match before approving.", 409);
+    }
+    const existing = await tx.$queryRaw<Array<{ id: string; status: string; revision: number }>>(Prisma.sql`
+      SELECT "id", "status", "revision" FROM "FixtureGuestApproval"
+      WHERE "fixtureId" = ${decision.fixtureId} AND "teamId" = ${input.teamId} AND "playerUserId" = ${decision.playerUserId}
+    `);
+    const previous = existing[0];
+    if ((previous?.revision ?? null) !== decision.expectedRevision) {
+      throw new GuestApprovalError("This approval was changed in another session. Reload before making a change.", 409);
+    }
+    const nextStatus = decision.decision === "approve" ? "APPROVED" : "REVOKED";
+    if (decision.decision === "revoke" && !previous) throw new GuestApprovalError("That approval was not found.", 404);
+    if (previous?.status === nextStatus) return { id: previous.id, status: nextStatus, changed: false };
+    if (decision.decision === "approve") {
+      const players = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT "id" FROM "User" WHERE "id" = ${decision.playerUserId} FOR SHARE
+      `);
+      if (!players[0]) throw new GuestApprovalError("Choose an existing SIXFL player.", 404);
+      const members = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT "id" FROM "TeamMember" WHERE "userId" = ${decision.playerUserId} AND "teamId" = ${input.teamId} LIMIT 1
+      `);
+      if (members[0]) throw new GuestApprovalError("This player is already in this team's permanent squad. Guest approval is not needed.", 409);
+      const otherSide = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT "id" FROM "FixtureGuestApproval" WHERE "fixtureId" = ${decision.fixtureId}
+          AND "playerUserId" = ${decision.playerUserId} AND "teamId" <> ${input.teamId} AND "status" = 'APPROVED'
+      `);
+      if (otherSide[0]) throw new GuestApprovalError("This player is already approved for the opposing team in this fixture.", 409);
+    }
+    const id = previous?.id ?? `fga_${randomUUID().replaceAll('-', '')}`;
+    const revision = (previous?.revision ?? 0) + 1;
+    if (!previous) {
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO "FixtureGuestApproval" ("id", "fixtureId", "teamId", "playerUserId", "status", "revision",
+          "approvedAt", "approvedByUserId", "approvedByName", "reason")
+        VALUES (${id}, ${decision.fixtureId}, ${input.teamId}, ${decision.playerUserId}, 'APPROVED', ${revision},
+          ${now}, ${input.actorUserId}, ${actorName}, ${decision.reason})
+      `);
+    } else if (decision.decision === "approve") {
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE "FixtureGuestApproval" SET "status" = 'APPROVED', "revision" = ${revision}, "approvedAt" = ${now},
+          "approvedByUserId" = ${input.actorUserId}, "approvedByName" = ${actorName}, "reason" = ${decision.reason},
+          "revokedAt" = NULL, "revokedByUserId" = NULL, "revokedByName" = NULL, "revocationReason" = NULL
+        WHERE "id" = ${id}
+      `);
+    } else {
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE "FixtureGuestApproval" SET "status" = 'REVOKED', "revision" = ${revision}, "revokedAt" = ${now},
+          "revokedByUserId" = ${input.actorUserId}, "revokedByName" = ${actorName}, "revocationReason" = ${decision.reason}
+        WHERE "id" = ${id}
+      `);
+    }
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "FixtureGuestApprovalEvent" ("id", "approvalId", "decision", "revision", "actorUserId", "actorName", "reason", "createdAt")
+      VALUES (${randomUUID()}, ${id}, ${nextStatus}, ${revision}, ${input.actorUserId}, ${actorName}, ${decision.reason}, ${now})
+    `);
+    return { id, status: nextStatus, changed: true };
+  });
+}

--- a/tests/fixture-guest-approvals.test.ts
+++ b/tests/fixture-guest-approvals.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { PrismaClient, Prisma } from "@prisma/client";
+import { assertGuestApprovalAccess, assertGuestApprovalOrigin, canManageGuestApprovals, GuestApprovalError, parseGuestDecision, readGuestDecision } from "../src/lib/fixtures/guest-approval-policy";
+import { getFixtureGuestApprovals, searchGuestCandidates, setFixtureGuestApproval } from "../src/lib/fixtures/guest-approvals";
+
+const baseAccess = { session: { user: { email: "admin@example.test" } }, user: { id: "admin", role: "ADMIN" }, isAdmin: true, isCaptain: false, accessMode: "captain" };
+const valid = { fixtureId: "f1", playerUserId: "p1", decision: "approve", reason: "", expectedRevision: null, expectedKickoffAt: new Date(Date.now() + 86400000).toISOString() };
+const status = (n: number) => (e: unknown) => e instanceof GuestApprovalError && e.status === n;
+
+test("only signed-in full admins can manage; captain and both preview modes cannot", () => {
+  assert.equal(canManageGuestApprovals(baseAccess), true);
+  for (const patch of [
+    { session: null }, { user: null }, { isAdmin: false, isCaptain: true },
+    { user: { id: "captain", role: "PLAYER" } }, { accessMode: "captain-preview" }, { accessMode: "admin-preview" },
+  ]) {
+    const access = { ...baseAccess, ...patch };
+    assert.equal(canManageGuestApprovals(access), false);
+    assert.throws(() => assertGuestApprovalAccess(access, true), status(403));
+  }
+  assert.doesNotThrow(() => assertGuestApprovalAccess({ ...baseAccess, isAdmin: false, isCaptain: true }));
+  assert.throws(() => assertGuestApprovalAccess({ ...baseAccess, isAdmin: false, isCaptain: false }), status(403));
+});
+
+test("decision input requires explicit fixture, player, revision and context", () => {
+  assert.equal(parseGuestDecision(valid).decision, "approve");
+  for (const patch of [{ fixtureId: "../other" }, { playerUserId: "" }, { decision: "delete" }, { expectedRevision: undefined }, { expectedRevision: -1 }, { expectedKickoffAt: "invalid" }, { reason: "x".repeat(501) }]) {
+    assert.throws(() => parseGuestDecision({ ...valid, ...patch }), GuestApprovalError);
+  }
+  assert.throws(() => parseGuestDecision({ ...valid, decision: "revoke", reason: " " }), GuestApprovalError);
+});
+
+test("same-origin approval requests only; absent origin and cross-site requests rejected", () => {
+  assert.doesNotThrow(() => assertGuestApprovalOrigin(new Request("https://sixfl.co.uk/api/test", { headers: { origin: "https://sixfl.co.uk" } })));
+  const cases: Record<string, string>[] = [{}, { origin: "https://attacker.example.test" }, { origin: "https://sixfl.co.uk", "sec-fetch-site": "cross-site" }];
+  for (const headers of cases) {
+    assert.throws(() => assertGuestApprovalOrigin(new Request("https://sixfl.co.uk/api/test", { headers })), status(403));
+  }
+});
+
+test("JSON body validation includes chunked uploads without Content-Length", async () => {
+  const request = (body: string, headers: Record<string, string> = { "Content-Type": "application/json" }) => new Request("https://sixfl.co.uk", { method: "POST", headers, body });
+  assert.equal((await readGuestDecision(request(JSON.stringify(valid)))).playerUserId, "p1");
+  await assert.rejects(() => readGuestDecision(request("x".repeat(8193))), status(413));
+  await assert.rejects(() => readGuestDecision(request("{}", { "Content-Type": "application/json", "Content-Length": "9000" })), status(413));
+  await assert.rejects(() => readGuestDecision(request("broken json")), status(400));
+  await assert.rejects(() => readGuestDecision(request("{}", { "Content-Type": "text/plain" })), status(415));
+});
+
+// A dedicated local-only database is mandatory; never touch production data during tests.
+const rawUrl = process.env.GUEST_APPROVAL_TEST_DATABASE_URL;
+if (!rawUrl) throw new Error("GUEST_APPROVAL_TEST_DATABASE_URL is required for the PostgreSQL integration contracts.");
+const url = new URL(rawUrl);
+if (!["localhost", "127.0.0.1", "postgres"].includes(url.hostname)) throw new Error("Guest approval tests require a local test database.");
+const schema = `guest_approval_contract_${randomUUID().replaceAll("-", "")}`;
+const admin = new PrismaClient({ datasources: { db: { url: rawUrl } } });
+url.searchParams.set("schema", schema);
+const db = new PrismaClient({ datasources: { db: { url: url.toString() } } });
+
+before(async () => {
+  await admin.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`);
+  const setup = [
+    'CREATE TABLE "User" ("id" TEXT PRIMARY KEY, "name" TEXT, "email" TEXT, "role" TEXT NOT NULL)',
+    'CREATE TABLE "Team" ("id" TEXT PRIMARY KEY, "name" TEXT NOT NULL)',
+    'CREATE TABLE "Fixture" ("id" TEXT PRIMARY KEY, "homeTeamId" TEXT NOT NULL, "awayTeamId" TEXT NOT NULL, "kickoffAt" TIMESTAMP(3) NOT NULL, "publishedAt" TIMESTAMP(3), "status" TEXT NOT NULL)',
+    'CREATE TABLE "TeamMember" ("id" TEXT PRIMARY KEY, "userId" TEXT NOT NULL, "teamId" TEXT NOT NULL)',
+    'CREATE TABLE "PlayerMatchFee" ("id" TEXT PRIMARY KEY, "amountPence" INTEGER, "status" TEXT, "note" TEXT)',
+  ];
+  for (const statement of setup) await db.$executeRawUnsafe(statement);
+  const migration = readFileSync("prisma/migrations/20260906010000_fixture_guest_approvals/migration.sql", "utf8");
+  for (const statement of migration.split(";").filter((s) => s.trim())) await db.$executeRawUnsafe(statement);
+});
+after(async () => {
+  await db.$disconnect();
+  await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  await admin.$disconnect();
+});
+
+async function seed() {
+  const key = randomUUID().replaceAll("-", "");
+  const [actor, player, a, b, c, fixtureId, memberId, feeId] = ["actor", "player", "a", "b", "c", "fixture", "member", "fee"].map((x) => `${x}_${key}`);
+  const kickoff = new Date(Date.now() + 86400000);
+  await db.$executeRaw(Prisma.sql`INSERT INTO "User" VALUES (${actor}, 'Test admin', ${`${key}@admin.example.test`}, 'ADMIN'), (${player}, ${`Guest ${key}`}, ${`${key}@player.example.test`}, 'PLAYER')`);
+  await db.$executeRaw(Prisma.sql`INSERT INTO "Team" VALUES (${a}, 'Receiving team'), (${b}, 'Opponent'), (${c}, 'Original team')`);
+  await db.$executeRaw(Prisma.sql`INSERT INTO "TeamMember" VALUES (${memberId}, ${player}, ${c})`);
+  await db.$executeRaw(Prisma.sql`INSERT INTO "PlayerMatchFee" VALUES (${feeId}, 750, 'PAID', 'Existing settled payment')`);
+  await db.$executeRaw(Prisma.sql`INSERT INTO "Fixture" VALUES (${fixtureId}, ${a}, ${b}, ${kickoff}, NOW(), 'SCHEDULED')`);
+  const input = { fixtureId, teamId: a, playerUserId: player, actorUserId: actor, decision: "approve" as const, reason: "Cover for absent player", expectedRevision: null, expectedKickoffAt: kickoff.toISOString() };
+  return { input, actor, player, a, b, c, fixtureId, memberId, feeId, key };
+}
+const save = (input: Parameters<typeof setFixtureGuestApproval>[0]) => setFixtureGuestApproval(input, db);
+const rows = <T>(sql: Prisma.Sql) => db.$queryRaw<T[]>(sql);
+
+test("approval persists against one match and leaves original membership and paid fees unchanged", async () => {
+  const s = await seed();
+  const beforeMembers = await rows(Prisma.sql`SELECT * FROM "TeamMember" WHERE "userId" = ${s.player}`);
+  const beforeFees = await rows(Prisma.sql`SELECT * FROM "PlayerMatchFee" WHERE "id" = ${s.feeId}`);
+  await save(s.input);
+  const result = await getFixtureGuestApprovals(s.a, s.fixtureId, db);
+  assert.equal(result.approvals.length, 1);
+  assert.equal(result.approvals[0].status, "APPROVED");
+  assert.equal(result.approvals[0].approvedByName, "Test admin");
+  assert.equal(result.fixture.teamName, "Receiving team");
+  assert.deepEqual(await rows(Prisma.sql`SELECT * FROM "TeamMember" WHERE "userId" = ${s.player}`), beforeMembers);
+  assert.deepEqual(await rows(Prisma.sql`SELECT * FROM "PlayerMatchFee" WHERE "id" = ${s.feeId}`), beforeFees);
+  assert.equal((await getFixtureGuestApprovals(s.b, s.fixtureId, db)).approvals.length, 0);
+});
+
+test("the storage layer independently rejects non-admin and missing actors", async () => {
+  const s = await seed();
+  await assert.rejects(() => save({ ...s.input, actorUserId: s.player }), status(403));
+  await assert.rejects(() => save({ ...s.input, actorUserId: "missing" }), status(403));
+});
+
+test("foreign team, unknown player and unpublished fixture cannot be approved", async () => {
+  const s = await seed();
+  await assert.rejects(() => save({ ...s.input, teamId: s.c }), status(404));
+  await assert.rejects(() => getFixtureGuestApprovals(s.c, s.fixtureId, db), status(404));
+  await assert.rejects(() => save({ ...s.input, playerUserId: "missing" }), status(404));
+  await db.$executeRaw(Prisma.sql`UPDATE "Fixture" SET "publishedAt" = NULL WHERE "id" = ${s.fixtureId}`);
+  await assert.rejects(() => save(s.input), status(404));
+});
+
+test("existing permanent member cannot gain redundant guest status", async () => {
+  const s = await seed();
+  await db.$executeRaw(Prisma.sql`INSERT INTO "TeamMember" VALUES (${`extra_${s.key}`}, ${s.player}, ${s.a})`);
+  await assert.rejects(() => save(s.input), status(409));
+  assert.equal((await getFixtureGuestApprovals(s.a, s.fixtureId, db)).approvals.length, 0);
+});
+
+test("scheduled future fixture is mandatory and a rescheduled match requires a fresh read", async () => {
+  const s = await seed();
+  for (const state of ["CANCELLED", "POSTPONED", "COMPLETED", "ABANDONED"]) {
+    await db.$executeRaw(Prisma.sql`UPDATE "Fixture" SET "status" = ${state} WHERE "id" = ${s.fixtureId}`);
+    await assert.rejects(() => save(s.input), status(409));
+  }
+  await db.$executeRaw(Prisma.sql`UPDATE "Fixture" SET "status" = 'SCHEDULED', "kickoffAt" = NOW() - INTERVAL '1 minute' WHERE "id" = ${s.fixtureId}`);
+  await assert.rejects(() => save(s.input), status(409));
+  await db.$executeRaw(Prisma.sql`UPDATE "Fixture" SET "kickoffAt" = NOW() + INTERVAL '2 days' WHERE "id" = ${s.fixtureId}`);
+  await assert.rejects(() => save(s.input), status(409));
+});
+
+test("concurrent approvals are serialized and create just one approval and audit event", async () => {
+  const s = await seed();
+  const outcomes = await Promise.allSettled([save(s.input), save(s.input)]);
+  assert.equal(outcomes.filter((r) => r.status === "fulfilled").length, 1);
+  const rejection = outcomes.find((r) => r.status === "rejected") as PromiseRejectedResult;
+  assert.equal(rejection.reason.status, 409);
+  const saved = (await getFixtureGuestApprovals(s.a, s.fixtureId, db)).approvals[0];
+  assert.equal(saved.revision, 1);
+  const events = await rows(Prisma.sql`SELECT * FROM "FixtureGuestApprovalEvent" WHERE "approvalId" = ${saved.id}`);
+  assert.equal(events.length, 1);
+});
+
+test("one player cannot be approved for both sides of the same match", async () => {
+  const s = await seed();
+  await save(s.input);
+  await assert.rejects(() => save({ ...s.input, teamId: s.b }), status(409));
+});
+
+test("repeat at current revision is idempotent, stale approval cannot overwrite a revocation", async () => {
+  const s = await seed();
+  await save(s.input);
+  assert.equal((await save({ ...s.input, expectedRevision: 1 })).changed, false);
+  await save({ ...s.input, decision: "revoke", reason: "Player no longer needed", expectedRevision: 1 });
+  await assert.rejects(() => save({ ...s.input, expectedRevision: 1 }), status(409));
+  assert.equal((await getFixtureGuestApprovals(s.a, s.fixtureId, db)).approvals[0].status, "REVOKED");
+});
+
+test("revoke and reapprove retain all audit history without creating a permanent registration", async () => {
+  const s = await seed();
+  const approved = await save(s.input);
+  await save({ ...s.input, decision: "revoke", expectedRevision: 1, reason: "Withdrawn by organiser" });
+  await save({ ...s.input, expectedRevision: 2, reason: "Organiser reconfirmed" });
+  const row = (await getFixtureGuestApprovals(s.a, s.fixtureId, db)).approvals[0];
+  assert.equal(row.revision, 3);
+  assert.equal(row.revokedAt, null);
+  const events = await rows<{ decision: string; revision: number }>(Prisma.sql`SELECT "decision", "revision" FROM "FixtureGuestApprovalEvent" WHERE "approvalId" = ${approved.id} ORDER BY "revision"`);
+  assert.deepEqual(events.map((e) => e.decision), ["APPROVED", "REVOKED", "APPROVED"]);
+  assert.equal((await rows(Prisma.sql`SELECT * FROM "TeamMember" WHERE "userId" = ${s.player}`)).length, 1);
+});
+
+test("revocation cannot rewrite permission history after kickoff", async () => {
+  const s = await seed();
+  await save(s.input);
+  await db.$executeRaw(Prisma.sql`UPDATE "Fixture" SET "kickoffAt" = NOW() - INTERVAL '1 minute' WHERE "id" = ${s.fixtureId}`);
+  await assert.rejects(() => save({ ...s.input, decision: "revoke", expectedRevision: 1, reason: "Late request" }), status(409));
+  assert.equal((await getFixtureGuestApprovals(s.a, s.fixtureId, db)).fixture.editable, false);
+});
+
+test("audit failure rolls back the approval as well", async () => {
+  const s = await seed();
+  await db.$executeRawUnsafe(`ALTER TABLE "FixtureGuestApprovalEvent" ADD CONSTRAINT "contract_failure" CHECK ("reason" <> 'force-audit-failure')`);
+  try {
+    await assert.rejects(() => save({ ...s.input, reason: "force-audit-failure" }));
+    assert.equal((await getFixtureGuestApprovals(s.a, s.fixtureId, db)).approvals.length, 0);
+  } finally { await db.$executeRawUnsafe('ALTER TABLE "FixtureGuestApprovalEvent" DROP CONSTRAINT "contract_failure"'); }
+});
+
+test("player search is bound, matches existing records, excludes permanent receiving members and escapes wildcards", async () => {
+  const s = await seed();
+  assert.equal((await searchGuestCandidates(s.a, s.key, db)).some((r) => r.id === s.player), true);
+  assert.equal((await searchGuestCandidates(s.c, s.key, db)).some((r) => r.id === s.player), false);
+  assert.equal((await searchGuestCandidates(s.a, "a", db)).length, 0);
+  assert.equal((await searchGuestCandidates(s.a, "%_", db)).length, 0);
+  await assert.rejects(() => searchGuestCandidates(s.a, "x".repeat(81), db), status(400));
+});
+
+test("permission does not carry into the next fixture", async () => {
+  const s = await seed();
+  await save(s.input);
+  const nextFixture = `next_${s.key}`;
+  await db.$executeRaw(Prisma.sql`INSERT INTO "Fixture" VALUES (${nextFixture}, ${s.a}, ${s.b}, NOW() + INTERVAL '7 days', NOW(), 'SCHEDULED')`);
+  assert.equal((await getFixtureGuestApprovals(s.a, nextFixture, db)).approvals.length, 0);
+});
+
+test("native route wiring, protected API, private-note redaction and original selection remain present after prebuild", () => {
+  const read = (p: string) => readFileSync(p, "utf8");
+  const layout = read("src/app/captain/team/[teamid]/match-fees/layout.tsx");
+  const page = read("src/app/captain/team/[teamid]/match-fees/page.tsx");
+  const route = read("src/app/api/captain/team/[teamid]/guest-approvals/route.ts");
+  const component = read("src/components/captain/FixtureGuestApprovals.tsx");
+  assert.match(layout, /<FixtureGuestApprovals/);
+  assert.match(layout, /\{children\}/);
+  assert.match(page, /MatchdaySquadSelectionForm/);
+  assert.match(route, /assertGuestApprovalAccess\(access, true\)/);
+  assert.match(route, /assertGuestApprovalOrigin\(request\)/);
+  assert.match(route, /canManage \? row :/);
+  assert.match(component, /Guest — SIXFL approved/);
+  assert.match(component, /Confirm revocation/);
+  assert.match(component, /key=\{`\$\{teamId\}:\$\{fixtureId\}`\}/);
+  const store = read("src/lib/fixtures/guest-approvals.ts");
+  assert.doesNotMatch(store, /(?:INSERT INTO|UPDATE|DELETE FROM) "(?:TeamMember|PlayerMatchFee|User|FixtureSelection)"/);
+});


### PR DESCRIPTION
## What this adds
Native **Guest approvals** panel on Matchday squad. In full admin captain view, select the fixture, click **Approve guest for this fixture**, find an existing player by name/email, select the correct person, add an optional internal note and choose **Confirm guest approval**. The row shows **Guest — SIXFL approved**, with the administrator and approval time. No player pass is needed to record permission.

Captains have a read-only list for their own team/fixture; they cannot search the user directory, approve/revoke guests or see internal notes. Full admins can revoke before kick-off with a reason. Reapproval retains prior decisions in the audit table. Past/non-scheduled fixtures are read-only.

## Scope
This records permission, not attendance or team acceptance. It does not create a permanent registration, alter matchday selection, create/waive fees or send messages. Existing temporary-player consent/linking and payment workflows remain unchanged. Normal guest, squad-size and disciplinary rules still apply. Approval is limited to the named receiving team and fixture, not future fixtures; retrospective approval/backdating is not available.

## Safeguards
Server-side admin and full-view checks, same-origin bounded JSON writes, database role recheck, fixture ownership/publication/status/kick-off validation, optimistic revisions, fixture row locks and atomic decision history. Redundant approval for permanent receiving-team members and approval for both sides of the same match are rejected. Only new files were added; existing payment, registration and selection source was not replaced.

## Verified before merge
All 14 GitHub Actions workflows passed on head `93cfe72897d7847e6a4baa300a496e2bf6c137ab`, including full production builds, the complete prebuild chain, critical-feature contracts, TypeScript checks, homepage/browser checks, payment policy, referee communications and guest-approval contracts.

Guest tests use an isolated local PostgreSQL schema and cover permissions, fixture scoping, concurrent/stale saves, revocation/reapproval audit, audit-failure rollback and unchanged membership/payment records. A negative control removed the database admin check and confirmed its test failed before restoring the source. Local syntax and pure policy checks also passed. The initial CI compilation issues with nullable client data and SIXFL's extended Prisma client were corrected before merge.

## Merge and live deployment
Merged as `7bec9c67648ad8881b1b57f33ceb191863cef1a2`. Railway deployed this exact commit in deployment `e46b4761-5980-4683-a2bc-dcb90093c564` and reported **SUCCESS**. Runtime logs confirm `20260906010000_fixture_guest_approvals` was applied, all migrations succeeded, and Next.js reached **Ready** at 2026-09-05T23:42:32Z.

No real player approval, membership or customer payment was changed during testing. A click-through approval in the user's authenticated production session has not been performed.