### PR TITLE
Create payment links directly from SIXFL-approved guest rows

### DIFF
--- a/.github/workflows/guest-payment-browser.yml
+++ b/.github/workflows/guest-payment-browser.yml
@@ -1,0 +1,22 @@
+name: Guest payment browser controls
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  guest-payment-browser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run prebuild
+      - name: Install isolated browser test dependency
+        run: npm install --no-save --package-lock=false playwright
+      - run: npx playwright install --with-deps chromium
+      - name: Exercise actual guest payment controls without production data
+        run: node tests/guest-payment-links-ui.mjs

--- a/.github/workflows/guest-payment-links.yml
+++ b/.github/workflows/guest-payment-links.yml
@@ -1,0 +1,56 @@
+name: Approved guest payment links
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  guest-payments:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sixfl_guest_payments_test
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sixfl_guest_payments_test"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_guest_payments_test
+      GUEST_PAYMENT_TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_guest_payments_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Apply complete production source preparation
+        run: npm run prebuild
+      - run: npx prisma generate
+      - name: Test guest fees with real isolated PostgreSQL
+        run: npx tsx --test tests/guest-payment-links.test.ts
+      - name: Prove approval checks cannot silently disappear
+        shell: bash
+        run: |
+          target=src/lib/fixtures/guest-payments.ts
+          original=$(mktemp)
+          cp "$target" "$original"
+          trap 'cp "$original" "$target"; rm -f "$original"' EXIT
+          node - <<'JS'
+          const fs = require('node:fs');
+          const file = 'src/lib/fixtures/guest-payments.ts';
+          const source = fs.readFileSync(file, 'utf8');
+          const guard = 'if (approval.approvalStatus !== "APPROVED")';
+          if (!source.includes(guard)) throw new Error('Approval guard missing');
+          fs.writeFileSync(file, source.replace(guard, 'if (false)'));
+          JS
+          if npx tsx --test --test-name-pattern="requires current SIXFL approval" tests/guest-payment-links.test.ts > guest-payment-negative.log 2>&1; then
+            cat guest-payment-negative.log
+            exit 1
+          fi
+          grep -q 'Missing expected rejection' guest-payment-negative.log
+      - name: Type-check the complete application
+        run: npx tsc --noEmit

--- a/docs/approved-guest-payment-links.md
+++ b/docs/approved-guest-payment-links.md
@@ -1,0 +1,15 @@
+# Payment links for SIXFL-approved guests
+
+Open the receiving team's **Matchday squad** or **Squad payments**, then select the fixture. Each approved guest has a **Guest payment** section.
+
+The team captain or full SIXFL administrator enters the agreed amount and clicks **Create fee and send payment link**. No additional player request or pass code is required. Creating the fee confirms the captain has agreed the appearance and amount with the player. Approval itself still does not create a fee.
+
+A positive amount creates the existing fixture-specific `PlayerMatchFee` with `temporaryUserId`, a secure payment token and URL, then queues the existing temporary-player payment email. £0 is an explicit no-payment choice and does not send a payment request. The permanent team and registration are unchanged. Existing temporary-player payments, public checkout, settlement, ledger and player fee views remain the payment authority.
+
+Existing fees are reused. Paid, waived and cancelled records are not silently reopened, repriced or duplicated. Changes to already-created amounts, cash collection and cancellations remain in the existing payment administration. The new row shows payment and email status and provides **Send payment link**, **Copy payment link** and **Open payment link** where applicable. A saved fee survives an email-queue failure; retry operates on that same record.
+
+Only the receiving team's authorised captain or full administrator can create/send. Captain/admin preview cannot write. The server rechecks active SIXFL approval, its revision, fixture identity/publication/time/status and the actor's actual role. Revoked approvals cannot be used for new creation/sending here; revocation does not automatically cancel an existing fee. Payments may be set for upcoming scheduled fixtures or completed fixtures in the last 30 days, using an approval recorded before kickoff.
+
+Identity locks are shared with one-time pass redemption, preventing a parallel pass and direct guest action from creating duplicate fees. Email-queue work is serialised for the same fee across manual actions and the existing cron. Queue failure is reported separately from successful fee creation; queued is never presented as delivered. Fees created through this path receive an atomic `FixtureGuestPaymentAudit` record with the approving record/revision, amount and fee-creating actor.
+
+Tests use a random localhost-only PostgreSQL schema, exercise real pass redemption races, preserve registrations and existing paid fees, verify atomic audit rollback and prove removal of the approval check causes a regression failure. No real player payments or customer emails are used by the tests.

--- a/prisma/migrations/20260906023000_fixture_guest_payment_audit/migration.sql
+++ b/prisma/migrations/20260906023000_fixture_guest_payment_audit/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "FixtureGuestPaymentAudit" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "approvalId" TEXT NOT NULL REFERENCES "FixtureGuestApproval"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "playerMatchFeeId" TEXT NOT NULL UNIQUE REFERENCES "PlayerMatchFee"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "approvalRevision" INTEGER NOT NULL,
+  "amountPence" INTEGER NOT NULL CHECK ("amountPence" >= 0 AND "amountPence" <= 10000),
+  "createdByUserId" TEXT REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "createdByName" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX "FixtureGuestPaymentAudit_approvalId_idx" ON "FixtureGuestPaymentAudit"("approvalId");

--- a/src/app/api/captain/team/[teamid]/guest-payments/route.ts
+++ b/src/app/api/captain/team/[teamid]/guest-payments/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireCaptain } from "@/lib/requireCaptain";
+import { prisma } from "@/lib/prisma";
+import { assertGuestApprovalAccess, assertGuestApprovalOrigin, GuestApprovalError } from "@/lib/fixtures/guest-approval-policy";
+import { assertGuestPaymentAccess, canManageGuestPayments, guestPaymentId, readGuestPayment } from "@/lib/fixtures/guest-payment-policy";
+import { getGuestPaymentState, prepareGuestPayment } from "@/lib/fixtures/guest-payments";
+import { buildPlayerMatchFeePaymentUrl } from "@/lib/payments/player-match-fees";
+import { queueTemporaryPlayerMatchFeeRequest } from "@/lib/payments/temporary-player-match-fee-requests";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+type Context = { params: Promise<{ teamid: string }> };
+const headers = { "Cache-Control": "no-store" };
+function failure(error: unknown) {
+  if (error instanceof GuestApprovalError) return NextResponse.json({ error: error.message }, { status: error.status, headers });
+  console.error("Approved guest payment failed", error);
+  return NextResponse.json({ error: "The payment change could not be confirmed. Reload this guest before retrying; do not create another player." }, { status: 500, headers });
+}
+
+export async function GET(request: Request, { params }: Context) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  try {
+    assertGuestApprovalAccess(access);
+    const url = new URL(request.url);
+    const state = await getGuestPaymentState({ teamId: teamid,
+      fixtureId: guestPaymentId(url.searchParams.get("fixtureId")),
+      approvalId: guestPaymentId(url.searchParams.get("approvalId")) });
+    const delivery = state.fee ? await prisma.notificationDispatch.findFirst({
+      where: { sourceType: "PLAYER_MATCH_FEE_REQUEST", sourceId: state.fee.id, channel: "EMAIL" },
+      orderBy: { createdAt: "desc" }, select: { status: true, sentAt: true, createdAt: true },
+    }) : null;
+    return NextResponse.json({ ...state, canManage: canManageGuestPayments(access), delivery }, { headers });
+  } catch (error) { return failure(error); }
+}
+
+export async function POST(request: Request, { params }: Context) {
+  const { teamid } = await params;
+  const access = await requireCaptain(teamid);
+  try {
+    assertGuestPaymentAccess(access);
+    assertGuestApprovalOrigin(request);
+    const input = await readGuestPayment(request);
+    const result = await prepareGuestPayment({ ...input, teamId: teamid, actorUserId: access.user!.id }, buildPlayerMatchFeePaymentUrl);
+    // Money is committed first. Queue failure must not encourage creating a second fee.
+    let paymentRequest: { status: string; queued?: number; skipped?: number } = { status: result.status === "PAID" ? "paid" : "no_fee" };
+    if (result.status === "OPEN" && result.amountPence > 0) {
+      try { paymentRequest = await queueTemporaryPlayerMatchFeeRequest(result.feeId); }
+      catch (error) {
+        console.error("Guest fee saved but email queue failed", { feeId: result.feeId, error });
+        paymentRequest = { status: "failed", queued: 0 };
+      }
+    }
+    revalidatePath(`/captain/team/${teamid}/match-fees`);
+    revalidatePath(`/captain/team/${teamid}/player-payments`);
+    return NextResponse.json({ ok: true, ...result, paymentRequest }, { headers });
+  } catch (error) { return failure(error); }
+}

