### PR TITLE
Show each omitted report fixture with its specific reasons and review link

### DIFF
--- a/.github/workflows/openai-matchweek-drafts.yml
+++ b/.github/workflows/openai-matchweek-drafts.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   reports:
     runs-on: ubuntu-latest
+    timeout-minutes: 18
     services:
       postgres:
         image: postgres:17
@@ -21,6 +22,13 @@ jobs:
           --health-timeout 5s --health-retries 10
     env:
       REPORT_TEST_DATABASE_URL: postgresql://postgres:test_only@localhost:5432/sixfl_report_test
+      DATABASE_URL: postgresql://invalid:invalid@127.0.0.1:65432/unused
+      NEXTAUTH_SECRET: isolated-report-render-only
+      NEXTAUTH_URL: http://localhost:3000
+      NEXT_PUBLIC_SITE_URL: http://localhost:3000
+      RESEND_API_KEY: re_nonfunctional_ci_placeholder
+      EMAIL_FROM: SIXFL <noreply@example.invalid>
+      EMAIL_REPLY_DOMAIN: example.invalid
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -33,17 +41,36 @@ jobs:
         run: |
           psql "$REPORT_TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -c 'CREATE TABLE "League" (id TEXT PRIMARY KEY)'
           psql "$REPORT_TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f prisma/migrations/20260910224500_openai_matchweek_drafts/migration.sql
-      - name: Test OpenAI request, factual boundaries, auth and real draft transactions
-        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs tests/matchweek-report-proxy.test.cjs
+      - name: Test request, auth, draft transactions and exact fixture omission reasons
+        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs tests/matchweek-report-proxy.test.cjs tests/report-omissions.test.cjs
       - run: npm run prebuild
       - run: npx prisma generate
       - name: Repeat tests against the production-prepared source
-        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs tests/matchweek-report-proxy.test.cjs
+        run: node --test tests/openai-matchweek-reports.test.cjs tests/admin-matchweek-reports.test.cjs tests/matchweek-report-proxy.test.cjs tests/report-omissions.test.cjs
       - name: Check critical contracts and types
         run: |
           node scripts/check-critical-feature-contracts.mjs
           npx tsc --noEmit
       - name: Audit report entry points and retired copy
         run: |
-          git grep -n -i -E 'weekly-report|matchweek.?report' -- src/app src/components src/lib/matchweek-reports
-          if grep -R -n 'A clean, data-led weekly round-up\|Recorded result:' 'src/app/(admin)/admin/matchweek-reports' src/components/admin/matchweek-reports; then exit 1; fi
+          mkdir -p .tmp/report-omissions
+          git grep -n -i -E 'weekly-report|matchweek.?report' -- src/app src/components src/lib/matchweek-reports > .tmp/report-omissions/entry-points.txt
+          git grep -n -E 'skippedFixtures|omittedFixtures|pendingFixtures|ReportSkippedFixtures' -- src > .tmp/report-omissions/source-inventory.txt
+          if grep -R -n 'A clean, data-led weekly round-up\|Recorded result:\|view.source.warnings.map' 'src/app/(admin)/admin/matchweek-reports' src/components/admin/matchweek-reports; then exit 1; fi
+      - run: npx next build
+      - name: Real editor browser interactions on desktop and mobile, no provider calls
+        run: |
+          npm install --prefix /tmp/report-browser --no-save --package-lock=false playwright@1.58.2
+          /tmp/report-browser/node_modules/.bin/playwright install --with-deps chromium
+          REPORT_PLAYWRIGHT_MODULE=/tmp/report-browser/node_modules/playwright node --test tests/report-omissions.browser.cjs
+      - name: Capture prepared source and visual verification
+        if: always()
+        run: |
+          mkdir -p .tmp/report-omissions
+          tar -czf .tmp/report-omissions/prepared-source.tgz src/lib/matchweek-reports src/components/admin/matchweek-reports 'src/app/(admin)/admin/matchweek-reports' 'src/app/api/admin/matchweek-reports' tests/report-omissions.*
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: report-omissions-verification
+          path: .tmp/report-omissions
+          retention-days: 7

--- a/docs/report-omitted-fixtures.md
+++ b/docs/report-omitted-fixtures.md
@@ -1,0 +1,28 @@
+# Per-fixture matchnight report omissions
+
+The existing `getReportSource` reader owns eligibility AND its explanation. It
+returns one `skippedFixtures` item for each pending/omitted published fixture on
+the selected London match date: fixture ID, sanitised teams, ISO kick-off,
+pending/omitted disposition, and every applicable reason. Counts reconcile to
+that list. The administrative query now labels abandonment and replacement
+records separately; no narratives, contacts or payment details are selected.
+
+`ReportSkippedFixtures` is rendered by the native admin `ReportEditor`, expanded
+by default, above the article. It uses `view.source` (current data), not the saved
+article snapshot. Fixture review links use the existing admin edit route and open
+in a new tab to avoid discarding report edits. The read-only Check saved status
+refreshes the list without a generation. No inclusion override is introduced.
+
+Old snapshots remain valid: the new optional review field is excluded from the
+source hash, and legacy summary warning values remain internally for hash
+compatibility. The editor no longer displays the generic catch-all warning.
+Included facts and omission counts still invalidate genuinely stale articles.
+The existing explicit OpenAI payload does NOT include omitted fixture identities
+or administrative reasons. No automatic generation or paid request is made.
+
+The permanent report workflow tests native and fully prepared classification
+against the former eligibility rules, every omission category, multiple reasons,
+counts, data minimisation, hash compatibility, legacy and saved-draft rendering,
+provider payload filtering and real editor desktop/mobile refresh interactions.
+Existing auth, proxy and disposable PostgreSQL draft transaction tests remain.
+No production fixture, result, payment, draft or notification data is changed.

