### PR TITLE
Add Matchweek Report tab to league navigation

### DIFF
--- a/src/components/leagues/LeagueQuickLinks.tsx
+++ b/src/components/leagues/LeagueQuickLinks.tsx
@@ -19,6 +19,7 @@ export default function LeagueQuickLinks({
     { href: `/leagues/${slug}/fixtures`, label: "Fixtures" },
     { href: `/leagues/${slug}/results`, label: "Results" },
     { href: `/leagues/${slug}/stats`, label: "Stats" },
+    { href: `/leagues/${slug}/weekly-report`, label: "Matchweek Report" },
   ];
 
   return (


### PR DESCRIPTION
Adds a Matchweek Report tab to the shared public league navigation, linking to `/leagues/[slug]/weekly-report` for each live league.