--- a/src/app/captain/team/[teamid]/player-payments/layout.tsx
+++ b/src/app/captain/team/[teamid]/player-payments/layout.tsx
@@ -1,0 +1,2 @@
+// The same fixture-scoped guest approval/payment rows are available in both team workflows.
+export { default } from "../match-fees/layout";

--- a/src/components/captain/FixtureGuestApprovals.tsx
+++ b/src/components/captain/FixtureGuestApprovals.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import GuestPaymentControl from "./GuestPaymentControl";
 
 type Approval = {
   id: string; playerUserId: string; playerName: string; status: "APPROVED" | "REVOKED";
@@ -117,7 +118,7 @@ function GuestApprovalPanel({ teamId, fixtureId, canManage }: { teamId: string; 
         </div>
         {editable ? <button type="button" disabled={busy} className={buttonStyle} onClick={() => setShowForm(!showForm)}>Approve guest for this fixture</button> : null}
       </div>
-      <p className="mt-3 text-sm leading-6 text-white/60">Permission only—not confirmation that the player has played. This does not add a permanent squad member, change selection, create a fee, waive payment or send a message. Normal guest and matchday squad limits still apply.</p>
+      <p className="mt-3 text-sm leading-6 text-white/60">Approval itself does not select a player, add a permanent squad member or request money. Once SIXFL has approved a guest, the captain can set their fee and send a payment link below without a second player request. Normal guest and matchday squad limits still apply.</p>
       {loading ? <p role="status" className="mt-3 text-sm text-white/70">Loading guest approvals…</p> : null}
       {error ? <div role="alert" className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{error}<button type="button" disabled={busy || loading} className="ml-3 underline" onClick={() => { setError(""); void reload().catch((err: Error) => setError(err.message)); }}>Reload approvals</button></div> : null}
       {message ? <p role="status" className="mt-4 rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-100">{message}</p> : null}
@@ -170,6 +171,7 @@ function GuestApprovalPanel({ teamId, fixtureId, canManage }: { teamId: string; 
             <p className="text-xs text-white/65">This removes permission only. Check any existing matchday selection or fee separately.</p>
             <div className="flex gap-3"><button disabled={busy || revokeReason.trim().length < 3} className="rounded-xl border border-red-400/30 bg-red-500/15 px-4 py-2 text-sm text-red-100 disabled:opacity-50">Confirm revocation</button><button type="button" disabled={busy} onClick={() => setRevoke(null)} className="px-3 py-2 text-sm text-white/70">Cancel</button></div>
           </form> : null}
+          <GuestPaymentControl teamId={teamId} fixtureId={fixtureId} approvalId={approval.id} revision={approval.revision} approvalStatus={approval.status} playerName={approval.playerName} />
         </article>)}
       </div>
     </section>

--- a/src/components/captain/GuestPaymentControl.tsx
+++ b/src/components/captain/GuestPaymentControl.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+type State = {
+  canManage: boolean; editable: boolean; hasEmail: boolean; conflict: boolean;
+  revision: number; kickoffAt: string; approvalStatus: string;
+  fee: { id: string; amountPence: number; status: string; paymentUrl: string | null } | null;
+  delivery: { status: string; sentAt: string | null; createdAt: string } | null;
+};
+const money = (pence: number) => new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(pence / 100);
+const buttonStyle = "rounded-xl border border-emerald-400/30 bg-emerald-500/15 px-4 py-2.5 text-sm font-semibold text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50";
+async function responseJson(response: Response) {
+  if (response.redirected) throw new Error("Sign in again and reload this fixture.");
+  const body = await response.json().catch(() => null);
+  if (!response.ok || !body) throw new Error(body?.error || "Guest payment details could not be loaded. Reload before retrying.");
+  return body;
+}
+
+export default function GuestPaymentControl({ teamId, fixtureId, approvalId, revision, approvalStatus, playerName }: {
+  teamId: string; fixtureId: string; approvalId: string; revision: number; approvalStatus: string; playerName: string;
+}) {
+  const router = useRouter();
+  const [state, setState] = useState<State | null>(null);
+  const [amount, setAmount] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const endpoint = `/api/captain/team/${encodeURIComponent(teamId)}/guest-payments`;
+  const url = `${endpoint}?fixtureId=${encodeURIComponent(fixtureId)}&approvalId=${encodeURIComponent(approvalId)}`;
+  const reload = useCallback(async () => {
+    const result = await responseJson(await fetch(url, { cache: "no-store" }));
+    setState(result as State);
+  }, [url]);
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true); setError(""); setState(null);
+    fetch(url, { cache: "no-store", signal: controller.signal }).then(responseJson)
+      .then((value: State) => { if (!controller.signal.aborted) setState(value); })
+      .catch((err: Error) => { if (!controller.signal.aborted) setError(err.message); })
+      .finally(() => { if (!controller.signal.aborted) setLoading(false); });
+    return () => controller.abort();
+  }, [url, revision, approvalStatus]);
+
+  async function submit(event: FormEvent, action: "create" | "send") {
+    event.preventDefault();
+    if (busy || !state?.canManage || !state.editable) return;
+    setBusy(true); setError(""); setMessage("");
+    try {
+      const result = await responseJson(await fetch(endpoint, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fixtureId, approvalId, action, amount, feeId: state.fee?.id ?? null,
+          expectedRevision: state.revision, expectedKickoffAt: state.kickoffAt }),
+      }));
+      const status = result.paymentRequest?.status;
+      setMessage(status === "queued" ? "Guest fee saved. Payment-link email queued."
+        : status === "already_sent" ? "This payment-link email is already queued or sent. No duplicate fee or email was created."
+        : status === "processing" ? "This payment request is already being prepared. Reload to check its status."
+        : status === "paid" ? "This guest fee is already paid. No new payment was requested."
+        : status === "no_fee" ? "No player payment is due. No payment email was sent."
+        : "The guest fee is saved, but the payment email was not queued. Check the player's email, then retry Send payment link. Do not create another fee.");
+      await reload(); router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "The change could not be confirmed. Reload before retrying.");
+      // A lost response may follow a successful commit; recover the existing row first.
+      await reload().catch(() => undefined);
+    } finally { setBusy(false); }
+  }
+
+  async function copyLink() {
+    if (!state?.fee?.paymentUrl) return;
+    try { await navigator.clipboard.writeText(state.fee.paymentUrl); setMessage("Payment link copied."); }
+    catch { setError("The browser could not copy the link. Open the payment link and copy its address."); }
+  }
+
+  const canAct = Boolean(state?.canManage && state.editable && !state.conflict && approvalStatus === "APPROVED");
+  const queuedOrSent = ["QUEUED", "PROCESSING", "SENT"].includes(state?.delivery?.status ?? "");
+  return <div className="mt-4 space-y-3 border-t border-white/10 pt-4">
+    <p className="text-sm font-semibold text-white">Guest payment</p>
+    {loading ? <p role="status" className="text-xs text-white/60">Loading payment details…</p> : null}
+    {error ? <p role="alert" className="text-sm text-red-100">{error}</p> : null}
+    {message ? <p role="status" className="text-sm text-emerald-100">{message}</p> : null}
+    {state?.conflict ? <p className="text-sm text-amber-100">An existing squad/prospect fee or duplicate fee needs SIXFL review. No additional charge can be created here.</p> : null}
+    {state?.fee ? <>
+      <p className="text-sm text-white/80">{money(state.fee.amountPence)} · {state.fee.status === "PAID" ? "Paid" : state.fee.status === "WAIVED" ? "No payment needed" : state.fee.status === "CANCELLED" ? "Cancelled" : "Awaiting payment"}</p>
+      {state.delivery ? <p className="text-xs text-white/60">Payment email: {state.delivery.status.toLowerCase().replaceAll("_", " ")}</p> : null}
+      {canAct && state.fee.status === "OPEN" ? <div className="flex flex-wrap gap-2">
+        <form onSubmit={(event) => void submit(event, "send")}>
+          <button disabled={busy || queuedOrSent || !state.hasEmail} className={buttonStyle}>{busy ? "Sending…" : queuedOrSent ? "Email queued / sent" : "Send payment link"}</button>
+        </form>
+        {state.fee.paymentUrl ? <><button type="button" className={buttonStyle} onClick={() => void copyLink()}>Copy payment link</button><a className={buttonStyle} href={state.fee.paymentUrl} target="_blank" rel="noopener noreferrer">Open payment link</a></> : null}
+      </div> : null}
+      <p className="text-xs text-white/55">The existing fee is reused, not charged again. Amount changes, cash payments and cancellations stay in the existing SIXFL payment controls.</p>
+    </> : !loading && state ? <>
+      <p className="text-sm text-white/65">No fee set for this guest.</p>
+      {canAct ? <form onSubmit={(event) => void submit(event, "create")} className="space-y-3">
+        <label className="block text-sm text-white/80">Match fee for {playerName} (£)
+          <input className="mt-2 block w-full max-w-48 rounded-xl border border-white/20 bg-black/30 px-3 py-2.5 text-white" aria-label={`Guest match fee for ${playerName}`} value={amount} onChange={(event) => setAmount(event.target.value)} type="number" inputMode="decimal" min="0" max="100" step="0.01" required disabled={busy} placeholder="Enter amount" />
+        </label>
+        <p className="text-xs leading-5 text-white/60">By creating the fee you confirm the player has agreed to play for this team and to this amount. Enter 0 only when no player fee is due. No second request or pass code is needed.</p>
+        <button className={buttonStyle} disabled={busy || !amount.trim() || (!state.hasEmail && Number(amount) !== 0)}>{busy ? "Saving…" : amount.trim() && Number(amount) === 0 ? "Save £0 — no payment needed" : "Create fee and send payment link"}</button>
+      </form> : null}
+    </> : null}
+    {state && !state.hasEmail ? <p className="text-sm text-amber-100">A real email address must be saved on this player's existing account before a payment link can be requested.</p> : null}
+    {state && !state.editable ? <p className="text-xs text-white/60">No new guest payment can be requested here while approval is revoked or the fixture is outside its payment window. Existing fees are not automatically cancelled.</p> : null}
+    <button type="button" disabled={busy || loading} onClick={() => { setError(""); void reload().catch((err: Error) => setError(err.message)); }} className="text-xs text-white/60 underline">Refresh payment status</button>
+  </div>;
+}

