### PR TITLE
Automate registration SMS and email chases for all managed squads

### DIFF
--- a/.github/workflows/managed-squad-registration-reminders.yml
+++ b/.github/workflows/managed-squad-registration-reminders.yml
@@ -5,21 +5,81 @@ on:
     branches: [main]
 permissions:
   contents: read
+concurrency:
+  group: registration-reminders-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   registration-reminders:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sixfl_registration_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready --health-interval 5s
+          --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_registration_test
+      NEXTAUTH_SECRET: registration-test-only
+      NEXTAUTH_URL: http://localhost:3000
+      NEXT_PUBLIC_SITE_URL: http://localhost:3000
+      EMAIL_REPLY_DOMAIN: example.invalid
+      CRON_SECRET: registration-test-only
+      SIXFL_ISOLATED_REGISTRATION_TEST: '1'
     steps:
       - uses: actions/checkout@v4
-      - name: Inventory all invitation, chase, response and activation callsites
-        run: |
-          git grep -n -E 'queueManagedSquadJoin|MANAGED_SQUAD_JOIN_|Send activation reminder|PlayerInterestResponse|ProspectInterestChaseCard' -- src scripts prisma > registration-inventory.txt || true
-          cat registration-inventory.txt
-          tar -czf registration-source.tgz src scripts prisma tests docs config .github package.json package-lock.json tsconfig.json next.config.ts AGENTS.md ENGINEERING.md DEV_RULES.md
-      - uses: actions/upload-artifact@v4
+      - uses: actions/setup-node@v4
         with:
-          name: registration-source-inventory
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Prepare the actual production source
+        run: npm run prebuild
+      - run: npx prisma generate
+      - name: Type check and protect existing critical features
+        run: |
+          npx tsc --noEmit
+          node scripts/check-critical-feature-contracts.mjs
+          node scripts/check-squad-invite-placeholders.mjs
+      - name: Create disposable local schema only
+        run: npx prisma db push --skip-generate
+      - name: Exercise real PostgreSQL worker, outbox, provider gates and native status display
+        run: node --test tests/managed-squad-registration-reminders.test.cjs | tee registration-test.log
+      - name: Prove removing the provider guard fails the regression tests
+        run: |
+          cp src/lib/notifications/processor.ts /tmp/registration-processor.ts
+          trap 'cp /tmp/registration-processor.ts src/lib/notifications/processor.ts' EXIT
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('src/lib/notifications/processor.ts')
+          p.write_text(p.read_text().replace('await applyRegistrationDeliveryGate(dispatch)', 'null'))
+          PY
+          if node --test tests/managed-squad-registration-reminders.test.cjs > registration-negative.log 2>&1; then
+            echo 'ERROR: missing delivery guards were not detected'
+            exit 1
+          fi
+          grep -E 'not ok|fail' registration-negative.log
+      - name: Production build
+        run: npx next build
+      - name: Verify all native routes and template-owned messages
+        run: |
+          git grep -n -E 'queueManagedSquadJoin|MANAGED_SQUAD_JOIN_|Send activation reminder|PlayerInterestResponse|RegistrationReminderPanel|applyRegistrationDeliveryGate|runManagedSquadRegistrationReminderJob' -- src scripts > registration-inventory.txt
+          cat registration-inventory.txt
+          git diff -- src/lib/managed-squad/registration-reminders.ts src/lib/managed-squad/registration-reminder-policy.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: registration-reminder-verification
           path: |
+            registration-test.log
+            registration-negative.log
             registration-inventory.txt
-            registration-source.tgz
-          retention-days: 3
+          retention-days: 14

--- a/.github/workflows/managed-squad-registration-reminders.yml
+++ b/.github/workflows/managed-squad-registration-reminders.yml
@@ -31,6 +31,8 @@ jobs:
       NEXTAUTH_SECRET: registration-test-only
       NEXTAUTH_URL: http://localhost:3000
       NEXT_PUBLIC_SITE_URL: http://localhost:3000
+      RESEND_API_KEY: re_registration_ci_placeholder
+      EMAIL_FROM: SIXFL <noreply@example.invalid>
       EMAIL_REPLY_DOMAIN: example.invalid
       CRON_SECRET: registration-test-only
       SIXFL_ISOLATED_REGISTRATION_TEST: '1'

--- a/.github/workflows/managed-squad-registration-reminders.yml
+++ b/.github/workflows/managed-squad-registration-reminders.yml
@@ -1,0 +1,25 @@
+name: Managed squad registration reminders
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  registration-reminders:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Inventory all invitation, chase, response and activation callsites
+        run: |
+          git grep -n -E 'queueManagedSquadJoin|MANAGED_SQUAD_JOIN_|Send activation reminder|PlayerInterestResponse|ProspectInterestChaseCard' -- src scripts prisma > registration-inventory.txt || true
+          cat registration-inventory.txt
+          tar -czf registration-source.tgz src scripts prisma tests docs config .github package.json package-lock.json tsconfig.json next.config.ts AGENTS.md ENGINEERING.md DEV_RULES.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: registration-source-inventory
+          path: |
+            registration-inventory.txt
+            registration-source.tgz
+          retention-days: 3

--- a/docs/managed-squad-registration-reminders.md
+++ b/docs/managed-squad-registration-reminders.md
@@ -1,0 +1,27 @@
+# Managed-squad registration reminders
+
+## Scope and source of truth
+
+`src/lib/managed-squad/registration-reminders.ts` owns read-only eligibility inspection, transactional queue creation and last-moment provider guards. `registration-reminder-policy.ts` owns timing. The existing `/api/cron/notifications` runs the job between its original and generated queue drains; no additional Railway scheduler is required.
+
+All MANAGED teams are included, regardless of recruiting toggle. Allocated prospects with NEW, CONTACTED, TRIAL or BACKUP status and a successfully SENT, team-owned squad activation invite qualify. This is squad activation, not optional profile-field completion or the separate PlayerPool form. Missing/failed original invitations need manual review. No account, membership, prospect status or consent is changed by this job.
+
+## Sequence
+
+One channel per stage: first SMS at invitation +24 hours; second email at +72 hours and at least 48 hours after the first reminder actually sent; final SMS at +7 days and at least 96 hours after the second actually sent. A permitted alternative channel is used when needed. An inactive/invalid template holds the message rather than silently switching templates. All automatic messages, including late delivery, respect 09:00–21:00 Europe/London and both clock changes.
+
+Existing overdue invitations enter one stage at a time. Legacy manual invite chases consume the three-reminder cap; a legacy final ends the sequence. Manual contact postpones automation. Other queued contact messages block new chases. Failed/skipped/uncertain reminder attempts require queue review rather than endless retries. A per-prospect transaction lock and unique prospect/team/stage index prevent duplicate stages under concurrent runs.
+
+## Stop conditions
+
+The same eligibility checks run just before both providers: completed registration or existing membership, declined/inactive/unallocated/moved prospect, inactive league, reply received, suppression, changed contact/link/template, disabled channel or a completed sequence. Actual MessageEntry rows are used for replies, including archived conversations; cached timestamps alone are not treated as replies. Suppression and preferences are checked across matching recipient records. Duplicate pending email/phone records are held for review, never merged.
+
+Late manual contact and quiet hours defer the existing outbox row. A reply, opt-out, stale link or closed prospect cancels it. Provider-accepted records are not made retryable. Existing manual invitation/YES-NO buttons remain; this feature does not schedule separate YES-NO nudges.
+
+## Operations and verification
+
+The admin and captain prospects layouts natively display Automatic registration reminders, with actual sent history, queued-not-sent schedules, and hold/review reasons. Rendering is read-only and remains behind requireAdmin/requireCaptain. `/admin/queue` remains the delivery diagnostic. Four transactional PLAYER templates are editable in System Templates; the migration preserves administrator edits and inactive settings.
+
+Enabled by default when CRON_SECRET is present. Set MANAGED_SQUAD_REGISTRATION_REMINDERS_ENABLED=false to stop new work and cancel unsent automatic reminders at delivery. Each cron pass queues at most 25 reminders, paginating managed prospects without hard-coded teams. Cron JSON includes managedSquadRegistrationReminders; runtime summaries use [managed-squad-registration]. Do not manually call the full production cron for testing: it also runs other messages and payment work.
+
+The dedicated PR workflow uses disposable localhost PostgreSQL, real queue/scheduler/processor code, stub email/SMS providers and the full production prebuild. Tests cover concurrency, index/template migration, timing/backlog, channel fallback, manual contact, all managed teams, replies/opt-outs/duplicates, identity preservation, provider cancellation, failures, quiet hours and native panel output. A negative control removes the provider gates and must fail tests. TypeScript, critical contracts and production build are required before merge. No real player messages or production data are used for testing.

