### PR TITLE
Keep matchweek reports private in the admin area

### DIFF
--- a/.github/workflows/admin-matchweek-reports.yml
+++ b/.github/workflows/admin-matchweek-reports.yml
@@ -1,0 +1,32 @@
+name: Admin-only matchweek reports
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Find existing report routes and shared navigation
+        run: git grep -l -i -E 'weekly-report|matchweek.?report|LeagueQuickLinks' HEAD^ -- src scripts || true
+      - run: npm ci
+      - name: Test native report privacy and navigation
+        run: node --test tests/admin-matchweek-reports.test.cjs
+      - run: npm run prebuild
+      - name: Test final production-prepared report privacy and navigation
+        run: node --test tests/admin-matchweek-reports.test.cjs
+      - name: Search final source for report routes and navigation
+        run: git grep -l -i -E 'weekly-report|matchweek.?report|LeagueQuickLinks' -- src scripts

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -3,6 +3,7 @@
 // ========================================
 
 import type { ReactNode } from "react";
+import Link from "next/link";
 import { ResultDisputeStatus } from "@prisma/client";
 
 import { requireAdmin } from "@/lib/requireAdmin";
@@ -110,6 +111,15 @@ export default async function AdminLayout({
       <AdminRefereeCommsHistoryBridge />
       <RefereeWelcomeInviteBridge />
       <AppHeader variant="admin" />
+
+      <nav aria-label="Admin reports" className="border-b border-white/10 px-3 py-3 sm:px-6 lg:px-8 xl:hidden">
+        <Link
+          href="/admin/matchweek-reports"
+          className="inline-flex min-h-10 items-center rounded-xl border border-emerald-400/20 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 hover:bg-emerald-500/20 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-emerald-400"
+        >
+          Matchweek reports
+        </Link>
+      </nav>
 
       <div className="flex w-full gap-5 px-3 py-4 sm:px-6 lg:px-8 lg:py-6">
         <aside className="hidden w-[34rem] shrink-0 xl:block 2xl:w-[38rem]">

--- a/src/app/(admin)/admin/matchweek-reports/[slug]/page.tsx
+++ b/src/app/(admin)/admin/matchweek-reports/[slug]/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { prisma } from "@/lib/prisma";
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata: Metadata = {
+  title: "Admin matchweek report preview | SIXFL",
+  robots: { index: false, follow: false },
+};
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+function formatDate(date: Date) {
+  return formatDateTimeInLondon(date, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export default async function AdminWeeklyLeagueReportPreview({ params }: PageProps) {
+  await requireAdmin();
+  const { slug } = await params;
+
+  const league = await prisma.league.findFirst({
+    where: { slug, isActive: true },
+    select: {
+      name: true,
+      slug: true,
+      area: true,
+      badgeUrl: true,
+      fixtures: {
+        where: {
+          status: "COMPLETED",
+          result: { isNot: null },
+          publishedAt: { not: null },
+        },
+        orderBy: { kickoffAt: "desc" },
+        take: 24,
+        select: {
+          id: true,
+          kickoffAt: true,
+          round: true,
+          homeTeam: { select: { id: true, name: true, logoUrl: true } },
+          awayTeam: { select: { id: true, name: true, logoUrl: true } },
+          result: {
+            select: {
+              homeScore: true,
+              awayScore: true,
+              teamMetadata: {
+                select: {
+                  teamId: true,
+                  scorers: true,
+                  playerOfMatchName: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!league) notFound();
+
+  const latest = league.fixtures[0];
+  if (!latest) {
+    return (
+      <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-8 text-white">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">Admin-only preview</p>
+        <h1 className="mt-3 text-3xl font-black">{league.name}</h1>
+        <h2 className="mt-5 text-xl font-bold">No completed results yet</h2>
+        <p className="mt-3 text-white/65">This private preview will appear once the league has published completed fixtures. The report itself will not be published.</p>
+        <Link href="/admin/matchweek-reports" className="mt-8 inline-flex rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Back to matchweek reports</Link>
+      </div>
+    );
+  }
+
+  const latestRound = latest.round;
+  const sameRound = latestRound
+    ? league.fixtures.filter((fixture) => fixture.round === latestRound)
+    : league.fixtures.filter((fixture) => {
+        const a = new Date(fixture.kickoffAt);
+        const b = new Date(latest.kickoffAt);
+        return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+      });
+
+  const matchweekFixtures = [...sameRound].sort(
+    (a, b) => new Date(a.kickoffAt).getTime() - new Date(b.kickoffAt).getTime(),
+  );
+
+  const totalGoals = matchweekFixtures.reduce((sum, fixture) => {
+    const result = fixture.result;
+    return sum + (result ? result.homeScore + result.awayScore : 0);
+  }, 0);
+
+  const biggestWin = [...matchweekFixtures]
+    .filter((fixture) => fixture.result)
+    .sort((a, b) => {
+      const ar = a.result!;
+      const br = b.result!;
+      return Math.abs(br.homeScore - br.awayScore) - Math.abs(ar.homeScore - ar.awayScore);
+    })[0];
+
+  return (
+    <div className="overflow-hidden rounded-3xl border border-white/10 bg-black text-white">
+      <div className="border-b border-amber-400/20 bg-amber-500/10 px-5 py-4 sm:px-8">
+        <Link href="/admin/matchweek-reports" className="text-sm font-semibold text-emerald-300 hover:text-emerald-200">← All matchweek reports</Link>
+        <p className="mt-2 text-sm text-amber-100">Admin-only preview — not published. This report is visible only to SIXFL administrators.</p>
+      </div>
+      <section className="border-b border-white/10 bg-gradient-to-b from-emerald-950/60 to-black">
+        <div className="mx-auto max-w-6xl px-5 py-10 sm:px-8 sm:py-14">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <p className="text-sm font-bold uppercase tracking-[0.24em] text-emerald-300">SIXFL Matchweek Report</p>
+            <span className="rounded-full border border-white/10 bg-white/[0.05] px-4 py-2 text-sm text-white/65">Private preview</span>
+          </div>
+          <h1 className="mt-5 max-w-4xl break-words text-3xl font-black leading-tight sm:text-5xl">{league.name}</h1>
+          <p className="mt-4 text-lg text-white/65">{formatDate(latest.kickoffAt)}{latestRound ? ` • Round ${latestRound}` : ""}</p>
+
+          <div className="mt-8 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-5"><div className="text-3xl font-black">{matchweekFixtures.length}</div><div className="mt-1 text-sm text-white/55">Matches played</div></div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-5"><div className="text-3xl font-black">{totalGoals}</div><div className="mt-1 text-sm text-white/55">Goals scored</div></div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-5"><div className="break-words text-lg font-black">{biggestWin ? `${biggestWin.homeTeam.name} ${biggestWin.result!.homeScore}–${biggestWin.result!.awayScore} ${biggestWin.awayTeam.name}` : "—"}</div><div className="mt-1 text-sm text-white/55">Biggest result</div></div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-5 py-10 sm:px-8">
+        <div className="mb-8 max-w-3xl">
+          <h2 className="text-3xl font-black">This week in {league.area || league.name}</h2>
+          <p className="mt-3 text-base leading-7 text-white/65">A clean, data-led weekly round-up using only recorded SIXFL results. We do not invent possession, chances, late goals or other match details that were not entered into the system.</p>
+        </div>
+
+        <div className="space-y-5">
+          {matchweekFixtures.map((fixture) => {
+            const result = fixture.result!;
+            const metadata = result.teamMetadata || [];
+            const potm = metadata.map((item) => item.playerOfMatchName).filter(Boolean).join(" / ");
+
+            return (
+              <article key={fixture.id} className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
+                <div className="grid gap-6 p-6 sm:grid-cols-[1fr_auto_1fr] sm:items-center sm:p-8">
+                  <div className="min-w-0 sm:text-right">
+                    <div className="break-words text-xl font-black">{fixture.homeTeam.name}</div>
+                  </div>
+                  <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-6 py-3 text-center text-3xl font-black text-emerald-200">{result.homeScore}–{result.awayScore}</div>
+                  <div className="min-w-0">
+                    <div className="break-words text-xl font-black">{fixture.awayTeam.name}</div>
+                  </div>
+                </div>
+                <div className="border-t border-white/10 px-6 py-5 sm:px-8">
+                  <p className="leading-7 text-white/72">Recorded result: {fixture.homeTeam.name} {result.homeScore}–{result.awayScore} {fixture.awayTeam.name}.</p>
+                  {potm ? <p className="mt-3 text-sm font-semibold text-emerald-300">Player of the Match: {potm}</p> : null}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+
+        <div className="mt-10 flex flex-wrap gap-3">
+          <Link href="/admin/matchweek-reports" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Choose another league</Link>
+          <Link href="/admin/fixtures" className="rounded-xl border border-white/15 bg-white/[0.05] px-5 py-3 font-bold text-white">Admin fixtures & results</Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/matchweek-reports/page.tsx
+++ b/src/app/(admin)/admin/matchweek-reports/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { requireAdmin } from "@/lib/requireAdmin";
+import { prisma } from "@/lib/prisma";
+import { formatDateTimeInLondon } from "@/lib/datetime/london";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata: Metadata = {
+  title: "Admin matchweek reports | SIXFL",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminMatchweekReportsPage() {
+  await requireAdmin();
+
+  const leagues = await prisma.league.findMany({
+    where: { isActive: true },
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      season: true,
+      area: true,
+      fixtures: {
+        where: {
+          status: "COMPLETED",
+          publishedAt: { not: null },
+          result: { isNot: null },
+        },
+        orderBy: { kickoffAt: "desc" },
+        take: 1,
+        select: { kickoffAt: true },
+      },
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      <header className="rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-6 sm:p-8">
+        <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-300">Comms & media · Admin only</p>
+        <h1 className="mt-3 text-3xl font-black text-white sm:text-4xl">Matchweek reports</h1>
+        <p className="mt-3 max-w-3xl leading-7 text-white/70">
+          Choose a league to review its latest matchweek report. These are private previews using recorded results — they are not published on the public website.
+        </p>
+      </header>
+
+      {leagues.length ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {leagues.map((league) => {
+            const latestResult = league.fixtures[0];
+            return (
+              <Link
+                key={league.id}
+                href={`/admin/matchweek-reports/${encodeURIComponent(league.slug)}`}
+                className="group min-w-0 rounded-2xl border border-white/10 bg-white/[0.04] p-6 transition hover:border-emerald-400/40 hover:bg-emerald-500/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-emerald-400"
+              >
+                <h2 className="break-words text-xl font-bold text-white">{league.name}</h2>
+                <p className="mt-2 text-sm text-white/55">{[league.area, league.season].filter(Boolean).join(" · ")}</p>
+                <p className="mt-4 text-sm text-white/65">
+                  {latestResult
+                    ? `Latest completed fixture: ${formatDateTimeInLondon(latestResult.kickoffAt, { day: "numeric", month: "long", year: "numeric" })}`
+                    : "No published completed results yet"}
+                </p>
+                <span className="mt-5 inline-flex font-semibold text-emerald-300">Open private preview →</span>
+              </Link>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 text-white/65">No active leagues are available yet.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/leagues/[slug]/weekly-report/page.tsx
+++ b/src/app/(public)/leagues/[slug]/weekly-report/page.tsx
@@ -1,169 +1,18 @@
-import Link from "next/link";
-import { notFound } from "next/navigation";
-import { prisma } from "@/lib/prisma";
-import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { requireAdmin } from "@/lib/requireAdmin";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
+export const metadata: Metadata = { robots: { index: false, follow: false } };
 
-type PageProps = {
+// Retain old bookmarks for administrators only. Never query or render a report here.
+export default async function LegacyWeeklyReport({
+  params,
+}: {
   params: Promise<{ slug: string }>;
-};
-
-function formatDate(date: Date) {
-  return formatDateTimeInLondon(date, {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-}
-
-export default async function WeeklyLeagueReportPreview({ params }: PageProps) {
+}) {
+  await requireAdmin();
   const { slug } = await params;
-
-  const league = await prisma.league.findFirst({
-    where: { slug, isActive: true },
-    select: {
-      name: true,
-      slug: true,
-      area: true,
-      badgeUrl: true,
-      fixtures: {
-        where: {
-          status: "COMPLETED",
-          result: { isNot: null },
-          publishedAt: { not: null },
-        },
-        orderBy: { kickoffAt: "desc" },
-        take: 24,
-        select: {
-          id: true,
-          kickoffAt: true,
-          round: true,
-          homeTeam: { select: { id: true, name: true, logoUrl: true } },
-          awayTeam: { select: { id: true, name: true, logoUrl: true } },
-          result: {
-            select: {
-              homeScore: true,
-              awayScore: true,
-              teamMetadata: {
-                select: {
-                  teamId: true,
-                  scorers: true,
-                  playerOfMatchName: true,
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  });
-
-  if (!league) notFound();
-
-  const latest = league.fixtures[0];
-  if (!latest) {
-    return (
-      <main className="min-h-screen bg-black px-5 py-16 text-white">
-        <div className="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-white/[0.04] p-8">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">SIXFL Matchweek</p>
-          <h1 className="mt-3 text-3xl font-black">No completed results yet</h1>
-          <p className="mt-3 text-white/65">This preview will appear once the league has published completed fixtures.</p>
-          <Link href={`/leagues/${league.slug}`} className="mt-8 inline-flex rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Back to league</Link>
-        </div>
-      </main>
-    );
-  }
-
-  const latestRound = latest.round;
-  const sameRound = latestRound
-    ? league.fixtures.filter((fixture) => fixture.round === latestRound)
-    : league.fixtures.filter((fixture) => {
-        const a = new Date(fixture.kickoffAt);
-        const b = new Date(latest.kickoffAt);
-        return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
-      });
-
-  const matchweekFixtures = [...sameRound].sort(
-    (a, b) => new Date(a.kickoffAt).getTime() - new Date(b.kickoffAt).getTime(),
-  );
-
-  const totalGoals = matchweekFixtures.reduce((sum, fixture) => {
-    const result = fixture.result;
-    return sum + (result ? result.homeScore + result.awayScore : 0);
-  }, 0);
-
-  const biggestWin = [...matchweekFixtures]
-    .filter((fixture) => fixture.result)
-    .sort((a, b) => {
-      const ar = a.result!;
-      const br = b.result!;
-      return Math.abs(br.homeScore - br.awayScore) - Math.abs(ar.homeScore - ar.awayScore);
-    })[0];
-
-  return (
-    <main className="min-h-screen bg-black text-white">
-      <section className="border-b border-white/10 bg-gradient-to-b from-emerald-950/60 to-black">
-        <div className="mx-auto max-w-6xl px-5 py-14 sm:px-8 sm:py-20">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <p className="text-sm font-bold uppercase tracking-[0.24em] text-emerald-300">SIXFL Matchweek Report</p>
-            <span className="rounded-full border border-white/10 bg-white/[0.05] px-4 py-2 text-sm text-white/65">Preview</span>
-          </div>
-          <h1 className="mt-5 max-w-4xl text-4xl font-black leading-tight sm:text-6xl">{league.name}</h1>
-          <p className="mt-4 text-lg text-white/65">{formatDate(latest.kickoffAt)}{latestRound ? ` • Round ${latestRound}` : ""}</p>
-
-          <div className="mt-8 grid gap-3 sm:grid-cols-3">
-            <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-5"><div className="text-3xl font-black">{matchweekFixtures.length}</div><div className="mt-1 text-sm text-white/55">Matches played</div></div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-5"><div className="text-3xl font-black">{totalGoals}</div><div className="mt-1 text-sm text-white/55">Goals scored</div></div>
-            <div className="rounded-2xl border border-white/10 bg-white/[0.05] p-5"><div className="text-lg font-black">{biggestWin ? `${biggestWin.homeTeam.name} ${biggestWin.result!.homeScore}–${biggestWin.result!.awayScore} ${biggestWin.awayTeam.name}` : "—"}</div><div className="mt-1 text-sm text-white/55">Biggest result</div></div>
-          </div>
-        </div>
-      </section>
-
-      <section className="mx-auto max-w-6xl px-5 py-12 sm:px-8">
-        <div className="mb-8 max-w-3xl">
-          <h2 className="text-3xl font-black">This week in {league.area || league.name}</h2>
-          <p className="mt-3 text-base leading-7 text-white/65">A clean, data-led weekly round-up using only recorded SIXFL results. We do not invent possession, chances, late goals or other match details that were not entered into the system.</p>
-        </div>
-
-        <div className="space-y-5">
-          {matchweekFixtures.map((fixture) => {
-            const result = fixture.result!;
-            const winner = result.homeScore === result.awayScore
-              ? null
-              : result.homeScore > result.awayScore
-                ? fixture.homeTeam
-                : fixture.awayTeam;
-            const metadata = result.teamMetadata || [];
-            const potm = metadata.map((item) => item.playerOfMatchName).filter(Boolean).join(" / ");
-
-            return (
-              <article key={fixture.id} className="overflow-hidden rounded-3xl border border-white/10 bg-white/[0.035]">
-                <div className="grid gap-6 p-6 sm:grid-cols-[1fr_auto_1fr] sm:items-center sm:p-8">
-                  <div className="sm:text-right">
-                    <div className="text-xl font-black">{fixture.homeTeam.name}</div>
-                  </div>
-                  <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-6 py-3 text-center text-3xl font-black text-emerald-200">{result.homeScore}–{result.awayScore}</div>
-                  <div>
-                    <div className="text-xl font-black">{fixture.awayTeam.name}</div>
-                  </div>
-                </div>
-                <div className="border-t border-white/10 px-6 py-5 sm:px-8">
-                  <p className="leading-7 text-white/72">{winner ? `${winner.name} took the three points with a ${result.homeScore}–${result.awayScore} win.` : `${fixture.homeTeam.name} and ${fixture.awayTeam.name} shared the points after a ${result.homeScore}–${result.awayScore} draw.`}</p>
-                  {potm ? <p className="mt-3 text-sm font-semibold text-emerald-300">Player of the Match: {potm}</p> : null}
-                </div>
-              </article>
-            );
-          })}
-        </div>
-
-        <div className="mt-10 flex flex-wrap gap-3">
-          <Link href={`/leagues/${league.slug}`} className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">League home</Link>
-          <Link href={`/leagues/${league.slug}/fixtures`} className="rounded-xl border border-white/15 bg-white/[0.05] px-5 py-3 font-bold text-white">Fixtures & results</Link>
-        </div>
-      </section>
-    </main>
-  );
+  redirect(`/admin/matchweek-reports/${encodeURIComponent(slug)}`);
 }

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -120,6 +120,12 @@ const navigationGroups = [
         description: "Cards",
       },
       {
+        name: "Matchweek reports",
+        href: "/admin/matchweek-reports",
+        icon: DocumentTextIcon,
+        description: "Private previews",
+      },
+      {
         name: "SIXFL TV",
         href: "/admin/sixfl-tv",
         icon: PhotoIcon,

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -54,7 +54,6 @@ const adminDesktopLinks: HeaderLink[] = [
   { label: "Fixtures", href: "/admin/fixtures" },
   { label: "Leads", href: "/admin/leads" },
   { label: "Messaging", href: "/admin/messaging" },
-  { label: "Matchweek reports", href: "/admin/matchweek-reports" },
 ];
 
 const adminMobileLinks: HeaderLink[] = [
@@ -66,7 +65,6 @@ const adminMobileLinks: HeaderLink[] = [
   { label: "Venues", href: "/admin/venues" },
   { label: "Fixtures", href: "/admin/fixtures" },
   { label: "Social", href: "/admin/social" },
-  { label: "Matchweek reports", href: "/admin/matchweek-reports" },
   { label: "Result Disputes", href: "/admin/results" },
   { label: "Payments", href: "/admin/payments" },
   { label: "Subscriptions", href: "/admin/payments/subscriptions" },

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -54,6 +54,7 @@ const adminDesktopLinks: HeaderLink[] = [
   { label: "Fixtures", href: "/admin/fixtures" },
   { label: "Leads", href: "/admin/leads" },
   { label: "Messaging", href: "/admin/messaging" },
+  { label: "Matchweek reports", href: "/admin/matchweek-reports" },
 ];
 
 const adminMobileLinks: HeaderLink[] = [
@@ -65,6 +66,7 @@ const adminMobileLinks: HeaderLink[] = [
   { label: "Venues", href: "/admin/venues" },
   { label: "Fixtures", href: "/admin/fixtures" },
   { label: "Social", href: "/admin/social" },
+  { label: "Matchweek reports", href: "/admin/matchweek-reports" },
   { label: "Result Disputes", href: "/admin/results" },
   { label: "Payments", href: "/admin/payments" },
   { label: "Subscriptions", href: "/admin/payments/subscriptions" },

--- a/src/components/leagues/LeagueQuickLinks.tsx
+++ b/src/components/leagues/LeagueQuickLinks.tsx
@@ -19,7 +19,6 @@ export default function LeagueQuickLinks({
     { href: `/leagues/${slug}/fixtures`, label: "Fixtures" },
     { href: `/leagues/${slug}/results`, label: "Results" },
     { href: `/leagues/${slug}/stats`, label: "Stats" },
-    { href: `/leagues/${slug}/weekly-report`, label: "Matchweek Report" },
   ];
 
   return (

--- a/tests/admin-matchweek-reports.test.cjs
+++ b/tests/admin-matchweek-reports.test.cjs
@@ -13,6 +13,7 @@ const root = path.resolve(__dirname, "..");
 const indexPath = "src/app/(admin)/admin/matchweek-reports/page.tsx";
 const detailPath = "src/app/(admin)/admin/matchweek-reports/[slug]/page.tsx";
 const legacyPath = "src/app/(public)/leagues/[slug]/weekly-report/page.tsx";
+const layoutPath = "src/app/(admin)/admin/layout.tsx";
 const pages = [indexPath, detailPath, legacyPath];
 const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
 const load = (file, mocks, transform = (source) => source) => {
@@ -59,11 +60,14 @@ function harness(role = null, email = "example@example.test") {
     "next-auth": { getServerSession: async () => state.session },
     "next-auth/react": { useSession: () => ({ data: state.session }) },
     "@/auth": { authOptions: {} },
-    "@prisma/client": { UserRole: { ADMIN: "ADMIN" } },
+    "@prisma/client": { UserRole: { ADMIN: "ADMIN" }, ResultDisputeStatus: { OPEN: "OPEN", REVIEW: "REVIEW" } },
     "@vercel/analytics": { track() {} },
+    "@/lib/messaging/service": { getAdminInboxSummary: async () => ({ unreadThreads: 0 }) },
+    "@/lib/night-board/next-night-issues": { getNextNightBoardIssueSummary: async () => ({ count: 0, level: null, dateLabel: null }) },
     "@/lib/datetime/london": { formatDateTimeInLondon: (value, options) => new Date(value).toLocaleString("en-GB", { ...options, timeZone: "Europe/London" }) },
     "@/lib/prisma": { prisma: {
       user: { findUnique: async () => state.user },
+      resultDispute: { count: async () => 0 },
       league: {
         findMany: async (query) => { state.queries.push(query); return state.leagues; },
         findFirst: async (query) => { state.queries.push(query); return state.league; },
@@ -123,7 +127,7 @@ test("private empty states and unknown league are handled", async () => {
   await assert.rejects(load(detailPath, mocks).default(props()), (error) => error.destination === "404");
 });
 
-test("report navigation is present in admin sidebar and menus but absent publicly", () => {
+test("report navigation is present in desktop and small-screen admin navigation but absent publicly", async () => {
   const { mocks } = harness("ADMIN");
   const Sidebar = load("src/components/admin/AdminSidebar.tsx", mocks).default;
   const sidebar = renderToStaticMarkup(React.createElement(Sidebar, {}));
@@ -131,8 +135,18 @@ test("report navigation is present in admin sidebar and menus but absent publicl
   assert.match(sidebar, /href="\/admin\/matchweek-reports"/);
   assert.match(sidebar, /Private previews/);
   const Header = load("src/components/layout/AppHeader.tsx", mocks).default;
-  const admin = renderToStaticMarkup(React.createElement(Header, { variant: "admin" }));
-  assert.equal((admin.match(/href="\/admin\/matchweek-reports"/g) || []).length, 2, "desktop and mobile menus both contain the link");
+  // Isolate unrelated layout widgets, but render the actual sidebar and header.
+  for (const [, dependency] of read(layoutPath).matchAll(/from ["'](@\/components\/[^"']+)["']/g)) {
+    mocks[dependency] = { __esModule: true, default: () => null };
+  }
+  mocks["@/components/admin/AdminSidebar"] = { __esModule: true, default: Sidebar };
+  mocks["@/components/layout/AppHeader"] = { __esModule: true, default: Header };
+  const Layout = load(layoutPath, mocks).default;
+  const admin = renderToStaticMarkup(await Layout({ children: React.createElement("p", null, "Test content") }));
+  assert.equal((admin.match(/href="\/admin\/matchweek-reports"/g) || []).length, 2, "desktop sidebar and mobile/tablet quick navigation both contain the link");
+  const smallScreenNav = admin.match(/<nav aria-label="Admin reports"[^>]*>[\s\S]*?<\/nav>/)?.[0] || "";
+  assert.match(smallScreenNav, /xl:hidden/);
+  assert.match(smallScreenNav, /href="\/admin\/matchweek-reports"/);
   const publicHeader = renderToStaticMarkup(React.createElement(Header, { variant: "public" }));
   assert.doesNotMatch(publicHeader, /matchweek-reports|weekly-report/);
   const QuickLinks = load("src/components/leagues/LeagueQuickLinks.tsx", mocks).default;

--- a/tests/admin-matchweek-reports.test.cjs
+++ b/tests/admin-matchweek-reports.test.cjs
@@ -1,0 +1,171 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { test } = require("node:test");
+const ts = require("typescript");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+// Run real pages, navigation and the production requireAdmin policy with isolated I/O.
+// No production database, session, provider or network is used.
+const root = path.resolve(__dirname, "..");
+const indexPath = "src/app/(admin)/admin/matchweek-reports/page.tsx";
+const detailPath = "src/app/(admin)/admin/matchweek-reports/[slug]/page.tsx";
+const legacyPath = "src/app/(public)/leagues/[slug]/weekly-report/page.tsx";
+const pages = [indexPath, detailPath, legacyPath];
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const load = (file, mocks, transform = (source) => source) => {
+  const { outputText } = ts.transpileModule(transform(read(file)), {
+    fileName: file,
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true },
+  });
+  const module = { exports: {} };
+  const allowed = new Set(["react", "react/jsx-runtime", "@heroicons/react/24/outline", "react-icons/hi"]);
+  vm.runInNewContext(outputText, {
+    module, exports: module.exports, console,
+    process: { env: { NODE_ENV: "production" } },
+    require(id) {
+      if (Object.prototype.hasOwnProperty.call(mocks, id)) return mocks[id];
+      if (allowed.has(id)) return require(id);
+      throw new Error(`Unexpected dependency (I/O blocked): ${id}`);
+    },
+  }, { filename: file });
+  return module.exports;
+};
+class NavigationExit extends Error {
+  constructor(destination) { super(destination); this.destination = destination; }
+}
+const exampleLeague = () => ({
+  id: "test-league", name: "Report Test League", slug: "example", area: "Test area", season: "Test season", badgeUrl: null,
+  fixtures: [{
+    id: "test-fixture", kickoffAt: new Date("2026-09-09T18:00:00Z"), round: 1,
+    homeTeam: { id: "a", name: "Test Team A", logoUrl: null },
+    awayTeam: { id: "b", name: "Test Team B", logoUrl: null },
+    result: { homeScore: 1, awayScore: 3, teamMetadata: [{ teamId: "b", scorers: [], playerOfMatchName: "Test player" }] },
+  }],
+});
+function harness(role = null, email = "example@example.test") {
+  const state = { session: role ? { user: { email } } : null, user: role ? { role, email } : null, queries: [], league: exampleLeague(), leagues: [exampleLeague()] };
+  const navigation = {
+    redirect(destination) { throw new NavigationExit(destination); },
+    notFound() { throw new NavigationExit("404"); },
+    usePathname: () => "/admin/matchweek-reports/example",
+  };
+  const mocks = {
+    "next/navigation": navigation,
+    "next/link": { __esModule: true, default: ({ children, ...props }) => React.createElement("a", props, children) },
+    "next/image": { __esModule: true, default: () => null },
+    "next-auth": { getServerSession: async () => state.session },
+    "next-auth/react": { useSession: () => ({ data: state.session }) },
+    "@/auth": { authOptions: {} },
+    "@prisma/client": { UserRole: { ADMIN: "ADMIN" } },
+    "@vercel/analytics": { track() {} },
+    "@/lib/datetime/london": { formatDateTimeInLondon: (value, options) => new Date(value).toLocaleString("en-GB", { ...options, timeZone: "Europe/London" }) },
+    "@/lib/prisma": { prisma: {
+      user: { findUnique: async () => state.user },
+      league: {
+        findMany: async (query) => { state.queries.push(query); return state.leagues; },
+        findFirst: async (query) => { state.queries.push(query); return state.league; },
+      },
+    } },
+  };
+  mocks["@/lib/requireAdmin"] = load("src/lib/requireAdmin.ts", mocks);
+  return { state, mocks };
+}
+const props = () => ({ params: Promise.resolve({ slug: "example" }) });
+
+for (const role of [null, "USER", "REFEREE"]) {
+  for (const page of pages) {
+    test(`${role || "anonymous"} cannot access ${page}`, async () => {
+      const { state, mocks } = harness(role);
+      await assert.rejects(load(page, mocks).default(props()), (error) => error instanceof NavigationExit && error.destination === (role ? "/dashboard" : "/login"));
+      assert.equal(state.queries.length, 0, "authorization must finish before report data is queried");
+    });
+  }
+}
+
+for (const [role, email] of [["ADMIN", "admin@example.test"], ["USER", "hello@sixfl.co.uk"]]) {
+  test(`${email} can choose a league and open a private preview`, async () => {
+    const { state, mocks } = harness(role, email);
+    const index = load(indexPath, mocks);
+    const html = renderToStaticMarkup(await index.default());
+    assert.match(html, /href="\/admin\/matchweek-reports\/example"/);
+    assert.match(html, /Report Test League/);
+    const detail = load(detailPath, mocks);
+    const report = renderToStaticMarkup(await detail.default(props()));
+    assert.match(report, /Admin-only preview/);
+    assert.match(report, /not published/);
+    assert.match(report, /Test Team A/);
+    assert.match(report, /Test Team B/);
+    assert.match(report, /Test player/);
+    assert.equal(index.metadata.robots.index, false);
+    assert.equal(detail.metadata.robots.index, false);
+    assert.equal(state.queries[0].where.isActive, true);
+    assert.equal(state.queries[1].where.slug, "example");
+    assert.equal(state.queries[1].select.fixtures.where.status, "COMPLETED");
+    assert.equal(state.queries[1].select.fixtures.where.publishedAt.not, null);
+    state.queries.length = 0;
+    const legacy = load(legacyPath, mocks);
+    await assert.rejects(legacy.default(props()), (error) => error.destination === "/admin/matchweek-reports/example");
+    assert.equal(state.queries.length, 0, "old public route must only redirect, not read results");
+    assert.equal(legacy.metadata.robots.index, false);
+  });
+}
+
+test("private empty states and unknown league are handled", async () => {
+  const { state, mocks } = harness("ADMIN");
+  state.leagues = [];
+  assert.match(renderToStaticMarkup(await load(indexPath, mocks).default()), /No active leagues/);
+  state.league.fixtures = [];
+  assert.match(renderToStaticMarkup(await load(detailPath, mocks).default(props())), /No completed results yet/);
+  state.league = null;
+  await assert.rejects(load(detailPath, mocks).default(props()), (error) => error.destination === "404");
+});
+
+test("report navigation is present in admin sidebar and menus but absent publicly", () => {
+  const { mocks } = harness("ADMIN");
+  const Sidebar = load("src/components/admin/AdminSidebar.tsx", mocks).default;
+  const sidebar = renderToStaticMarkup(React.createElement(Sidebar, {}));
+  assert.match(sidebar, /Comms &amp; media/);
+  assert.match(sidebar, /href="\/admin\/matchweek-reports"/);
+  assert.match(sidebar, /Private previews/);
+  const Header = load("src/components/layout/AppHeader.tsx", mocks).default;
+  const admin = renderToStaticMarkup(React.createElement(Header, { variant: "admin" }));
+  assert.equal((admin.match(/href="\/admin\/matchweek-reports"/g) || []).length, 2, "desktop and mobile menus both contain the link");
+  const publicHeader = renderToStaticMarkup(React.createElement(Header, { variant: "public" }));
+  assert.doesNotMatch(publicHeader, /matchweek-reports|weekly-report/);
+  const QuickLinks = load("src/components/leagues/LeagueQuickLinks.tsx", mocks).default;
+  const publicNav = renderToStaticMarkup(React.createElement(QuickLinks, { slug: "example" }));
+  assert.doesNotMatch(publicNav, /Matchweek|weekly-report|matchweek-reports/);
+  for (const label of ["League table", "Fixtures", "Results", "Stats"]) assert.ok(publicNav.includes(label));
+});
+
+test("negative control detects removal of the page-level admin guard", async () => {
+  const { state, mocks } = harness();
+  const unguarded = load(indexPath, mocks, (source) => source.replace("await requireAdmin();", ""));
+  await unguarded.default();
+  assert.throws(() => assert.equal(state.queries.length, 0), assert.AssertionError);
+});
+
+test("repository-wide scan finds no alternate public report links or implementation", () => {
+  const matches = [];
+  function visit(directory) {
+    for (const entry of fs.readdirSync(path.join(root, directory), { withFileTypes: true })) {
+      const file = `${directory}/${entry.name}`;
+      if (entry.isDirectory()) visit(file);
+      else if (/\.(?:[cm]?[jt]sx?)$/.test(file)) {
+        const source = read(file);
+        if (!/weekly-report|matchweek.?report/i.test(source)) continue;
+        matches.push(file);
+        const publiclyReachable = file.startsWith("src/app/(public)/") || file.startsWith("src/app/captain/") || file.startsWith("src/app/player/") || file.startsWith("src/components/leagues/");
+        if (publiclyReachable) assert.equal(file, legacyPath, `Unexpected report exposure in ${file}`);
+      }
+    }
+  }
+  visit("src");
+  console.log("Report reference audit:", matches.join(", "));
+  assert.doesNotMatch(read(legacyPath), /prisma|teamMetadata|homeScore|awayScore/);
+  assert.ok(matches.includes(indexPath));
+  assert.ok(matches.includes(detailPath));
+});


### PR DESCRIPTION
## Requested change
Move the early matchweek-report prototype into the admin navigation and make it admin-only while it is developed.

## Implementation
- Add Matchweek reports under Admin → Comms & media in the desktop sidebar, plus a native quick link in the protected admin layout on mobile/tablet (below xl, where the sidebar is hidden).
- Add `/admin/matchweek-reports` with a league chooser and `/admin/matchweek-reports/[slug]` for the preview.
- Both pages explicitly await the existing production `requireAdmin()` policy before querying report data, in addition to the protected admin layout.
- Remove the report link from shared public league navigation. The old `/leagues/[slug]/weekly-report` route no longer queries or renders results; it authenticates administrators and redirects their existing bookmarks to the private admin route.
- Mark all report entry routes noindex/nofollow and clearly label previews as admin-only and unpublished.
- Keep output read-only, within the admin shell, with links back to the chooser and admin fixtures. Recorded-score wording does not assume league points for a fixture whose competition outcome has not been checked.

## Scope and DOM policy
The first version added links to the shared AppHeader, whose pre-existing body-scroll mutation triggered the DOM gate. Those AppHeader changes have been fully reverted. The mobile/tablet link is instead rendered natively by the protected admin layout: no shared public-header change, no DOM bridge, no exception or gate bypass, no unrelated mobile-drawer rewrite.

## Verification
Isolated tests exercise real pages, the real protected admin layout/sidebar and production authorization policy for anonymous users, ordinary users, referees, database admins and allowlisted admins. Coverage includes empty/unknown leagues, legacy URL protection, public-tab removal, desktop and mobile/tablet navigation, and an admin-guard negative control. A repository-wide reference scan runs before and after preparation. Dedicated CI runs tests before and after the full prebuild chain. Existing critical-feature, DOM-policy and type-check gates remain required.

No database migration, data reset, result/fixture/payment writes, publication, emails or SMS. Deployment/live verification checked separately after CI.