--- a/src/lib/fixtures/guest-payment-policy.ts
+++ b/src/lib/fixtures/guest-payment-policy.ts
@@ -1,0 +1,82 @@
+import { GuestApprovalError, type GuestApprovalAccess } from "./guest-approval-policy";
+
+export function canManageGuestPayments(access: GuestApprovalAccess) {
+  return Boolean(access.session && access.user?.id && access.accessMode === "captain" &&
+    ((access.isAdmin && access.user.role === "ADMIN") ||
+      (access.isCaptain && access.user.role !== "ADMIN")));
+}
+
+export function assertGuestPaymentAccess(access: GuestApprovalAccess) {
+  if (!canManageGuestPayments(access)) {
+    throw new GuestApprovalError("Open this team as its captain or in full SIXFL admin view to manage guest payments.", 403);
+  }
+}
+
+export function guestPaymentId(value: unknown): string {
+  if (typeof value !== "string" || !/^[a-zA-Z0-9_-]{1,150}$/.test(value)) {
+    throw new GuestApprovalError("Choose a valid approved guest and fixture.");
+  }
+  return value;
+}
+
+export function parseGuestAmount(value: unknown): number {
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d{0,2})(?:\.\d{1,2})?$/.test(value.trim())) {
+    throw new GuestApprovalError("Enter a fee from £0 to £100 with no more than two decimal places.");
+  }
+  const [whole, fraction = ""] = value.trim().split(".");
+  const pence = Number(whole) * 100 + Number(fraction.padEnd(2, "0"));
+  if (pence > 10000) throw new GuestApprovalError("The guest fee must be between £0 and £100.");
+  return pence;
+}
+
+export type GuestPaymentInput = {
+  approvalId: string; fixtureId: string; action: "create" | "send";
+  amountPence: number | null; feeId: string | null;
+  expectedRevision: number; expectedKickoffAt: string;
+};
+
+export function parseGuestPayment(value: unknown): GuestPaymentInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new GuestApprovalError("Choose an approved guest first.");
+  const data = value as Record<string, unknown>;
+  if (data.action !== "create" && data.action !== "send") throw new GuestApprovalError("Choose create fee or send link.");
+  if (!Number.isSafeInteger(data.expectedRevision) || Number(data.expectedRevision) < 1 ||
+      typeof data.expectedKickoffAt !== "string" || !Number.isFinite(Date.parse(data.expectedKickoffAt))) {
+    throw new GuestApprovalError("Reload this guest before setting their fee.", 409);
+  }
+  return {
+    approvalId: guestPaymentId(data.approvalId), fixtureId: guestPaymentId(data.fixtureId),
+    action: data.action, amountPence: data.action === "create" ? parseGuestAmount(data.amount) : null,
+    feeId: data.action === "send" ? guestPaymentId(data.feeId) : null,
+    expectedRevision: Number(data.expectedRevision), expectedKickoffAt: data.expectedKickoffAt,
+  };
+}
+
+export async function readGuestPayment(request: Request) {
+  if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+    throw new GuestApprovalError("Send a JSON payment request.", 415);
+  }
+  const limit = 4096;
+  if (Number(request.headers.get("content-length")) > limit) throw new GuestApprovalError("Payment request too large.", 413);
+  const reader = request.body?.getReader();
+  if (!reader) throw new GuestApprovalError("Payment request is empty.");
+  let text = ""; let bytes = 0;
+  const decoder = new TextDecoder();
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      bytes += chunk.value.byteLength;
+      if (bytes > limit) { await reader.cancel(); throw new GuestApprovalError("Payment request too large.", 413); }
+      text += decoder.decode(chunk.value, { stream: true });
+    }
+    text += decoder.decode();
+  } finally { reader.releaseLock(); }
+  let value: unknown;
+  try { value = JSON.parse(text); } catch { throw new GuestApprovalError("Payment request could not be read."); }
+  return parseGuestPayment(value);
+}
+
+export function guestFixtureAcceptsPayment(status: string, kickoffAt: Date, now = new Date()) {
+  return (status === "SCHEDULED" && kickoffAt > now) ||
+    (status === "COMPLETED" && kickoffAt <= now && kickoffAt.getTime() >= now.getTime() - 30 * 86400000);
+}