--- a/prisma/migrations/20260907214500_managed_squad_registration_reminders/migration.sql
+++ b/prisma/migrations/20260907214500_managed_squad_registration_reminders/migration.sql
@@ -1,0 +1,16 @@
+-- A stage is attempted once per prospect/team, regardless of channel or outcome.
+CREATE UNIQUE INDEX IF NOT EXISTS "managed_registration_prospect_team_stage_key"
+ON "NotificationDispatch" ("sourceId", (metadata->>'teamId'), (metadata->>'stage'))
+WHERE "sourceType" = 'MANAGED_SQUAD_REGISTRATION_REMINDER';
+
+-- Preserve administrator edits and disabled templates on reapplication.
+INSERT INTO "NotificationTemplate" (id,key,name,description,kind,channel,audience,subject,body,"ctaLabel","ctaUrlKey","isActive","createdAt","updatedAt") VALUES
+('managed-registration-reminder-sms','managed-squad-registration-reminder-sms','Managed squad registration reminder SMS','Automatic pending squad activation reminder; one channel per stage.','TRANSACTIONAL','SMS','PLAYER',NULL,
+E'Hi {{firstName}}, please confirm your place with {{teamName}} using your SIXFL squad link: {{joinConfirmationUrl}}\nReply if you need help or no longer wish to join.',NULL,NULL,true,NOW(),NOW()),
+('managed-registration-final-sms','managed-squad-registration-final-sms','Managed squad final registration SMS','Final automatic reminder; stops the sequence without removing the player.','TRANSACTIONAL','SMS','PLAYER',NULL,
+E'Hi {{firstName}}, this is the last automatic reminder to confirm your place with {{teamName}}: {{joinConfirmationUrl}}\nReply if you need help or no longer wish to join.',NULL,NULL,true,NOW(),NOW()),
+('managed-registration-reminder-email','managed-squad-registration-reminder-email','Managed squad registration reminder email','Automatic pending squad activation reminder or permitted SMS fallback.','TRANSACTIONAL','EMAIL','PLAYER','Your {{teamName}} squad registration',
+E'Hi {{firstName}},\n\nYour squad activation for {{teamName}} is still waiting for confirmation.\n\n{{teamContextLine}}\n\nPlease use your personal squad link below to confirm your place.\n\n{{cta}}\n\nReply to this email if you need help or no longer wish to join.\n\nThanks,\nSIXFL','Confirm my squad place','joinConfirmationUrl',true,NOW(),NOW()),
+('managed-registration-final-email','managed-squad-registration-final-email','Managed squad final registration email','Final automatic reminder or permitted SMS fallback; no automatic removal.','TRANSACTIONAL','EMAIL','PLAYER','Final registration reminder for {{teamName}}',
+E'Hi {{firstName}},\n\nThis is the last automatic reminder to confirm your squad place with {{teamName}}.\n\n{{cta}}\n\nReply if you need help or no longer wish to join. We will not send further automatic registration reminders after this message.\n\nThanks,\nSIXFL','Confirm my squad place','joinConfirmationUrl',true,NOW(),NOW())
+ON CONFLICT (key) DO NOTHING;

