### PR TITLE
Search player prospects by name, email or mobile across every page

### DIFF
--- a/.github/workflows/player-prospect-search.yml
+++ b/.github/workflows/player-prospect-search.yml
@@ -1,0 +1,48 @@
+name: Player prospect search
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  search:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://test:test@127.0.0.1:5432/sixfl_search_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run prebuild
+      - run: npx prisma generate
+      - name: Test search and the actual prepared server page with isolated data
+        run: node --import tsx --test tests/player-prospect-search.test.mjs
+      - name: Prove the page test detects a removed search filter
+        shell: bash
+        run: |
+          target='src/app/(admin)/admin/player-prospects/page.tsx'
+          original=$(mktemp)
+          cp "$target" "$original"
+          trap 'cp "$original" "$target"; rm -f "$original"' EXIT
+          node - <<'JS'
+          const fs = require('node:fs');
+          const file = 'src/app/(admin)/admin/player-prospects/page.tsx';
+          const source = fs.readFileSync(file, 'utf8');
+          const guard = ' && matchesSearch(prospect)';
+          if (!source.includes(guard)) throw new Error('Search filter not found');
+          fs.writeFileSync(file, source.replace(guard, ''));
+          JS
+          if node --import tsx --test --test-name-pattern='search finds a player beyond' tests/player-prospect-search.test.mjs > /tmp/search-negative.log 2>&1; then
+            cat /tmp/search-negative.log
+            echo 'ERROR: search regression was not detected'
+            exit 1
+          fi
+          grep -q 'AssertionError' /tmp/search-negative.log
+          echo 'Removing the real page search filter caused its regression test to fail.'
+      - name: Type-check the prepared application
+        run: npx tsc --noEmit

--- a/docs/player-prospect-search.md
+++ b/docs/player-prospect-search.md
@@ -1,0 +1,11 @@
+# Search player prospects
+
+On **Admin → Player prospects**, the **Search players** box accepts all or part of a name, email address or mobile number. Press **Enter** or **Search**. Name and email searches ignore case; name accents and apostrophes are tolerated. UK mobile searches accept spaces, punctuation and national/international prefixes.
+
+Filtering runs on the server over all prospects before calculating status counts or selecting a page. It is not limited to the twelve currently visible cards. The existing league filter also applies. **Open pipeline**, **Active players**, **Duplicates** and **Not interested** each show the number of matches in that status. Switching status or page preserves the search. A new form submission starts on page one.
+
+**Clear search** removes the name/email/mobile filter while preserving the selected league and status. **Clear league** keeps the search and status. Empty results distinguish matches in another status from no matches under the current search and league.
+
+The search is a read-only GET form on the existing admin-protected page. It does not create, move or merge players, send invitations or alter payment records. No new database table, dependency or preparation script is required.
+
+The regression workflow tests matching plus the actual server page after the complete production preparation chain with isolated data/auth fixtures: later-page matches, league/status filtering, URL continuity, pagination reset, empty results, safe escaping and admin access. A negative control removes the real search predicate and requires the later-page test to fail. Existing application type checks and build workflows also run.