--- a/src/lib/fixtures/guest-payments.ts
+++ b/src/lib/fixtures/guest-payments.ts
@@ -1,0 +1,153 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { lockTemporaryFixtureFee } from "@/lib/payments/temporary-fee-lock";
+import { GuestApprovalError } from "./guest-approval-policy";
+import { guestFixtureAcceptsPayment, type GuestPaymentInput } from "./guest-payment-policy";
+
+type Tx = Pick<Prisma.TransactionClient, "$queryRaw" | "$executeRaw">;
+type Db = Pick<Tx, "$queryRaw"> & { $transaction<T>(fn: (tx: Tx) => Promise<T>): Promise<T> };
+export type GuestPaymentContext = {
+  teamId: string; fixtureId: string; approvalId: string;
+};
+type ApprovalContext = {
+  id: string; playerUserId: string; approvalStatus: string; revision: number;
+  email: string | null; playerName: string | null; kickoffAt: Date; fixtureStatus: string;
+};
+export type GuestFee = {
+  id: string; amountPence: number; status: string; paymentUrl: string | null;
+  temporaryUserId: string | null; paidAt: Date | null;
+};
+
+async function approvalContext(input: GuestPaymentContext, db: Pick<Tx, "$queryRaw">) {
+  const rows = await db.$queryRaw<ApprovalContext[]>(Prisma.sql`
+    SELECT a."id", a."playerUserId", a."status" AS "approvalStatus", a."revision",
+      u."email", u."name" AS "playerName", f."kickoffAt", f."status"::text AS "fixtureStatus"
+    FROM "FixtureGuestApproval" a
+    JOIN "Fixture" f ON f."id" = a."fixtureId"
+    JOIN "User" u ON u."id" = a."playerUserId"
+    WHERE a."id" = ${input.approvalId} AND a."fixtureId" = ${input.fixtureId}
+      AND a."teamId" = ${input.teamId} AND f."publishedAt" IS NOT NULL
+      AND (f."homeTeamId" = ${input.teamId} OR f."awayTeamId" = ${input.teamId})
+  `);
+  if (!rows[0]) throw new GuestApprovalError("This guest approval does not belong to the selected team and fixture.", 404);
+  return rows[0];
+}
+
+async function matchingFees(input: GuestPaymentContext, approval: ApprovalContext, db: Pick<Tx, "$queryRaw">) {
+  // Also detect an ordinary member/prospect fee, but never relink an ambiguous identity.
+  return db.$queryRaw<GuestFee[]>(Prisma.sql`
+    SELECT fee."id", fee."amountPence", fee."status"::text, fee."paymentUrl", fee."temporaryUserId", fee."paidAt"
+    FROM "PlayerMatchFee" fee
+    LEFT JOIN "TeamMember" m ON m."id" = fee."teamMemberId"
+    LEFT JOIN "TeamPlayerProspect" p ON p."id" = fee."prospectId"
+    WHERE fee."fixtureId" = ${input.fixtureId} AND fee."teamId" = ${input.teamId}
+      AND (fee."temporaryUserId" = ${approval.playerUserId} OR m."userId" = ${approval.playerUserId}
+        OR (${approval.email}::text IS NOT NULL AND NULLIF(TRIM(p."email"), '') IS NOT NULL
+            AND LOWER(TRIM(p."email")) = LOWER(TRIM(${approval.email}::text))))
+    ORDER BY fee."createdAt", fee."id"
+  `);
+}
+
+export async function getGuestPaymentState(input: GuestPaymentContext, db: Db = prisma) {
+  const approval = await approvalContext(input, db);
+  const fees = await matchingFees(input, approval, db);
+  const active = fees.filter((fee) => fee.status !== "CANCELLED");
+  const fee = active[0] ?? fees[0] ?? null;
+  const conflict = active.length > 1 || Boolean(fee && fee.temporaryUserId !== approval.playerUserId);
+  return {
+    approvalStatus: approval.approvalStatus, revision: approval.revision,
+    kickoffAt: approval.kickoffAt.toISOString(),
+    editable: approval.approvalStatus === "APPROVED" && guestFixtureAcceptsPayment(approval.fixtureStatus, approval.kickoffAt),
+    hasEmail: Boolean(approval.email?.trim() && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(approval.email.trim())),
+    conflict,
+    fee: fee ? {
+      id: fee.id, amountPence: fee.amountPence, status: fee.status,
+      paymentUrl: approval.approvalStatus === "APPROVED" && !conflict && fee.status === "OPEN" ? fee.paymentUrl : null,
+    } : null,
+  };
+}
+
+/** Creating a fee is explicit captain acceptance, not a permanent registration or appearance. */
+export async function prepareGuestPayment(
+  input: GuestPaymentContext & GuestPaymentInput & { actorUserId: string },
+  paymentUrlForToken: (token: string) => string,
+  db: Db = prisma,
+) {
+  if (input.action === "create" && (!Number.isInteger(input.amountPence) || input.amountPence! < 0 || input.amountPence! > 10000)) {
+    throw new GuestApprovalError("Choose a guest fee between £0 and £100.");
+  }
+  return db.$transaction(async (tx) => {
+    const actors = await tx.$queryRaw<Array<{ role: string; name: string | null }>>(Prisma.sql`
+      SELECT "role"::text, "name" FROM "User" WHERE "id" = ${input.actorUserId} FOR SHARE
+    `);
+    const actor = actors[0];
+    const captains = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      SELECT m."id" FROM "TeamMember" m JOIN "Team" t ON t."id" = m."teamId"
+      WHERE m."userId" = ${input.actorUserId} AND m."teamId" = ${input.teamId}
+        AND m."role"::text = 'CAPTAIN' AND t."teamMode"::text <> 'MANAGED' FOR SHARE OF m
+    `);
+    if (!actor || (actor.role !== "ADMIN" && !captains[0])) {
+      throw new GuestApprovalError("Only this team's captain or SIXFL admin can set guest payments.", 403);
+    }
+    // Same fixture lock as approval/revocation; NO KEY UPDATE permits existing fee FK inserts.
+    await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "Fixture" WHERE "id" = ${input.fixtureId} FOR NO KEY UPDATE`);
+    const approval = await approvalContext(input, tx);
+    if (approval.approvalStatus !== "APPROVED") throw new GuestApprovalError("SIXFL approval is required before creating or sending a guest fee.", 409);
+    if (approval.revision !== input.expectedRevision || approval.kickoffAt.getTime() !== Date.parse(input.expectedKickoffAt)) {
+      throw new GuestApprovalError("The approval or fixture has changed. Reload and check it before sending.", 409);
+    }
+    if (!guestFixtureAcceptsPayment(approval.fixtureStatus, approval.kickoffAt)) {
+      throw new GuestApprovalError("Guest payments can be set for upcoming scheduled fixtures or completed matches from the last 30 days.", 409);
+    }
+    await lockTemporaryFixtureFee(tx, { fixtureId: input.fixtureId, teamId: input.teamId, userId: approval.playerUserId });
+    const fees = await matchingFees(input, approval, tx);
+    const active = fees.filter((fee) => fee.status !== "CANCELLED");
+    const existing = active[0] ?? fees[0];
+    if (active.length > 1 || (existing && existing.temporaryUserId !== approval.playerUserId)) {
+      throw new GuestApprovalError("A squad/prospect fee or duplicate fee already exists for this player. Ask SIXFL to reconcile it; no new charge has been created.", 409);
+    }
+    if (existing) {
+      // Lock and re-read: a concurrent payment must never be reset or changed.
+      const rows = await tx.$queryRaw<GuestFee[]>(Prisma.sql`
+        SELECT "id", "amountPence", "status"::text, "paymentUrl", "temporaryUserId", "paidAt"
+        FROM "PlayerMatchFee" WHERE "id" = ${existing.id} FOR UPDATE
+      `);
+      const current = rows[0];
+      if (current.status === "CANCELLED") throw new GuestApprovalError("This fee was cancelled. Ask SIXFL to review it rather than creating another charge.", 409);
+      if (input.action === "send" && input.feeId !== current.id) throw new GuestApprovalError("The fee has changed. Reload the guest row.", 409);
+      if (input.action === "create" && current.amountPence !== input.amountPence) {
+        throw new GuestApprovalError("This player already has a fee for this match. The existing amount has been preserved; reload to view it.", 409);
+      }
+      if (current.status === "OPEN" && !approval.email?.trim()) throw new GuestApprovalError("Add a real email address to this player's existing account before sending a payment link.");
+      return { feeId: current.id, status: current.status, amountPence: current.amountPence, created: false };
+    }
+    if (input.action !== "create") throw new GuestApprovalError("Create this guest's fee first.", 404);
+    const members = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      SELECT "id" FROM "TeamMember" WHERE "teamId" = ${input.teamId} AND "userId" = ${approval.playerUserId} LIMIT 1
+    `);
+    if (members[0]) throw new GuestApprovalError("This player has joined the permanent squad. Use their normal squad payment row.", 409);
+    const amountPence = input.amountPence!;
+    if (amountPence > 0 && (!approval.email?.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(approval.email.trim()))) {
+      throw new GuestApprovalError("Add a real email address to this player's existing account before creating their payment link.");
+    }
+    const id = `tmpg_${randomUUID().replaceAll("-", "")}`;
+    const token = amountPence > 0 ? randomBytes(24).toString("hex") : null;
+    const paymentUrl = token ? paymentUrlForToken(token) : null;
+    const status = amountPence === 0 ? "WAIVED" : "OPEN";
+    const now = new Date();
+    const actorName = actor.name?.trim() || "SIXFL team organiser";
+    const note = `SIXFL-approved guest accepted for this fixture by ${actorName}. Team-set guest fee: £${(amountPence / 100).toFixed(2)}. Approval ${approval.id}. Permanent registration unchanged.`;
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "PlayerMatchFee" ("id", "fixtureId", "teamId", "temporaryUserId", "amountPence", "status",
+        "waivedAt", "paymentToken", "paymentUrl", "note", "createdAt", "updatedAt")
+      VALUES (${id}, ${input.fixtureId}, ${input.teamId}, ${approval.playerUserId}, ${amountPence}, ${status}::"PlayerMatchFeeStatus",
+        ${amountPence === 0 ? now : null}, ${token}, ${paymentUrl}, ${note}, ${now}, ${now})
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "FixtureGuestPaymentAudit" ("id", "approvalId", "playerMatchFeeId", "approvalRevision", "amountPence", "createdByUserId", "createdByName")
+      VALUES (${randomUUID()}, ${approval.id}, ${id}, ${approval.revision}, ${amountPence}, ${input.actorUserId}, ${actorName})
+    `);
+    return { feeId: id, status, amountPence, created: true };
+  });
+}