--- a/src/app/(admin)/admin/teams/[id]/prospects/layout.tsx
+++ b/src/app/(admin)/admin/teams/[id]/prospects/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+import RegistrationReminderPanel from "@/components/managed-squad/RegistrationReminderPanel";
+import { requireAdmin } from "@/lib/requireAdmin";
+
+export const dynamic = "force-dynamic";
+export default async function ProspectsReminderLayout({ children, params }: { children: ReactNode; params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  await requireAdmin();
+  return <><RegistrationReminderPanel teamId={id} />{children}</>;
+}

--- a/src/app/api/cron/notifications/route.ts
+++ b/src/app/api/cron/notifications/route.ts
@@ -3,6 +3,7 @@
 // ========================================
 
 import { NextRequest, NextResponse } from "next/server";
+import { runManagedSquadRegistrationReminderJob } from "@/lib/managed-squad/registration-reminders";
 import { runCaptainOnboardingEmailJob } from "@/lib/captain/onboarding-emails";
 import { runCaptainRulesOnboardingEmailJob } from "@/lib/captain/rules-onboarding-emails";
 import { repairUpcomingAiPredictionIntegrity } from "@/lib/fixtures/aiPredictionIntegrity";
@@ -143,6 +144,11 @@ export async function GET(request: NextRequest) {
     failures,
     runTeamLeadConfirmationSmsReminderJob,
   );
+  const managedSquadRegistrationReminders = await runCronStep(
+    "managed-squad-registration-reminders",
+    failures,
+    runManagedSquadRegistrationReminderJob,
+  );
   const fixtureConfirmations = await runCronStep(
     "fixture-confirmation-reminders",
     failures,
@@ -222,6 +228,7 @@ export async function GET(request: NextRequest) {
     rulesOnboarding,
     playerPoolProfileSmsReminders,
     teamLeadConfirmationSmsReminders,
+    managedSquadRegistrationReminders,
     fixtureConfirmations,
     fixtureConfirmationEmails,
     fixtureConfirmationWarnings,

--- a/src/app/captain/team/[teamid]/prospects/layout.tsx
+++ b/src/app/captain/team/[teamid]/prospects/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+import RegistrationReminderPanel from "@/components/managed-squad/RegistrationReminderPanel";
+import { requireCaptain } from "@/lib/requireCaptain";
+
+export const dynamic = "force-dynamic";
+export default async function ProspectsReminderLayout({ children, params }: { children: ReactNode; params: Promise<{ teamid: string }> }) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+  return <><RegistrationReminderPanel teamId={teamid} />{children}</>;
+}

--- a/src/components/managed-squad/RegistrationReminderPanel.tsx
+++ b/src/components/managed-squad/RegistrationReminderPanel.tsx
@@ -1,0 +1,33 @@
+import { getRegistrationReminderOverview, type RegistrationOverviewRow } from "@/lib/managed-squad/registration-reminders";
+import { registrationEnabled } from "@/lib/managed-squad/registration-reminder-policy";
+import { prisma } from "@/lib/prisma";
+
+function time(value: Date | null) {
+  return value ? new Intl.DateTimeFormat("en-GB", { timeZone: "Europe/London", day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit", hourCycle: "h23" }).format(value) : "";
+}
+export function RegistrationReminderTable({ rows, enabled }: { rows: RegistrationOverviewRow[]; enabled: boolean }) {
+  return <section className="mb-6 rounded-2xl border border-emerald-400/25 bg-emerald-500/10 p-5 text-white" aria-label="Automatic registration reminders">
+    <h2 className="text-lg font-semibold">Automatic registration reminders {enabled ? "— on" : "— off"}</h2>
+    <p className="mt-2 text-sm text-white/70">All managed squads: SMS after 24 hours, email after 3 days, final SMS after 7 days. Later messages also wait for the previous reminder to be sent. A permitted alternative channel is used when needed. Messages stop when a player joins, declines, replies or opts out.</p>
+    <p className="mt-2 text-xs text-white/60">UK sending hours: 09:00–21:00. Existing overdue invitations receive one reminder at a time, not a batch of missed chases. Manual contact postpones automation. This is squad activation, not the optional profile-completeness badge.</p>
+    <details className="mt-4">
+      <summary className="cursor-pointer font-medium">View reminder status for {rows.length} pending {rows.length === 1 ? "player" : "players"}</summary>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead><tr className="border-b border-white/15"><th className="p-2">Player</th><th className="p-2">Next action / hold</th><th className="p-2">Reminder history</th></tr></thead>
+          <tbody>{rows.map((row) => <tr key={row.id} className="border-b border-white/10 align-top">
+            <td className="p-2 font-medium">{row.name}<div className="mt-1 text-xs font-normal text-white/60">{row.inviteSentAt ? `Invite sent: ${time(row.inviteSentAt)}` : "No confirmed sent invite"}</div></td>
+            <td className="p-2">{row.plan.note}{row.plan.dueAt ? <div className="mt-1 text-xs text-white/60">{row.plan.state === "queued" ? "Queue schedule" : "Next eligible check"}: {time(row.plan.dueAt)}</div> : null}</td>
+            <td className="p-2 text-xs text-white/70">{row.history.length ? row.history.map((d) => <div key={d.id} className="mb-2">{d.channel} — {d.status === "SENT" && d.sentAt ? `Sent: ${time(d.sentAt)}` : d.status === "QUEUED" ? `Queued for ${time(d.scheduledFor)} (not sent)` : d.status}{d.failureReason ? ` · ${d.failureReason}` : ""}</div>) : "No reminders sent"}</td>
+          </tr>)}</tbody>
+        </table>
+      </div>
+    </details>
+  </section>;
+}
+/** Parent layouts authorize the team before calling this read-only component. */
+export default async function RegistrationReminderPanel({ teamId }: { teamId: string }) {
+  const team = await prisma.team.findUnique({ where: { id: teamId }, select: { teamMode: true } });
+  if (team?.teamMode !== "MANAGED") return null;
+  return <RegistrationReminderTable rows={await getRegistrationReminderOverview(teamId)} enabled={registrationEnabled()} />;
+}

--- a/src/lib/managed-squad/registration-reminder-policy.ts
+++ b/src/lib/managed-squad/registration-reminder-policy.ts
@@ -1,0 +1,72 @@
+/** Shared by the worker, delivery gate and read-only status panel. */
+export const REGISTRATION_SOURCE = "MANAGED_SQUAD_REGISTRATION_REMINDER";
+export const REGISTRATION_PENDING_STATUSES = ["NEW", "CONTACTED", "TRIAL", "BACKUP"];
+export const REGISTRATION_INVITE_SOURCE = "MANAGED_SQUAD_JOIN_CONFIRMATION";
+export const REGISTRATION_LEGACY_CHASES = ["MANAGED_SQUAD_JOIN_CHASE", "MANAGED_SQUAD_JOIN_FINAL_CHASE"];
+export const HOUR = 3_600_000;
+export const REGISTRATION_DELAYS = [24 * HOUR, 72 * HOUR, 168 * HOUR];
+export const REGISTRATION_GAPS = [0, 48 * HOUR, 96 * HOUR];
+export type RegistrationChannel = "EMAIL" | "SMS";
+export type RegistrationStage = 1 | 2 | 3;
+export type RegistrationHistoryItem = {
+  id: string; sourceType: string | null; status: string; channel: string;
+  sentAt: Date | null; createdAt: Date; scheduledFor: Date;
+  failureReason: string | null; metadata: unknown;
+};
+export type RegistrationPlan = {
+  state: "waiting" | "paused" | "review" | "complete" | "scheduled" | "queued";
+  note: string; stage: RegistrationStage | null; channel: RegistrationChannel | null; dueAt: Date | null;
+};
+export function registrationMetadata(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+export function registrationEnabled() {
+  return Boolean(process.env.CRON_SECRET?.trim()) && process.env.MANAGED_SQUAD_REGISTRATION_REMINDERS_ENABLED?.trim().toLowerCase() !== "false";
+}
+export function registrationTemplateKey(stage: RegistrationStage, channel: RegistrationChannel) {
+  return `managed-squad-registration-${stage === 3 ? "final" : "reminder"}-${channel.toLowerCase()}`;
+}
+/** UK morning is always outside the DST transition itself. Round-trip local
+ * parts rather than adding 24h to a UTC morning across a clock change. */
+export function nextRegistrationWindow(date: Date): Date {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London", year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", hourCycle: "h23",
+  }).formatToParts(date);
+  const n = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+  const hour = n("hour");
+  if (hour >= 9 && hour < 21) return date;
+  const morningGuess = new Date(Date.UTC(n("year"), n("month") - 1, n("day") + (hour >= 21 ? 1 : 0), 9));
+  const localHour = Number(new Intl.DateTimeFormat("en-GB", { timeZone: "Europe/London", hour: "2-digit", hourCycle: "h23" }).format(morningGuess));
+  return new Date(morningGuess.getTime() - (localHour - 9) * HOUR);
+}
+export function registrationPlan(input: {
+  inviteSentAt: Date | null; history: RegistrationHistoryItem[];
+  emailAllowed: boolean; smsAllowed: boolean; lastManualContactAt: Date | null;
+  pendingContact: boolean; blockedReason: string | null;
+}): RegistrationPlan {
+  const hold = (state: RegistrationPlan["state"], note: string): RegistrationPlan => ({ state, note, stage: null, channel: null, dueAt: null });
+  if (input.blockedReason) return hold("paused", input.blockedReason);
+  if (!input.inviteSentAt) return hold("waiting", "Waiting for a successfully sent squad activation invite for this team.");
+  const history = [...input.history].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id));
+  const pending = history.find((d) => d.status === "QUEUED" || d.status === "PROCESSING");
+  if (pending) return { ...hold("queued", pending.status === "PROCESSING" ? "Reminder is being processed; do not resend." : "Reminder queued, not yet sent."), dueAt: pending.scheduledFor };
+  if (history.some((d) => d.status !== "SENT" || !d.sentAt)) return hold("review", "A previous reminder was not confirmed sent. Review the queue; no automatic retry.");
+  const sent = history.filter((d) => d.status === "SENT" && d.sentAt);
+  if (sent.some((d) => d.sourceType === "MANAGED_SQUAD_JOIN_FINAL_CHASE" || registrationMetadata(d.metadata).stage === 3) || sent.length >= 3) {
+    return hold("complete", "Reminder sequence finished. No further automatic messages; review manually.");
+  }
+  if (input.pendingContact) return hold("waiting", "Another message is queued for this contact. Automatic reminders wait.");
+  const stage = (sent.length + 1) as RegistrationStage;
+  const preferred: RegistrationChannel = stage === 2 ? "EMAIL" : "SMS";
+  const channel = preferred === "SMS"
+    ? (input.smsAllowed ? "SMS" : input.emailAllowed ? "EMAIL" : null)
+    : (input.emailAllowed ? "EMAIL" : input.smsAllowed ? "SMS" : null);
+  if (!channel) return hold("paused", "No permitted contact channel. Check contact details and preferences.");
+  const lastSent = Math.max(0, ...sent.map((d) => d.sentAt!.getTime()));
+  const dueAt = nextRegistrationWindow(new Date(Math.max(
+    input.inviteSentAt.getTime() + REGISTRATION_DELAYS[stage - 1],
+    lastSent ? lastSent + REGISTRATION_GAPS[stage - 1] : 0,
+    input.lastManualContactAt ? input.lastManualContactAt.getTime() + 48 * HOUR : 0,
+  )));
+  return { state: "scheduled", note: `Automatic reminder ${stage}/3 by ${channel}.`, stage, channel, dueAt };
+}

--- a/src/lib/managed-squad/registration-reminders.ts
+++ b/src/lib/managed-squad/registration-reminders.ts
@@ -1,0 +1,271 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { normalizePhoneNumber } from "@/lib/notifications/phone";
+import { queueNotificationFromTemplate } from "@/lib/notifications/service";
+import { logNotificationDispatchToThread } from "@/lib/communications/log-dispatch";
+import { buildProspectEmailContext, getManagedSquadJoinConfirmationUrl } from "./prospectJoinConfirmation";
+import {
+  HOUR, REGISTRATION_SOURCE, REGISTRATION_INVITE_SOURCE, REGISTRATION_LEGACY_CHASES,
+  REGISTRATION_PENDING_STATUSES, nextRegistrationWindow, registrationEnabled,
+  registrationMetadata, registrationPlan, registrationTemplateKey,
+  type RegistrationHistoryItem, type RegistrationPlan, type RegistrationStage,
+} from "./registration-reminder-policy";
+
+type Db = Pick<typeof prisma, "$queryRaw" | "teamPlayerProspect" | "notificationDispatch" | "notificationRecipient" | "notificationPreference" | "notificationTemplate">;
+const normalEmail = (value: string | null | undefined) => value?.trim().toLowerCase() || null;
+function phoneForms(phone: string | null) {
+  if (!phone) return ["not-a-phone"];
+  const digits = phone.replace(/\D/g, "");
+  return [...new Set([digits, `00${digits}`, ...(digits.startsWith("44") ? [`0${digits.slice(2)}`, digits.slice(2), `440${digits.slice(2)}`] : [])])];
+}
+function identitySql(emailColumn: Prisma.Sql, phoneColumn: Prisma.Sql, email: string, phones: string[]) {
+  return Prisma.sql`(LOWER(TRIM(COALESCE(${emailColumn}, ''))) = ${email}
+    OR REGEXP_REPLACE(COALESCE(${phoneColumn}, ''), '[^0-9]', '', 'g') IN (${Prisma.join(phones)}))`;
+}
+const prospectSelect = {
+  id: true, firstName: true, lastName: true, email: true, phone: true, status: true,
+  teamId: true, lastContactedAt: true,
+  team: { select: { id: true, name: true, teamMode: true, logoUrl: true,
+    league: { select: { id: true, name: true, season: true, area: true, dayOfWeek: true, venueName: true, isActive: true } },
+  } },
+} as const;
+
+/** Read-only: used unchanged for preview, scheduling and the last provider gate.
+ * excludeDispatchId lets the provider validate its claimed row, not mistake it
+ * for a new reminder. Existing accounts/prospects/consent are never changed. */
+export async function inspectRegistrationReminder(prospectId: string, db: Db = prisma, excludeDispatchId?: string) {
+  const prospect = await db.teamPlayerProspect.findUnique({ where: { id: prospectId }, select: prospectSelect });
+  const email = normalEmail(prospect?.email);
+  const phone = normalizePhoneNumber(prospect?.phone);
+  let blockedReason: string | null = !registrationEnabled() ? "Automatic registration reminders are disabled." : null;
+  if (!prospect?.teamId || !prospect.team || prospect.team.teamMode !== "MANAGED") blockedReason = "Prospect is not allocated to a managed squad.";
+  else if (!REGISTRATION_PENDING_STATUSES.includes(prospect.status)) blockedReason = "Player has joined, declined or left the pending recruitment pipeline.";
+  else if (prospect.team.league?.isActive === false) blockedReason = "The team's league is inactive.";
+  else if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) blockedReason = "Save a valid email first; the squad activation link requires it.";
+  if (blockedReason || !prospect || !email) return {
+    prospect, email, phone, history: [] as RegistrationHistoryItem[], inviteSentAt: null as Date | null,
+    plan: registrationPlan({ inviteSentAt: null, history: [], emailAllowed: false, smsAllowed: false, lastManualContactAt: null, pendingContact: false, blockedReason }),
+  };
+  const teamId = prospect.teamId!;
+  const phones = phoneForms(phone);
+  const relatedIds = await db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT r.id FROM "NotificationRecipient" r WHERE
+      (r."sourceType" = 'GENERAL' AND r."sourceId" = ${`team-prospect:${prospectId}`})
+      OR ${identitySql(Prisma.sql`r.email`, Prisma.sql`r.phone`, email, phones)}
+      OR r."emailNormalized" = ${email} OR (${phone}::text IS NOT NULL AND r."phoneNormalized" = ${phone})
+  `);
+  const [recipients, ownDispatches, duplicate, member] = await Promise.all([
+    db.notificationRecipient.findMany({ where: { id: { in: relatedIds.map((r) => r.id) } }, include: { preferences: true } }),
+    db.notificationDispatch.findMany({
+      where: { sourceId: prospectId, ...(excludeDispatchId ? { id: { not: excludeDispatchId } } : {}),
+        sourceType: { in: [REGISTRATION_INVITE_SOURCE, REGISTRATION_SOURCE, ...REGISTRATION_LEGACY_CHASES] } },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    }),
+    db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      SELECT p.id FROM "TeamPlayerProspect" p JOIN "Team" t ON t.id = p."teamId"
+      WHERE p.id <> ${prospectId} AND t."teamMode" = 'MANAGED'
+        AND p.status IN (${Prisma.join(REGISTRATION_PENDING_STATUSES)})
+        AND ${identitySql(Prisma.sql`p.email`, Prisma.sql`p.phone`, email, phones)} LIMIT 1
+    `),
+    db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      SELECT m.id FROM "TeamMember" m JOIN "User" u ON u.id = m."userId"
+      WHERE m."teamId" = ${teamId} AND LOWER(TRIM(u.email)) = ${email} LIMIT 1
+    `),
+  ]);
+  if (duplicate.length) blockedReason = "Duplicate pending contact records: review before automatically messaging this person.";
+  if (member.length) blockedReason = "An account with this email is already in this squad; review rather than chase or merge.";
+  if (recipients.some((r) => r.isSuppressed)) blockedReason = "This contact has opted out or is suppressed. Automatic reminders stopped.";
+  const emailAllowed = recipients.every((r) => r.transactionalEmailOptIn && r.preferences?.emailEnabled !== false);
+  const smsAllowed = Boolean(phone) && recipients.every((r) => r.transactionalSmsOptIn && r.preferences?.smsEnabled !== false);
+  const teamDispatches = ownDispatches.filter((d) => registrationMetadata(d.metadata).teamId === teamId);
+  const invites = teamDispatches.filter((d) => d.sourceType === REGISTRATION_INVITE_SOURCE && d.status === "SENT" && d.sentAt);
+  const inviteSentAt = invites.reduce<Date | null>((latest, d) => !latest || d.sentAt! > latest ? d.sentAt : latest, null);
+  // Automatic stage records survive subsequent manual invitations. Otherwise a
+  // re-invite could restart the sequence or collide with its unique stage key.
+  const history: RegistrationHistoryItem[] = teamDispatches.filter((d) => d.sourceType === REGISTRATION_SOURCE ||
+    REGISTRATION_LEGACY_CHASES.includes(d.sourceType || ""));
+  let pendingContact = false;
+  let lastManualContactAt: Date | null = null;
+  if (inviteSentAt) {
+    const contactIds = recipients.map((r) => r.id);
+    const [contacts, inbound, interestReplies, outbound] = await Promise.all([
+      db.notificationDispatch.findMany({ where: { ...(excludeDispatchId ? { id: { not: excludeDispatchId } } : {}),
+        OR: [{ sourceId: prospectId }, { recipientId: { in: contactIds } }],
+        status: { in: ["QUEUED", "PROCESSING", "SENT"] } },
+        select: { id: true, sourceType: true, status: true, sentAt: true } }),
+      db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT e.id FROM "MessageEntry" e JOIN "MessageThread" t ON t.id = e."threadId"
+        WHERE e.direction = 'INBOUND' AND COALESCE(e."receivedAt", e."createdAt") >= ${inviteSentAt}
+          AND (${identitySql(Prisma.sql`e."fromEmail"`, Prisma.sql`e."fromNumber"`, email, phones)}
+            OR t."recipientId" IN (${Prisma.join(contactIds.length ? contactIds : ["no-recipient"] )})
+            OR t."sourceId" IN (${prospectId}, ${`team-prospect:${prospectId}`})) LIMIT 1
+      `),
+      db.$queryRaw<Array<{ response: string; respondedAt: Date }>>(Prisma.sql`
+        SELECT response, "respondedAt" FROM "PlayerInterestResponse"
+        WHERE "prospectId" = ${prospectId} AND ("teamId" = ${teamId} OR "teamId" IS NULL)
+        ORDER BY "respondedAt" DESC LIMIT 1
+      `),
+      db.$queryRaw<Array<{ sentAt: Date }>>(Prisma.sql`
+        SELECT MAX(e."sentAt") AS "sentAt" FROM "MessageEntry" e
+        JOIN "MessageThread" t ON t.id = e."threadId"
+        LEFT JOIN "NotificationDispatch" d ON d.id = e."notificationDispatchId"
+        WHERE e.direction = 'OUTBOUND' AND e."sentAt" > ${inviteSentAt}
+          AND (d.id IS NULL OR d."sourceType" IS DISTINCT FROM ${REGISTRATION_SOURCE})
+          AND (d.id IS NULL OR d."sourceType" IS DISTINCT FROM ${REGISTRATION_INVITE_SOURCE})
+          AND (${identitySql(Prisma.sql`e."toEmail"`, Prisma.sql`e."toNumber"`, email, phones)}
+            OR t."recipientId" IN (${Prisma.join(contactIds.length ? contactIds : ["no-recipient"] )})
+            OR t."sourceId" IN (${prospectId}, ${`team-prospect:${prospectId}`}))
+      `),
+    ]);
+    if (inbound.length || interestReplies.some((r) => r.response === "NO" || r.respondedAt >= inviteSentAt)) {
+      blockedReason = "A reply has been received. Automatic reminders paused for a person to follow up.";
+    }
+    pendingContact = contacts.some((d) => d.status === "QUEUED" || d.status === "PROCESSING");
+    const manualTimes = [prospect.lastContactedAt, outbound[0]?.sentAt,
+      ...contacts.filter((d) => d.sourceType !== REGISTRATION_SOURCE && d.sourceType !== REGISTRATION_INVITE_SOURCE).map((d) => d.sentAt)]
+      .filter((d): d is Date => Boolean(d && d > inviteSentAt));
+    if (manualTimes.length) lastManualContactAt = new Date(Math.max(...manualTimes.map((d) => d.getTime())));
+  }
+  const plan = registrationPlan({ inviteSentAt, history, emailAllowed, smsAllowed, lastManualContactAt, pendingContact, blockedReason });
+  if (plan.stage && plan.channel) {
+    const template = await db.notificationTemplate.findUnique({ where: { key: registrationTemplateKey(plan.stage, plan.channel) } });
+    if (!template?.isActive || template.channel !== plan.channel || template.kind !== "TRANSACTIONAL" || template.audience !== "PLAYER") {
+      plan.state = "review"; plan.note = "The reminder template is missing, disabled or has incompatible settings."; plan.dueAt = null;
+    }
+  }
+  return { prospect, email, phone, history, inviteSentAt, plan };
+}
+
+/** Row lock + unique prospect/team/stage index serialize simultaneous cron runs.
+ * No provider calls, account creation or consent changes occur in this transaction. */
+export async function queueDueRegistrationReminder(prospectId: string, now = new Date()) {
+  if (!registrationEnabled() || nextRegistrationWindow(now).getTime() !== now.getTime()) return null;
+  return prisma.$transaction(async (db) => {
+    await db.$queryRaw(Prisma.sql`SELECT id FROM "TeamPlayerProspect" WHERE id = ${prospectId} FOR UPDATE`);
+    const view = await inspectRegistrationReminder(prospectId, db);
+    const { prospect, plan } = view;
+    if (!prospect?.team || !prospect.teamId || plan.state !== "scheduled" || !plan.dueAt || plan.dueAt > now || !plan.stage || !plan.channel) return null;
+    const context = await buildProspectEmailContext(prospect);
+    if (!context) return null;
+    const contact = { displayName: context.displayName, email: view.email, emailNormalized: view.email,
+      phone: view.phone, phoneNormalized: view.phone, lastSyncedAt: now };
+    const recipient = await db.notificationRecipient.upsert({
+      where: { sourceType_sourceId: { sourceType: "GENERAL", sourceId: `team-prospect:${prospectId}` } },
+      update: contact, // Never re-enable opt-outs, suppression or preferences.
+      create: { ...contact, sourceType: "GENERAL", sourceId: `team-prospect:${prospectId}`, audience: "PLAYER",
+        marketingEmailOptIn: false, marketingSmsOptIn: false,
+        metadata: { teamId: prospect.teamId, prospectId, entityType: "TEAM_PLAYER_PROSPECT" } },
+    });
+    await db.notificationPreference.upsert({ where: { recipientId: recipient.id }, update: {}, create: { recipientId: recipient.id } });
+    const templateKey = registrationTemplateKey(plan.stage, plan.channel);
+    const dispatch = await queueNotificationFromTemplate({
+      templateKey, recipientId: recipient.id, sourceType: REGISTRATION_SOURCE, sourceId: prospectId,
+      variables: context.variables, scheduledFor: now,
+      metadata: { automatic: true, stage: plan.stage, teamId: prospect.teamId, prospectId,
+        contactName: context.displayName, contactEmail: view.email, contactPhone: view.phone,
+        origin: "managed_squad_registration_reminder", originLabel: "Automatic squad registration reminder",
+        templateKey, joinConfirmationUrl: context.joinConfirmationUrl },
+      emailBranding: { teamName: prospect.team.name, teamLogoUrl: prospect.team.logoUrl, leagueName: context.leagueName },
+    }, db);
+    return { dispatch, recipient, stage: plan.stage };
+  }, { maxWait: 5000, timeout: 20000 });
+}
+
+type DeliveryDispatch = {
+  id: string; sourceType: string | null; sourceId: string | null; channel: string;
+  recipientId: string; metadata: unknown; variables: unknown; templateId: string | null;
+};
+export type RegistrationDeliveryDecision = { reason: string; deferUntil?: Date };
+export async function registrationDeliveryDecision(dispatch: DeliveryDispatch, now = new Date()): Promise<RegistrationDeliveryDecision | null> {
+  if (dispatch.sourceType !== REGISTRATION_SOURCE) return null;
+  const meta = registrationMetadata(dispatch.metadata);
+  if (!dispatch.sourceId || ![1, 2, 3].includes(Number(meta.stage))) return { reason: "Invalid registration reminder reference." };
+  const view = await inspectRegistrationReminder(dispatch.sourceId, prisma, dispatch.id);
+  if (!view.prospect?.teamId || view.prospect.teamId !== meta.teamId) return { reason: "Prospect moved or was removed; stale registration reminder cancelled." };
+  const recipient = await prisma.notificationRecipient.findUnique({ where: { id: dispatch.recipientId }, include: { preferences: true } });
+  if (!recipient || recipient.isSuppressed || normalEmail(recipient.email) !== view.email || meta.contactEmail !== view.email ||
+    (dispatch.channel === "EMAIL" && (!recipient.transactionalEmailOptIn || recipient.preferences?.emailEnabled === false)) ||
+    (dispatch.channel === "SMS" && (!recipient.transactionalSmsOptIn || recipient.preferences?.smsEnabled === false ||
+      !view.phone || normalizePhoneNumber(recipient.phone) !== view.phone || meta.contactPhone !== view.phone))) {
+    return { reason: "Contact or notification permission changed; registration reminder cancelled." };
+  }
+  const vars = registrationMetadata(dispatch.variables);
+  if (vars.joinConfirmationUrl !== getManagedSquadJoinConfirmationUrl(dispatch.sourceId)) return { reason: "Stale or invalid squad activation link." };
+  const stage = Number(meta.stage) as RegistrationStage;
+  const template = dispatch.templateId ? await prisma.notificationTemplate.findUnique({ where: { id: dispatch.templateId } }) : null;
+  if (!template?.isActive || template.key !== registrationTemplateKey(stage, dispatch.channel === "SMS" ? "SMS" : "EMAIL") ||
+    template.channel !== dispatch.channel || template.kind !== "TRANSACTIONAL" || template.audience !== "PLAYER") {
+    return { reason: "Registration reminder template is disabled or changed." };
+  }
+  if (view.plan.state === "waiting" && view.inviteSentAt) {
+    return { reason: view.plan.note, deferUntil: nextRegistrationWindow(new Date(now.getTime() + HOUR)) };
+  }
+  if (view.plan.state !== "scheduled" || view.plan.stage !== stage || view.plan.channel !== dispatch.channel) return { reason: view.plan.note };
+  const dueAt = nextRegistrationWindow(new Date(Math.max(now.getTime(), view.plan.dueAt!.getTime())));
+  if (dueAt > now) return { reason: "Registration reminder postponed for spacing or UK quiet hours.", deferUntil: dueAt };
+  return null;
+}
+
+/** Run immediately before each provider (email as well as SMS). Only our claimed,
+ * unsent row may be deferred/cancelled; provider-accepted records are untouched. */
+export async function applyRegistrationDeliveryGate(dispatch: DeliveryDispatch, now = new Date()) {
+  const decision = await registrationDeliveryDecision(dispatch, now);
+  if (!decision) return null;
+  await prisma.notificationDispatch.updateMany({
+    where: { id: dispatch.id, sourceType: REGISTRATION_SOURCE, status: "PROCESSING", sentAt: null, providerMessageId: null },
+    data: decision.deferUntil
+      ? { status: "QUEUED", processedAt: null, scheduledFor: decision.deferUntil, failureReason: decision.reason }
+      : { status: "CANCELLED", cancelledAt: now, failureReason: decision.reason },
+  });
+  return decision.reason;
+}
+
+export async function runManagedSquadRegistrationReminderJob(now = new Date()) {
+  const summary = { enabled: registrationEnabled(), quietHours: nextRegistrationWindow(now) > now, scanned: 0, queued: 0, emailQueued: 0, smsQueued: 0, held: 0, errors: [] as string[] };
+  if (!summary.enabled || summary.quietHours) {
+    console.info("[managed-squad-registration]", JSON.stringify(summary));
+    return summary;
+  }
+  let cursor: string | undefined;
+  do {
+    const page = await prisma.teamPlayerProspect.findMany({
+      where: { status: { in: REGISTRATION_PENDING_STATUSES }, team: { teamMode: "MANAGED" } },
+      select: { id: true }, orderBy: { id: "asc" }, take: 100, ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+    if (!page.length) break;
+    for (const row of page) {
+      summary.scanned++;
+      try {
+        const result = await queueDueRegistrationReminder(row.id, now);
+        if (!result || result.dispatch.status !== "QUEUED") { summary.held++; continue; }
+        summary.queued++;
+        if (result.dispatch.channel === "SMS") summary.smsQueued++; else summary.emailQueued++;
+        // Outbox committed first: a history logging failure never queues another send.
+        await logNotificationDispatchToThread(result);
+      } catch (error) {
+        if (summary.errors.length < 20) summary.errors.push(`${row.id}: ${error instanceof Error ? error.message : "Registration reminder failed"}`);
+      }
+      if (summary.queued >= 25) break;
+    }
+    cursor = page[page.length - 1].id;
+    if (page.length < 100) break;
+  } while (summary.queued < 25);
+  console.info("[managed-squad-registration]", JSON.stringify(summary));
+  return summary;
+}
+
+export type RegistrationOverviewRow = { id: string; name: string; plan: RegistrationPlan; inviteSentAt: Date | null; history: RegistrationHistoryItem[] };
+export async function getRegistrationReminderOverview(teamId: string): Promise<RegistrationOverviewRow[]> {
+  const prospects = await prisma.teamPlayerProspect.findMany({ where: { teamId, team: { teamMode: "MANAGED" }, status: { in: REGISTRATION_PENDING_STATUSES } },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }], select: { id: true, firstName: true, lastName: true } });
+  const rows: RegistrationOverviewRow[] = [];
+  // Bounded read concurrency; never queue messages while rendering a page.
+  for (let i = 0; i < prospects.length; i += 4) {
+    const batch = await Promise.all(prospects.slice(i, i + 4).map(async (p) => {
+      const view = await inspectRegistrationReminder(p.id);
+      return { id: p.id, name: [p.firstName, p.lastName].filter(Boolean).join(" "), plan: view.plan, inviteSentAt: view.inviteSentAt, history: view.history };
+    }));
+    rows.push(...batch);
+  }
+  return rows;
+}

