### PR TITLE
Show actual lead replies and legacy conversations beside SMS chase status

### DIFF
--- a/.github/workflows/lead-communication-evidence.yml
+++ b/.github/workflows/lead-communication-evidence.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm run prebuild
       - run: npx prisma generate
       - name: Test actual query, reply presentation, status endpoint and reminder holds
-        run: node --test tests/lead-communication-evidence.test.cjs
+        run: node --test tests/lead-communication-evidence.test.cjs tests/lead-sms-status-links.test.cjs
       - name: Prove an outbound-only regression is caught
         shell: bash
         run: |

--- a/.github/workflows/lead-communication-evidence.yml
+++ b/.github/workflows/lead-communication-evidence.yml
@@ -1,0 +1,58 @@
+name: Lead reply evidence and timeline
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  lead-evidence:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sixfl_lead_evidence_test
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sixfl_lead_evidence_test"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_lead_evidence_test
+      LEAD_EVIDENCE_TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_lead_evidence_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run prebuild
+      - run: npx prisma generate
+      - name: Test actual query, reply presentation, status endpoint and reminder holds
+        run: node --test tests/lead-communication-evidence.test.cjs
+      - name: Prove an outbound-only regression is caught
+        shell: bash
+        run: |
+          target=src/lib/leads/communication-evidence.ts
+          original=$(mktemp)
+          cp "$target" "$original"
+          trap 'cp "$original" "$target"; rm -f "$original"' EXIT
+          node - <<'JS'
+          const fs = require('node:fs');
+          const target = 'src/lib/leads/communication-evidence.ts';
+          const original = fs.readFileSync(target, 'utf8');
+          const guard = ` AND message."direction"::text = 'INBOUND'`;
+          if (!original.includes(guard)) throw new Error('Inbound guard not found');
+          fs.writeFileSync(target, original.replace(guard, ''));
+          JS
+          if node --test --test-name-pattern="legacy automation reply" tests/lead-communication-evidence.test.cjs > negative-control.log 2>&1; then
+            cat negative-control.log
+            echo "ERROR: test did not detect the removed inbound filter"
+            exit 1
+          fi
+          grep -Eq 'AssertionError|Cannot read properties of null' negative-control.log
+          echo "Negative control passed: removing the inbound filter fails the reply test."
+      - run: npx tsc --noEmit

--- a/docs/lead-reply-evidence.md
+++ b/docs/lead-reply-evidence.md
@@ -1,0 +1,15 @@
+# Lead replies: shared evidence and visible history
+
+Admin lead details/edit layouts, automatic SMS status and the team-lead reminder job now use `loadLeadCommunicationEvidence` in `src/lib/leads/communication-evidence.ts`.
+
+The resolver includes the old source-ID and lead-owned notification-recipient links, even for archived or legacy automation conversations. It does not search unrelated contacts by email/phone alone. Conflicting team/lead ownership is flagged for review rather than merged. Actual reply evidence requires an INBOUND contact entry, content and a matching lead or lead-owned recipient sender address. A cached timestamp alone is not proof.
+
+The lead page starts with **Latest incoming reply**, actual message content, sender, channel and UK date/time, and a direct **View conversation** link using `filter=all&thread=...`. This bypasses the central inbox's default unread filter and 100-thread list. The timeline uses the same trusted conversation IDs. Latest-reply evidence is fetched independently of the timeline's 100-message-per-thread window and remains visible after many outgoing messages. Incoming entries show RECEIVED rather than a misleading sent-message explanation.
+
+SMS status only says reply received with actual evidence. It includes the reply date/channel and a lead-page evidence URL. Unsupported timestamps and conflicting records say **Reply record needs checking**. They preserve existing automation holds; the read-time repair cannot restart a stopped chase. A question is not confirmation of a team place.
+
+Historical records are resolved on read, not rewritten or copied, so the fix does not depend on another reminder being sent. No new migration, automatic resend, cron restart, reassignment or mark-read action is required. Existing queue timing, templates, payment and player workflows remain unchanged.
+
+Tests use only a random localhost PostgreSQL schema and synthetic contacts. They execute the real resolver SQL, native panel/layout, status endpoint and reminder hold path after full production prebuild. The negative control removes the INBOUND filter and must fail. No customer message, contact or quote is included in test data.
+
+Deployment and authenticated-production verification are reported separately in the pull request.

--- a/src/app/(admin)/admin/leads/[id]/layout.tsx
+++ b/src/app/(admin)/admin/leads/[id]/layout.tsx
@@ -11,6 +11,8 @@ import CommunicationStatusBadge, {
   CommunicationStatusExplanation,
 } from "@/components/admin/communications/CommunicationStatusBadge";
 import CancelQueuedSmsButton from "@/components/admin/messages/CancelQueuedSmsButton";
+import LeadReplyEvidence from "@/components/admin/leads/LeadReplyEvidence";
+import { emptyLeadEvidence, leadConversationHref, loadLeadCommunicationEvidence } from "@/lib/leads/communication-evidence";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 
@@ -26,6 +28,7 @@ function formatDateTime(value: Date | null | undefined) {
     year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    timeZone: "Europe/London",
   }).format(value);
 }
 