--- a/src/lib/payments/temporary-fee-lock.ts
+++ b/src/lib/payments/temporary-fee-lock.ts
@@ -1,0 +1,10 @@
+import { Prisma } from "@prisma/client";
+
+export async function lockTemporaryFixtureFee(
+  tx: Pick<Prisma.TransactionClient, "$executeRaw">,
+  input: { fixtureId: string; teamId: string; userId: string },
+) {
+  // The pass route and approved-guest route must use the same identity lock.
+  const key = JSON.stringify(["sixfl-temporary-fee", input.fixtureId, input.teamId, input.userId]);
+  await tx.$executeRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`);
+}

--- a/src/lib/payments/temporary-player-match-fee-requests.ts
+++ b/src/lib/payments/temporary-player-match-fee-requests.ts
@@ -13,6 +13,7 @@ import {
   ensurePlayerMatchFeeReminderTemplates,
 } from "@/lib/payments/player-match-fees";
 import { prisma } from "@/lib/prisma";
+import { withTemporaryRequestLock } from "./temporary-request-lock";
 
 type TemporaryPlayerFeeRow = {
   id: string;
@@ -91,6 +92,10 @@ async function getTemporaryPlayerFee(feeId: string) {
 }
 
 export async function queueTemporaryPlayerMatchFeeRequest(feeId: string) {
+  return withTemporaryRequestLock(feeId, () => queueTemporaryPlayerMatchFeeRequestUnlocked(feeId));
+}
+
+async function queueTemporaryPlayerMatchFeeRequestUnlocked(feeId: string) {
   await ensurePlayerMatchFeeReminderTemplates();
   await ensurePlayerMatchFeePaymentDetails(feeId);
 

--- a/src/lib/payments/temporary-request-lock.ts
+++ b/src/lib/payments/temporary-request-lock.ts
@@ -1,0 +1,19 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+type Tx = Pick<Prisma.TransactionClient, "$queryRaw">;
+type Db = { $transaction<T>(fn: (tx: Tx) => Promise<T>, options?: { timeout: number }): Promise<T> };
+
+/** Queue mutex only: the callback commits its normal outbox writes, not money changes. */
+export async function withTemporaryRequestLock<T>(feeId: string, queue: () => Promise<T>, db: Db = prisma) {
+  return db.$transaction(async (tx) => {
+    const key = `sixfl-temporary-fee-email:${feeId}`;
+    const rows = await tx.$queryRaw<Array<{ locked: boolean }>>(Prisma.sql`
+      SELECT pg_try_advisory_xact_lock(hashtextextended(${key}, 0)) AS locked
+    `);
+    if (!rows[0]?.locked) return { queued: 0, skipped: 0, status: "processing" as const };
+    // The normal queue checks persisted QUEUED/PROCESSING/SENT rows. A lost response
+    // is therefore safe to retry after the mutex is released. No provider send here.
+    return queue();
+  }, { timeout: 20000 });
+}

--- a/src/lib/temporary-player-passes.ts
+++ b/src/lib/temporary-player-passes.ts
@@ -2,6 +2,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { FixtureStatus, Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
+import { lockTemporaryFixtureFee } from "@/lib/payments/temporary-fee-lock";
 
 const PASS_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const PASS_LIFETIME_MS = 24 * 60 * 60 * 1000;
@@ -398,6 +399,7 @@ export async function redeemTemporaryPlayerPass(input: {
       );
     }
 
+    await lockTemporaryFixtureFee(tx, { fixtureId: input.fixtureId, teamId: input.teamId, userId: pass.userId });
     const existingFees = await tx.$queryRaw<IdRow[]>(Prisma.sql`
       SELECT "id"
       FROM "PlayerMatchFee"

--- a/tests/guest-payment-links-ui.mjs
+++ b/tests/guest-payment-links-ui.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+
+// The real production component, isolated from auth and money using localhost-only API fixtures.
+const bundled = await build({
+  stdin: { contents: `import React from 'react'; import {createRoot} from 'react-dom/client'; import GuestPaymentControl from './src/components/captain/GuestPaymentControl'; createRoot(document.getElementById('root')).render(<GuestPaymentControl teamId="home" fixtureId="fixture" approvalId="approval" revision={1} approvalStatus="APPROVED" playerName="Guest Player" />);`, loader: 'tsx', resolveDir: process.cwd() },
+  bundle: true, write: false, platform: 'browser', format: 'iife', jsx: 'automatic',
+  plugins: [{name:'next-navigation-test',setup(builder){
+    builder.onResolve({filter:/^next\/navigation$/},()=>({path:'next-navigation',namespace:'test'}));
+    builder.onLoad({filter:/.*/,namespace:'test'},()=>({contents:'export const useRouter = () => ({ refresh() {} });',loader:'js'}));
+  }}],
+});
+const server = createServer((req,res)=>{
+  if(req.url==='/bundle.js'){res.setHeader('Content-Type','text/javascript');res.end(bundled.outputFiles[0].text);}
+  else {res.setHeader('Content-Type','text/html');res.end('<!doctype html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"></head><body><div id="root"></div><script src="/bundle.js"></script></body></html>');}
+});
+server.listen(0,'127.0.0.1'); await once(server,'listening');
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch({headless:true});
+const page = await browser.newPage({viewport:{width:390,height:844}});
+const errors=[]; page.on('pageerror',error=>errors.push(error.message));
+let state; let calls; let failQueue=false;
+const base=()=>({canManage:true,editable:true,hasEmail:true,conflict:false,revision:1,kickoffAt:'2026-10-01T18:00:00.000Z',approvalStatus:'APPROVED',fee:null,delivery:null});
+await page.route('**/api/captain/team/home/guest-payments*',async route=>{
+  if(route.request().method()==='GET'){await route.fulfill({json:state});return;}
+  const body=route.request().postDataJSON(); calls.push(body);
+  assert.equal(body.fixtureId,'fixture'); assert.equal(body.approvalId,'approval');
+  assert.equal(body.expectedRevision,1); assert.equal('passCode' in body,false);
+  if(body.action==='create') state.fee={id:'fee',amountPence:Math.round(Number(body.amount)*100),status:Number(body.amount)===0?'WAIVED':'OPEN',paymentUrl:`${origin}/pay/player-match-fee/test`};
+  let status=state.fee.status==='WAIVED'?'no_fee':failQueue?'failed':'queued';
+  state.delivery=status==='queued'?{status:'QUEUED',sentAt:null,createdAt:new Date().toISOString()}:null;
+  await route.fulfill({json:{ok:true,feeId:state.fee.id,amountPence:state.fee.amountPence,status:state.fee.status,paymentRequest:{status}}});
+});
+async function load(next=base()) {state=next;calls=[];await page.goto(origin);await page.getByText('Loading payment details…').waitFor({state:'hidden'});}
+try {
+  await load();
+  assert.equal(await page.getByRole('spinbutton').inputValue(),'');
+  await page.getByRole('spinbutton').fill('6.25');
+  await page.getByRole('button',{name:'Create fee and send payment link',exact:true}).click();
+  await page.getByText('Guest fee saved. Payment-link email queued.').waitFor();
+  assert.equal(calls.length,1);assert.equal(calls[0].amount,'6.25');
+  assert.equal(await page.getByRole('button',{name:'Email queued / sent',exact:true}).isDisabled(),true);
+  assert.equal(await page.getByRole('link',{name:'Open payment link',exact:true}).count(),1);
+  console.log('PASS: create agreed guest fee and queue without a player pass.');
+
+  await load();await page.getByRole('spinbutton').fill('0');
+  await page.getByRole('button',{name:'Save £0 — no payment needed',exact:true}).click();
+  await page.getByText('No player payment is due. No payment email was sent.').waitFor();
+  assert.equal(state.fee.status,'WAIVED');assert.equal(state.delivery,null);
+  console.log('PASS: explicit zero does not send a payment request.');
+
+  await load({...base(),fee:{id:'fee',amountPence:625,status:'PAID',paymentUrl:null}});
+  assert.equal(await page.getByRole('spinbutton').count(),0);
+  assert.equal(await page.getByRole('button',{name:'Send payment link',exact:true}).count(),0);
+  console.log('PASS: paid fees cannot be recreated.');
+
+  await load({...base(),canManage:false});
+  assert.equal(await page.getByRole('spinbutton').count(),0);
+  await load({...base(),approvalStatus:'REVOKED',editable:false});
+  assert.equal(await page.getByRole('spinbutton').count(),0);
+  await load({...base(),hasEmail:false});await page.getByRole('spinbutton').fill('6');
+  assert.equal(await page.getByRole('button',{name:'Create fee and send payment link',exact:true}).isDisabled(),true);
+  console.log('PASS: preview/revoked/no-email states do not expose payable creation.');
+
+  failQueue=true;await load();await page.getByRole('spinbutton').fill('5');
+  await page.getByRole('button',{name:'Create fee and send payment link',exact:true}).click();
+  await page.getByText(/The guest fee is saved, but the payment email was not queued/).waitFor();
+  failQueue=false;await page.getByRole('button',{name:'Send payment link',exact:true}).click();
+  await page.getByText('Guest fee saved. Payment-link email queued.').waitFor();
+  assert.deepEqual(calls.map(call=>call.action),['create','send']);assert.equal(calls[1].feeId,'fee');
+  console.log('PASS: queue failure retries the same fee, not another creation.');
+  assert.deepEqual(errors,[]);
+} finally {await browser.close();await new Promise(resolve=>server.close(resolve));}

--- a/tests/guest-payment-links.test.ts
+++ b/tests/guest-payment-links.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { before, after, beforeEach, test } from "node:test";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { PrismaClient } from "@prisma/client";
+import { canManageGuestPayments, assertGuestPaymentAccess, parseGuestAmount, parseGuestPayment, readGuestPayment } from "../src/lib/fixtures/guest-payment-policy";
+
+const rawUrl = process.env.GUEST_PAYMENT_TEST_DATABASE_URL;
+if (!rawUrl) throw new Error("Use an isolated local GUEST_PAYMENT_TEST_DATABASE_URL; this suite never uses production.");
+const url = new URL(rawUrl);
+if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(url.hostname)) throw new Error("Guest payment tests require localhost.");
+const schema = `guest_payments_${randomUUID().replaceAll("-", "")}`;
+const admin = new PrismaClient({ datasources: { db: { url: rawUrl } } });
+url.searchParams.set("schema", schema);
+process.env.DATABASE_URL = url.toString();
+const db = new PrismaClient({ datasources: { db: { url: url.toString() } } });
+let service: typeof import("../src/lib/fixtures/guest-payments");
+let passes: typeof import("../src/lib/temporary-player-passes");
+let locks: typeof import("../src/lib/payments/temporary-request-lock");
+let appDb: typeof import("../src/lib/prisma");
+const kickoff = new Date(Date.now() + 7 * 86400000);
+const paymentUrl = (token: string) => `https://example.invalid/pay/player-match-fee/${token}`;
+const input = () => ({ teamId: "home", actorUserId: "captain", ...parseGuestPayment({
+  fixtureId: "fixture", approvalId: "approval", action: "create", amount: "6.00",
+  expectedRevision: 1, expectedKickoffAt: kickoff.toISOString(),
+}) });
+
+async function sql(source: string) {
+  for (const statement of source.split(";").map((s) => s.trim()).filter(Boolean)) await db.$executeRawUnsafe(statement);
+}
+before(async () => {
+  await admin.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`);
+  await sql(`
+    CREATE TYPE "FixtureStatus" AS ENUM ('SCHEDULED','COMPLETED','CANCELLED','POSTPONED','ABANDONED');
+    CREATE TYPE "PlayerMatchFeeStatus" AS ENUM ('OPEN','PAID','WAIVED','CANCELLED');
+    CREATE TYPE "TeamRole" AS ENUM ('CAPTAIN','PLAYER');
+    CREATE TABLE "User" ("id" TEXT PRIMARY KEY, "name" TEXT, "email" TEXT, "role" TEXT NOT NULL);
+    CREATE TABLE "Team" ("id" TEXT PRIMARY KEY, "name" TEXT, "teamMode" TEXT NOT NULL);
+    CREATE TABLE "Fixture" ("id" TEXT PRIMARY KEY, "homeTeamId" TEXT REFERENCES "Team"("id"), "awayTeamId" TEXT REFERENCES "Team"("id"), "kickoffAt" TIMESTAMP(3), "publishedAt" TIMESTAMP(3), "status" "FixtureStatus" NOT NULL);
+    CREATE TABLE "TeamMember" ("id" TEXT PRIMARY KEY, "teamId" TEXT REFERENCES "Team"("id"), "userId" TEXT REFERENCES "User"("id"), "role" "TeamRole");
+    CREATE TABLE "TeamPlayerProspect" ("id" TEXT PRIMARY KEY, "email" TEXT);
+    CREATE TABLE "PlayerMatchFee" (
+      "id" TEXT PRIMARY KEY, "fixtureId" TEXT REFERENCES "Fixture"("id"), "teamId" TEXT REFERENCES "Team"("id"),
+      "temporaryUserId" TEXT REFERENCES "User"("id"), "teamMemberId" TEXT REFERENCES "TeamMember"("id"), "prospectId" TEXT REFERENCES "TeamPlayerProspect"("id"),
+      "amountPence" INTEGER NOT NULL, "status" "PlayerMatchFeeStatus" NOT NULL, "waivedAt" TIMESTAMP(3), "paidAt" TIMESTAMP(3),
+      "paymentToken" TEXT, "paymentUrl" TEXT, "note" TEXT, "lastChasedAt" TIMESTAMP(3), "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP, "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await sql(readFileSync("prisma/migrations/20260906010000_fixture_guest_approvals/migration.sql", "utf8"));
+  await sql(readFileSync("prisma/migrations/20260906023000_fixture_guest_payment_audit/migration.sql", "utf8"));
+  service = await import("../src/lib/fixtures/guest-payments");
+  passes = await import("../src/lib/temporary-player-passes");
+  locks = await import("../src/lib/payments/temporary-request-lock");
+  appDb = await import("../src/lib/prisma");
+  await passes.ensureTemporaryPlayerPassTable();
+});
+after(async () => {
+  await appDb?.prisma.$disconnect();
+  await db.$disconnect();
+  await admin.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  await admin.$disconnect();
+});
+beforeEach(async () => {
+  await db.$executeRawUnsafe('TRUNCATE "User", "Team", "Fixture", "TeamMember", "TeamPlayerProspect", "PlayerMatchFee", "FixtureGuestApproval", "FixtureGuestApprovalEvent", "FixtureGuestPaymentAudit", "TemporaryPlayerPass" CASCADE');
+  await sql(`INSERT INTO "User" VALUES ('admin','Admin','admin@example.invalid','ADMIN'), ('captain','Captain','captain@example.invalid','USER'), ('guest','Guest Player','guest@example.invalid','USER'), ('other','Other Captain','other@example.invalid','USER');
+    INSERT INTO "Team" VALUES ('home','Receiving team','STANDARD'), ('away','Opponents','STANDARD'), ('permanent','Permanent team','STANDARD');
+    INSERT INTO "TeamMember" VALUES ('cap','home','captain','CAPTAIN'), ('othercap','away','other','CAPTAIN'), ('original','permanent','guest','PLAYER')`);
+  await db.$executeRawUnsafe('INSERT INTO "Fixture" VALUES ($1,$2,$3,$4,NOW(),\'SCHEDULED\')', 'fixture','home','away',kickoff);
+  await db.$executeRawUnsafe('INSERT INTO "FixtureGuestApproval" ("id","fixtureId","teamId","playerUserId","status","revision","approvedAt","approvedByUserId","approvedByName") VALUES (\'approval\',\'fixture\',\'home\',\'guest\',\'APPROVED\',1,NOW(),\'admin\',\'Admin\')');
+});
+
+test("strict penny amounts reject blanks, negative values, exponent notation and excess precision", () => {
+  for (const bad of ["", "-1", "1e1", ".5", "5.001", "100.01", "101", "Infinity", "£6", null, 6]) assert.throws(() => parseGuestAmount(bad));
+  assert.equal(parseGuestAmount("6.25"),625); assert.equal(parseGuestAmount("0"),0); assert.equal(parseGuestAmount("100"),10000);
+});
+test("only real captain/admin sessions can write; both preview modes and unauthenticated users are blocked", () => {
+  const access = { session: {}, user: { id: "captain", role: "USER" }, isCaptain: true, isAdmin: false, accessMode: "captain" };
+  assert.equal(canManageGuestPayments(access),true);
+  assert.equal(canManageGuestPayments({ ...access, user: { id: "admin", role: "ADMIN" }, isAdmin: true }),true);
+  for (const changed of [{ session: null }, { accessMode: "captain-preview" }, { accessMode: "admin-preview" }, { isCaptain: false }]) assert.throws(() => assertGuestPaymentAccess({ ...access, ...changed }));
+});
+test("bounded JSON rejects malformed, oversized and wrong-media-type requests", async () => {
+  await assert.rejects(readGuestPayment(new Request("https://example.invalid", { method: "POST", body: "{}" })));
+  await assert.rejects(readGuestPayment(new Request("https://example.invalid", { method: "POST", headers: { "content-type": "application/json" }, body: "x".repeat(5000) })), /too large/);
+  await assert.rejects(readGuestPayment(new Request("https://example.invalid", { method: "POST", headers: { "content-type": "application/json" }, body: "{" })), /could not be read/);
+});
+test("captain creates fixture-specific guest fee, stable payment URL and atomic audit without permanent membership", async () => {
+  const result = await service.prepareGuestPayment(input(), paymentUrl, db);
+  assert.equal(result.status,"OPEN"); assert.equal(result.amountPence,600); assert.equal(result.created,true);
+  const state = await service.getGuestPaymentState(input(),db);
+  assert.equal(state.fee?.id,result.feeId); assert.match(state.fee?.paymentUrl ?? "", /^https:\/\/example\.invalid\/pay\/player-match-fee\/[a-f0-9]{48}$/);
+  const members = await db.$queryRawUnsafe<Array<{ teamId: string }>>('SELECT "teamId" FROM "TeamMember" WHERE "userId"=\'guest\'');
+  assert.deepEqual(members,[{ teamId: "permanent" }]);
+  const audits = await db.$queryRawUnsafe<Array<{ createdByUserId: string; approvalId: string; amountPence: number }>>('SELECT "createdByUserId","approvalId","amountPence" FROM "FixtureGuestPaymentAudit"');
+  assert.deepEqual(audits,[{createdByUserId:"captain",approvalId:"approval",amountPence:600}]);
+});
+test("storage independently blocks another team's captain", async () => {
+  await assert.rejects(service.prepareGuestPayment({ ...input(), actorUserId: "other" },paymentUrl,db), /Only this team's captain/);
+});
+test("requires current SIXFL approval, not a revoked record", async () => {
+  await db.$executeRawUnsafe('UPDATE "FixtureGuestApproval" SET "status"=\'REVOKED\'');
+  await assert.rejects(service.prepareGuestPayment(input(),paymentUrl,db), /approval is required/);
+});
+test("wrong receiving team and fixture are rejected even for an administrator", async () => {
+  await assert.rejects(service.prepareGuestPayment({ ...input(), actorUserId: "admin", teamId:"away" },paymentUrl,db), /does not belong/);
+  await assert.rejects(service.prepareGuestPayment({ ...input(), fixtureId:"missing" },paymentUrl,db), /does not belong/);
+});
+test("stale approval revision and rescheduled fixture require a reload", async () => {
+  await assert.rejects(service.prepareGuestPayment({ ...input(), expectedRevision: 2 },paymentUrl,db), /has changed/);
+  await assert.rejects(service.prepareGuestPayment({ ...input(), expectedKickoffAt: new Date(kickoff.getTime()+60000).toISOString() },paymentUrl,db), /has changed/);
+});
+test("unpublished and cancelled fixtures cannot create fees", async () => {
+  await db.$executeRawUnsafe('UPDATE "Fixture" SET "publishedAt"=NULL');
+  await assert.rejects(service.prepareGuestPayment(input(),paymentUrl,db), /does not belong/);
+  await db.$executeRawUnsafe('UPDATE "Fixture" SET "publishedAt"=NOW(),"status"=\'CANCELLED\'');
+  await assert.rejects(service.prepareGuestPayment(input(),paymentUrl,db), /upcoming scheduled/);
+});
+test("completed recent fixtures can collect an already-approved guest fee", async () => {
+  const past = new Date(Date.now()-86400000);
+  await db.$executeRawUnsafe('UPDATE "Fixture" SET "status"=\'COMPLETED\',"kickoffAt"=$1',past);
+  const result = await service.prepareGuestPayment({ ...input(), expectedKickoffAt:past.toISOString() },paymentUrl,db);
+  assert.equal(result.amountPence,600);
+});
+test("missing email blocks a payable fee without creating a debt", async () => {
+  await db.$executeRawUnsafe('UPDATE "User" SET "email"=NULL WHERE "id"=\'guest\'');
+  await assert.rejects(service.prepareGuestPayment(input(),paymentUrl,db), /real email address/);
+  assert.equal((await service.getGuestPaymentState(input(),db)).fee,null);
+});
+test("explicit zero creates no payable link", async () => {
+  const result = await service.prepareGuestPayment({ ...input(), amountPence:0 },paymentUrl,db);
+  assert.equal(result.status,"WAIVED");
+  const rows = await db.$queryRawUnsafe<Array<{paymentToken: string|null; paymentUrl: string|null}>>('SELECT "paymentToken","paymentUrl" FROM "PlayerMatchFee"');
+  assert.deepEqual(rows,[{paymentToken:null,paymentUrl:null}]);
+});
+test("retries and simultaneous double-clicks create one fee and one audit", async () => {
+  const results = await Promise.all(Array.from({length:5},()=>service.prepareGuestPayment(input(),paymentUrl,db)));
+  assert.equal(new Set(results.map(r=>r.feeId)).size,1);
+  assert.equal(results.filter(r=>r.created).length,1);
+  const audits = await db.$queryRawUnsafe<Array<{n:bigint}>>('SELECT COUNT(*) AS n FROM "FixtureGuestPaymentAudit"');
+  assert.equal(Number(audits[0].n),1);
+});
+test("paid and waived fees are never reopened or altered", async () => {
+  const created = await service.prepareGuestPayment(input(),paymentUrl,db);
+  await db.$executeRawUnsafe('UPDATE "PlayerMatchFee" SET "status"=\'PAID\',"paidAt"=NOW()');
+  const repeated = await service.prepareGuestPayment(input(),paymentUrl,db);
+  assert.equal(repeated.feeId,created.feeId); assert.equal(repeated.status,"PAID");
+  await assert.rejects(service.prepareGuestPayment({ ...input(), amountPence:700 },paymentUrl,db), /existing amount/);
+  await db.$executeRawUnsafe('UPDATE "PlayerMatchFee" SET "status"=\'WAIVED\'');
+  assert.equal((await service.prepareGuestPayment(input(),paymentUrl,db)).status,"WAIVED");
+});
+test("cancelled fees require review rather than a second charge", async () => {
+  await service.prepareGuestPayment(input(),paymentUrl,db);
+  await db.$executeRawUnsafe('UPDATE "PlayerMatchFee" SET "status"=\'CANCELLED\'');
+  await assert.rejects(service.prepareGuestPayment(input(),paymentUrl,db), /cancelled/);
+});
+test("existing temporary-player fee is reused, including when no new guest audit exists", async () => {
+  await db.$executeRawUnsafe('INSERT INTO "PlayerMatchFee" ("id","fixtureId","teamId","temporaryUserId","amountPence","status") VALUES (\'existing\',\'fixture\',\'home\',\'guest\',600,\'OPEN\')');
+  const result = await service.prepareGuestPayment(input(),paymentUrl,db);
+  assert.equal(result.feeId,"existing"); assert.equal(result.created,false);
+});
+test("prospect email conflicts cannot silently create duplicate fee records", async () => {
+  await db.$executeRawUnsafe('INSERT INTO "TeamPlayerProspect" VALUES (\'prospect\',\'guest@example.invalid\')');
+  await db.$executeRawUnsafe('INSERT INTO "PlayerMatchFee" ("id","fixtureId","teamId","prospectId","amountPence","status") VALUES (\'existing\',\'fixture\',\'home\',\'prospect\',600,\'OPEN\')');
+  await assert.rejects(service.prepareGuestPayment(input(),paymentUrl,db), /reconcile/);
+});
+test("failed audit rolls back the fee", async () => {
+  await db.$executeRawUnsafe('ALTER TABLE "FixtureGuestPaymentAudit" ADD CONSTRAINT test_reject CHECK ("amountPence" <> 601)');
+  try {
+    await assert.rejects(service.prepareGuestPayment({ ...input(), amountPence:601 },paymentUrl,db));
+    assert.equal((await service.getGuestPaymentState(input(),db)).fee,null);
+  } finally { await db.$executeRawUnsafe('ALTER TABLE "FixtureGuestPaymentAudit" DROP CONSTRAINT test_reject'); }
+});
+test("real pass redemption racing direct approval payment never creates two fees", async () => {
+  await db.$executeRawUnsafe('INSERT INTO "TemporaryPlayerPass" ("id","userId","fixtureId","teamId","code","expiresAt") VALUES (\'pass\',\'guest\',\'fixture\',\'home\',\'TP-ABC234\',$1)',kickoff);
+  const results = await Promise.allSettled([
+    service.prepareGuestPayment(input(),paymentUrl,db),
+    passes.redeemTemporaryPlayerPass({code:"TP-ABC234",fixtureId:"fixture",teamId:"home",amountPence:600,acceptedByUserId:"captain"}),
+  ]);
+  assert(results.some(result=>result.status === "fulfilled"));
+  const fees = await db.$queryRawUnsafe<Array<{id:string}>>('SELECT "id" FROM "PlayerMatchFee"');
+  assert.equal(fees.length,1);
+  for (const result of results) if (result.status === "rejected") assert.match(String(result.reason),/already added/);
+});
+test("email mutex prevents overlapping manual and cron queue work and releases on failure", async () => {
+  let started!: () => void; let release!: () => void;
+  const entered = new Promise<void>(resolve=>{started=resolve;});
+  const gate = new Promise<void>(resolve=>{release=resolve;});
+  const first = locks.withTemporaryRequestLock("fee",async()=>{started();await gate;return {status:"queued",queued:1,skipped:0};},db);
+  await entered;
+  let secondRan = false;
+  const second = await locks.withTemporaryRequestLock("fee",async()=>{secondRan=true;return {status:"queued"};},db);
+  assert.equal(second.status,"processing"); assert.equal(secondRan,false);
+  release(); await first;
+  await assert.rejects(locks.withTemporaryRequestLock("fee",async()=>{throw new Error("simulated queue failure");},db));
+  assert.equal((await locks.withTemporaryRequestLock("fee",async()=>({status:"queued"}),db)).status,"queued");
+});
+test("native UI, API and pass mutex survive full production preparation", () => {
+  const read = (file:string)=>readFileSync(file,"utf8");
+  assert.match(read("src/components/captain/FixtureGuestApprovals.tsx"), /<GuestPaymentControl/);
+  assert.match(read("src/app/captain/team/[teamid]/player-payments/layout.tsx"), /match-fees\/layout/);
+  const api = read("src/app/api/captain/team/[teamid]/guest-payments/route.ts");
+  assert.match(api,/assertGuestPaymentAccess\(access\)/); assert.match(api,/assertGuestApprovalOrigin\(request\)/);
+  assert.match(api,/queueTemporaryPlayerMatchFeeRequest\(result.feeId\)/);
+  const pass = read("src/lib/temporary-player-passes.ts");
+  assert(pass.indexOf("await lockTemporaryFixtureFee") < pass.indexOf("const existingFees"));
+  assert.match(pass,/FixtureStatus.COMPLETED/);
+  const source = read("src/lib/fixtures/guest-payments.ts");
+  assert.doesNotMatch(source,/teamMember\.(create|upsert)|INSERT INTO "TeamMember"/);
+  assert.doesNotMatch(source,/paymentIntents\.(create|confirm)|checkout\.sessions\.create/);
+});


### PR DESCRIPTION
## Implemented workflow
SIXFL approves a fixture-specific guest → the receiving team's captain enters the agreed amount on that guest row → **Create fee and send payment link**. No second player request or pass code is required.

The same guest rows are available in **Matchday squad** and **Squad payments** for the selected fixture. They show the existing fee and email status, with send/copy/open link controls where applicable. Explicit £0 creates no payable link and sends no payment request. Approval itself still does not create money records or change permanent registration.

## Payment safeguards
Uses the existing `PlayerMatchFee.temporaryUserId`, public payment URLs, temporary-player email template/queue and downstream checkout/settlement. No new payment integration. Paid, waived and cancelled fees are not silently reopened or repriced. Existing temporary fees are reused; conflicting squad/prospect fees are blocked for review. New guest fees receive an atomic audit record. Amount changes, cash collection and cancellations remain in the existing payment administration.

The approved-guest and existing pass paths share an identity lock; manual/cron temporary email requests share a nonblocking mutex and the existing persisted dispatch deduplication. A fee remains saved if email queuing fails, and retry uses that same fee. Queued is not presented as delivered.

Server-side authorisation is repeated inside the transaction: only the receiving captain or full administrator can create/send, never preview mode. Current SIXFL approval, revision, fixture ownership, publication, status and kickoff snapshot are checked. Revocation blocks new creation/sending through this row without silently cancelling an existing fee. Payment creation is supported for upcoming scheduled fixtures or completed matches from the past 30 days, using a recorded approval.

## Verified before merge
All **16 GitHub Actions workflows** passed on `bbed0ba5183319f053e5ccf73959187ee31e5125`, including full production preparation, Prisma generation, TypeScript and production builds, existing critical-feature contracts, guest approvals, payment policy and referee/sign-in regressions.

The new localhost-only PostgreSQL suite exercised fee creation, atomic audit rollback, permissions, revoked/stale/wrong-fixture data, £0, missing email, paid/cancelled preservation, simultaneous double-clicks, real pass-redemption concurrency and queue-lock recovery. A negative control confirmed removing the approval guard makes its test fail.

The actual GuestPaymentControl React component also passed Chromium tests for positive/£0 fees, preserved paid fees, preview/revoked/missing-email states and retry after an email-queue failure using the existing fee. Browser API data and database records were isolated test fixtures. No real customer fee or email was created during testing. An authenticated production payment/receipt has not been performed.

## Merge and successful live deployment
Merged to `main` as `5e446c3be5492f67156ebed5b216aa0e9079d34a`.
Railway deployment `17773a5f-156c-4e46-8d24-2e5cc7c6adcf` deployed this exact commit and reports **SUCCESS**. Runtime logs confirm migration `20260906023000_fixture_guest_payment_audit` was applied, all migrations succeeded, and Next.js reached **Ready** at 2026-09-06T00:27:55Z. The production service is Sixfl, tracking main and serving sixfl.co.uk / www.sixfl.co.uk. No manual Railway variable or cron changes were required.