--- a/src/components/admin/matchweek-reports/ReportEditor.tsx
+++ b/src/components/admin/matchweek-reports/ReportEditor.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { ReportContent, ReportView } from "@/lib/matchweek-reports/types";
+import ReportSkippedFixtures from "./ReportSkippedFixtures";
 
 const inputClass = "mt-2 w-full rounded-xl border border-white/15 bg-black/40 p-3 text-base leading-7 text-white focus:border-emerald-400 focus:outline-none";
 const buttonClass = "inline-flex min-h-11 items-center justify-center rounded-xl border border-white/15 px-4 py-2 text-sm font-bold text-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40";
@@ -88,11 +89,12 @@ export default function ReportEditor({ slug, initialView }: { slug: string; init
         {view.generating ? <p className="mt-3 text-amber-200">A generation is in progress. Use Check saved status to retrieve it; do not start another.</p> : null}
         {view.latestError ? <p className="mt-3 text-amber-200">Last generation: {view.latestError}</p> : null}
         {view.stale ? <p className="mt-3 rounded-xl border border-amber-300/25 bg-amber-500/10 p-3 text-amber-100">The recorded results have changed since this draft was generated. The article and its scorecards still show its saved source snapshot. Review the current facts below and regenerate before using it.</p> : null}
-        {view.source.warnings.map(w => <p key={w} className="mt-3 text-sm text-amber-100">{w}</p>)}
         {dirty ? <p className="mt-3 font-semibold text-amber-200">Unsaved changes — save your draft before leaving.</p> : null}
         {notice ? <p role="status" className="mt-3 text-emerald-200">{notice}</p> : null}
         {error ? <p role="alert" className="mt-3 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-red-100">{error}</p> : null}
       </section>
+
+      <ReportSkippedFixtures source={view.source} />
 
       {content ? <article className="rounded-3xl border border-white/10 bg-white/[0.035] p-6 sm:p-10">
         <p className="text-xs font-bold uppercase tracking-[0.18em] text-emerald-300">SIXFL Matchnight · Private draft</p>

--- a/src/components/admin/matchweek-reports/ReportSkippedFixtures.tsx
+++ b/src/components/admin/matchweek-reports/ReportSkippedFixtures.tsx
@@ -1,0 +1,42 @@
+import type { ReportSource } from "@/lib/matchweek-reports/types";
+
+const kickoffLabel = (value: string) => {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "Kick-off time unavailable" : new Intl.DateTimeFormat("en-GB", {
+    day: "numeric", month: "short", hour: "2-digit", minute: "2-digit", timeZone: "Europe/London",
+  }).format(date);
+};
+
+/** Always uses current source data, never the old article's source snapshot. */
+export default function ReportSkippedFixtures({ source }: { source: ReportSource }) {
+  const fixtures = source.skippedFixtures ?? [];
+  const count = source.omittedFixtures + source.pendingFixtures;
+  if (!count && !fixtures.length) return null;
+  return (
+    <section aria-labelledby="report-skipped-heading" className="rounded-2xl border border-amber-300/25 bg-amber-500/[0.06] p-5 sm:p-6">
+      <h2 id="report-skipped-heading" className="text-lg font-bold text-amber-100">Matches not included ({count})</h2>
+      <p className="mt-2 text-sm leading-6 text-white/70">
+        {source.omittedFixtures} omitted · {source.pendingFixtures} awaiting completion. These are the current fixture records for this night, not the saved article. Times are UK local time.
+      </p>
+      {fixtures.length ? <ul className="mt-4 space-y-3">
+        {fixtures.map(f => <li key={f.fixtureId} className="min-w-0 rounded-xl border border-white/10 bg-black/20 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 basis-48">
+              <h3 className="break-words text-base font-bold leading-7 text-white">{f.teamA} <span className="font-normal text-white/50">vs</span> {f.teamB}</h3>
+              <p className="mt-1 text-sm text-white/65"><time dateTime={f.kickoffAt}>{kickoffLabel(f.kickoffAt)}</time> · {f.disposition === "pending" ? "Awaiting completion" : "Omitted from report"}</p>
+            </div>
+            <a href={`/admin/fixtures/${encodeURIComponent(f.fixtureId)}/edit`} target="_blank" rel="noopener noreferrer"
+              aria-label={`Review ${f.teamA} vs ${f.teamB} (opens in a new tab)`}
+              className="inline-flex min-h-11 items-center rounded-lg border border-amber-200/20 px-3 py-2 text-sm font-semibold text-amber-100 underline underline-offset-4 hover:bg-white/10">
+              Review fixture ↗
+            </a>
+          </div>
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-sm leading-6 text-amber-100">
+            {f.reasons.map(reason => <li key={reason.code} className="break-words">{reason.message}</li>)}
+          </ul>
+        </li>)}
+      </ul> : <p className="mt-4 text-sm leading-6 text-amber-100">This older view has no per-match details. Use Check saved status to load the latest fixture reasons; no report generation is needed.</p>}
+      <p className="mt-4 text-xs leading-6 text-white/60">Review links open in a new tab so your draft stays here. After correcting a fixture, use Check saved status to refresh this list. This list does not include matches in the article automatically.</p>
+    </section>
+  );
+}

--- a/src/lib/matchweek-reports/facts.ts
+++ b/src/lib/matchweek-reports/facts.ts
@@ -3,11 +3,16 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { parseLondonDateTime, toLondonDateInputValue } from "@/lib/datetime/london";
 import { getFixturePlaceholderTeamIds } from "@/lib/teams/fixture-placeholders";
-import { ReportError, validDate, type ReportSource, type ReportMatch } from "./types";
+import { ReportError, validDate, type ReportSource, type ReportMatch, type ReportSkippedFixture } from "./types";
 
 // No standings are calculated here. Table/form claims are deliberately omitted
 // until the central standings service supports a verified historical snapshot.
-export const sourceHash = (source: ReportSource) => createHash("sha256").update(JSON.stringify(source)).digest("hex");
+export function sourceHash(source: ReportSource) {
+  // Adding admin-only explanations must not invalidate existing saved articles
+  // or force another paid generation. Included facts/counts still affect the hash.
+  const { skippedFixtures: _reviewDetails, ...articleSource } = source;
+  return createHash("sha256").update(JSON.stringify(articleSource)).digest("hex");
+}
 const name = (value: unknown) => typeof value === "string" && !value.includes("@") ? value.replace(/[\r\n\t]+/g, " ").trim().slice(0, 160) : "";
 export function recordedScorers(value: unknown, team: string, score: number) {
   if (!Array.isArray(value)) return [];
@@ -43,33 +48,63 @@ export async function getReportSource(slug: string, requestedDate?: string): Pro
   if (fixtures.length > 40) throw new ReportError("This match night is too large for one report. Please contact SIXFL support.");
   const ids = fixtures.map(f => f.id);
   const placeholders = await getFixturePlaceholderTeamIds(fixtures.flatMap(f => [f.homeTeam.id, f.awayTeam.id]));
-  // Only IDs are read: no conduct notes, payment information or contact details
-  // are passed to OpenAI. Administrative/replacement outcomes need human review.
-  const exceptions = ids.length ? await prisma.$queryRaw<Array<{ fixtureId: string }>>(Prisma.sql`
-    SELECT "fixtureId" FROM "FixtureAbandonment" WHERE "fixtureId" IN (${Prisma.join(ids)})
-    UNION SELECT "fixtureId" FROM "LastMinuteReplacementResolution" WHERE "fixtureId" IN (${Prisma.join(ids)})
+  // Read only fixture IDs and a fixed category, never conduct narratives, contacts
+  // or payment information. These details stay in the private editorial view.
+  const exceptions = ids.length ? await prisma.$queryRaw<Array<{ fixtureId: string; reason: string }>>(Prisma.sql`
+    SELECT "fixtureId", 'abandonment'::text AS "reason" FROM "FixtureAbandonment" WHERE "fixtureId" IN (${Prisma.join(ids)})
+    UNION SELECT "fixtureId", 'replacement'::text AS "reason" FROM "LastMinuteReplacementResolution" WHERE "fixtureId" IN (${Prisma.join(ids)})
   `) : [];
-  const excluded = new Set(exceptions.map(r => r.fixtureId));
+  const exceptionReasons = new Map<string, ReportSkippedFixture["reasons"]>();
+  for (const row of exceptions) {
+    const reason = row.reason === "abandonment"
+      ? { code: "abandonment", message: "An abandonment record is attached to this fixture; its administrative outcome needs editorial review." }
+      : row.reason === "replacement"
+        ? { code: "replacement", message: "A last-minute replacement is recorded for this fixture; it needs editorial review before inclusion." }
+        : { code: "administrative_record", message: "An administrative exception is recorded for this fixture and needs editorial review." };
+    const reasons = exceptionReasons.get(row.fixtureId) ?? [];
+    if (!reasons.some(r => r.code === reason.code)) reasons.push(reason);
+    exceptionReasons.set(row.fixtureId, reasons);
+  }
   let pendingFixtures = 0, omittedFixtures = 0;
   const warnings: string[] = [];
   const matches: ReportMatch[] = [];
+  const skippedFixtures: ReportSkippedFixture[] = [];
+  const now = new Date();
   for (const f of fixtures) {
-    if (f.status === "SCHEDULED" || (f.status === "COMPLETED" && !f.result)) { pendingFixtures++; continue; }
-    if (f.status !== "COMPLETED") { omittedFixtures++; continue; }
-    const r = f.result!;
-    if (f.kickoffAt > new Date() || r.isDisputed || r.disputes.length || excluded.has(f.id) || placeholders.has(f.homeTeam.id) || placeholders.has(f.awayTeam.id) || [f.homeTeam.name, f.awayTeam.name].some(n => n.trim().toUpperCase() === "TBC")) { omittedFixtures++; continue; }
-    if (![r.homeScore, r.awayScore].every(n => Number.isInteger(n) && n >= 0 && n <= 99)) { omittedFixtures++; continue; }
+    const r = f.result;
     const teamA = name(f.homeTeam.name), teamB = name(f.awayTeam.name);
-    if (!teamA || !teamB) { omittedFixtures++; continue; }
-    const a = r.teamMetadata.find(m => m.teamId === f.homeTeam.id), b = r.teamMetadata.find(m => m.teamId === f.awayTeam.id);
-    const scorers = [...recordedScorers(a?.scorers, teamA, r.homeScore), ...recordedScorers(b?.scorers, teamB, r.awayScore)];
+    const reasons: ReportSkippedFixture["reasons"] = [];
+    const pending = f.status === "SCHEDULED" || (f.status === "COMPLETED" && !r);
+    if (f.status === "SCHEDULED") reasons.push({ code: "scheduled", message: r ? "A result is saved, but the fixture is still marked scheduled rather than completed." : "No completed result is recorded; the fixture is still marked scheduled." });
+    else if (f.status === "COMPLETED" && !r) reasons.push({ code: "missing_result", message: "The fixture is marked completed, but no result has been saved." });
+    else if (f.status === "POSTPONED") reasons.push({ code: "postponed", message: "The fixture is marked postponed." });
+    else if (f.status === "CANCELLED") reasons.push({ code: "cancelled", message: "The fixture is marked cancelled." });
+    else if (f.status !== "COMPLETED") reasons.push({ code: "not_completed", message: `The fixture is not marked completed (recorded status: ${f.status}).` });
+    if (f.kickoffAt > now) reasons.push({ code: "future_kickoff", message: "The recorded kick-off time is still in the future." });
+    if (r?.isDisputed) reasons.push({ code: "disputed_result", message: "The saved result is flagged as disputed." });
+    if (r?.disputes.length) reasons.push({ code: "unresolved_dispute", message: "There is an open or under-review dispute against the result." });
+    reasons.push(...(exceptionReasons.get(f.id) ?? []));
+    if (placeholders.has(f.homeTeam.id) || placeholders.has(f.awayTeam.id) || [f.homeTeam.name, f.awayTeam.name].some(n => n.trim().toUpperCase() === "TBC")) reasons.push({ code: "placeholder", message: "The fixture contains a placeholder or TBC team rather than two confirmed teams." });
+    if (r && ![r.homeScore, r.awayScore].every(n => Number.isInteger(n) && n >= 0 && n <= 99)) reasons.push({ code: "invalid_score", message: "The saved score is invalid: both scores must be whole numbers between 0 and 99." });
+    if (!teamA || !teamB) reasons.push({ code: "invalid_team_name", message: "One or both team names are missing or unsuitable for reporting. Review the fixture to identify the teams." });
+    if (reasons.length) {
+      if (pending) pendingFixtures++; else omittedFixtures++;
+      skippedFixtures.push({ fixtureId: f.id, teamA: teamA || "Unnamed team", teamB: teamB || "Unnamed team", kickoffAt: f.kickoffAt.toISOString(), disposition: pending ? "pending" : "omitted", reasons });
+      continue;
+    }
+    // Same eligibility rules as before; only the explanations above are new.
+    const result = r!;
+    const a = result.teamMetadata.find(m => m.teamId === f.homeTeam.id), b = result.teamMetadata.find(m => m.teamId === f.awayTeam.id);
+    const scorers = [...recordedScorers(a?.scorers, teamA, result.homeScore), ...recordedScorers(b?.scorers, teamB, result.awayScore)];
     const playersOfMatch = [[a, teamA], [b, teamB]].flatMap(([meta, team]) => {
       const player = name((meta as typeof a)?.playerOfMatchName);
       return player ? [{ team: team as string, name: player }] : [];
     });
-    matches.push({ fixtureId: f.id, teamA, teamB, scoreA: r.homeScore, scoreB: r.awayScore, scorers, playersOfMatch });
+    matches.push({ fixtureId: f.id, teamA, teamB, scoreA: result.homeScore, scoreB: result.awayScore, scorers, playersOfMatch });
   }
+  // Preserve legacy summary fields for saved source hashes. The editor renders
+  // the structured fixture explanations, not this old catch-all warning.
   if (pendingFixtures) warnings.push(`${pendingFixtures} published fixture(s) still await a completed result. This will be a partial round-up.`);
   if (omittedFixtures) warnings.push(`${omittedFixtures} fixture(s) omitted: postponed, cancelled, disputed, placeholder, abandonment, replacement or invalid result. Review these separately.`);
-  return { leagueId: league.id, leagueName: name(league.name), area: name(league.area) || null, matchDate, matches, pendingFixtures, omittedFixtures, warnings };
+  return { leagueId: league.id, leagueName: name(league.name), area: name(league.area) || null, matchDate, matches, pendingFixtures, omittedFixtures, warnings, skippedFixtures };
 }

--- a/src/lib/matchweek-reports/types.ts
+++ b/src/lib/matchweek-reports/types.ts
@@ -7,6 +7,15 @@ export type ReportMatch = {
   scorers: Array<{ team: string; name: string; goals: number }>;
   playersOfMatch: Array<{ team: string; name: string }>;
 };
+/** Admin-only explanation of a published fixture excluded from the article. */
+export type ReportSkippedFixture = {
+  fixtureId: string;
+  teamA: string;
+  teamB: string;
+  kickoffAt: string;
+  disposition: "pending" | "omitted";
+  reasons: Array<{ code: string; message: string }>;
+};
 export type ReportSource = {
   leagueId: string;
   leagueName: string;
@@ -16,6 +25,9 @@ export type ReportSource = {
   omittedFixtures: number;
   pendingFixtures: number;
   warnings: string[];
+  // Older saved snapshots have only the counts. Fresh reads always include this.
+  // Never send administrative reasons to the article-writing provider.
+  skippedFixtures?: ReportSkippedFixture[];
 };
 export type ReportContent = {
   title: string;

--- a/tests/admin-matchweek-reports.test.cjs
+++ b/tests/admin-matchweek-reports.test.cjs
@@ -81,6 +81,7 @@ function harness(role = null, email = "example@example.test") {
     if (!state.league) return null;
     return { source: { leagueId: state.league.id, leagueName: state.league.name, area: state.league.area, matchDate: "2026-09-09", pendingFixtures: 0, omittedFixtures: 0, warnings: [], matches: state.league.fixtures.map(f => ({ fixtureId: f.id, teamA: f.homeTeam.name, teamB: f.awayTeam.name, scoreA: f.result.homeScore, scoreB: f.result.awayScore, scorers: [], playersOfMatch: [{ name: "Test player", team: f.awayTeam.name }] })) }, sourceHash: "test", draft: null, configured: true, model: "test-model", stale: false, generating: false, latestError: null };
   } };
+  mocks["./ReportSkippedFixtures"] = load("src/components/admin/matchweek-reports/ReportSkippedFixtures.tsx", mocks);
   mocks["@/components/admin/matchweek-reports/ReportEditor"] = load("src/components/admin/matchweek-reports/ReportEditor.tsx", mocks);
   return { state, mocks };
 }

--- a/tests/report-omissions.browser.cjs
+++ b/tests/report-omissions.browser.cjs
@@ -1,0 +1,56 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict'), fs = require('node:fs'), path = require('node:path'), http = require('node:http');
+const { build } = require('esbuild');
+const { chromium } = require(process.env.REPORT_PLAYWRIGHT_MODULE || 'playwright');
+let browser, server, origin;
+before(async () => {
+  const view = JSON.parse(fs.readFileSync('.tmp/report-omissions/view.json', 'utf8'));
+  const savedView = JSON.parse(fs.readFileSync('.tmp/report-omissions/saved-view.json', 'utf8'));
+  const entry = `import React from 'react';import{createRoot}from'react-dom/client';import Editor from './src/components/admin/matchweek-reports/ReportEditor';
+    const root=createRoot(document.getElementById('root'));window.base=${JSON.stringify(view)};window.saved=${JSON.stringify(savedView)};window.nextView=window.base;window.calls=[];
+    window.fetch=async(url,opts={})=>{window.calls.push({url,method:opts.method||'GET'});if(opts.method==='POST')throw Error('No generation or save allowed in this test');return new Response(JSON.stringify({ok:true,view:window.nextView}),{headers:{'content-type':'application/json'}})};
+    let key=0;window.show=(view)=>root.render(<Editor key={++key} slug='example' initialView={view}/>);window.show(window.base);`;
+  const bundle = (await build({ stdin: { contents: entry, resolveDir: process.cwd(), loader: 'tsx' }, bundle: true, write: false, platform: 'browser', format: 'iife', jsx: 'automatic', plugins: [{ name: 'test-router', setup(b) { b.onResolve({ filter: /^next\/navigation$/ }, () => ({ path: 'router', namespace: 'mock' })); b.onLoad({ filter: /.*/, namespace: 'mock' }, () => ({ contents: 'export const useRouter=()=>({push(url){window.lastRoute=url}})' })); } }] })).outputFiles[0].text;
+  const files = d => fs.readdirSync(d, { withFileTypes: true }).flatMap(e => e.isDirectory() ? files(path.join(d, e.name)) : [path.join(d, e.name)]);
+  const css = files('.next/static').filter(f => f.endsWith('.css')).map(f => fs.readFileSync(f, 'utf8')).join('\n'); assert.ok(css.length);
+  server = http.createServer((req, res) => {
+    if (req.url === '/app.js') { res.setHeader('content-type', 'text/javascript'); res.end(bundle); }
+    else if (req.url === '/app.css') { res.setHeader('content-type', 'text/css'); res.end(css); }
+    else { res.setHeader('content-type', 'text/html'); res.end('<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="/app.css"></head><body style="background:#06120d;color:white"><main id="root" style="padding:16px;max-width:1200px;margin:auto"></main><script src="/app.js"></script></body></html>'); }
+  });
+  await new Promise(r => server.listen(0, '127.0.0.1', r)); origin = 'http://127.0.0.1:' + server.address().port; browser = await chromium.launch();
+});
+after(async () => { await browser?.close(); if (server) await new Promise(r => server.close(r)); });
+for (const width of [1440, 390]) test(`current omitted matches are visible and refresh without generation at ${width}px`, async () => {
+  const page = await browser.newPage({ viewport: { width, height: 1000 } }), errors = [];
+  page.on('pageerror', e => errors.push(e.message));
+  await page.route('**/*', r => r.request().url().startsWith(origin) ? r.continue() : r.abort());
+  try {
+    await page.goto(origin);
+    const panel = page.getByRole('region', { name: 'Matches not included (2)' }); await panel.waitFor();
+    assert.equal(await panel.getByText('Example City', { exact: false }).first().isVisible(), true);
+    assert.equal(await panel.getByText(/last-minute replacement/).isVisible(), true);
+    assert.equal(await panel.getByText(/marked cancelled/).isVisible(), true);
+    assert.equal(await page.evaluate(() => window.calls.length), 0);
+    const link = panel.getByRole('link', { name: /Review Example City/ });
+    assert.equal(await link.getAttribute('href'), '/admin/fixtures/replacement/edit'); assert.equal(await link.getAttribute('target'), '_blank');
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false);
+    await panel.scrollIntoViewIfNeeded(); await page.screenshot({ path: `.tmp/report-omissions/omissions-${width}.png`, fullPage: true });
+    // An older saved draft must not replace the CURRENT review list.
+    await page.evaluate(() => window.show(window.saved)); await page.getByRole('heading', { name: 'Saved article' }).waitFor();
+    assert.equal(await panel.getByText(/last-minute replacement/).isVisible(), true);
+    assert.equal(await page.getByText('STALE OMITTED LABEL', { exact: false }).count(), 0);
+    await page.evaluate(() => { window.nextView = structuredClone(window.saved); window.nextView.source.skippedFixtures = [window.nextView.source.skippedFixtures[0]]; window.nextView.source.omittedFixtures = 1; });
+    await page.getByRole('button', { name: 'Check saved status', exact: true }).click();
+    await page.getByRole('region', { name: 'Matches not included (1)' }).waitFor();
+    assert.equal(await page.getByText(/last-minute replacement/).count(), 0);
+    assert.equal(await page.getByRole('heading', { name: 'Saved article' }).isVisible(), true);
+    await page.evaluate(() => { window.nextView = structuredClone(window.saved); window.nextView.source.skippedFixtures = []; window.nextView.source.omittedFixtures = 0; });
+    await page.getByRole('button', { name: 'Check saved status', exact: true }).click();
+    await page.getByRole('region', { name: /Matches not included/ }).waitFor({ state: 'detached' });
+    assert.equal(await page.evaluate(() => window.calls.length), 2); assert.ok((await page.evaluate(() => window.calls)).every(c => c.method === 'GET'));
+    await page.getByLabel('Match night', { exact: true }).fill('2026-09-09'); await page.getByRole('button', { name: 'Load night', exact: true }).click();
+    assert.equal(await page.evaluate(() => window.lastRoute), '/admin/matchweek-reports/example?date=2026-09-09');
+    assert.deepEqual(errors, []);
+  } finally { await page.close(); }
+});

--- a/tests/report-omissions.test.cjs
+++ b/tests/report-omissions.test.cjs
@@ -1,0 +1,139 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createHash } = require('node:crypto');
+const ts = require('typescript');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const ROOT = path.resolve(__dirname, '..');
+const NOW = new Date('2026-09-11T00:00:00Z');
+class FixedDate extends Date { constructor(...args) { super(...(args.length ? args : [NOW.getTime()])); } static now() { return NOW.getTime(); } }
+function loader(mocks = {}, network = async () => { throw Error('External requests forbidden'); }) {
+  const cache = new Map();
+  function load(file) {
+    file = path.resolve(ROOT, file);
+    if (!fs.existsSync(file)) file += fs.existsSync(file + '.ts') ? '.ts' : '.tsx';
+    if (cache.has(file)) return cache.get(file).exports;
+    const module = { exports: {} }; cache.set(file, module);
+    const js = ts.transpileModule(fs.readFileSync(file, 'utf8'), { fileName: file, compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true } }).outputText;
+    new Function('require', 'module', 'exports', 'Date', 'fetch', 'process', js)(id => {
+      if (Object.hasOwn(mocks, id)) return mocks[id];
+      if (id === 'next/navigation') return { useRouter: () => ({ push() {}, refresh() {} }) };
+      if (id.startsWith('@/')) return load('src/' + id.slice(2));
+      if (id.startsWith('.')) return load(path.resolve(path.dirname(file), id));
+      if (id === '@prisma/client' || id.startsWith('node:') || id.startsWith('react')) return require(id);
+      throw Error('Unexpected dependency: ' + id);
+    }, module, module.exports, FixedDate, network, { env: { NODE_ENV: 'production', OPENAI_API_KEY: 'ISOLATED_TEST_ONLY' } });
+    return module.exports;
+  }
+  return load;
+}
+const fixture = (id, extra = {}) => ({ id, status: 'COMPLETED', kickoffAt: new Date('2026-09-08T18:00:00Z'), homeTeam: { id: 'a', name: 'Example Athletic' }, awayTeam: { id: 'b', name: 'Example United' }, result: { homeScore: 2, awayScore: 1, isDisputed: false, disputes: [], teamMetadata: [] }, ...extra });
+function harness(fixtures, exceptions = [], placeholderIds = []) {
+  const queries = [], load = loader({
+    '@/lib/prisma': { prisma: { league: { findFirst: async () => ({ id: 'league', name: 'Example Tuesday', area: 'Example' }) },
+      fixture: { findMany: async q => { queries.push(q); return fixtures; } },
+      $queryRaw: async q => { queries.push(q); return exceptions; } } },
+    '@/lib/teams/fixture-placeholders': { getFixturePlaceholderTeamIds: async () => new Set(placeholderIds) },
+  });
+  return { facts: load('src/lib/matchweek-reports/facts.ts'), load, queries };
+}
+// Exact former classification, independent of the new explanations. Keep this
+// as an executable assertion that this UI fix does not change report eligibility.
+function oldDisposition(f, exceptions, placeholders) {
+  const usableName = value => typeof value === 'string' && !value.includes('@') && value.replace(/[\r\n\t]+/g, ' ').trim();
+  if (f.status === 'SCHEDULED' || (f.status === 'COMPLETED' && !f.result)) return 'pending';
+  if (f.status !== 'COMPLETED') return 'omitted';
+  const r = f.result;
+  if (f.kickoffAt > NOW || r.isDisputed || r.disputes.length || exceptions.some(e => e.fixtureId === f.id) || placeholders.includes(f.homeTeam.id) || placeholders.includes(f.awayTeam.id) || [f.homeTeam.name, f.awayTeam.name].some(n => n.trim().toUpperCase() === 'TBC')) return 'omitted';
+  if (![r.homeScore, r.awayScore].every(n => Number.isInteger(n) && n >= 0 && n <= 99)) return 'omitted';
+  if (!usableName(f.homeTeam.name) || !usableName(f.awayTeam.name)) return 'omitted';
+  return 'included';
+}
+test('every excluded fixture has its own exact reasons, names, time and unchanged classification', async () => {
+  const rows = [fixture('included'), fixture('scheduled', { status: 'SCHEDULED', result: null }), fixture('scheduled-score', { status: 'SCHEDULED' }),
+    fixture('no-result', { result: null }), fixture('cancelled', { status: 'CANCELLED' }), fixture('postponed', { status: 'POSTPONED' }),
+    fixture('flagged', { result: { ...fixture('base').result, isDisputed: true } }), fixture('review', { result: { ...fixture('base').result, disputes: [{ id: 'open-dispute' }] } }),
+    fixture('tbc', { awayTeam: { id: 'tbc', name: 'TBC' } }), fixture('placeholder', { homeTeam: { id: 'placeholder-id', name: 'Stand-in slot' } }),
+    fixture('future', { kickoffAt: new Date('2099-01-01T18:00:00Z') }), fixture('invalid-negative', { result: { ...fixture('base').result, homeScore: -1 } }),
+    fixture('invalid-decimal', { result: { ...fixture('base').result, awayScore: 1.5 } }), fixture('invalid-large', { result: { ...fixture('base').result, homeScore: 100 } }),
+    fixture('missing-name', { homeTeam: { id: 'no-name', name: '' } }), fixture('unsafe-name', { awayTeam: { id: 'bad-name', name: 'private@example.invalid' } }),
+    fixture('abandonment'), fixture('replacement'), fixture('multiple', { result: { ...fixture('base').result, isDisputed: true, disputes: [{ id: 'd' }] } }),
+    fixture('pending-and-replaced', { status: 'SCHEDULED', result: null })];
+  const exceptions = [{ fixtureId: 'abandonment', reason: 'abandonment' }, { fixtureId: 'replacement', reason: 'replacement' },
+    { fixtureId: 'multiple', reason: 'abandonment' }, { fixtureId: 'multiple', reason: 'replacement' }, { fixtureId: 'multiple', reason: 'replacement' }, { fixtureId: 'pending-and-replaced', reason: 'replacement' }];
+  const placeholders = ['placeholder-id'], h = harness(rows, exceptions, placeholders), source = await h.facts.getReportSource('example', '2026-09-08');
+  assert.equal(source.matches.length + source.skippedFixtures.length, rows.length);
+  for (const row of rows) {
+    const expected = oldDisposition(row, exceptions, placeholders), skipped = source.skippedFixtures.find(f => f.fixtureId === row.id);
+    if (expected === 'included') { assert.equal(skipped, undefined); assert.ok(source.matches.some(f => f.fixtureId === row.id)); }
+    else { assert.equal(skipped.disposition, expected); assert.ok(skipped.teamA && skipped.teamB && skipped.reasons.length); assert.equal(skipped.kickoffAt, row.kickoffAt.toISOString()); }
+  }
+  const byId = id => source.skippedFixtures.find(f => f.fixtureId === id);
+  assert.deepEqual(byId('cancelled').reasons.map(r => r.code), ['cancelled']);
+  assert.deepEqual(byId('postponed').reasons.map(r => r.code), ['postponed']);
+  assert.deepEqual(byId('abandonment').reasons.map(r => r.code), ['abandonment']);
+  assert.deepEqual(byId('replacement').reasons.map(r => r.code), ['replacement']);
+  assert.deepEqual(byId('multiple').reasons.map(r => r.code), ['disputed_result', 'unresolved_dispute', 'abandonment', 'replacement']);
+  assert.match(byId('scheduled-score').reasons[0].message, /result is saved, but/);
+  assert.match(byId('no-result').reasons[0].message, /completed, but no result/);
+  assert.equal(source.pendingFixtures, source.skippedFixtures.filter(f => f.disposition === 'pending').length);
+  assert.equal(source.omittedFixtures, source.skippedFixtures.filter(f => f.disposition === 'omitted').length);
+  assert.doesNotMatch(JSON.stringify(source), /private@example/);
+  assert.equal(h.queries[0].where.publishedAt.not, null);
+  assert.equal(h.queries[0].where.kickoffAt.gte.toISOString(), '2026-09-07T23:00:00.000Z');
+  assert.match(h.queries[1].sql, /'abandonment'::text AS "reason"/); assert.match(h.queries[1].sql, /'replacement'::text AS "reason"/);
+  assert.doesNotMatch(h.queries[1].sql, /notes|email|payment|SELECT \*/i);
+});
+test('admin-only details preserve old article hashes; included facts and counts still invalidate', async () => {
+  const h = harness([fixture('included'), fixture('cancelled', { status: 'CANCELLED' })]);
+  const source = await h.facts.getReportSource('example', '2026-09-08');
+  const { skippedFixtures, ...legacy } = source;
+  const legacyHash = createHash('sha256').update(JSON.stringify(legacy)).digest('hex');
+  assert.equal(h.facts.sourceHash(source), legacyHash);
+  assert.equal(h.facts.sourceHash({ ...source, skippedFixtures: [{ ...skippedFixtures[0], teamA: 'Corrected omitted label' }] }), legacyHash);
+  assert.notEqual(h.facts.sourceHash({ ...source, matches: [{ ...source.matches[0], scoreA: 4 }] }), legacyHash);
+  assert.notEqual(h.facts.sourceHash({ ...source, omittedFixtures: 0 }), legacyHash);
+});
+test('provider gets included facts/counts only, never omitted identities or administrative reasons', async () => {
+  const h = harness([fixture('included'), fixture('PRIVATE_OMITTED', { homeTeam: { id: 'private', name: 'Only for admin' } })], [{ fixtureId: 'PRIVATE_OMITTED', reason: 'abandonment' }]);
+  const source = await h.facts.getReportSource('example', '2026-09-08');
+  let calls = 0;
+  const load = loader({}, async (url, options) => {
+    calls++; const input = JSON.parse(JSON.parse(options.body).input);
+    assert.equal(input.omittedFixtures, 1); assert.equal(input.matches.length, 1);
+    assert.doesNotMatch(JSON.stringify(input), /PRIVATE_OMITTED|Only for admin|skippedFixtures|abandonment|editorial review/);
+    const content = { title: 'Example Athletic win', introduction: 'One included result.', matches: [{ fixtureId: 'included', paragraph: 'Example Athletic beat Example United 2–1.' }], closing: '' };
+    return new Response(JSON.stringify({ status: 'completed', output: [{ type: 'message', content: [{ type: 'output_text', text: JSON.stringify(content) }] }] }));
+  });
+  await load('src/lib/matchweek-reports/openai.ts').writeOpenAiReport(source); assert.equal(calls, 1);
+});
+test('owning editor shows current omissions without generation, including with an old saved draft', async () => {
+  const h = harness([fixture('included'), fixture('cancelled', { status: 'CANCELLED', homeTeam: { id: 'c', name: 'Example Rovers' } }), fixture('replacement', { homeTeam: { id: 'r', name: 'Example City' } })], [{ fixtureId: 'replacement', reason: 'replacement' }]);
+  const source = await h.facts.getReportSource('example', '2026-09-08');
+  const view = { source, sourceHash: h.facts.sourceHash(source), draft: null, configured: true, model: 'test-model', stale: false, generating: false, latestError: null };
+  const Editor = h.load('src/components/admin/matchweek-reports/ReportEditor.tsx').default;
+  const html = renderToStaticMarkup(React.createElement(Editor, { slug: 'example', initialView: view }));
+  assert.match(html, /Matches not included \(2\)/); assert.match(html, /Example Rovers/); assert.match(html, /Example City/);
+  assert.match(html, /marked cancelled/); assert.match(html, /last-minute replacement/); assert.match(html, /19:00/);
+  assert.match(html, /\/admin\/fixtures\/replacement\/edit/); assert.match(html, /target="_blank"/);
+  assert.doesNotMatch(html, /postponed, cancelled, disputed, placeholder/);
+  const oldSource = { ...source, skippedFixtures: [{ ...source.skippedFixtures[0], teamA: 'STALE OMITTED LABEL' }] };
+  const content = { title: 'Saved article', introduction: 'Do not overwrite this draft.', matches: [{ fixtureId: 'included', paragraph: 'An existing saved paragraph.' }], closing: '' };
+  const savedView = { ...view, draft: { id: 'draft', version: 1, source: oldSource, sourceHash: view.sourceHash, content, model: 'test', updatedAt: '2026-09-08T20:00:00Z' } };
+  const savedHtml = renderToStaticMarkup(React.createElement(Editor, { slug: 'example', initialView: savedView }));
+  assert.match(savedHtml, /Example City/); assert.match(savedHtml, /Saved article/); assert.doesNotMatch(savedHtml, /STALE OMITTED LABEL/);
+  const target = path.join(ROOT, '.tmp/report-omissions'); fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, 'view.json'), JSON.stringify(view)); fs.writeFileSync(path.join(target, 'saved-view.json'), JSON.stringify(savedView)); fs.writeFileSync(path.join(target, 'editor.html'), html);
+});
+test('empty, pending-only and legacy snapshots render accurately, with no crash or hidden details', async () => {
+  const h = harness([]), source = await h.facts.getReportSource('example', '2026-09-08');
+  const Panel = h.load('src/components/admin/matchweek-reports/ReportSkippedFixtures.tsx').default;
+  const render = source => renderToStaticMarkup(React.createElement(Panel, { source }));
+  assert.equal(render(source), '');
+  assert.match(render({ ...source, pendingFixtures: 1, skippedFixtures: undefined }), /Check saved status/);
+  const pending = await harness([fixture('pending', { status: 'SCHEDULED', result: null })]).facts.getReportSource('example', '2026-09-08');
+  assert.match(render(pending), /Matches not included \(1\)/); assert.match(render(pending), /still marked scheduled/);
+  assert.match(render({ ...pending, skippedFixtures: pending.skippedFixtures.map(f => ({ ...f, teamA: '<script>alert(1)</script>' })) }), /&lt;script&gt;/);
+});


### PR DESCRIPTION
Replace the private report editor's catch-all omission warning with a visible list of every omitted or pending published fixture on the selected London match night. Show sanitised team names, kick-off time, specific recorded reasons (including separate abandonment and replacement categories), all applicable blockers, and a review link to the existing admin fixture edit page in a new tab.

The shared getReportSource reader remains the sole eligibility source. The new ReportSkippedFixtures component always uses current view.source, including before generation and alongside an older saved draft. Check saved status refreshes the list without generating. No inclusion override, status/result change or automatic paid request is introduced. Legacy source hashes and snapshots remain compatible; included facts/counts still drive stale detection. Omitted identities/reasons are not added to the explicit OpenAI input.

Extend the existing report workflow with native/prepared omission/classification/hash/provider-privacy tests and real editor desktop/mobile refresh interactions. Existing administrator, proxy and real disposable PostgreSQL draft tests remain. Run all affected critical/DOM checks, build and the existing Vercel function-size gate before merge. Verify Railway and Vercel deployment separately before reporting live.

No production data writes, messages, migrations, forced regeneration or draft replacement. The user's actual omitted Harrogate fixtures have not been queried through a signed-in live account.