@@ -80,6 +83,7 @@ export default async function AdminLeadLayout({
   await requireAdmin();
 
   const { id } = await params;
+  const evidence = (await loadLeadCommunicationEvidence([id])).get(id) ?? emptyLeadEvidence();
 
   const leadForHistory = await prisma.interestLead.findUnique({
     where: { id },
@@ -197,10 +201,7 @@ export default async function AdminLeadLayout({
   );
 
   const threads = await prisma.messageThread.findMany({
-    where: {
-      sourceType: "LEAD",
-      sourceId: id,
-    },
+    where: { id: { in: evidence.threadIds } },
     include: {
       messages: {
         orderBy: [{ createdAt: "desc" }],
@@ -253,7 +254,9 @@ export default async function AdminLeadLayout({
           templateName: message.dispatch?.template?.name ?? null,
           templateKey: message.dispatch?.template?.key ?? null,
           originLabel: message.dispatch ? getOriginLabel(message.dispatch.metadata) : "Inbox thread",
-          contactValue: message.toEmail || message.toNumber || message.fromEmail || message.fromNumber || null,
+          contactValue: message.direction === "INBOUND"
+            ? message.fromEmail || message.fromNumber || null
+            : message.toEmail || message.toNumber || null,
           occurredAt: message.receivedAt ?? message.sentAt ?? message.createdAt,
           scheduledFor: message.dispatch?.scheduledFor ?? null,
           canCancelQueuedSms,
@@ -266,6 +269,7 @@ export default async function AdminLeadLayout({
 
   return (
     <div className="space-y-8">
+      <LeadReplyEvidence evidence={evidence} />
       <section className="rounded-3xl border border-emerald-400/15 bg-emerald-500/[0.06] p-6 shadow-[0_20px_70px_rgba(0,0,0,0.25)]">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
@@ -326,7 +330,7 @@ export default async function AdminLeadLayout({
                     {email.subject}
                   </div>
                   <div className="mt-1 text-xs text-white/45">
-                    {formatDateTime(email.occurredAt)}
+                    {formatDateTime(email.occurredAt)} (UK)
                     {email.scheduledFor ? ` · Scheduled ${formatDateTime(email.scheduledFor)}` : ""}
                     {email.sentTo ? ` · To ${email.sentTo}` : ""}
                     {email.statusLabel ? ` · ${email.statusLabel}` : ""}
@@ -358,7 +362,7 @@ export default async function AdminLeadLayout({
               Lead communication timeline
             </h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-              SMS and central dispatch messages for this lead now appear here, using the same queued, skipped, sent, failed and cancelled rules as the rest of Communications.
+              Incoming and outgoing messages from this lead's linked conversations, including older automatic SMS threads and archived conversations. Shows up to 100 recent messages per conversation; the latest incoming reply is always shown above, even when older than that window.
             </p>
           </div>
 
@@ -395,7 +399,7 @@ export default async function AdminLeadLayout({
                   <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] font-semibold text-white/70">
                     {item.direction}
                   </span>
-                  <CommunicationStatusBadge status={String(item.providerStatus)} />
+                  {item.direction === "INBOUND" ? <span className="rounded-full bg-emerald-500/15 px-2.5 py-1 text-[11px] font-semibold text-emerald-100">RECEIVED</span> : <CommunicationStatusBadge status={String(item.providerStatus)} />}
                   <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1 text-[11px] text-white/55">
                     {item.originLabel}
                   </span>
@@ -416,9 +420,9 @@ export default async function AdminLeadLayout({
                     {item.subject || `${item.channel} message`}
                   </div>
                   <div className="mt-1 text-xs text-white/45">
-                    {formatDateTime(item.occurredAt)}
+                    {formatDateTime(item.occurredAt)} (UK)
                     {item.scheduledFor ? ` · Scheduled ${formatDateTime(item.scheduledFor)}` : ""}
-                    {item.contactValue ? ` · ${item.contactValue}` : ""}
+                    {item.contactValue ? ` · ${item.direction === "INBOUND" ? "From" : "To"} ${item.contactValue}` : ""}
                   </div>
                 </div>
 
@@ -433,10 +437,12 @@ export default async function AdminLeadLayout({
                 )}
 
                 <div className="flex flex-wrap items-center justify-between gap-3">
-                  <CommunicationStatusExplanation status={String(item.providerStatus)}>
-                    {item.failureReason ? `Reason: ${item.failureReason}` : undefined}
-                  </CommunicationStatusExplanation>
-
+                  {item.direction === "INBOUND" ? <p className="text-xs text-emerald-100">Incoming message received from the contact.</p> : (
+                    <CommunicationStatusExplanation status={String(item.providerStatus)}>
+                      {item.failureReason ? `Reason: ${item.failureReason}` : undefined}
+                    </CommunicationStatusExplanation>
+                  )}
+                  <Link href={leadConversationHref(item.threadId)} className="text-sm font-semibold text-emerald-200 underline underline-offset-4">View conversation</Link>
                   {item.canCancelQueuedSms ? (
                     <CancelQueuedSmsButton
                       messageId={item.id}

--- a/src/app/api/admin/leads/team-confirmation-sms-status/route.ts
+++ b/src/app/api/admin/leads/team-confirmation-sms-status/route.ts
@@ -3,390 +3,172 @@ import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
+import { emptyLeadEvidence, leadReplyHref, leadReplyState, loadLeadCommunicationEvidence } from "@/lib/leads/communication-evidence";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 const FIRST_SMS_DELAY_MS = 48 * 60 * 60 * 1000;
 const FINAL_SMS_DELAY_MS = 5 * 24 * 60 * 60 * 1000;
-
 const FIRST_SMS_SOURCE_TYPE = "LEAD_TEAM_CONFIRMATION_SMS_NUDGE_1";
 const FINAL_SMS_SOURCE_TYPE = "LEAD_TEAM_CONFIRMATION_SMS_NUDGE_FINAL";
-
 const RELEVANT_EMAIL_SOURCE_TYPES = [
-  "LEAD_REASSURANCE_EMAIL",
-  "LEAD_LIVE_LEAGUE_REASSURANCE_EMAIL",
-  "LEAD_TEAM_CONFIRMATION",
-  "LEAD_TEAM_CONFIRMATION_CHASE",
+  "LEAD_REASSURANCE_EMAIL", "LEAD_LIVE_LEAGUE_REASSURANCE_EMAIL",
+  "LEAD_TEAM_CONFIRMATION", "LEAD_TEAM_CONFIRMATION_CHASE",
 ] as const;
 
 type StatusTone = "muted" | "info" | "success" | "warning" | "danger";
-
-type StatusLine = {
-  text: string;
-  tone: StatusTone;
-  title?: string | null;
-};
-
-type TeamLeadSmsStatus = {
-  lines: StatusLine[];
-};
-
+type StatusLine = { text: string; tone: StatusTone; title?: string | null; href?: string; linkText?: string };
+type TeamLeadSmsStatus = { lines: StatusLine[] };
 type TeamLeadSmsStatusRow = {
-  leadId: string;
-  phone: string | null;
-  leadStatus: string;
-  convertedTeamId: string | null;
-  confirmationStatus: string;
-  latestRelevantEmailSentAt: Date | null;
-  latestInboundAt: Date | null;
-  firstStatus: string | null;
-  firstCreatedAt: Date | null;
-  firstUpdatedAt: Date | null;
-  firstScheduledFor: Date | null;
-  firstProcessedAt: Date | null;
-  firstSentAt: Date | null;
-  firstFailedAt: Date | null;
-  firstCancelledAt: Date | null;
-  firstFailureReason: string | null;
-  finalStatus: string | null;
-  finalCreatedAt: Date | null;
-  finalUpdatedAt: Date | null;
-  finalScheduledFor: Date | null;
-  finalProcessedAt: Date | null;
-  finalSentAt: Date | null;
-  finalFailedAt: Date | null;
-  finalCancelledAt: Date | null;
-  finalFailureReason: string | null;
+  leadId: string; phone: string | null; leadStatus: string; convertedTeamId: string | null;
+  confirmationStatus: string; latestRelevantEmailSentAt: Date | null;
+  latestInboundAt: Date | null; replyReviewRequired?: boolean;
+  firstStatus: string | null; firstCreatedAt: Date | null; firstUpdatedAt: Date | null;
+  firstScheduledFor: Date | null; firstProcessedAt: Date | null; firstSentAt: Date | null;
+  firstFailedAt: Date | null; firstCancelledAt: Date | null; firstFailureReason: string | null;
+  finalStatus: string | null; finalCreatedAt: Date | null; finalUpdatedAt: Date | null;
+  finalScheduledFor: Date | null; finalProcessedAt: Date | null; finalSentAt: Date | null;
+  finalFailedAt: Date | null; finalCancelledAt: Date | null; finalFailureReason: string | null;
 };
-
 type DispatchSnapshot = {
-  status: string | null;
-  createdAt: Date | null;
-  updatedAt: Date | null;
-  scheduledFor: Date | null;
-  processedAt: Date | null;
-  sentAt: Date | null;
-  failedAt: Date | null;
-  cancelledAt: Date | null;
-  failureReason: string | null;
+  status: string | null; createdAt: Date | null; updatedAt: Date | null; scheduledFor: Date | null;
+  processedAt: Date | null; sentAt: Date | null; failedAt: Date | null;
+  cancelledAt: Date | null; failureReason: string | null;
 };
-
 function formatDateTime(value: Date) {
   return new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZone: "Europe/London",
+    day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit", hourCycle: "h23", timeZone: "Europe/London",
   }).format(value);
 }
-
-function addMilliseconds(value: Date, milliseconds: number) {
-  return new Date(value.getTime() + milliseconds);
-}
-
-function latestDate(first: Date, second: Date | null) {
-  if (!second) return first;
-  return second.getTime() > first.getTime() ? second : first;
-}
-
-function dispatchStatusLine(
-  label: "First SMS" | "Final SMS",
-  dispatch: DispatchSnapshot,
-  now: Date,
-): StatusLine | null {
+function addMilliseconds(value: Date, milliseconds: number) { return new Date(value.getTime() + milliseconds); }
+function latestDate(first: Date, second: Date | null) { return second && second > first ? second : first; }
+function dispatchStatusLine(label: "First SMS" | "Final SMS", dispatch: DispatchSnapshot, now: Date): StatusLine | null {
   if (!dispatch.status) return null;
-
   if (dispatch.status === "SENT") {
-    const sentAt = dispatch.sentAt ?? dispatch.processedAt ?? dispatch.createdAt;
-    return {
-      text: sentAt ? `${label} sent ${formatDateTime(sentAt)}` : `${label} sent`,
-      tone: "success",
-    };
+    const at = dispatch.sentAt ?? dispatch.processedAt ?? dispatch.createdAt;
+    return { text: at ? `${label} sent ${formatDateTime(at)}` : `${label} sent`, tone: "success" };
   }
-
   if (dispatch.status === "FAILED") {
-    const failedAt = dispatch.failedAt ?? dispatch.processedAt ?? dispatch.updatedAt ?? dispatch.createdAt;
-    return {
-      text: failedAt ? `${label} failed ${formatDateTime(failedAt)}` : `${label} failed`,
-      tone: "danger",
-      title: dispatch.failureReason,
-    };
+    const at = dispatch.failedAt ?? dispatch.processedAt ?? dispatch.updatedAt ?? dispatch.createdAt;
+    return { text: at ? `${label} failed ${formatDateTime(at)}` : `${label} failed`, tone: "danger", title: dispatch.failureReason };
   }
-
   if (dispatch.status === "PROCESSING") {
-    const processingAt = dispatch.updatedAt ?? dispatch.createdAt;
-    return {
-      text: processingAt
-        ? `${label} sending ${formatDateTime(processingAt)}`
-        : `${label} sending`,
-      tone: "info",
-    };
+    const at = dispatch.updatedAt ?? dispatch.createdAt;
+    return { text: at ? `${label} sending ${formatDateTime(at)}` : `${label} sending`, tone: "info" };
   }
-
   if (dispatch.status === "QUEUED") {
-    const scheduledFor = dispatch.scheduledFor ?? dispatch.createdAt;
-    const isFuture = Boolean(scheduledFor && scheduledFor.getTime() > now.getTime() + 60_000);
-    return {
-      text: scheduledFor
-        ? `${label} queued${isFuture ? " for" : ""} ${formatDateTime(scheduledFor)}`
-        : `${label} queued`,
-      tone: "info",
-    };
+    const at = dispatch.scheduledFor ?? dispatch.createdAt;
+    const future = Boolean(at && at.getTime() > now.getTime() + 60_000);
+    return { text: at ? `${label} queued${future ? " for" : ""} ${formatDateTime(at)}` : `${label} queued`, tone: "info" };
   }
-
   if (dispatch.status === "CANCELLED") {
-    const cancelledAt = dispatch.cancelledAt ?? dispatch.processedAt ?? dispatch.updatedAt ?? dispatch.createdAt;
-    return {
-      text: cancelledAt
-        ? `${label} not sent ${formatDateTime(cancelledAt)}`
-        : `${label} not sent`,
-      tone: "warning",
-      title: dispatch.failureReason,
-    };
+    const at = dispatch.cancelledAt ?? dispatch.processedAt ?? dispatch.updatedAt ?? dispatch.createdAt;
+    return { text: at ? `${label} not sent ${formatDateTime(at)}` : `${label} not sent`, tone: "warning", title: dispatch.failureReason };
   }
-
-  return {
-    text: `${label}: ${dispatch.status.toLowerCase()}`,
-    tone: "muted",
-  };
+  return { text: `${label}: ${dispatch.status.toLowerCase()}`, tone: "muted" };
 }
-
 function stopReason(row: TeamLeadSmsStatusRow) {
   if (row.confirmationStatus === "CONFIRMED") return "team place confirmed";
   if (row.confirmationStatus === "DECLINED") return "place released";
   if (row.convertedTeamId) return "team created";
   if (row.leadStatus === "QUALIFIED") return "lead qualified";
   if (row.leadStatus === "CLOSED") return "lead closed";
-
-  if (
-    row.latestInboundAt &&
-    row.latestRelevantEmailSentAt &&
-    row.latestInboundAt.getTime() >= row.latestRelevantEmailSentAt.getTime()
-  ) {
-    return "reply received";
+  if (row.latestInboundAt && row.latestRelevantEmailSentAt && row.latestInboundAt >= row.latestRelevantEmailSentAt) {
+    return row.replyReviewRequired ? "reply record needs checking" : "reply received";
   }
-
   return null;
 }
-
 function buildStatus(row: TeamLeadSmsStatusRow, now: Date): TeamLeadSmsStatus {
   const firstDispatch: DispatchSnapshot = {
-    status: row.firstStatus,
-    createdAt: row.firstCreatedAt,
-    updatedAt: row.firstUpdatedAt,
-    scheduledFor: row.firstScheduledFor,
-    processedAt: row.firstProcessedAt,
-    sentAt: row.firstSentAt,
-    failedAt: row.firstFailedAt,
-    cancelledAt: row.firstCancelledAt,
-    failureReason: row.firstFailureReason,
+    status: row.firstStatus, createdAt: row.firstCreatedAt, updatedAt: row.firstUpdatedAt,
+    scheduledFor: row.firstScheduledFor, processedAt: row.firstProcessedAt, sentAt: row.firstSentAt,
+    failedAt: row.firstFailedAt, cancelledAt: row.firstCancelledAt, failureReason: row.firstFailureReason,
   };
   const finalDispatch: DispatchSnapshot = {
-    status: row.finalStatus,
-    createdAt: row.finalCreatedAt,
-    updatedAt: row.finalUpdatedAt,
-    scheduledFor: row.finalScheduledFor,
-    processedAt: row.finalProcessedAt,
-    sentAt: row.finalSentAt,
-    failedAt: row.finalFailedAt,
-    cancelledAt: row.finalCancelledAt,
-    failureReason: row.finalFailureReason,
+    status: row.finalStatus, createdAt: row.finalCreatedAt, updatedAt: row.finalUpdatedAt,
+    scheduledFor: row.finalScheduledFor, processedAt: row.finalProcessedAt, sentAt: row.finalSentAt,
+    failedAt: row.finalFailedAt, cancelledAt: row.finalCancelledAt, failureReason: row.finalFailureReason,
   };
-
   const firstLine = dispatchStatusLine("First SMS", firstDispatch, now);
   const finalLine = dispatchStatusLine("Final SMS", finalDispatch, now);
   const stopped = stopReason(row);
-
-  if (!firstLine && !finalLine && stopped) {
-    return {
-      lines: [{ text: `Automatic SMS stopped — ${stopped}`, tone: "muted" }],
-    };
-  }
-
-  if (!firstLine && !finalLine && !row.phone?.trim()) {
-    return {
-      lines: [{ text: "Automatic SMS unavailable — no phone number", tone: "warning" }],
-    };
-  }
-
-  if (!firstLine && !finalLine && !row.latestRelevantEmailSentAt) {
-    return {
-      lines: [{ text: "Automatic SMS waiting for email delivery", tone: "muted" }],
-    };
-  }
-
+  if (!firstLine && !finalLine && stopped) return { lines: [{ text: `Automatic SMS stopped — ${stopped}`, tone: "muted" }] };
+  if (!firstLine && !finalLine && !row.phone?.trim()) return { lines: [{ text: "Automatic SMS unavailable — no phone number", tone: "warning" }] };
+  if (!firstLine && !finalLine && !row.latestRelevantEmailSentAt) return { lines: [{ text: "Automatic SMS waiting for email delivery", tone: "muted" }] };
   const lines: StatusLine[] = [];
-
-  if (firstLine) {
-    lines.push(firstLine);
-  } else if (stopped) {
-    lines.push({ text: `First SMS stopped — ${stopped}`, tone: "muted" });
-  } else if (row.latestRelevantEmailSentAt) {
-    const firstDueAt = addMilliseconds(
-      row.latestRelevantEmailSentAt,
-      FIRST_SMS_DELAY_MS,
-    );
-    lines.push({
-      text:
-        firstDueAt.getTime() <= now.getTime()
-          ? "First SMS due now"
-          : `First SMS due ${formatDateTime(firstDueAt)}`,
-      tone: firstDueAt.getTime() <= now.getTime() ? "warning" : "info",
-    });
+  if (firstLine) lines.push(firstLine);
+  else if (stopped) lines.push({ text: `First SMS stopped — ${stopped}`, tone: "muted" });
+  else if (row.latestRelevantEmailSentAt) {
+    const at = addMilliseconds(row.latestRelevantEmailSentAt, FIRST_SMS_DELAY_MS);
+    lines.push({ text: at <= now ? "First SMS due now" : `First SMS due ${formatDateTime(at)}`, tone: at <= now ? "warning" : "info" });
   }
-
-  if (finalLine) {
-    lines.push(finalLine);
-  } else if (stopped) {
-    lines.push({ text: `Final SMS stopped — ${stopped}`, tone: "muted" });
-  } else if (row.firstSentAt) {
-    const fiveDaysAfterFirst = addMilliseconds(row.firstSentAt, FINAL_SMS_DELAY_MS);
-    const fortyEightHoursAfterLatestEmail = row.latestRelevantEmailSentAt
-      ? addMilliseconds(row.latestRelevantEmailSentAt, FIRST_SMS_DELAY_MS)
-      : null;
-    const finalDueAt = latestDate(
-      fiveDaysAfterFirst,
-      fortyEightHoursAfterLatestEmail,
-    );
-
-    lines.push({
-      text:
-        finalDueAt.getTime() <= now.getTime()
-          ? "Final SMS due now"
-          : `Final SMS due ${formatDateTime(finalDueAt)}`,
-      tone: finalDueAt.getTime() <= now.getTime() ? "warning" : "info",
-    });
-  } else if (row.firstStatus === "FAILED" || row.firstStatus === "CANCELLED") {
-    lines.push({
-      text: "Final SMS stopped — first SMS was not sent",
-      tone: "muted",
-    });
-  } else {
-    lines.push({ text: "Final SMS not due yet", tone: "muted" });
-  }
-
+  if (finalLine) lines.push(finalLine);
+  else if (stopped) lines.push({ text: `Final SMS stopped — ${stopped}`, tone: "muted" });
+  else if (row.firstSentAt) {
+    const at = latestDate(addMilliseconds(row.firstSentAt, FINAL_SMS_DELAY_MS), row.latestRelevantEmailSentAt ? addMilliseconds(row.latestRelevantEmailSentAt, FIRST_SMS_DELAY_MS) : null);
+    lines.push({ text: at <= now ? "Final SMS due now" : `Final SMS due ${formatDateTime(at)}`, tone: at <= now ? "warning" : "info" });
+  } else if (row.firstStatus === "FAILED" || row.firstStatus === "CANCELLED") lines.push({ text: "Final SMS stopped — first SMS was not sent", tone: "muted" });
+  else lines.push({ text: "Final SMS not due yet", tone: "muted" });
   return { lines };
 }
 
 export async function GET() {
   await requireAdmin();
-
   const rows = await prisma.$queryRaw<TeamLeadSmsStatusRow[]>(Prisma.sql`
-    SELECT
-      lead."id" AS "leadId",
-      lead."phone",
-      lead."status"::text AS "leadStatus",
-      lead."convertedTeamId",
-      confirmation."status"::text AS "confirmationStatus",
-      latest_email."sentAt" AS "latestRelevantEmailSentAt",
-      (
-        SELECT MAX(thread."latestInboundAt")
-        FROM "MessageThread" thread
-        WHERE thread."latestInboundAt" IS NOT NULL
-          AND (
-            thread."sourceId" = lead."id"
-            OR thread."recipientId" IN (
-              SELECT recipient."id"
-              FROM "NotificationRecipient" recipient
-              WHERE recipient."sourceType"::text = 'LEAD'
-                AND recipient."sourceId" = lead."id"
-            )
-          )
-      ) AS "latestInboundAt",
-      first_sms."status"::text AS "firstStatus",
-      first_sms."createdAt" AS "firstCreatedAt",
-      first_sms."updatedAt" AS "firstUpdatedAt",
-      first_sms."scheduledFor" AS "firstScheduledFor",
-      first_sms."processedAt" AS "firstProcessedAt",
-      first_sms."sentAt" AS "firstSentAt",
-      first_sms."failedAt" AS "firstFailedAt",
-      first_sms."cancelledAt" AS "firstCancelledAt",
+    SELECT lead."id" AS "leadId", lead."phone", lead."status"::text AS "leadStatus", lead."convertedTeamId",
+      confirmation."status"::text AS "confirmationStatus", latest_email."sentAt" AS "latestRelevantEmailSentAt",
+      NULL::timestamp AS "latestInboundAt",
+      first_sms."status"::text AS "firstStatus", first_sms."createdAt" AS "firstCreatedAt",
+      first_sms."updatedAt" AS "firstUpdatedAt", first_sms."scheduledFor" AS "firstScheduledFor",
+      first_sms."processedAt" AS "firstProcessedAt", first_sms."sentAt" AS "firstSentAt",
+      first_sms."failedAt" AS "firstFailedAt", first_sms."cancelledAt" AS "firstCancelledAt",
       first_sms."failureReason" AS "firstFailureReason",
-      final_sms."status"::text AS "finalStatus",
-      final_sms."createdAt" AS "finalCreatedAt",
-      final_sms."updatedAt" AS "finalUpdatedAt",
-      final_sms."scheduledFor" AS "finalScheduledFor",
-      final_sms."processedAt" AS "finalProcessedAt",
-      final_sms."sentAt" AS "finalSentAt",
-      final_sms."failedAt" AS "finalFailedAt",
-      final_sms."cancelledAt" AS "finalCancelledAt",
+      final_sms."status"::text AS "finalStatus", final_sms."createdAt" AS "finalCreatedAt",
+      final_sms."updatedAt" AS "finalUpdatedAt", final_sms."scheduledFor" AS "finalScheduledFor",
+      final_sms."processedAt" AS "finalProcessedAt", final_sms."sentAt" AS "finalSentAt",
+      final_sms."failedAt" AS "finalFailedAt", final_sms."cancelledAt" AS "finalCancelledAt",
       final_sms."failureReason" AS "finalFailureReason"
     FROM "InterestLead" lead
-    JOIN "LeadTeamConfirmation" confirmation
-      ON confirmation."leadId" = lead."id"
+    JOIN "LeadTeamConfirmation" confirmation ON confirmation."leadId" = lead."id"
     LEFT JOIN LATERAL (
-      SELECT dispatch."sentAt"
-      FROM "NotificationDispatch" dispatch
-      WHERE dispatch."sourceId" = lead."id"
-        AND dispatch."channel"::text = 'EMAIL'
-        AND dispatch."status"::text = 'SENT'
-        AND dispatch."sourceType" IN (${Prisma.join(RELEVANT_EMAIL_SOURCE_TYPES)})
-        AND dispatch."createdAt" >=
-          COALESCE(confirmation."sentAt", confirmation."createdAt") - INTERVAL '5 minutes'
-      ORDER BY dispatch."sentAt" DESC NULLS LAST, dispatch."createdAt" DESC
-      LIMIT 1
+      SELECT dispatch."sentAt" FROM "NotificationDispatch" dispatch
+      WHERE dispatch."sourceId" = lead."id" AND dispatch."channel"::text = 'EMAIL'
+        AND dispatch."status"::text = 'SENT' AND dispatch."sourceType" IN (${Prisma.join(RELEVANT_EMAIL_SOURCE_TYPES)})
+        AND dispatch."createdAt" >= COALESCE(confirmation."sentAt", confirmation."createdAt") - INTERVAL '5 minutes'
+      ORDER BY dispatch."sentAt" DESC NULLS LAST, dispatch."createdAt" DESC LIMIT 1
     ) latest_email ON TRUE
     LEFT JOIN LATERAL (
-      SELECT
-        dispatch."status",
-        dispatch."createdAt",
-        dispatch."updatedAt",
-        dispatch."scheduledFor",
-        dispatch."processedAt",
-        dispatch."sentAt",
-        dispatch."failedAt",
-        dispatch."cancelledAt",
-        dispatch."failureReason"
-      FROM "NotificationDispatch" dispatch
-      WHERE dispatch."sourceId" = lead."id"
-        AND dispatch."sourceType" = ${FIRST_SMS_SOURCE_TYPE}
+      SELECT dispatch.* FROM "NotificationDispatch" dispatch
+      WHERE dispatch."sourceId" = lead."id" AND dispatch."sourceType" = ${FIRST_SMS_SOURCE_TYPE}
         AND dispatch."channel"::text = 'SMS'
-      ORDER BY
-        (dispatch."status"::text = 'CANCELLED') ASC,
-        dispatch."createdAt" DESC
-      LIMIT 1
+      ORDER BY (dispatch."status"::text = 'CANCELLED') ASC, dispatch."createdAt" DESC LIMIT 1
     ) first_sms ON TRUE
     LEFT JOIN LATERAL (
-      SELECT
-        dispatch."status",
-        dispatch."createdAt",
-        dispatch."updatedAt",
-        dispatch."scheduledFor",
-        dispatch."processedAt",
-        dispatch."sentAt",
-        dispatch."failedAt",
-        dispatch."cancelledAt",
-        dispatch."failureReason"
-      FROM "NotificationDispatch" dispatch
-      WHERE dispatch."sourceId" = lead."id"
-        AND dispatch."sourceType" = ${FINAL_SMS_SOURCE_TYPE}
+      SELECT dispatch.* FROM "NotificationDispatch" dispatch
+      WHERE dispatch."sourceId" = lead."id" AND dispatch."sourceType" = ${FINAL_SMS_SOURCE_TYPE}
         AND dispatch."channel"::text = 'SMS'
-      ORDER BY
-        (dispatch."status"::text = 'CANCELLED') ASC,
-        dispatch."createdAt" DESC
-      LIMIT 1
+      ORDER BY (dispatch."status"::text = 'CANCELLED') ASC, dispatch."createdAt" DESC LIMIT 1
     ) final_sms ON TRUE
     WHERE lead."interestType"::text = 'TEAM'
-    ORDER BY lead."createdAt" DESC
-    LIMIT 1000
+    ORDER BY lead."createdAt" DESC LIMIT 1000
   `);
-
+  const evidenceByLead = await loadLeadCommunicationEvidence(rows.map((row) => row.leadId));
   const now = new Date();
   const statuses: Record<string, TeamLeadSmsStatus> = {};
-
   for (const row of rows) {
-    statuses[row.leadId] = buildStatus(row, now);
+    const evidence = evidenceByLead.get(row.leadId) ?? emptyLeadEvidence();
+    const state = leadReplyState(evidence, row.latestRelevantEmailSentAt);
+    const status = buildStatus({ ...row, latestInboundAt: evidence.automationHoldAt, replyReviewRequired: state === "review" }, now);
+    if (state === "received" && evidence.latestReply) status.lines.push({
+      text: `Incoming ${evidence.latestReply.channel} · ${formatDateTime(evidence.latestReply.occurredAt)} (UK) — view reply on lead`,
+      tone: "success", title: evidence.latestReply.body.slice(0, 300), href: leadReplyHref(row.leadId), linkText: "View reply",
+    });
+    if (state === "review") status.lines.push({
+      text: "Reply record needs checking — chase remains paused; open lead to review",
+      tone: "warning", href: leadReplyHref(row.leadId), linkText: "Review reply record",
+    });
+    statuses[row.leadId] = status;
   }
-
-  return NextResponse.json(
-    { ok: true, statuses },
-    {
-      headers: {
-        "Cache-Control": "private, no-store, max-age=0",
-      },
-    },
-  );
+  return NextResponse.json({ ok: true, statuses }, { headers: { "Cache-Control": "private, no-store, max-age=0" } });
 }

--- a/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
+++ b/src/components/admin/leads/LeadConfirmationQuickSendButton.tsx
@@ -6,20 +6,13 @@
 
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import LeadSmsStatusLines, { type LeadSmsStatusLine } from "@/components/admin/leads/LeadSmsStatusLines";
 
 import { sendTeamCommitmentEmailAction } from "@/app/(admin)/admin/leads/team-commitment-email-actions";
 import { sendLeadReassuranceEmailAction } from "@/app/(admin)/admin/leads/reassurance-email-actions";
 
-type SmsStatusTone = "muted" | "info" | "success" | "warning" | "danger";
-
-type SmsStatusLine = {
-  text: string;
-  tone: SmsStatusTone;
-  title?: string | null;
-};
-
 type TeamLeadSmsStatus = {
-  lines: SmsStatusLine[];
+  lines: LeadSmsStatusLine[];
 };
 
 type TeamLeadSmsStatusResponse = {
@@ -28,11 +21,13 @@ type TeamLeadSmsStatusResponse = {
 };
 
 let sharedStatusRequest: Promise<Record<string, TeamLeadSmsStatus>> | null = null;
+let sharedStatusRequestedAt = 0;
 
 async function loadTeamLeadSmsStatuses(force = false) {
-  if (force) sharedStatusRequest = null;
+  if (force || Date.now() - sharedStatusRequestedAt > 30_000) sharedStatusRequest = null;
 
   if (!sharedStatusRequest) {
+    sharedStatusRequestedAt = Date.now();
     sharedStatusRequest = fetch("/api/admin/leads/team-confirmation-sms-status", {
       cache: "no-store",
       credentials: "same-origin",
@@ -56,14 +51,6 @@ async function loadTeamLeadSmsStatuses(force = false) {
   }
 
   return sharedStatusRequest;
-}
-
-function statusToneClass(tone: SmsStatusTone) {
-  if (tone === "success") return "text-emerald-200/90";
-  if (tone === "danger") return "text-rose-200/90";
-  if (tone === "warning") return "text-amber-200/90";
-  if (tone === "info") return "text-sky-200/85";
-  return "text-white/45";
 }
 
 export default function LeadConfirmationQuickSendButton({
@@ -225,17 +212,8 @@ export default function LeadConfirmationQuickSendButton({
           <div className="text-[9px] font-bold uppercase tracking-[0.16em] text-white/35">
             Automatic SMS
           </div>
-          <div className="mt-1 space-y-0.5 text-[11px] leading-4">
-            {smsStatus.lines.map((line, index) => (
-              <div
-                key={`${line.text}-${index}`}
-                className={statusToneClass(line.tone)}
-                title={line.title || undefined}
-              >
-                {line.text}
-              </div>
-            ))}
-          </div>
+          <LeadSmsStatusLines lines={smsStatus.lines} />
+          {smsStatusFailed ? <p className="mt-2 text-[11px] text-amber-100">Refresh failed; these details may be out of date.</p> : null}
         </div>
       ) : smsStatusFailed ? (
         <div className="max-w-[190px] text-right text-[11px] leading-4 text-amber-200/70">
@@ -243,6 +221,7 @@ export default function LeadConfirmationQuickSendButton({
           <div className="text-white/35">This does not mean SMS is disabled.</div>
         </div>
       ) : null}
+      <button type="button" onClick={() => void refreshSmsStatus(true)} disabled={pending} className="rounded px-2 py-1 text-[11px] text-white/60 underline underline-offset-4 hover:text-white">Refresh status</button>
     </div>
   );
 }

--- a/src/components/admin/leads/LeadReplyEvidence.tsx
+++ b/src/components/admin/leads/LeadReplyEvidence.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import EmailHtmlPreview from "@/components/admin/email/EmailHtmlPreview";
+import { leadConversationHref, type LeadCommunicationEvidence } from "@/lib/leads/communication-evidence";
+
+function when(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: "Europe/London",
+  }).format(value);
+}
+export default function LeadReplyEvidence({ evidence }: { evidence: LeadCommunicationEvidence }) {
+  const reply = evidence.latestReply;
+  if (!reply && !evidence.reviewAt) return null;
+  return (
+    <section id="lead-reply-evidence" className="scroll-mt-6 space-y-4 rounded-3xl border border-emerald-400/25 bg-emerald-500/[0.07] p-5 sm:p-6">
+      {reply ? <>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Latest incoming reply</h2>
+            <p className="mt-2 text-sm text-emerald-100">{reply.channel} · INBOUND · {when(reply.occurredAt)} (UK)</p>
+            <p className="mt-1 break-all text-xs text-white/65">From {reply.from}</p>
+          </div>
+          <Link href={leadConversationHref(reply.threadId)} className="rounded-xl border border-emerald-400/30 bg-emerald-500/15 px-4 py-2.5 text-sm font-semibold text-emerald-100">View conversation</Link>
+        </div>
+        {reply.subject ? <p className="font-semibold text-white">{reply.subject}</p> : null}
+        {reply.body.trim() ? <blockquote className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-2xl bg-black/25 p-4 text-sm leading-6 text-white/90">{reply.body}</blockquote>
+          : reply.htmlBody ? <EmailHtmlPreview html={reply.htmlBody} /> : null}
+        <p className="text-xs leading-5 text-white/60">This is an incoming message, not a delivery receipt or confirmation of a team place. Opening this page does not send a message or restart the chase.</p>
+      </> : null}
+      {evidence.reviewAt ? <div className="space-y-2 rounded-2xl border border-amber-400/25 bg-amber-500/10 p-4 text-sm text-amber-100">
+        <h3 className="font-semibold">Reply record needs checking</h3>
+        <p>There is an incoming timestamp or linked conversation that cannot be verified against a message from this lead. It is not proof that they replied. Any existing automatic chase hold is preserved.</p>
+        <p className="text-xs">Record dated {when(evidence.reviewAt)} (UK).</p>
+        <div className="flex flex-wrap gap-3">{evidence.reviewThreadIds.map((id, index) => <Link key={id} href={leadConversationHref(id)} className="underline underline-offset-4">Review linked conversation{evidence.reviewThreadIds.length > 1 ? ` ${index + 1}` : ""}</Link>)}</div>
+      </div> : null}
+    </section>
+  );
+}

--- a/src/components/admin/leads/LeadSmsStatusLines.tsx
+++ b/src/components/admin/leads/LeadSmsStatusLines.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export type LeadSmsStatusLine = {
+  text: string; tone: "muted" | "info" | "success" | "warning" | "danger";
+  title?: string | null; href?: string; linkText?: string;
+};
+function toneClass(tone: LeadSmsStatusLine["tone"]) {
+  if (tone === "success") return "text-emerald-200/90";
+  if (tone === "danger") return "text-rose-200/90";
+  if (tone === "warning") return "text-amber-200/90";
+  if (tone === "info") return "text-sky-200/85";
+  return "text-white/45";
+}
+export default function LeadSmsStatusLines({ lines }: { lines: LeadSmsStatusLine[] }) {
+  return <div className="mt-1 space-y-1 text-[11px] leading-4">{lines.map((line, index) => (
+    <div key={`${line.text}-${index}`} className={toneClass(line.tone)} title={line.title || undefined}>
+      <div>{line.text}</div>
+      {line.href?.startsWith("/admin/leads/") ? <Link href={line.href} className="mt-1 inline-flex rounded px-1 py-1 font-semibold underline underline-offset-4 hover:bg-white/10">{line.linkText || "View reply"}</Link> : null}
+    </div>
+  ))}</div>;
+}

--- a/src/lib/leads/communication-evidence.ts
+++ b/src/lib/leads/communication-evidence.ts
@@ -1,0 +1,135 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { normalizePhoneNumber } from "@/lib/messaging/phone";
+
+export type LeadReply = {
+  id: string; threadId: string; channel: string; occurredAt: Date;
+  subject: string | null; body: string; htmlBody: string | null; from: string;
+};
+export type LeadCommunicationEvidence = {
+  threadIds: string[];
+  reviewThreadIds: string[];
+  latestReply: LeadReply | null;
+  reviewAt: Date | null;
+  // A historical timestamp is a conservative hold, never proof of a reply.
+  // Reading/fixing history must not restart a stopped chase.
+  automationHoldAt: Date | null;
+};
+export type LeadCommunicationRow = {
+  leadId: string; leadEmail: string | null; leadPhone: string | null;
+  threadId: string; sourceType: string | null; sourceId: string | null; teamId: string | null;
+  recipientSourceType: string | null; recipientSourceId: string | null;
+  recipientEmail: string | null; recipientPhone: string | null;
+  cachedInboundAt: Date | null;
+  messageId: string | null; direction: string | null; participantRole: string | null;
+  channel: string | null; receivedAt: Date | null; messageCreatedAt: Date | null;
+  subject: string | null; body: string | null; htmlBody: string | null;
+  fromEmail: string | null; fromNumber: string | null;
+};
+const genericSources = new Set(["", "GENERAL", "MESSAGE_THREAD", "INBOUND_SMS", "INBOUND_EMAIL"]);
+const email = (value: string | null) => value?.trim().toLowerCase() || null;
+const newer = (a: Date | null, b: Date | null) => !a ? b : !b ? a : a > b ? a : b;
+export const emptyLeadEvidence = (): LeadCommunicationEvidence => ({
+  threadIds: [], reviewThreadIds: [], latestReply: null, reviewAt: null, automationHoldAt: null,
+});
+
+/** Explicit lead/recipient ownership only; never join different people by a shared contact address. */
+export function isLeadOwnedConversation(row: LeadCommunicationRow) {
+  const source = row.sourceType || "";
+  const recipientOwned = row.recipientSourceType === "LEAD" && row.recipientSourceId === row.leadId;
+  const conflictingLead = row.recipientSourceType === "LEAD" && row.recipientSourceId !== row.leadId;
+  if (row.teamId || conflictingLead) return false;
+  if (row.sourceId === row.leadId && (source === "LEAD" || source.startsWith("LEAD_"))) return true;
+  return recipientOwned && genericSources.has(source);
+}
+
+export function summariseLeadCommunications(leadIds: string[], rows: LeadCommunicationRow[]) {
+  const result = new Map(leadIds.map((id) => [id, emptyLeadEvidence()]));
+  for (const row of rows) {
+    const evidence = result.get(row.leadId);
+    if (!evidence) continue;
+    const owned = isLeadOwnedConversation(row);
+    if (owned && !evidence.threadIds.includes(row.threadId)) evidence.threadIds.push(row.threadId);
+    const occurredAt = row.receivedAt ?? row.messageCreatedAt;
+    const actualInbound = Boolean(row.messageId && row.direction === "INBOUND" && row.participantRole !== "SYSTEM");
+    const recipientOwned = row.recipientSourceType === "LEAD" && row.recipientSourceId === row.leadId;
+    const senderMatches = row.channel === "SMS"
+      ? Boolean(normalizePhoneNumber(row.fromNumber) && [row.leadPhone, recipientOwned ? row.recipientPhone : null]
+          .some((value) => value && normalizePhoneNumber(value) === normalizePhoneNumber(row.fromNumber)))
+      : row.channel === "EMAIL" && Boolean(email(row.fromEmail) && [row.leadEmail, recipientOwned ? row.recipientEmail : null]
+          .some((value) => value && email(value) === email(row.fromEmail)));
+    const hasContent = Boolean(row.body?.trim() || row.htmlBody?.trim());
+    const verified = owned && actualInbound && senderMatches && occurredAt && hasContent;
+    evidence.automationHoldAt = newer(evidence.automationHoldAt, row.cachedInboundAt);
+    if (actualInbound) evidence.automationHoldAt = newer(evidence.automationHoldAt, occurredAt);
+    if (verified && (!evidence.latestReply || occurredAt > evidence.latestReply.occurredAt)) {
+      evidence.latestReply = {
+        id: row.messageId!, threadId: row.threadId, channel: row.channel!, occurredAt,
+        subject: row.subject, body: row.body || "", htmlBody: row.htmlBody,
+        from: (row.channel === "SMS" ? row.fromNumber : row.fromEmail) || "",
+      };
+    }
+    // Small write-time differences are harmless; an unsupported newer timestamp is not.
+    const unsupportedCache = row.cachedInboundAt && (!verified || row.cachedInboundAt.getTime() > occurredAt!.getTime() + 1000);
+    const reviewAt = newer(unsupportedCache ? row.cachedInboundAt : null, actualInbound && !verified ? occurredAt : null);
+    if (reviewAt) {
+      evidence.reviewAt = newer(evidence.reviewAt, reviewAt);
+      if (!evidence.reviewThreadIds.includes(row.threadId)) evidence.reviewThreadIds.push(row.threadId);
+    }
+  }
+  return result;
+}
+
+export function leadReplyState(evidence: LeadCommunicationEvidence, since: Date | null): "none" | "received" | "review" {
+  if (!since) return "none";
+  if (evidence.reviewAt && evidence.reviewAt >= since &&
+      (!evidence.latestReply || evidence.reviewAt.getTime() > evidence.latestReply.occurredAt.getTime() + 1000)) return "review";
+  if (evidence.latestReply && evidence.latestReply.occurredAt >= since) return "received";
+  return evidence.automationHoldAt && evidence.automationHoldAt >= since ? "review" : "none";
+}
+export function leadConversationHref(threadId: string) {
+  return `/admin/messaging?filter=all&thread=${encodeURIComponent(threadId)}`;
+}
+export function leadReplyHref(leadId: string) {
+  return `/admin/leads/${encodeURIComponent(leadId)}#lead-reply-evidence`;
+}
+
+/** Shared READ-ONLY resolver for the lead timeline, SMS status and reminder job.
+ * Includes archived and legacy automation threads, regardless of the inbox's 100-row window.
+ * Fetch the last real inbound entry independently of later outbound messages.
+ * No historical thread is rewritten, requeued, reassigned or marked read here.
+ */
+export async function loadLeadCommunicationEvidence(
+  leadIds: string[], db: Pick<Prisma.TransactionClient, "$queryRaw"> = prisma,
+) {
+  const ids = [...new Set(leadIds.filter(Boolean))];
+  if (!ids.length) return new Map<string, LeadCommunicationEvidence>();
+  const rows = await db.$queryRaw<LeadCommunicationRow[]>(Prisma.sql`
+    SELECT lead."id" AS "leadId", lead."email" AS "leadEmail", lead."phone" AS "leadPhone",
+      thread."id" AS "threadId", thread."sourceType", thread."sourceId", thread."teamId",
+      recipient."sourceType"::text AS "recipientSourceType", recipient."sourceId" AS "recipientSourceId",
+      recipient."email" AS "recipientEmail", recipient."phone" AS "recipientPhone",
+      thread."latestInboundAt" AS "cachedInboundAt",
+      inbound."id" AS "messageId", inbound."direction"::text, inbound."participantRole"::text,
+      inbound."channel"::text, inbound."receivedAt", inbound."createdAt" AS "messageCreatedAt",
+      inbound."subject", COALESCE(NULLIF(inbound."textBody", ''), inbound."body") AS "body",
+      inbound."htmlBody", inbound."fromEmail", inbound."fromNumber"
+    FROM "InterestLead" lead
+    JOIN "MessageThread" thread ON (
+      thread."sourceId" = lead."id" OR thread."recipientId" IN (
+        SELECT r."id" FROM "NotificationRecipient" r
+        WHERE r."sourceType"::text = 'LEAD' AND r."sourceId" = lead."id"
+      )
+    )
+    LEFT JOIN "NotificationRecipient" recipient ON recipient."id" = thread."recipientId"
+    LEFT JOIN LATERAL (
+      SELECT message.* FROM "MessageEntry" message
+      WHERE message."threadId" = thread."id" AND message."direction"::text = 'INBOUND'
+      ORDER BY COALESCE(message."receivedAt", message."createdAt") DESC, message."id" DESC
+      LIMIT 1
+    ) inbound ON TRUE
+    WHERE lead."id" IN (${Prisma.join(ids)})
+    ORDER BY thread."id"
+  `);
+  return summariseLeadCommunications(ids, rows);
+}

--- a/src/lib/leads/team-confirmation-sms-reminders.ts
+++ b/src/lib/leads/team-confirmation-sms-reminders.ts
@@ -7,6 +7,7 @@ import {
 
 import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
 import { getTeamPlaceConfirmationUrl } from "@/lib/leads/teamPlaceConfirmation";
+import { loadLeadCommunicationEvidence } from "@/lib/leads/communication-evidence";
 import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
 import { queueNotificationFromTemplate } from "@/lib/notifications/service";
 import { prisma } from "@/lib/prisma";
@@ -88,7 +89,7 @@ function hasRepliedSinceLatestEmail(lead: AwaitingTeamLeadDecisionRow) {
 }
 
 async function getAwaitingTeamLeadDecisions() {
-  return prisma.$queryRaw<AwaitingTeamLeadDecisionRow[]>(Prisma.sql`
+  const rows = await prisma.$queryRaw<AwaitingTeamLeadDecisionRow[]>(Prisma.sql`
     SELECT
       lead."id" AS "leadId",
       lead."contactName",
@@ -116,20 +117,7 @@ async function getAwaitingTeamLeadDecisions() {
           AND dispatch."createdAt" >=
             COALESCE(confirmation."sentAt", confirmation."createdAt") - INTERVAL '5 minutes'
       ) AS "latestRelevantEmailSentAt",
-      (
-        SELECT MAX(thread."latestInboundAt")
-        FROM "MessageThread" thread
-        WHERE thread."latestInboundAt" IS NOT NULL
-          AND (
-            thread."sourceId" = lead."id"
-            OR thread."recipientId" IN (
-              SELECT recipient."id"
-              FROM "NotificationRecipient" recipient
-              WHERE recipient."sourceType"::text = 'LEAD'
-                AND recipient."sourceId" = lead."id"
-            )
-          )
-      ) AS "latestInboundAt",
+      NULL::timestamp AS "latestInboundAt",
       (
         SELECT MAX(dispatch."createdAt")
         FROM "NotificationDispatch" dispatch
@@ -168,6 +156,10 @@ async function getAwaitingTeamLeadDecisions() {
     ORDER BY confirmation."sentAt" ASC NULLS LAST
     LIMIT 500
   `);
+  const evidence = await loadLeadCommunicationEvidence(rows.map((row) => row.leadId));
+  // Share the timeline/status scope, retaining unsupported historical holds for review.
+  // Never turn a missing/ambiguous message into permission to restart a chase.
+  return rows.map((row) => ({ ...row, latestInboundAt: evidence.get(row.leadId)?.automationHoldAt ?? null }));
 }
 
 async function queueTeamLeadSms(input: {
@@ -307,8 +299,8 @@ export async function runTeamLeadConfirmationSmsReminderJob(): Promise<TeamLeadC
       continue;
     }
 
-    // Any inbound email or SMS received after the latest relevant email counts
-    // as a reply. A later newly-sent decision email can begin the clock again.
+    // Real replies and unresolved historical reply records both retain the hold.
+    // The admin status distinguishes proven replies from records needing review.
     if (hasRepliedSinceLatestEmail(lead)) {
       summary.skippedReplied += 1;
       continue;

--- a/tests/lead-communication-evidence.test.cjs
+++ b/tests/lead-communication-evidence.test.cjs
@@ -1,0 +1,246 @@
+const assert = require('node:assert/strict');
+const { test, before, after, beforeEach } = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+const { randomUUID } = require('node:crypto');
+const ts = require('typescript');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const { PrismaClient, Prisma } = require('@prisma/client');
+
+const rawUrl = process.env.LEAD_EVIDENCE_TEST_DATABASE_URL;
+if (!rawUrl) throw new Error('An isolated local test database is required');
+const url = new URL(rawUrl);
+if (!['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname)) throw new Error('Tests only run on localhost, never production');
+const schema = `lead_evidence_${randomUUID().replaceAll('-', '')}`;
+const rootDb = new PrismaClient({ datasources: { db: { url: rawUrl } } });
+url.searchParams.set('schema', schema);
+const db = new PrismaClient({ datasources: { db: { url: url.toString() } } });
+const root = path.resolve(__dirname, '..');
+function loadTs(file, replacements = {}) {
+  const filename = path.join(root, file);
+  const compiled = ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true }, fileName: filename,
+  }).outputText;
+  const instance = new Module(filename, module);
+  instance.filename = filename;
+  instance.paths = Module._nodeModulePaths(path.dirname(filename));
+  const native = instance.require.bind(instance);
+  instance.require = (name) => Object.hasOwn(replacements, name) ? replacements[name] : native(name);
+  instance._compile(compiled, filename);
+  return instance.exports;
+}
+const phone = loadTs('src/lib/messaging/phone.ts');
+const evidenceLib = loadTs('src/lib/leads/communication-evidence.ts', {
+  '@/lib/prisma': { prisma: db }, '@/lib/messaging/phone': phone,
+});
+const { loadLeadCommunicationEvidence, leadReplyState, leadConversationHref, emptyLeadEvidence } = evidenceLib;
+const at = new Date('2026-09-03T10:00:00Z');
+const beforeReply = new Date('2026-09-01T10:00:00Z');
+const later = new Date('2026-09-04T10:00:00Z');
+
+before(async () => {
+  await rootDb.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`);
+  const ddl = [
+    'CREATE TABLE "InterestLead" ("id" TEXT PRIMARY KEY, "email" TEXT, "phone" TEXT)',
+    'CREATE TABLE "NotificationRecipient" ("id" TEXT PRIMARY KEY, "sourceType" TEXT, "sourceId" TEXT, "email" TEXT, "phone" TEXT)',
+    'CREATE TABLE "MessageThread" ("id" TEXT PRIMARY KEY, "sourceType" TEXT, "sourceId" TEXT, "teamId" TEXT, "recipientId" TEXT, "latestInboundAt" TIMESTAMP(3), "status" TEXT DEFAULT \'OPEN\')',
+    'CREATE TABLE "MessageEntry" ("id" TEXT PRIMARY KEY, "threadId" TEXT NOT NULL, "direction" TEXT, "participantRole" TEXT, "channel" TEXT, "receivedAt" TIMESTAMP(3), "createdAt" TIMESTAMP(3), "subject" TEXT, "textBody" TEXT, "body" TEXT, "htmlBody" TEXT, "fromEmail" TEXT, "fromNumber" TEXT)',
+  ];
+  for (const sql of ddl) await db.$executeRawUnsafe(sql);
+});
+after(async () => {
+  await db.$disconnect();
+  await rootDb.$executeRawUnsafe(`DROP SCHEMA "${schema}" CASCADE`);
+  await rootDb.$disconnect();
+});
+beforeEach(async () => {
+  await db.$executeRawUnsafe('TRUNCATE "MessageEntry", "MessageThread", "NotificationRecipient", "InterestLead"');
+  await db.$executeRaw`INSERT INTO "InterestLead" VALUES ('lead-a', 'alex@example.test', '07700 900123'), ('lead-b', 'other@example.test', '07700 900123')`;
+  await db.$executeRaw`INSERT INTO "NotificationRecipient" VALUES ('recipient-a', 'LEAD', 'lead-a', 'alex@example.test', '+447700900123'), ('recipient-b', 'LEAD', 'lead-b', 'other@example.test', '+447700900123')`;
+});
+async function thread(overrides = {}) {
+  const row = { id: 'legacy', sourceType: 'LEAD_TEAM_CONFIRMATION_SMS_NUDGE_1', sourceId: 'lead-a', teamId: null, recipientId: 'recipient-a', latestInboundAt: at, status: 'ARCHIVED', ...overrides };
+  await db.$executeRaw`INSERT INTO "MessageThread" ("id", "sourceType", "sourceId", "teamId", "recipientId", "latestInboundAt", "status") VALUES (${row.id}, ${row.sourceType}, ${row.sourceId}, ${row.teamId}, ${row.recipientId}, ${row.latestInboundAt}, ${row.status})`;
+}
+async function message(overrides = {}) {
+  const row = { id: 'incoming-a', threadId: 'legacy', direction: 'INBOUND', participantRole: 'CONTACT', channel: 'SMS', receivedAt: at, createdAt: at, subject: null, textBody: 'Where do we play, and what is the team fee?', body: '', htmlBody: null, fromEmail: null, fromNumber: '+447700900123', ...overrides };
+  await db.$executeRaw`INSERT INTO "MessageEntry" ("id", "threadId", "direction", "participantRole", "channel", "receivedAt", "createdAt", "subject", "textBody", "body", "htmlBody", "fromEmail", "fromNumber") VALUES (${row.id}, ${row.threadId}, ${row.direction}, ${row.participantRole}, ${row.channel}, ${row.receivedAt}, ${row.createdAt}, ${row.subject}, ${row.textBody}, ${row.body}, ${row.htmlBody}, ${row.fromEmail}, ${row.fromNumber})`;
+}
+async function read() { return (await loadLeadCommunicationEvidence(['lead-a'], db)).get('lead-a'); }
+async function fixture() { await thread(); await message(); }
+
+test('legacy automation reply is visible even after newer outbound messages and archiving', async () => {
+  await fixture();
+  await message({ id: 'new-outbound', direction: 'OUTBOUND', receivedAt: null, createdAt: later, textBody: 'This is our outgoing chase, not their reply.' });
+  const result = await read();
+  assert.deepEqual(result.threadIds, ['legacy']);
+  assert.equal(result.latestReply.id, 'incoming-a');
+  assert.equal(result.latestReply.body, 'Where do we play, and what is the team fee?');
+  assert.equal(result.latestReply.occurredAt.toISOString(), at.toISOString());
+  assert.equal(leadReplyState(result, beforeReply), 'received');
+  assert.equal(result.reviewAt, null);
+});
+test('recipient-linked generic conversation resolves even without a lead source ID', async () => {
+  await thread({ sourceType: 'GENERAL', sourceId: null }); await message();
+  assert.equal((await read()).latestReply.id, 'incoming-a');
+});
+test('outbound sent text alone never proves a reply', async () => {
+  await thread({ latestInboundAt: null }); await message({ direction: 'OUTBOUND', receivedAt: null });
+  const result = await read();
+  assert.equal(result.latestReply, null); assert.equal(result.automationHoldAt, null); assert.equal(leadReplyState(result, beforeReply), 'none');
+});
+test('orphan incoming timestamp is review-only and cannot restart the chase', async () => {
+  await thread(); const result = await read();
+  assert.equal(result.latestReply, null); assert.equal(leadReplyState(result, beforeReply), 'review');
+  assert.equal(result.automationHoldAt.toISOString(), at.toISOString()); assert.deepEqual(result.reviewThreadIds, ['legacy']);
+});
+test('unsupported newer timestamp retains hold without claiming another reply', async () => {
+  await thread({ latestInboundAt: later }); await message(); const result = await read();
+  assert.equal(leadReplyState(result, beforeReply), 'review');
+  assert.equal(result.latestReply.occurredAt.toISOString(), at.toISOString());
+  assert.equal(result.automationHoldAt.toISOString(), later.toISOString());
+});
+test('a real reply is found even when denormalized timestamp is absent', async () => {
+  await thread({ latestInboundAt: null }); await message(); assert.equal(leadReplyState(await read(), beforeReply), 'received');
+});
+test('shared phone does not pull in another lead conversation', async () => {
+  await thread({ sourceId: 'lead-b', recipientId: 'recipient-b' }); await message();
+  assert.deepEqual(await read(), emptyLeadEvidence());
+});
+test('conflicting lead binding is review-only, not merged or presented as this lead reply', async () => {
+  await thread({ sourceType: 'LEAD', sourceId: 'lead-b' }); await message(); const result = await read();
+  assert.deepEqual(result.threadIds, []); assert.equal(result.latestReply, null); assert.equal(leadReplyState(result, beforeReply), 'review');
+});
+test('another team conversation cannot be accepted merely through the recipient record', async () => {
+  await thread({ sourceType: 'TEAM', sourceId: 'team-b', teamId: 'team-b' }); await message();
+  assert.equal((await read()).latestReply, null); assert.deepEqual((await read()).threadIds, []);
+});
+test('wrong sender or empty message cannot substantiate reply received', async () => {
+  await thread(); await message({ fromNumber: '+447700900999' });
+  assert.equal(leadReplyState(await read(), beforeReply), 'review');
+  await db.$executeRaw`UPDATE "MessageEntry" SET "fromNumber" = '+447700900123', "textBody" = '', "body" = ''`;
+  assert.equal(leadReplyState(await read(), beforeReply), 'review');
+});
+test('actual email reply accepts normalized sender and uses received time', async () => {
+  await thread({ sourceType: 'LEAD_REASSURANCE_EMAIL' });
+  await message({ channel: 'EMAIL', fromNumber: null, fromEmail: ' ALEX@EXAMPLE.TEST ', subject: 'Re: league', receivedAt: at, createdAt: beforeReply });
+  const result = await read(); assert.equal(result.latestReply.channel, 'EMAIL'); assert.equal(leadReplyState(result, beforeReply), 'received');
+});
+test('historical owned recipient contact supports a changed lead email', async () => {
+  await thread(); await message({ channel: 'EMAIL', fromNumber: null, fromEmail: 'alex@example.test' });
+  await db.$executeRaw`UPDATE "InterestLead" SET "email" = 'new@example.test' WHERE "id" = 'lead-a'`;
+  assert.equal(leadReplyState(await read(), beforeReply), 'received');
+});
+test('system entry and old reply cannot masquerade as a new contact reply', async () => {
+  await fixture(); assert.equal(leadReplyState(await read(), later), 'none');
+  await db.$executeRaw`UPDATE "MessageEntry" SET "participantRole" = 'SYSTEM'`;
+  assert.equal((await read()).latestReply, null); assert.equal(leadReplyState(await read(), beforeReply), 'review');
+});
+test('reply lookup is not limited by the inbox or timeline page sizes', async () => {
+  await fixture();
+  await db.$executeRaw`INSERT INTO "MessageEntry" ("id", "threadId", "direction", "participantRole", "channel", "createdAt", "body") SELECT 'out-' || n, 'legacy', 'OUTBOUND', 'SYSTEM', 'SMS', ${later}, 'sent reminder' FROM generate_series(1,150) n`;
+  assert.equal((await read()).latestReply.id, 'incoming-a');
+});
+test('resolver is read only and deduplicates repeated lead IDs', async () => {
+  await fixture();
+  const snapshot = async () => JSON.stringify(await db.$queryRaw`SELECT (SELECT jsonb_agg(t) FROM "MessageThread" t) AS threads, (SELECT jsonb_agg(m) FROM "MessageEntry" m) AS messages`);
+  const initial = await snapshot(); const result = await loadLeadCommunicationEvidence(['lead-a', 'lead-a'], db);
+  assert.equal(result.size, 1); assert.equal(await snapshot(), initial);
+});
+
+const Anchor = ({ href, children, ...rest }) => React.createElement('a', { ...rest, href }, children);
+const Preview = ({ html }) => React.createElement('iframe', { sandbox: '', srcDoc: html });
+const ReplyPanel = loadTs('src/components/admin/leads/LeadReplyEvidence.tsx', {
+  'next/link': { default: Anchor, __esModule: true },
+  '@/components/admin/email/EmailHtmlPreview': { default: Preview, __esModule: true },
+  '@/lib/leads/communication-evidence': evidenceLib,
+}).default;
+test('native reply panel shows message, direction, UK time and direct archived conversation link', async () => {
+  await fixture(); const html = renderToStaticMarkup(React.createElement(ReplyPanel, { evidence: await read() }));
+  assert.match(html, /Latest incoming reply/); assert.match(html, /Where do we play/); assert.match(html, /INBOUND/);
+  assert.match(html, /03 Sept? 2026/); assert.match(html, /11:00/);
+  assert.match(html, /filter=all&amp;thread=legacy/); assert.match(html, /View conversation/);
+});
+test('review panel does not invent an incoming reply or delivery evidence', async () => {
+  await thread(); const html = renderToStaticMarkup(React.createElement(ReplyPanel, { evidence: await read() }));
+  assert.match(html, /Reply record needs checking/); assert.doesNotMatch(html, /Latest incoming reply/);
+  assert.match(html, /hold is preserved/); assert.match(html, /Review linked conversation/);
+});
+test('reply text and conversation IDs are escaped rather than executed', async () => {
+  await thread(); await message({ textBody: '<script>alert(1)</script>' });
+  const html = renderToStaticMarkup(React.createElement(ReplyPanel, { evidence: await read() }));
+  assert.doesNotMatch(html, /<script>/); assert.match(html, /&lt;script&gt;/);
+  assert.equal(leadConversationHref('a&other=1'), '/admin/messaging?filter=all&thread=a%26other%3D1');
+});
+function statusRow() {
+  const row = { leadId: 'lead-a', phone: '07700900123', leadStatus: 'CONTACTED', convertedTeamId: null, confirmationStatus: 'PENDING', latestRelevantEmailSentAt: beforeReply, latestInboundAt: null };
+  for (const stage of ['first', 'final']) for (const field of ['Status','CreatedAt','UpdatedAt','ScheduledFor','ProcessedAt','SentAt','FailedAt','CancelledAt','FailureReason']) row[stage + field] = null;
+  return row;
+}
+function statusModule(guard = async () => {}) {
+  const runtimeDb = { $queryRaw: (query) => query.sql.includes('JOIN "LeadTeamConfirmation"') ? Promise.resolve([statusRow()]) : db.$queryRaw(query) };
+  return loadTs('src/app/api/admin/leads/team-confirmation-sms-status/route.ts', {
+    'next/server': { NextResponse: { json: (body, options) => Response.json(body, options) } },
+    '@/lib/prisma': { prisma: runtimeDb }, '@/lib/requireAdmin': { requireAdmin: guard },
+    '@/lib/leads/communication-evidence': evidenceLib,
+  });
+}
+test('actual status endpoint returns evidence date and view-reply link', async () => {
+  await fixture(); const response = await statusModule().GET(); const payload = await response.json();
+  assert.match(JSON.stringify(payload), /reply received/); assert.match(JSON.stringify(payload), /Incoming SMS/);
+  assert.ok(payload.statuses['lead-a'].lines.some((line) => line.href === '/admin/leads/lead-a#lead-reply-evidence'));
+  assert.match(response.headers.get('cache-control'), /private, no-store/);
+});
+test('actual status endpoint labels orphan timestamp for review instead of reply received', async () => {
+  await thread(); const payload = await (await statusModule().GET()).json();
+  assert.match(JSON.stringify(payload), /reply record needs checking/); assert.doesNotMatch(JSON.stringify(payload), /reply received/);
+});
+test('status endpoint requires admin before querying history', async () => {
+  await assert.rejects(statusModule(async () => { throw new Error('admin required'); }).GET(), /admin required/);
+});
+test('actual reminder job retains orphan and real-reply holds without sending', async () => {
+  await thread();
+  const runtimeDb = { $queryRaw: async () => [{ ...statusRow(), contactName: 'Alex Example', teamName: 'Example FC', effectiveLeagueId: 'league-a', leagueName: 'Example league', leagueSeason: null, firstSmsCreatedAt: null, firstSmsSentAt: null, finalSmsCreatedAt: null }] };
+  const unexpectedSend = () => { throw new Error('The test must not reach any message queue or write'); };
+  const job = loadTs('src/lib/leads/team-confirmation-sms-reminders.ts', {
+    '@/lib/prisma': { prisma: runtimeDb }, '@/lib/leads/communication-evidence': evidenceLib,
+    '@/lib/communications/log-dispatch': { logNotificationDispatchToThread: unexpectedSend },
+    '@/lib/leads/teamPlaceConfirmation': { getTeamPlaceConfirmationUrl: unexpectedSend },
+    '@/lib/notifications/recipients': { upsertNotificationRecipient: unexpectedSend },
+    '@/lib/notifications/service': { queueNotificationFromTemplate: unexpectedSend },
+  });
+  for (const hasMessage of [false, true]) {
+    if (hasMessage) await message(); const result = await job.runTeamLeadConfirmationSmsReminderJob();
+    assert.equal(result.skippedReplied, 1); assert.equal(result.firstSmsQueued, 0); assert.equal(result.finalSmsQueued, 0); assert.deepEqual(result.errors, []);
+  }
+});
+test('prepared lead layout requests the shared thread IDs and shows reply before email history', async () => {
+  await fixture(); let requested;
+  const layout = loadTs('src/app/(admin)/admin/leads/[id]/layout.tsx', {
+    'next/link': { default: Anchor, __esModule: true },
+    '@/components/admin/email/EmailHtmlPreview': { default: Preview, __esModule: true },
+    '@/components/admin/communications/CommunicationStatusBadge': { default: () => null, CommunicationStatusExplanation: () => null, __esModule: true },
+    '@/components/admin/messages/CancelQueuedSmsButton': { default: () => null, __esModule: true },
+    '@/components/admin/leads/LeadReplyEvidence': { default: ReplyPanel, __esModule: true },
+    '@/lib/leads/communication-evidence': evidenceLib,
+    '@/lib/requireAdmin': { requireAdmin: async () => {} },
+    '@/lib/prisma': { prisma: {
+      interestLead: { findUnique: async () => ({ id: 'lead-a', email: null, emails: [] }) },
+      notificationDispatch: { findMany: async () => [] },
+      messageThread: { findMany: async (args) => { requested = args.where; return []; } },
+    } },
+  }).default;
+  const html = renderToStaticMarkup(await layout({ params: Promise.resolve({ id: 'lead-a' }), children: React.createElement('p', null, 'Lead details') }));
+  assert.deepEqual(requested, { id: { in: ['legacy'] } });
+  assert.ok(html.indexOf('Latest incoming reply') < html.indexOf('Combined email audit trail'));
+  assert.match(html, /Where do we play/); assert.match(html, /Lead details/); assert.match(html, /Lead communication timeline/);
+});
+test('all three consumers share the resolver, with no duplicate cached-only query', () => {
+  for (const file of ['src/app/(admin)/admin/leads/[id]/layout.tsx', 'src/app/api/admin/leads/team-confirmation-sms-status/route.ts', 'src/lib/leads/team-confirmation-sms-reminders.ts']) {
+    const source = fs.readFileSync(path.join(root, file), 'utf8');
+    assert.match(source, /loadLeadCommunicationEvidence/);
+    assert.doesNotMatch(source, /SELECT MAX\(thread\."latestInboundAt"\)/);
+  }
+});

--- a/tests/lead-sms-status-links.test.cjs
+++ b/tests/lead-sms-status-links.test.cjs
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+const ts = require('typescript');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const filename = path.resolve(__dirname, '../src/components/admin/leads/LeadSmsStatusLines.tsx');
+const instance = new Module(filename, module);
+instance.filename = filename;
+instance.paths = Module._nodeModulePaths(path.dirname(filename));
+const native = instance.require.bind(instance);
+instance.require = (name) => name === 'next/link' ? { __esModule: true, default: ({ href, children, ...rest }) => React.createElement('a', { ...rest, href }, children) } : native(name);
+instance._compile(ts.transpileModule(fs.readFileSync(filename, 'utf8'), { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true } }).outputText, filename);
+const Lines = instance.exports.default;
+test('SMS status renders a real View reply link, not just tooltip text', () => {
+  const html = renderToStaticMarkup(React.createElement(Lines, { lines: [{ text: 'Incoming SMS · 3 Sep', tone: 'success', title: 'Where do we play?', href: '/admin/leads/lead-a#lead-reply-evidence', linkText: 'View reply' }] }));
+  assert.match(html, /href="\/admin\/leads\/lead-a#lead-reply-evidence"/); assert.match(html, />View reply<\/a>/);
+  assert.match(html, /Where do we play/); assert.doesNotMatch(html, /<button/);
+});
+test('review records link to evidence without an unverified reply claim', () => {
+  const html = renderToStaticMarkup(React.createElement(Lines, { lines: [{ text: 'Reply record needs checking', tone: 'warning', href: '/admin/leads/lead-a#lead-reply-evidence', linkText: 'Review reply record' }] }));
+  assert.match(html, /Review reply record/); assert.doesNotMatch(html, /reply received/);
+});
+test('untrusted non-lead URLs cannot become status links', () => {
+  const html = renderToStaticMarkup(React.createElement(Lines, { lines: [{ text: '<script>test</script>', tone: 'warning', href: 'javascript:alert(1)' }] }));
+  assert.doesNotMatch(html, /href=/); assert.doesNotMatch(html, /<script>/); assert.match(html, /&lt;script&gt;/);
+});
+test('owning status component mounts links and offers read-only refresh', () => {
+  const file = fs.readFileSync(path.resolve(__dirname, '../src/components/admin/leads/LeadConfirmationQuickSendButton.tsx'), 'utf8');
+  assert.match(file, /<LeadSmsStatusLines lines=\{smsStatus.lines\}/);
+  assert.match(file, /onClick=\{\(\) => void refreshSmsStatus\(true\)\}/);
+  assert.match(file, /Date.now\(\) - sharedStatusRequestedAt > 30_000/);
+});


### PR DESCRIPTION
## Implemented fix
The shared source is `loadLeadCommunicationEvidence` in `src/lib/leads/communication-evidence.ts`. It is used by the admin lead details/edit timeline, automatic team-lead SMS status API and the reminder job. Legacy automation and lead-recipient-linked conversations are recovered on read, including archived threads, without sending another reminder or rewriting historical records.

The lead page shows **Latest incoming reply** above the email history: actual stored content, sender, SMS/email channel, INBOUND direction, UK date/time and a direct **View conversation** link. The link selects the exact conversation with `filter=all`, bypassing the inbox's unread default and its 100-thread list. The timeline uses the same trusted thread IDs; the latest inbound message is fetched independently of the 100-message timeline window so newer outgoing messages cannot hide it.

The existing lead-list SMS control now renders a native **View reply** link (or **Review reply record**) from the status API. It also has a read-only **Refresh status** button and a bounded shared cache. The reassurance/decision sending actions were retained, not repurposed as refresh actions.

## Evidence and safety
A cached incoming timestamp alone cannot substantiate `reply received`. Actual evidence requires an INBOUND non-system entry with content and a sender matching the lead or explicitly lead-owned recipient contact. Wrong senders, unsupported timestamps and conflicting lead/team ownership are labelled **Reply record needs checking**, with review links, rather than treated as a verified reply or merged into another person's timeline. A shared phone/email alone does not attach another lead's conversation.

Existing automation holds are conservatively preserved for unsupported historical records: this visibility repair cannot restart a previously stopped chase. Incoming entries show RECEIVED and From, rather than the outbound sent-message explanation or the recipient's address. A question is not interpreted as confirmation of a team place.

No database migration, manual cron invocation, customer resend, mark-read action, reassignment, team-place confirmation, player or payment change was made. No real customer identity or message was copied into test data. Historical thread records remain intact.

## Verification
All **20 current GitHub Actions PR workflows** passed on head `d94b36722262742d70d92e530e13866cc5ece736`, tested together with concurrent main `14acb9644bec83e2079defa1de231712f7fe6906` (synthetic merge `837d70da6eb2264ff2504c1ffc1e31d441bb4939`). This includes full production prebuild, TypeScript, production application builds, DOM policy and existing critical-feature contracts.

The new localhost-only PostgreSQL suite executes the actual resolver query with synthetic data, including legacy/archived and recipient-linked threads, newer outbound messages, absent/stale timestamps, mismatched/shared contacts, email/SMS, preserved holds and read-only behaviour. It also executes the actual status endpoint and reminder hold path with isolated boundaries, and renders the native reply panel, owning lead layout and status links. Removing the SQL INBOUND filter caused the expected regression failure, and the source was restored. The post-change contract verifies all three consumers use the shared resolver and no longer contain their duplicate cached-only MAX(thread.latestInboundAt) lookup. Committed diffs and the merged helper, documentation and owning link controls were fetched and inspected.

## Merge and successful deployment
Merged to `main` as **`89b8e7da8f5637c5a76a146f81beda9b3bea2bf5`**, preserving the concurrent team-logo export change.

Railway deployment **`6aaaa354-d18c-4b86-bfe5-320a0cfccde3`** deployed this exact commit to the existing **Sixfl production** service and reports **SUCCESS**. Runtime logs show Next.js **Ready** at **2026-09-07T13:00:30Z**. No Railway variable or cron configuration was changed.

The code, isolated tests, production build and live service startup were verified. The reported lead's actual record and links have **not** been opened in an authenticated production admin session; this is not a claim of having re-read that customer's live message.