--- a/src/lib/notifications/processor.ts
+++ b/src/lib/notifications/processor.ts
@@ -3,6 +3,7 @@
 // ========================================
 
 import { NotificationChannel } from "@prisma/client";
+import { applyRegistrationDeliveryGate } from "@/lib/managed-squad/registration-reminders";
 import { cancelOwnedReplacementSms, getReplacementSmsCancellationReason } from "@/lib/fixtures/replacement-sms-lifecycle";
 import { getUnresolvedEmailPlaceholderReason } from "./renderer";
 import { getUnpublishedFixtureBlockReason } from "@/lib/fixtures/publishing";
@@ -388,6 +389,12 @@ export async function processNotificationQueue(limit = 25) {
         const replyTo = thread.replyAddress?.trim();
         if (!replyTo) throw new Error("Email thread reply address is missing.");
 
+        const registrationBlock = await applyRegistrationDeliveryGate(dispatch);
+        if (registrationBlock) {
+          result.skipped += 1;
+          result.items.push({ dispatchId: dispatch.id, status: "skipped", channel: dispatch.channel, message: registrationBlock });
+          continue;
+        }
         const sendResult = await sendEmailWithResend({
           to: dispatch.recipient.email,
           subject: dispatch.subject,
@@ -449,6 +456,12 @@ export async function processNotificationQueue(limit = 25) {
           await cancelOwnedReplacementSms(dispatch.id, replacementSmsBlock);
           result.skipped += 1;
           result.items.push({ dispatchId: dispatch.id, status: "skipped", channel: dispatch.channel, message: replacementSmsBlock });
+          continue;
+        }
+        const registrationBlock = await applyRegistrationDeliveryGate(dispatch);
+        if (registrationBlock) {
+          result.skipped += 1;
+          result.items.push({ dispatchId: dispatch.id, status: "skipped", channel: dispatch.channel, message: registrationBlock });
           continue;
         }
         const sendResult = await sendSmsWithTwilio({ to: dispatch.recipient.phone, body: dispatch.bodyText });

--- a/tests/managed-squad-registration-reminders.test.cjs
+++ b/tests/managed-squad-registration-reminders.test.cjs
@@ -254,10 +254,10 @@ test('failed sends require queue review, not endless automatic re-creation', asy
 test('late queue delivery defers both channels overnight and disabling automation cancels unsent reminders', async () => {
   for (const channel of ['SMS', 'EMAIL']) {
     const t = channel === 'EMAIL' ? await eligibleEmail() : await target(); const q = await queue(t);
-    test.mock.timers.setTime(new Date('2026-09-08T20:00:00Z'));
+    test.mock.timers.setTime(new Date('2026-09-08T20:00:00Z').getTime());
     await processor.processNotificationQueue(100); assert.equal(providerCalls.length, 0);
     assert.equal((await get(q.dispatch.id)).scheduledFor.toISOString(), '2026-09-09T08:00:00.000Z');
-    test.mock.timers.setTime(baseNow);
+    test.mock.timers.setTime(baseNow.getTime());
   }
   const t = await target(); const q = await queue(t); process.env.MANAGED_SQUAD_REGISTRATION_REMINDERS_ENABLED = 'false';
   await processor.processNotificationQueue(100); assert.equal((await get(q.dispatch.id)).status, 'CANCELLED');

--- a/tests/managed-squad-registration-reminders.test.cjs
+++ b/tests/managed-squad-registration-reminders.test.cjs
@@ -1,0 +1,286 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const ts = require('typescript');
+const { PrismaClient } = require('@prisma/client');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const root = path.resolve(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+const migration = 'prisma/migrations/20260907214500_managed_squad_registration_reminders/migration.sql';
+const baseNow = new Date('2026-09-08T12:00:00Z');
+const H = 3600000;
+const ago = (h) => new Date(baseNow.getTime() - h * H);
+const dbUrl = new URL(process.env.DATABASE_URL || 'https://invalid');
+assert.ok(process.env.SIXFL_ISOLATED_REGISTRATION_TEST === '1' && dbUrl.hostname === '127.0.0.1' && dbUrl.pathname === '/sixfl_registration_test', 'Disposable localhost database only');
+const prisma = new PrismaClient();
+const sql = (query) => execFileSync('psql', [dbUrl.toString(), '-X', '-v', 'ON_ERROR_STOP=1', '-Atc', query], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+const apply = (file) => sql(read(file));
+let providerCalls = [], failProvider = false, phoneIndex = 0;
+// Real notification service/renderer, PostgreSQL queries and queue processor;
+// only external providers and unrelated feature guards are substituted.
+function loader() {
+  const cache = new Map();
+  const mocks = {
+    '@/lib/prisma': { prisma },
+    '@/lib/fixtures/publishing': { getUnpublishedFixtureBlockReason: async () => null },
+    '@/lib/fixtures/replacement-sms-lifecycle': { cancelClosedReplacementSms: async () => 0, getReplacementSmsCancellationReason: async () => null, cancelOwnedReplacementSms: async () => 0 },
+    '@/lib/referees/evening-notifications': { refereeEveningDeliveryBlock: async () => null },
+    '@/lib/player-pool/profile-sms-reminders': { getPlayerPoolProfileSmsDeliveryBlock: async () => null },
+    './providers/resend': { sendEmailWithResend: async (input) => {
+      providerCalls.push({ channel: 'EMAIL', input }); if (failProvider) throw new Error('Simulated provider failure');
+      return { provider: 'resend', providerMessageId: randomUUID(), fromEmail: 'test@example.invalid', responsePayload: {} };
+    } },
+    './providers/twilio': { sendSmsWithTwilio: async (input) => {
+      providerCalls.push({ channel: 'SMS', input }); if (failProvider) throw new Error('Simulated provider failure');
+      return { provider: 'twilio', providerMessageId: randomUUID(), fromNumber: '+447700900000', responsePayload: {} };
+    } },
+  };
+  function load(file) {
+    if (cache.has(file)) return cache.get(file).exports;
+    const module = { exports: {} }; cache.set(file, module);
+    const js = ts.transpileModule(read(file), { fileName: file, compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true } }).outputText;
+    const req = (id) => {
+      if (Object.hasOwn(mocks, id)) return mocks[id];
+      if (id.startsWith('@/') || id.startsWith('.')) {
+        const base = id.startsWith('@/') ? 'src/' + id.slice(2) : path.join(path.dirname(file), id);
+        const target = [base, base + '.ts', base + '.tsx', base + '/index.ts'].find((p) => fs.existsSync(path.join(root, p)) && fs.statSync(path.join(root, p)).isFile());
+        if (target) return load(target);
+      }
+      return require(id);
+    };
+    new Function('require', 'module', 'exports', js)(req, module, module.exports);
+    return module.exports;
+  }
+  return load;
+}
+const load = loader();
+const policy = load('src/lib/managed-squad/registration-reminder-policy.ts');
+const service = load('src/lib/managed-squad/registration-reminders.ts');
+const processor = load('src/lib/notifications/processor.ts');
+const invite = load('src/lib/managed-squad/prospectJoinConfirmation.ts');
+const SRC = policy.REGISTRATION_SOURCE;
+const get = (id) => prisma.notificationDispatch.findUniqueOrThrow({ where: { id }, include: { recipient: true } });
+const queue = (t, now = baseNow) => service.queueDueRegistrationReminder(t.prospect.id, now);
+const inspect = (t) => service.inspectRegistrationReminder(t.prospect.id);
+
+async function target({ hours = 25, phone = true, inviteStatus = 'SENT', teamMode = 'MANAGED', status = 'CONTACTED', activeLeague = true } = {}) {
+  const id = randomUUID();
+  const league = await prisma.league.create({ data: { name: `Test ${id}`, slug: id, isActive: activeLeague, dayOfWeek: 'MONDAY', venueName: 'Test venue' } });
+  const team = await prisma.team.create({ data: { name: `Squad ${id}`, claimCode: id, leagueId: league.id, teamMode, isRecruiting: false } });
+  const prospect = await prisma.teamPlayerProspect.create({ data: { teamId: team.id, firstName: 'Test', lastName: 'Player', email: `${id}@example.invalid`, phone: phone ? `07700900${String(++phoneIndex).padStart(3, '0')}` : null, status } });
+  const recipient = await prisma.notificationRecipient.create({ data: {
+    sourceType: 'GENERAL', sourceId: `team-prospect:${prospect.id}`, audience: 'PLAYER', email: prospect.email, phone: prospect.phone,
+    emailNormalized: prospect.email, preferences: { create: {} },
+  } });
+  if (inviteStatus) await prisma.notificationDispatch.create({ data: {
+    recipientId: recipient.id, channel: 'EMAIL', audience: 'PLAYER', subject: 'Test invite', bodyText: 'Test invite',
+    sourceType: policy.REGISTRATION_INVITE_SOURCE, sourceId: prospect.id, metadata: { teamId: team.id }, status: inviteStatus,
+    sentAt: inviteStatus === 'SENT' ? ago(hours) : null, createdAt: ago(hours + 1), scheduledFor: ago(hours + 1),
+  } });
+  return { prospect, recipient, team, league };
+}
+async function prior(t, stage = 1, hours = 49, sourceType = SRC, status = 'SENT') {
+  const channel = stage === 2 ? 'EMAIL' : 'SMS';
+  const template = await prisma.notificationTemplate.findUniqueOrThrow({ where: { key: policy.registrationTemplateKey(stage, channel) } });
+  return prisma.notificationDispatch.create({ data: {
+    recipientId: t.recipient.id, channel, audience: 'PLAYER', templateId: template.id,
+    sourceType, sourceId: t.prospect.id, bodyText: 'Test reminder', subject: 'Test reminder', status,
+    metadata: { teamId: t.team.id, stage, contactEmail: t.prospect.email, contactPhone: t.prospect.phone ? '+44' + t.prospect.phone.slice(1) : null },
+    variables: { joinConfirmationUrl: invite.getManagedSquadJoinConfirmationUrl(t.prospect.id) },
+    sentAt: status === 'SENT' ? ago(hours) : null, createdAt: ago(hours), scheduledFor: ago(hours),
+  } });
+}
+async function inbound(t, channel = 'EMAIL', cachedOnly = false) {
+  const thread = await prisma.messageThread.create({ data: { channel, status: 'ARCHIVED', recipientId: t.recipient.id, latestInboundAt: ago(1) } });
+  if (!cachedOnly) await prisma.messageEntry.create({ data: { threadId: thread.id, channel, direction: 'INBOUND', body: 'Can you help?',
+    fromEmail: channel === 'EMAIL' ? ` ${t.prospect.email.toUpperCase()} ` : null, fromNumber: channel === 'SMS' ? '+44' + t.prospect.phone.slice(1) : null, receivedAt: ago(1) } });
+}
+async function eligibleEmail() { const t = await target({ hours: 200 }); await prior(t, 1, 49); return t; }
+
+test.before(() => {
+  globalThis.fetch = async () => { throw new Error('External requests prohibited in registration tests'); };
+  apply('prisma/migrations/20260526120000_player_interest_response/migration.sql');
+  apply('prisma/migrations/20260705193500_allow_general_player_interest_response/migration.sql');
+  sql('ALTER TABLE "League" ADD COLUMN IF NOT EXISTS "proposedStartDate" TIMESTAMP(3)');
+  apply(migration);
+});
+test.beforeEach(() => {
+  test.mock.timers.enable({ apis: ['Date'], now: baseNow });
+  sql('TRUNCATE "NotificationDispatch", "NotificationRecipient", "MessageThread", "TeamPlayerProspect", "Team", "League", "User", "PlayerInterestResponse" CASCADE');
+  process.env.CRON_SECRET = 'registration-test-only';
+  delete process.env.MANAGED_SQUAD_REGISTRATION_REMINDERS_ENABLED;
+  providerCalls = []; failProvider = false;
+});
+test.afterEach(() => test.mock.timers.reset());
+test.after(async () => prisma.$disconnect());
+
+test('policy spaces three stages and respects UK hours across both DST changes', () => {
+  assert.deepEqual(policy.REGISTRATION_DELAYS, [24, 72, 168].map(h => h * H));
+  assert.deepEqual(policy.REGISTRATION_GAPS, [0, 48, 96].map(h => h * H));
+  for (const [input, expected] of [
+    ['2026-09-08T07:59:59Z', '2026-09-08T08:00:00Z'], ['2026-09-08T08:00:00Z', '2026-09-08T08:00:00Z'],
+    ['2026-09-08T20:00:00Z', '2026-09-09T08:00:00Z'], ['2026-03-28T21:00:00Z', '2026-03-29T08:00:00Z'],
+    ['2026-10-24T20:00:00Z', '2026-10-25T09:00:00Z'], ['2026-12-01T08:00:00Z', '2026-12-01T09:00:00Z'],
+  ]) assert.equal(policy.nextRegistrationWindow(new Date(input)).toISOString(), new Date(expected).toISOString());
+});
+test('first reminder requires a genuinely sent team-owned invite, and a full 24 hours', async () => {
+  for (const inviteStatus of [null, 'QUEUED', 'FAILED', 'SKIPPED']) assert.equal(await queue(await target({ inviteStatus })), null);
+  const t = await target({ hours: 24 }); assert.equal(await queue(t, new Date(baseNow.getTime() - 1)), null);
+  const queued = await queue(t); assert.equal(queued.stage, 1); assert.equal(queued.dispatch.channel, 'SMS');
+  assert.match(queued.dispatch.bodyText, /Test/); assert.equal(queued.dispatch.variables.teamName, t.team.name);
+  assert.equal(queued.dispatch.variables.joinConfirmationUrl, invite.getManagedSquadJoinConfirmationUrl(t.prospect.id));
+  assert.equal(await queue(t), null);
+});
+test('concurrent cron workers and database stage index allow exactly one outbox row', async () => {
+  const t = await target();
+  const results = await Promise.all(Array.from({ length: 4 }, () => queue(t)));
+  assert.equal(results.filter(Boolean).length, 1);
+  assert.equal(await prisma.notificationDispatch.count({ where: { sourceType: SRC, sourceId: t.prospect.id } }), 1);
+  await assert.rejects(() => prior(t, 1, 1), /Unique constraint/);
+});
+test('old invitation backlog sends one stage, waits for actual delivery then spaces later stages', async () => {
+  const t = await target({ hours: 600 }); const one = await queue(t); assert.equal(one.stage, 1);
+  assert.equal(await queue(t, new Date(baseNow.getTime() + 300 * H)), null, 'queued is not sent');
+  await prisma.notificationDispatch.update({ where: { id: one.dispatch.id }, data: { status: 'SENT', sentAt: baseNow } });
+  assert.equal(await queue(t, new Date(baseNow.getTime() + 48 * H - 1)), null);
+  const two = await queue(t, new Date(baseNow.getTime() + 48 * H)); assert.equal(two.stage, 2); assert.equal(two.dispatch.channel, 'EMAIL');
+  await prisma.notificationDispatch.update({ where: { id: two.dispatch.id }, data: { status: 'SENT', sentAt: new Date(baseNow.getTime() + 48 * H) } });
+  assert.equal(await queue(t, new Date(baseNow.getTime() + 144 * H - 1)), null);
+  const three = await queue(t, new Date(baseNow.getTime() + 144 * H)); assert.equal(three.stage, 3);
+  await prisma.notificationDispatch.update({ where: { id: three.dispatch.id }, data: { status: 'SENT', sentAt: new Date(baseNow.getTime() + 144 * H) } });
+  assert.equal(await queue(t, new Date(baseNow.getTime() + 900 * H)), null);
+});
+test('manual legacy chases consume the cap; a legacy final and uncertain attempts stop automation', async () => {
+  const t = await target({ hours: 400 }); await prior(t, 1, 200, 'MANAGED_SQUAD_JOIN_CHASE'); await prior(t, 2, 100, 'MANAGED_SQUAD_JOIN_CHASE');
+  assert.equal((await queue(t)).stage, 3);
+  const final = await target({ hours: 400 }); await prior(final, 3, 100, 'MANAGED_SQUAD_JOIN_FINAL_CHASE'); assert.equal(await queue(final), null);
+  for (const status of ['QUEUED', 'PROCESSING', 'FAILED', 'SKIPPED', 'CANCELLED']) {
+    const t = await target({ hours: 400 }); await prior(t, 1, 200, SRC, status); assert.equal(await queue(t), null);
+  }
+});
+test('one permitted channel per stage, with fallback and without restoring opt-outs', async () => {
+  const noPhone = await target({ phone: false }); assert.equal((await queue(noPhone)).dispatch.channel, 'EMAIL');
+  const smsOff = await target(); await prisma.notificationPreference.update({ where: { recipientId: smsOff.recipient.id }, data: { smsEnabled: false } });
+  assert.equal((await queue(smsOff)).dispatch.channel, 'EMAIL');
+  assert.equal((await prisma.notificationPreference.findUniqueOrThrow({ where: { recipientId: smsOff.recipient.id } })).smsEnabled, false);
+  const emailOff = await eligibleEmail(); await prisma.notificationRecipient.update({ where: { id: emailOff.recipient.id }, data: { transactionalEmailOptIn: false } });
+  assert.equal((await queue(emailOff)).dispatch.channel, 'SMS');
+});
+test('suppression and channel opt-outs on alternate contact records are respected', async () => {
+  const t = await target();
+  const alt = await prisma.notificationRecipient.create({ data: { sourceType: 'GENERAL', sourceId: randomUUID(), audience: 'PLAYER', email: ` ${t.prospect.email.toUpperCase()} `, phone: '+44' + t.prospect.phone.slice(1), isSuppressed: true } });
+  assert.equal(await queue(t), null);
+  await prisma.notificationRecipient.update({ where: { id: alt.id }, data: { isSuppressed: false, transactionalEmailOptIn: false, transactionalSmsOptIn: false } });
+  assert.equal(await queue(t), null);
+});
+test('registered, declined, closed, unassigned, inactive and standard squads are excluded', async () => {
+  for (const status of ['ACTIVE_SQUAD', 'DECLINED', 'CLOSED', 'QUALIFIED', 'INACTIVE']) assert.equal(await queue(await target({ status })), null);
+  assert.equal(await queue(await target({ teamMode: 'STANDARD' })), null);
+  assert.equal(await queue(await target({ activeLeague: false })), null);
+  const t = await target(); await prisma.teamPlayerProspect.update({ where: { id: t.prospect.id }, data: { teamId: null } }); assert.equal(await queue(t), null);
+});
+test('existing membership and duplicate contact records are held, never merged or promoted', async () => {
+  const t = await target(); const user = await prisma.user.create({ data: { name: 'Different Person', email: t.prospect.email } });
+  await prisma.teamMember.create({ data: { teamId: t.team.id, userId: user.id, role: 'PLAYER' } }); assert.equal(await queue(t), null);
+  assert.equal((await prisma.user.findUniqueOrThrow({ where: { id: user.id } })).name, 'Different Person');
+  const duplicate = await target(); const other = await target();
+  await prisma.teamPlayerProspect.update({ where: { id: other.prospect.id }, data: { email: ` ${duplicate.prospect.email.toUpperCase()} ` } }); assert.equal(await queue(duplicate), null);
+  await prisma.teamPlayerProspect.update({ where: { id: other.prospect.id }, data: { email: other.prospect.email, phone: '0044' + duplicate.prospect.phone.slice(1) } }); assert.equal(await queue(duplicate), null);
+});
+test('actual email/SMS replies and YES/NO responses pause, including archived threads; cached timestamps are not evidence', async () => {
+  for (const channel of ['EMAIL', 'SMS']) { const t = await target(); await inbound(t, channel); assert.equal(await queue(t), null); }
+  const cached = await target(); await inbound(cached, 'EMAIL', true); assert.ok(await queue(cached));
+  for (const response of ['YES', 'NO']) {
+    const t = await target(); await prisma.$executeRawUnsafe('INSERT INTO "PlayerInterestResponse" (id,"teamId","prospectId",response,"tokenHash","respondedAt") VALUES ($1,$2,$3,$4,$5,$6)', randomUUID(), t.team.id, t.prospect.id, response, randomUUID(), ago(1));
+    assert.equal(await queue(t), null);
+  }
+});
+test('all managed squads are scanned regardless of recruiting toggle, without changing identities', async () => {
+  const a = await target(), b = await target(), standard = await target({ teamMode: 'STANDARD' });
+  const before = await prisma.teamPlayerProspect.findMany({ orderBy: { id: 'asc' } });
+  const summary = await service.runManagedSquadRegistrationReminderJob(baseNow);
+  assert.equal(summary.queued, 2); assert.equal(summary.errors.length, 0);
+  assert.equal(await prisma.notificationDispatch.count({ where: { sourceType: SRC, sourceId: standard.prospect.id } }), 0);
+  assert.deepEqual(await prisma.teamPlayerProspect.findMany({ orderBy: { id: 'asc' } }), before);
+  assert.equal(await prisma.user.count(), 0); assert.equal(await prisma.teamMember.count(), 0);
+  assert.equal((await service.getRegistrationReminderOverview(a.team.id)).length, 1);
+});
+test('manual contact after queueing postpones the existing reminder, not a second message', async () => {
+  const t = await target(); const q = await queue(t);
+  await prisma.teamPlayerProspect.update({ where: { id: t.prospect.id }, data: { lastContactedAt: baseNow } });
+  const d = await service.registrationDeliveryDecision(await get(q.dispatch.id), baseNow);
+  assert.equal(d.deferUntil.toISOString(), new Date(baseNow.getTime() + 48 * H).toISOString());
+  await processor.processNotificationQueue(100); assert.equal(providerCalls.length, 0);
+  const saved = await get(q.dispatch.id); assert.equal(saved.status, 'QUEUED'); assert.equal(saved.scheduledFor.toISOString(), d.deferUntil.toISOString());
+});
+test('provider gate rechecks both channels after completion, replies, opt-out and allocation/contact changes', async () => {
+  for (const channel of ['SMS', 'EMAIL']) for (const change of ['joined', 'declined', 'reply', 'optout', 'move', 'email', 'phone', 'link', 'template']) {
+    const t = channel === 'EMAIL' ? await eligibleEmail() : await target(); const q = await queue(t); assert.equal(q.dispatch.channel, channel);
+    if (change === 'joined' || change === 'declined') await prisma.teamPlayerProspect.update({ where: { id: t.prospect.id }, data: { status: change === 'joined' ? 'ACTIVE_SQUAD' : 'DECLINED' } });
+    if (change === 'reply') await inbound(t);
+    if (change === 'optout') await prisma.notificationRecipient.update({ where: { id: t.recipient.id }, data: { isSuppressed: true } });
+    if (change === 'move') await prisma.teamPlayerProspect.update({ where: { id: t.prospect.id }, data: { teamId: null } });
+    if (change === 'email') await prisma.teamPlayerProspect.update({ where: { id: t.prospect.id }, data: { email: 'changed@example.invalid' } });
+    if (change === 'phone') {
+      if (channel === 'SMS') await prisma.teamPlayerProspect.update({ where: { id: t.prospect.id }, data: { phone: '+447700900999' } });
+      else await prisma.notificationPreference.update({ where: { recipientId: t.recipient.id }, data: { emailEnabled: false } });
+    }
+    if (change === 'link') await prisma.notificationDispatch.update({ where: { id: q.dispatch.id }, data: { variables: { joinConfirmationUrl: 'https://example.invalid/wrong' } } });
+    if (change === 'template') await prisma.notificationTemplate.update({ where: { id: q.dispatch.templateId }, data: { isActive: false } });
+    const before = providerCalls.length; await processor.processNotificationQueue(100);
+    assert.equal(providerCalls.length, before, `${channel}/${change} must never reach provider`);
+    assert.equal((await get(q.dispatch.id)).status, 'CANCELLED', `${channel}/${change}`);
+    if (change === 'template') await prisma.notificationTemplate.update({ where: { id: q.dispatch.templateId }, data: { isActive: true } });
+  }
+});
+test('real processor sends eligible SMS and email once and records history', async () => {
+  for (const channel of ['SMS', 'EMAIL']) {
+    const t = channel === 'EMAIL' ? await eligibleEmail() : await target(); const q = await queue(t);
+    const before = providerCalls.length; await processor.processNotificationQueue(100);
+    assert.equal(providerCalls.length, before + 1); assert.equal(providerCalls.at(-1).channel, channel);
+    const sent = await get(q.dispatch.id); assert.equal(sent.status, 'SENT'); assert.ok(sent.sentAt); assert.ok(sent.providerMessageId);
+    await processor.processNotificationQueue(100); assert.equal(providerCalls.length, before + 1);
+  }
+});
+test('failed sends require queue review, not endless automatic re-creation', async () => {
+  const t = await target(); const q = await queue(t); failProvider = true; await processor.processNotificationQueue(100);
+  assert.equal((await get(q.dispatch.id)).status, 'FAILED'); assert.equal(await queue(t, new Date(baseNow.getTime() + 240 * H)), null);
+  assert.equal(providerCalls.length, 1);
+});
+test('late queue delivery defers both channels overnight and disabling automation cancels unsent reminders', async () => {
+  for (const channel of ['SMS', 'EMAIL']) {
+    const t = channel === 'EMAIL' ? await eligibleEmail() : await target(); const q = await queue(t);
+    test.mock.timers.setTime(new Date('2026-09-08T20:00:00Z'));
+    await processor.processNotificationQueue(100); assert.equal(providerCalls.length, 0);
+    assert.equal((await get(q.dispatch.id)).scheduledFor.toISOString(), '2026-09-09T08:00:00.000Z');
+    test.mock.timers.setTime(baseNow);
+  }
+  const t = await target(); const q = await queue(t); process.env.MANAGED_SQUAD_REGISTRATION_REMINDERS_ENABLED = 'false';
+  await processor.processNotificationQueue(100); assert.equal((await get(q.dispatch.id)).status, 'CANCELLED');
+  assert.equal(providerCalls.length, 0); assert.equal((await service.runManagedSquadRegistrationReminderJob()).queued, 0);
+});
+test('template migrations preserve administrator copy and inactive settings; no hard-coded automatic message bodies', async () => {
+  const key = policy.registrationTemplateKey(1, 'SMS'); const old = await prisma.notificationTemplate.findUniqueOrThrow({ where: { key } });
+  try {
+    await prisma.notificationTemplate.update({ where: { key }, data: { body: 'Edited reminder for {{firstName}}: {{joinConfirmationUrl}}' } }); apply(migration);
+    const t = await target(); assert.match((await queue(t)).dispatch.bodyText, /Edited reminder/);
+    await prisma.notificationTemplate.update({ where: { key }, data: { isActive: false } }); apply(migration);
+    assert.equal(await queue(await target()), null);
+  } finally { await prisma.notificationTemplate.update({ where: { key }, data: { body: old.body, isActive: old.isActive } }); }
+  assert.doesNotMatch(read('src/lib/managed-squad/registration-reminders.ts'), /queueDirectNotification|Hi \{\{/);
+});
+test('read-only native panel separates queued from sent; entry points retain guards and prior jobs', () => {
+  const { RegistrationReminderTable } = load('src/components/managed-squad/RegistrationReminderPanel.tsx');
+  const html = renderToStaticMarkup(React.createElement(RegistrationReminderTable, { enabled: true, rows: [{ id: 'x', name: 'Test Player', inviteSentAt: ago(25), plan: { state: 'queued', note: 'Reminder queued, not yet sent.', dueAt: baseNow }, history: [{ id: 'a', channel: 'SMS', status: 'QUEUED', sentAt: null, scheduledFor: baseNow }] }] }));
+  assert.match(html, /Automatic registration reminders/); assert.match(html, /Queued for/); assert.match(html, /not sent/);
+  const code = read('src/lib/notifications/processor.ts');
+  assert.equal((code.match(/await applyRegistrationDeliveryGate\(dispatch\)/g) || []).length, 2);
+  assert.match(read('src/app/api/cron/notifications/route.ts'), /runManagedSquadRegistrationReminderJob/);
+  assert.match(read('src/app/api/cron/notifications/route.ts'), /processNotificationQueue\(100\)/);
+  assert.match(read('src/app/(admin)/admin/teams/[id]/prospects/layout.tsx'), /await requireAdmin\(\)/);
+  assert.match(read('src/app/captain/team/[teamid]/prospects/layout.tsx'), /await requireCaptain\(teamid\)/);
+});


### PR DESCRIPTION
## Implemented and deployed
Merged as e19fc3a30aeb1672955111ed4d5740300da95db3. Railway production deployment f6906228-b5cc-4233-bcbb-615409c1b020 reached SUCCESS at 2026-09-07T22:15:20.669Z. Startup logs confirmed migration 20260907214500_managed_squad_registration_reminders applied successfully and Next.js Ready at 22:15:20.359Z.

The normal five-minute scheduler invoked /api/cron/notifications after deployment and completed HTTP 200 / all steps completed at 22:20:39Z. The exact deployed web service logged at 22:20:38.458Z: [managed-squad-registration] {"enabled":true,"quietHours":true,"scanned":0,"queued":0,"emailQueued":0,"smsQueued":0,"held":0,"errors":[]}. Thus the new job is enabled and running, correctly withholding reminders outside UK sending hours. Eligible overdue prospects can be picked up by normal runs from 09:00 UK time on 8 September. No manual production cron or customer test messages were triggered.

## Behaviour
All MANAGED teams and existing allocated prospects awaiting /squad/join confirmation are included. First SMS at sent invitation +24h; second email at +72h and at least 48h after the first reminder actually sent; final SMS at +7 days and at least 96h after the second actually sent. One permitted channel per stage, with fallback. Older invitations are picked up one stage at a time, not a catch-up blast. Messages only send 09:00–21:00 Europe/London. No automatic player removal.

Shared source: src/lib/managed-squad/registration-reminders.ts and registration-reminder-policy.ts. The existing notification cron, both provider gates and native authorized admin/captain prospects panels use this service. Real sent invite history is required; missing/failed original invitations are flagged for review. Legacy manual chases consume the cap and other manual contact delays automation. Registration, declines, actual incoming replies, opt-outs/suppression, duplicate pending contacts, existing membership and stale allocation/contact/link/template changes stop or hold reminders. A row lock and unique prospect/team/stage index prevent duplicate outbox entries. No account/membership/prospect status or consent edits.

Four transactional PLAYER NotificationTemplate records were installed idempotently, preserving administrator edits and disabled templates. New read-only Automatic registration reminders panels distinguish sent, queued-not-sent and review/hold states. Existing manual invitation and YES/NO controls remain unchanged. This is squad activation, not optional profile-field completeness.

## Verification
All 29 PR workflows passed on 7bea350cedf7cc9b757c2a6d6e0d95874d175f1f, including DOM policy, critical contracts, the complementary squad-activation workflow and production builds. Vercel preview also subsequently passed. Dedicated run 34165484325 tested the combined merge with main 84cb04df0c1b70afb0a0e781bcd9b3880d080a3b: full-prebuild TypeScript, 55 critical assertions, 11 invite-placeholder checks, all 18 real PostgreSQL/queue/renderer/processor/UI tests and production build passed. Removing the two provider gates caused four test failures as intended. Providers were stubbed and external requests blocked. Verification artifact: 10034045102.

Post-prebuild source inventory confirmed one registration cron entry, both email/SMS provider gates, both authorized native prospects layouts and preservation of all existing manual invite/chase callsites. No duplicate automatic entry point or prebuild rewrite of the new service was found. The final merged tree 315b6e33f5d43f0028b30bb70d41305ea0920507 exactly matches the tested synthetic merge tree. Main PR #467's separate initial account-activation email for ACTIVE_SQUAD records without membership is preserved.

## Remaining live limits
Deployment, migration, running scheduler and quiet-hours behaviour are verified. Individual Thirsk Nomads eligibility/counts, authenticated panel appearance and actual phone/mailbox receipt have not been independently inspected. The quiet-hours heartbeat deliberately scanned and queued zero prospects; it is not proof all 15 reported players qualify or have received a message. Use the live prospects panel and /admin/queue to see each record's current state.