--- a/src/app/(admin)/admin/player-prospects/page.tsx
+++ b/src/app/(admin)/admin/player-prospects/page.tsx
@@ -14,6 +14,7 @@ import FormListboxField, {
   type FormListboxOption,
 } from "@/components/ui/FormListboxField";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import { createProspectSearchMatcher, normaliseProspectSearch } from "@/lib/players/prospect-search";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import {
@@ -37,6 +38,7 @@ type SearchParams = {
   leagueId?: string;
   view?: string;
   page?: string;
+  q?: string | string[];
 };
 
 type LeagueFilterOption = {
@@ -277,11 +279,13 @@ function buildProspectHref(input: {
   leagueId: string;
   view: ProspectView;
   page?: number;
+  q?: string;
 }) {
   const params = new URLSearchParams();
   if (input.leagueId) params.set("leagueId", input.leagueId);
   if (input.view !== "pipeline") params.set("view", input.view);
   if ((input.page ?? 1) > 1) params.set("page", String(input.page));
+  if (input.q) params.set("q", input.q);
   const query = params.toString();
   return `/admin/player-prospects${query ? `?${query}` : ""}`;
 }
@@ -948,7 +952,7 @@ function ProspectCard({
               </Link>
               <Link
                 href={`/admin/teams/${prospect.team.id}/communications`}
-                className="inline-flex items-center rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 transition hover:bg-white/10"
+                className="inline-flex items-center rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 transition hover:bg-white/10 hover:text-white"
               >
                 Team comms
               </Link>
@@ -979,6 +983,8 @@ export default async function AdminPlayerProspectsPage({
   const selectedLeagueId = String(filters.leagueId ?? "").trim();
   const selectedView = parseView(filters.view);
   const requestedPage = parsePage(filters.page);
+  const searchQuery = normaliseProspectSearch(filters.q);
+  const matchesSearch = createProspectSearchMatcher(searchQuery);
 
   const [rawProspects, teams, leagues] = await Promise.all([
     prisma.teamPlayerProspect.findMany({
@@ -1064,8 +1070,9 @@ export default async function AdminPlayerProspectsPage({
 
   const selectedLeague =
     leagues.find((league) => league.id === selectedLeagueId) ?? null;
+  // Search before status counts and pagination, not just the twelve visible cards.
   const prospects = allProspects.filter((prospect) =>
-    prospectMatchesLeague(prospect, selectedLeague),
+    prospectMatchesLeague(prospect, selectedLeague) && matchesSearch(prospect),
   );
   const activeSquadMembershipKeys = await loadActiveMembershipKeys(prospects);
   const activeReasonById = new Map<string, string>();
@@ -1196,11 +1203,31 @@ export default async function AdminPlayerProspectsPage({
             <form
               method="get"
               action="/admin/player-prospects"
+              role="search"
+              aria-label="Search player prospects"
               className="mt-6 rounded-3xl border border-white/10 bg-black/20 p-4"
             >
               <input type="hidden" name="view" value={selectedView} />
               <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/40">
                 Filter prospects
+              </p>
+              <label htmlFor="prospect-search" className="mt-3 block text-sm font-medium text-white/80">
+                Search players
+              </label>
+              <input
+                key={searchQuery}
+                id="prospect-search"
+                name="q"
+                type="search"
+                defaultValue={searchQuery}
+                placeholder="Name, email or mobile number"
+                maxLength={120}
+                autoComplete="off"
+                aria-describedby="prospect-search-help"
+                className="mt-2 h-12 w-full min-w-0 rounded-xl border border-white/15 bg-[#0d1424] px-4 text-sm text-white outline-none placeholder:text-white/40 focus:border-emerald-400 focus:ring-1 focus:ring-emerald-400"
+              />
+              <p id="prospect-search-help" className="mt-2 text-xs leading-5 text-white/50">
+                Searches every page, not just the visible players. The tabs show matching players in each status.
               </p>
               <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-end">
                 <FormListboxField
@@ -1214,17 +1241,18 @@ export default async function AdminPlayerProspectsPage({
                   type="submit"
                   className="inline-flex h-12 items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
                 >
-                  Apply
+                  Search
                 </button>
                 {selectedLeague ? (
                   <Link
                     href={buildProspectHref({
                       leagueId: "",
                       view: selectedView,
+                      q: searchQuery,
                     })}
                     className="inline-flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 px-5 text-sm font-medium text-white/70 transition hover:bg-white/10 hover:text-white"
                   >
-                    Clear
+                    Clear league
                   </Link>
                 ) : null}
               </div>
@@ -1234,6 +1262,17 @@ export default async function AdminPlayerProspectsPage({
                   {selectedLeagueLabel}
                 </span>
               </p>
+              {searchQuery ? (
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-emerald-400/20 bg-emerald-500/[0.07] px-3 py-2 text-sm text-emerald-100">
+                  <span className="min-w-0 break-words">Matching “{searchQuery}” · {prospects.length} across all status tabs</span>
+                  <Link
+                    href={buildProspectHref({ leagueId: selectedLeagueId, view: selectedView })}
+                    className="shrink-0 rounded-lg px-2 py-1 font-semibold underline underline-offset-4 hover:bg-white/10"
+                  >
+                    Clear search
+                  </Link>
+                </div>
+              ) : null}
             </form>
           </div>
 
@@ -1291,7 +1330,7 @@ export default async function AdminPlayerProspectsPage({
         ).map(([view, label, count]) => (
           <Link
             key={view}
-            href={buildProspectHref({ leagueId: selectedLeagueId, view })}
+            href={buildProspectHref({ leagueId: selectedLeagueId, view, q: searchQuery })}
             className={[
               "flex min-h-12 items-center justify-between rounded-2xl border px-4 py-3 text-sm font-semibold transition",
               selectedView === view
@@ -1318,14 +1357,18 @@ export default async function AdminPlayerProspectsPage({
             </h2>
           </div>
           <div className="text-sm text-white/50">
-            Showing {pageStart}-{pageEnd} of {viewProspects.length}
+            Showing {pageStart}-{pageEnd} of {viewProspects.length}{searchQuery ? " matching players" : ""}
           </div>
         </div>
 
         <div className="mt-5 space-y-3">
           {pageProspects.length === 0 ? (
             <div className="rounded-2xl border border-white/10 bg-black/20 p-6 text-sm text-white/55">
-              {viewMeta.empty}
+              {searchQuery
+                ? prospects.length > 0
+                  ? "No matching players in this status. Check the other status tabs above, or clear the search."
+                  : "No players match this search and league filter. Try part of a name, email or mobile number, or clear the filters."
+                : viewMeta.empty}
             </div>
           ) : (
             pageProspects.map((prospect) => (
@@ -1357,6 +1400,7 @@ export default async function AdminPlayerProspectsPage({
                   leagueId: selectedLeagueId,
                   view: selectedView,
                   page: currentPage - 1,
+                  q: searchQuery,
                 })}
                 className="inline-flex min-h-11 items-center justify-center rounded-xl border border-white/10 bg-black/20 px-4 py-2 text-sm font-semibold text-white/75 transition hover:bg-white/[0.06] hover:text-white"
               >
@@ -1369,6 +1413,7 @@ export default async function AdminPlayerProspectsPage({
                   leagueId: selectedLeagueId,
                   view: selectedView,
                   page: currentPage + 1,
+                  q: searchQuery,
                 })}
                 className="inline-flex min-h-11 items-center justify-center rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15"
               >

--- a/src/lib/players/prospect-search.ts
+++ b/src/lib/players/prospect-search.ts
@@ -1,0 +1,55 @@
+export type SearchableProspect = {
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+/** Keep shared/bookmarked URLs bounded, and tolerate repeated query parameters. */
+export function normaliseProspectSearch(value: unknown): string {
+  const first = Array.isArray(value) ? value[0] : value;
+  return typeof first === "string" ? first.trim().replace(/\s+/g, " ").slice(0, 120) : "";
+}
+
+function fold(value: string) {
+  return value.normalize("NFKD").replace(/[\u0300-\u036f]/g, "")
+    .replace(/['\u2018\u2019]/g, "").toLowerCase();
+}
+
+/** Include UK national/international forms without changing the stored number. */
+function phoneForms(value: string) {
+  const digits = value.replace(/\D/g, "");
+  if (!digits) return [];
+  const forms = new Set([digits]);
+  const international = digits.startsWith("0044") ? digits.slice(2) : digits;
+  forms.add(international);
+  if (international.startsWith("44") && international.length >= 7) {
+    forms.add(`0${international.slice(2).replace(/^0/, "")}`);
+  } else if (digits.startsWith("0") && !digits.startsWith("00") && digits.length >= 4) {
+    forms.add(`44${digits.slice(1)}`);
+  }
+  return [...forms];
+}
+
+/** Pure, read-only filtering. Apply before pagination and status counts. */
+export function createProspectSearchMatcher(value: unknown) {
+  const query = normaliseProspectSearch(value);
+  if (!query) return (_prospect: SearchableProspect) => true;
+  const folded = fold(query);
+  // Punctuation alone must not turn into an empty match-all term.
+  if (!folded.trim()) return (_prospect: SearchableProspect) => false;
+  const terms = folded.split(/\s+/);
+  const phoneOnly = /^[+\d\s().-]+$/.test(query) && query.replace(/\D/g, "").length >= 3;
+  const queryPhones = phoneOnly ? phoneForms(query) : [];
+
+  return (prospect: SearchableProspect) => {
+    const text = fold([prospect.firstName, prospect.lastName, prospect.email].filter(Boolean).join(" "));
+    const phones = phoneForms(prospect.phone ?? "");
+    if (phoneOnly) {
+      return text.includes(folded) || queryPhones.some((part) => phones.some((phone) => phone.includes(part)));
+    }
+    return terms.every((term) => text.includes(term) || (
+      /^\+?\d{3,}$/.test(term) && phoneForms(term).some((part) => phones.some((phone) => phone.includes(part)))
+    ));
+  };
+}

--- a/tests/player-prospect-search.test.mjs
+++ b/tests/player-prospect-search.test.mjs
@@ -6,9 +6,14 @@ import Module, { createRequire } from "node:module";
 import ts from "typescript";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import * as search from "../src/lib/players/prospect-search.ts";
+import * as searchModule from "../src/lib/players/prospect-search.ts";
 
+// tsx loads .ts files as CommonJS in this repository; Node exposes that object
+// as the default export when this ESM test imports it. Production uses Next.js.
+const search = searchModule.default ?? searchModule;
 const { normaliseProspectSearch, createProspectSearchMatcher } = search;
+assert.equal(typeof normaliseProspectSearch, "function");
+assert.equal(typeof createProspectSearchMatcher, "function");
 const sample = { firstName: "Gaël", lastName: "Example", email: "gael+football@example.test", phone: "+44 (0)7700 900123" };
 for (const query of ["gael", "GAËL", "example gael", "  Gael    Example ", "gael+football@", "EXAMPLE.TEST", "07700900123", "+44 7700 900123", "0044 7700 900123", "07700 900 123", "900123", "gael 900123"]) {
   test(`matches name/email/mobile: ${JSON.stringify(query)}`, () => {

--- a/tests/player-prospect-search.test.mjs
+++ b/tests/player-prospect-search.test.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import Module, { createRequire } from "node:module";
+import ts from "typescript";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import * as search from "../src/lib/players/prospect-search.ts";
+
+const { normaliseProspectSearch, createProspectSearchMatcher } = search;
+const sample = { firstName: "Gaël", lastName: "Example", email: "gael+football@example.test", phone: "+44 (0)7700 900123" };
+for (const query of ["gael", "GAËL", "example gael", "  Gael    Example ", "gael+football@", "EXAMPLE.TEST", "07700900123", "+44 7700 900123", "0044 7700 900123", "07700 900 123", "900123", "gael 900123"]) {
+  test(`matches name/email/mobile: ${JSON.stringify(query)}`, () => {
+    assert.equal(createProspectSearchMatcher(query)(sample), true);
+  });
+}
+test("blank and repeated queries are normalised safely", () => {
+  for (const query of [undefined, null, 123, {}, "  "]) assert.equal(normaliseProspectSearch(query), "");
+  assert.equal(normaliseProspectSearch(["  gael  example  ", "ignored"]), "gael example");
+  assert.equal(normaliseProspectSearch("x".repeat(1000)).length, 120);
+  assert.equal(createProspectSearchMatcher(" ")({ firstName: null, lastName: null, email: null, phone: null }), true);
+});
+test("literal punctuation, nonmatches and empty contacts do not match every record", () => {
+  for (const query of ["zzzz", "%", "_", ".*", "[", "'", "gael missing", "999999999"]) {
+    assert.equal(createProspectSearchMatcher(query)(sample), false, query);
+  }
+  assert.equal(createProspectSearchMatcher("someone")({ firstName: null, lastName: null, email: null, phone: null }), false);
+  assert.equal(createProspectSearchMatcher("oneill")({ ...sample, lastName: "O’Neill" }), true);
+});
+test("UK phone search works in both directions without matching scattered groups", () => {
+  assert.equal(createProspectSearchMatcher("+44 7700 900123")({ ...sample, phone: "07700-900123" }), true);
+  assert.equal(createProspectSearchMatcher("00447700900123")({ ...sample, phone: "07700900123" }), true);
+  assert.equal(createProspectSearchMatcher("123 900")({ ...sample, phone: "07700900123" }), false);
+});
+
+// Execute the actual prepared server page, not a second implementation of its
+// filtering/pagination. Only data, auth and unrelated card widgets are mocked.
+const require = createRequire(import.meta.url);
+const pagePath = path.resolve("src/app/(admin)/admin/player-prospects/page.tsx");
+const pageSource = fs.readFileSync(pagePath, "utf8");
+const emitted = ts.transpileModule(pageSource, { compilerOptions: {
+  target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS,
+  jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true,
+} }).outputText;
+const leagueA = { id: "league-a", name: "North Example", season: "2026", area: "North", dayOfWeek: "MONDAY" };
+const leagueB = { id: "league-b", name: "South Example", season: "2026", area: "South", dayOfWeek: "TUESDAY" };
+const teamA = { id: "team-a", name: "Example Managed", teamMode: "MANAGED", league: leagueA };
+const now = new Date("2026-09-01T12:00:00Z");
+function prospect(id, overrides = {}) {
+  return { id, teamId: null, firstName: "Test", lastName: id, email: `${id}@example.test`,
+    phone: null, preferredPositions: null, availabilitySummary: null, source: null,
+    status: "NEW", notes: null, createdAt: now, updatedAt: now, lastContactedAt: null, team: null, ...overrides };
+}
+const fixtures = [
+  ...Array.from({ length: 25 }, (_, i) => prospect(`ordinary-${i}`)),
+  prospect("target", { ...sample, firstName: "Gael", lastName: "Needle", notes: "Area: North" }),
+  prospect("active", { firstName: "Gael", lastName: "Active", status: "ACTIVE_SQUAD", teamId: "team-a", team: teamA }),
+  prospect("duplicate", { firstName: "Gael", lastName: "Duplicate", status: "DUPLICATE", notes: "Area: North" }),
+  prospect("declined", { firstName: "Gael", lastName: "Declined", status: "DECLINED", notes: "Area: South" }),
+  prospect("linked", { firstName: "Existing", lastName: "Member", teamId: "team-a", team: teamA }),
+];
+function harness({ rows = fixtures, denied = false } = {}) {
+  const calls = { auth: 0, reads: 0, enrichedIds: [] };
+  const mocks = {
+    "@/lib/players/prospect-search": search,
+    "@/lib/requireAdmin": { requireAdmin: async () => { calls.auth++; if (denied) throw new Error("ADMIN_REQUIRED"); } },
+    "@/lib/prisma": { prisma: {
+      teamPlayerProspect: { findMany: async () => { calls.reads++; return structuredClone(rows); } },
+      team: { findMany: async () => [teamA] },
+      league: { findMany: async () => [leagueA, leagueB] },
+      notificationDispatch: { findMany: async (args) => { calls.enrichedIds = args.where.sourceId.in; return []; } },
+      $queryRaw: async (query) => {
+        const text = query.sql ?? query.strings?.join("") ?? "";
+        if (text.includes('JOIN "TeamMember"')) return [{ emailNormalized: "linked@example.test", teamId: "team-a" }];
+        return [];
+      },
+    } },
+    "next/link": { __esModule: true, default: (props) => React.createElement("a", props, props.children) },
+    "@/components/admin/player-prospects/ProspectNativeActions": { __esModule: true, default: () => null },
+    "@/components/ui/FormListboxField": { __esModule: true, default: ({ name, options, value, label, disabled }) =>
+      React.createElement("label", null, label, React.createElement("select", { name, defaultValue: value, disabled },
+        options.map((option) => React.createElement("option", { key: option.value, value: option.value }, option.label)))) },
+    "@/lib/datetime/london": { formatDateTimeInLondon: (date) => date.toISOString() },
+    "./actions": { assignPlayerProspectToTeamAction: "/test/no-writes", sendPlayerProspectSquadInviteAction: "/test/no-writes", sendPlayerProspectYesNoChaseAction: "/test/no-writes" },
+  };
+  const mod = new Module(pagePath);
+  mod.filename = pagePath;
+  mod.paths = Module._nodeModulePaths(process.cwd());
+  mod.require = (name) => Object.hasOwn(mocks, name) ? mocks[name] : require(name);
+  mod._compile(emitted, pagePath);
+  return { calls, render: async (params = {}) => renderToStaticMarkup(await mod.exports.default({ searchParams: Promise.resolve(params) })).replace(/<!--.*?-->/g, "") };
+}
+function cardNames(html) {
+  return [...html.matchAll(/<h3[^>]*>([^<]*)<\/h3>/g)].map((match) => match[1]);
+}
+function linkParams(html, label) {
+  for (const match of html.matchAll(/<a\b[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g)) {
+    const text = match[2].replace(/<[^>]+>/g, "").trim();
+    if (text === label || text.startsWith(label)) return new URL(match[1].replaceAll("&amp;", "&"), "https://test.invalid").searchParams;
+  }
+  assert.fail(`Link not found: ${label}`);
+}
+
+test("search finds a player beyond the first twelve cards", async () => {
+  const h = harness();
+  const original = await h.render();
+  assert.equal(cardNames(original).length, 12);
+  assert.ok(!cardNames(original).includes("Gael Needle"));
+  const html = await h.render({ q: "needle" });
+  assert.deepEqual(cardNames(html), ["Gael Needle"]);
+  assert.match(html, /Showing 1-1 of 1 matching players/);
+  assert.deepEqual(h.calls.enrichedIds, ["target"]);
+  assert.equal(h.calls.auth, 2);
+});
+test("email and formatted mobile searches render the existing player card", async () => {
+  for (const q of ["GAEL+FOOTBALL@EXAMPLE.TEST", "07700 900123", "+44 7700 900123"]) {
+    assert.deepEqual(cardNames(await harness().render({ q })), ["Gael Needle"]);
+  }
+});
+test("search combines with the league filter and keeps unassigned area matches", async () => {
+  assert.deepEqual(cardNames(await harness().render({ q: "gael", leagueId: "league-a" })), ["Gael Needle"]);
+  const html = await harness().render({ q: "needle", leagueId: "league-b" });
+  assert.deepEqual(cardNames(html), []);
+  assert.match(html, /No players match this search and league filter/);
+});
+test("all four status tabs keep the search and show their own matched counts", async () => {
+  for (const [view, name] of [["pipeline", "Gael Needle"], ["active", "Gael Active"], ["duplicates", "Gael Duplicate"], ["declined", "Gael Declined"]]) {
+    const html = await harness().render({ q: "gael", view });
+    assert.deepEqual(cardNames(html), [name]);
+    assert.match(html, /4 across all status tabs/);
+    for (const label of ["Open pipeline", "Active players", "Duplicates", "Not interested"]) {
+      const params = linkParams(html, label);
+      assert.equal(params.get("q"), "gael");
+      assert.equal(params.has("page"), false);
+    }
+  }
+});
+test("existing linked-member classification remains active rather than assignable", async () => {
+  assert.deepEqual(cardNames(await harness().render({ q: "Existing" })), []);
+  assert.deepEqual(cardNames(await harness().render({ q: "Existing", view: "active" })), ["Existing Member"]);
+});
+test("query and league survive next/previous while new searches reset pagination", async () => {
+  const rows = Array.from({ length: 30 }, (_, i) => prospect(`match-${i}`, { notes: "Area: North" }));
+  const h = harness({ rows });
+  const html = await h.render({ q: "test", page: "2", leagueId: "league-a" });
+  assert.equal(cardNames(html).length, 12);
+  assert.match(html, /Showing 13-24 of 30 matching players/);
+  for (const [label, page] of [["Previous", "1"], ["Next", "3"]]) {
+    const params = linkParams(html, label);
+    assert.equal(params.get("q"), "test");
+    assert.equal(params.get("leagueId"), "league-a");
+    assert.equal(params.get("page") ?? "1", page);
+  }
+  const form = html.match(/<form[^>]*role="search"[\s\S]*?<\/form>/)?.[0];
+  assert.ok(form);
+  assert.match(form, /method="get"/);
+  assert.match(form, /name="q"/);
+  assert.match(form, /name="view"/);
+  assert.match(form, /name="leagueId"/);
+  assert.ok(!form.includes('name="page"'));
+  assert.match(form, /type="submit"/);
+});
+test("clear search retains league and status; clear league retains search", async () => {
+  const html = await harness().render({ q: "Gael+football@", leagueId: "league-a", view: "active" });
+  const clearSearch = linkParams(html, "Clear search");
+  assert.equal(clearSearch.get("leagueId"), "league-a");
+  assert.equal(clearSearch.get("view"), "active");
+  assert.equal(clearSearch.has("q"), false);
+  assert.equal(clearSearch.has("page"), false);
+  const clearLeague = linkParams(html, "Clear league");
+  assert.equal(clearLeague.get("q"), "Gael+football@");
+  assert.equal(clearLeague.get("view"), "active");
+  assert.equal(clearLeague.has("leagueId"), false);
+});
+test("empty current status points to other matches; old page numbers clamp safely", async () => {
+  const html = await harness().render({ q: "Active", page: "999" });
+  assert.deepEqual(cardNames(html), []);
+  assert.match(html, /Check the other status tabs/);
+  assert.match(html, /Showing 0-0 of 0 matching players/);
+  assert.deepEqual(cardNames(await harness().render({ q: "needle", page: "999" })), ["Gael Needle"]);
+});
+test("search text is escaped and repeat/empty parameters do not crash", async () => {
+  const html = await harness().render({ q: '<script>alert("x")</script>' });
+  assert.ok(!html.includes('<script>alert("x")</script>'));
+  assert.match(html, /&lt;script&gt;/);
+  assert.deepEqual(cardNames(await harness().render({ q: ["needle", "other"] })), ["Gael Needle"]);
+  assert.equal(cardNames(await harness().render({ q: "   " })).length, 12);
+});
+test("admin access is still required before loading the prospect directory", async () => {
+  const h = harness({ denied: true });
+  await assert.rejects(h.render({ q: "needle" }), /ADMIN_REQUIRED/);
+  assert.equal(h.calls.reads, 0);
+});


### PR DESCRIPTION
## Implemented change
Adds **Search players** above the league selector on Admin → Player prospects. Enter all or part of a name, email or mobile number and press Enter or Search. The search filters all records before status counts and pagination, not just the 12 visible cards.

Names/emails ignore case; name accents and apostrophes are tolerated. Mobile matching ignores formatting and supports UK 07 / +44 / 0044 forms. The existing league filter remains combined with search. Status tabs show matching counts and preserve the query; page links preserve query/league/status. Submitting a new search resets to page one. Separate **Clear search** and **Clear league** controls preserve the other filter. Empty results point to matches in another status when present.

## Scope
Native read-only GET form on the existing admin-protected page. No DOM bridge, extra API, new database migration, dependency or preparation script. Existing prospect assignment, invitation, membership classification, payment and communication workflows remain unchanged. No real player was assigned and no customer email or SMS was sent during implementation.

## Verified before merge
All **17 GitHub Actions PR workflows** passed on final head `9f86902621e7cf971afe8c7b22063cd4eb435a7f`, including full production preparation, TypeScript, critical-feature contracts and the production application build.

The search workflow passed **25 tests**, including helper matching and execution of the actual prepared server page with isolated data/auth fixtures. Coverage includes players beyond the first page, phone/email search, all four status tabs, league combinations, existing-member classification, pagination/reset, URL escaping/clear behaviour, empty results and admin access. A negative control removed the real page search predicate and verified that the later-page search test failed. The initial mixed ESM/CommonJS test import issue was corrected before these successful runs.

## Merge and live deployment
Merged into main as `d471447e9ec5edab720cb3ba22cac8050f1370f9`, retaining the concurrent main update `029a84703c792937c70e41e1937a6a9aeb6fe839`.

Railway deployment `219bb57c-6007-4f8b-ba13-ebe313e98251` deployed this exact merge commit and reports **SUCCESS**. Runtime logs confirm no pending migrations and Next.js **Ready** at 2026-09-06T16:37:47Z. The existing Sixfl production service serves sixfl.co.uk / www.sixfl.co.uk. No Railway configuration changes were needed.

A search within the user's signed-in production admin session has not been performed.