### PR TITLE
Preserve report generation behind Railway's public-host proxy

### DIFF
--- a/.github/workflows/openai-matchweek-drafts.yml
+++ b/.github/workflows/openai-matchweek-drafts.yml
@@ -34,11 +34,11 @@ jobs:
           psql "$REPORT_TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -c 'CREATE TABLE "League" (id TEXT PRIMARY KEY)'
           psql "$REPORT_TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f prisma/migrations/20260910224500_openai_matchweek_drafts/migration.sql
       - name: Test OpenAI request, factual boundaries, auth and real draft transactions
-        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs
+        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs tests/matchweek-report-proxy.test.cjs
       - run: npm run prebuild
       - run: npx prisma generate
       - name: Repeat tests against the production-prepared source
-        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs
+        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs tests/matchweek-report-proxy.test.cjs
       - name: Check critical contracts and types
         run: |
           node scripts/check-critical-feature-contracts.mjs

--- a/src/app/api/admin/matchweek-reports/[slug]/route.ts
+++ b/src/app/api/admin/matchweek-reports/[slug]/route.ts
@@ -29,7 +29,15 @@ export async function POST(request: NextRequest, context: Context) {
     for (const url of [process.env.NEXTAUTH_URL, process.env.NEXT_PUBLIC_SITE_URL, process.env.NEXT_PUBLIC_APP_URL]) {
       try { if (url) allowed.add(new URL(url).origin); } catch { /* Ignore invalid configured origins. */ }
     }
-    if (!allowed.has(request.headers.get("origin") || "") || request.headers.get("x-sixfl-report") !== "1" || !request.headers.get("content-type")?.includes("application/json")) throw new ReportError("This request is not allowed. Reload the report page.", 403);
+    // Railway can expose its internal HTTP URL here. Match the actual forwarded
+    // browser host too, as in SIXFL's existing authenticated JSON mutation routes.
+    const hosts = [request.nextUrl.host, request.headers.get("host"), request.headers.get("x-forwarded-host")?.split(",")[0]?.trim()];
+    let sameOrigin = false;
+    try {
+      const origin = new URL(request.headers.get("origin") || "");
+      sameOrigin = ["http:", "https:"].includes(origin.protocol) && (allowed.has(origin.origin) || hosts.includes(origin.host));
+    } catch { /* Deny missing or malformed origins. */ }
+    if (!sameOrigin || request.headers.get("sec-fetch-site") === "cross-site" || request.headers.get("x-sixfl-report") !== "1" || !request.headers.get("content-type")?.includes("application/json")) throw new ReportError("This request is not allowed. Reload the report page.", 403);
     const text = await request.text();
     if (text.length > 100000) throw new ReportError("The report is too long.", 413);
     let body: Record<string, unknown>;

--- a/tests/matchweek-report-proxy.test.cjs
+++ b/tests/matchweek-report-proxy.test.cjs
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { test } = require("node:test");
+const ts = require("typescript");
+const { NextRequest } = require("next/server");
+
+test("report mutations accept Railway's forwarded browser origin and reject cross-site or unauthorised requests", async () => {
+  let writes = 0;
+  let authorised = true;
+  class ReportError extends Error { constructor(message, status = 400) { super(message); this.status = status; } }
+  const file = path.resolve(__dirname, "../src/app/api/admin/matchweek-reports/[slug]/route.ts");
+  const module = { exports: {} };
+  const code = ts.transpileModule(fs.readFileSync(file, "utf8"), { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } }).outputText;
+  const mocks = {
+    "@/lib/requireAdmin": { requireAdmin: async () => { if (!authorised) throw new ReportError("Sign in as admin", 401); } },
+    "@/lib/matchweek-reports/types": { ReportError },
+    "@/lib/matchweek-reports/service": { generateReport: async () => { writes++; return {}; }, saveReport: async () => { writes++; return {}; } },
+  };
+  vm.runInNewContext(code, { module, exports: module.exports, URL, console, process: { env: { NEXTAUTH_URL: "https://www.sixfl.example" } }, require(id) {
+    if (id in mocks) return mocks[id];
+    if (["next/server", "next/dist/client/components/redirect-error"].includes(id)) return require(id);
+    throw new Error(`Unexpected dependency: ${id}`);
+  } });
+  const route = module.exports;
+  const context = { params: Promise.resolve({ slug: "example" }) };
+  const request = (origin, extra = {}) => new NextRequest("http://0.0.0.0:8080/api/admin/matchweek-reports/example", {
+    method: "POST", headers: { origin, "x-forwarded-host": "sixfl.example", "Content-Type": "application/json", "X-Sixfl-Report": "1", ...extra }, body: JSON.stringify({ action: "generate" }),
+  });
+  assert.equal((await route.POST(request("https://sixfl.example"), context)).status, 200);
+  assert.equal(writes, 1);
+  for (const [origin, extra] of [["https://evil.example", {}], ["null", {}], ["https://sixfl.example", { "sec-fetch-site": "cross-site" }], ["https://sixfl.example", { "X-Sixfl-Report": "" }]]) {
+    assert.equal((await route.POST(request(origin, extra), context)).status, 403);
+  }
+  authorised = false;
+  assert.equal((await route.POST(request("https://sixfl.example"), context)).status, 401);
+  assert.equal(writes, 1, "rejected requests must not reach generation or saving");
+});


### PR DESCRIPTION
Follow-up verification for #489 found a reproducible proxy-origin edge case: NextRequest may expose an internal HTTP origin while the browser is on the canonical apex domain and an older configured URL still uses www. Match the forwarded browser host, as the existing SIXFL SMS/announcement JSON routes do, rather than falsely rejecting the Generate/Save request. Keep administrator authentication, explicit custom header and JSON requirements; also reject Sec-Fetch-Site cross-site requests.

A new isolated runtime test exercises the real route against this exact internal-host/legacy-www setup, plus hostile/missing origins, missing custom header and unauthorised requests, asserting no generation/save on denial. Included before and after the full prebuild in existing OpenAI report CI. Local report tests, new proxy test, 55 critical contracts and TypeScript pass against prepared source.

Only the report POST boundary, its test and test workflow change. No storage migration, provider call, access-policy weakening, private data, notifications, publication or unrelated source changes. Production key/billing and signed-in live generation are still separate unverified checks.