### PR TITLE
Include completed replacement games in matchnight reports

### DIFF
--- a/docs/report-omitted-fixtures.md
+++ b/docs/report-omitted-fixtures.md
@@ -4,8 +4,20 @@ The existing `getReportSource` reader owns eligibility AND its explanation. It
 returns one `skippedFixtures` item for each pending/omitted published fixture on
 the selected London match date: fixture ID, sanitised teams, ISO kick-off,
 pending/omitted disposition, and every applicable reason. Counts reconcile to
-that list. The administrative query now labels abandonment and replacement
-records separately; no narratives, contacts or payment details are selected.
+that list. Abandonment records still require editorial review; no narratives,
+contacts or payment details are selected.
+
+## Completed replacement games
+
+A `LastMinuteReplacementResolution` record describes a successfully allocated
+replacement, not an unresolved result. It is no longer queried or used as a report
+blocker. Completed replacement fixtures are included using the current assigned
+teams, saved scores and metadata for those teams. A replacement can appear in
+more than one fixture on the same night; each fixture is reported separately.
+All other checks remain: published selected-date fixtures only, completed status,
+a saved valid score, no disputes, no abandonment, no future kick-off, and valid
+non-placeholder teams. Replacement history never overrides any of those checks.
+The reporting reader does not alter fixtures, results or replacement audit records.
 
 `ReportSkippedFixtures` is rendered by the native admin `ReportEditor`, expanded
 by default, above the article. It uses `view.source` (current data), not the saved
@@ -13,16 +25,20 @@ article snapshot. Fixture review links use the existing admin edit route and ope
 in a new tab to avoid discarding report edits. The read-only Check saved status
 refreshes the list without a generation. No inclusion override is introduced.
 
-Old snapshots remain valid: the new optional review field is excluded from the
+Old snapshots remain valid: the optional review field is excluded from the
 source hash, and legacy summary warning values remain internally for hash
-compatibility. The editor no longer displays the generic catch-all warning.
-Included facts and omission counts still invalidate genuinely stale articles.
-The existing explicit OpenAI payload does NOT include omitted fixture identities
-or administrative reasons. No automatic generation or paid request is made.
+compatibility. Their historic replacement label is not a current eligibility
+rule and is not displayed. Included facts and omission counts still invalidate
+stale articles. When newly eligible replacement games change a four-match source
+to six, the existing draft is retained and marked stale. An administrator must
+explicitly regenerate to include the extra matches in the article; refreshing
+alone does not incur generation charges or rewrite saved editorial text.
 
-The permanent report workflow tests native and fully prepared classification
-against the former eligibility rules, every omission category, multiple reasons,
-counts, data minimisation, hash compatibility, legacy and saved-draft rendering,
-provider payload filtering and real editor desktop/mobile refresh interactions.
-Existing auth, proxy and disposable PostgreSQL draft transaction tests remain.
-No production fixture, result, payment, draft or notification data is changed.
+The explicit OpenAI payload contains included fixture facts, not excluded-game
+identities, administrative reasons, dropped-team details or payment information.
+The permanent report workflow tests native and fully prepared classification,
+all remaining blockers with replacement history, counts, current-team scorers,
+two games by the same replacement team, old-draft preservation/staleness and the
+six-result provider payload. Desktop/mobile tests exercise the four-to-six refresh
+without POST requests. Existing auth, proxy and disposable PostgreSQL draft tests
+remain. No production data, migration or customer message is changed.

--- a/src/lib/matchweek-reports/facts.ts
+++ b/src/lib/matchweek-reports/facts.ts
@@ -48,19 +48,18 @@ export async function getReportSource(slug: string, requestedDate?: string): Pro
   if (fixtures.length > 40) throw new ReportError("This match night is too large for one report. Please contact SIXFL support.");
   const ids = fixtures.map(f => f.id);
   const placeholders = await getFixturePlaceholderTeamIds(fixtures.flatMap(f => [f.homeTeam.id, f.awayTeam.id]));
-  // Read only fixture IDs and a fixed category, never conduct narratives, contacts
-  // or payment information. These details stay in the private editorial view.
+  // A resolved replacement is successful scheduling history, not a result
+  // blocker. Report the teams currently assigned to the completed fixture.
+  // Only abandonment records need this extra review; all normal result checks
+  // below still apply. Read no private narratives, contacts or payment data.
   const exceptions = ids.length ? await prisma.$queryRaw<Array<{ fixtureId: string; reason: string }>>(Prisma.sql`
     SELECT "fixtureId", 'abandonment'::text AS "reason" FROM "FixtureAbandonment" WHERE "fixtureId" IN (${Prisma.join(ids)})
-    UNION SELECT "fixtureId", 'replacement'::text AS "reason" FROM "LastMinuteReplacementResolution" WHERE "fixtureId" IN (${Prisma.join(ids)})
   `) : [];
   const exceptionReasons = new Map<string, ReportSkippedFixture["reasons"]>();
   for (const row of exceptions) {
     const reason = row.reason === "abandonment"
       ? { code: "abandonment", message: "An abandonment record is attached to this fixture; its administrative outcome needs editorial review." }
-      : row.reason === "replacement"
-        ? { code: "replacement", message: "A last-minute replacement is recorded for this fixture; it needs editorial review before inclusion." }
-        : { code: "administrative_record", message: "An administrative exception is recorded for this fixture and needs editorial review." };
+      : { code: "administrative_record", message: "An administrative exception is recorded for this fixture and needs editorial review." };
     const reasons = exceptionReasons.get(row.fixtureId) ?? [];
     if (!reasons.some(r => r.code === reason.code)) reasons.push(reason);
     exceptionReasons.set(row.fixtureId, reasons);
@@ -92,7 +91,7 @@ export async function getReportSource(slug: string, requestedDate?: string): Pro
       skippedFixtures.push({ fixtureId: f.id, teamA: teamA || "Unnamed team", teamB: teamB || "Unnamed team", kickoffAt: f.kickoffAt.toISOString(), disposition: pending ? "pending" : "omitted", reasons });
       continue;
     }
-    // Same eligibility rules as before; only the explanations above are new.
+    // Completed replacement games reach this same path as any other valid result.
     const result = r!;
     const a = result.teamMetadata.find(m => m.teamId === f.homeTeam.id), b = result.teamMetadata.find(m => m.teamId === f.awayTeam.id);
     const scorers = [...recordedScorers(a?.scorers, teamA, result.homeScore), ...recordedScorers(b?.scorers, teamB, result.awayScore)];
@@ -103,7 +102,8 @@ export async function getReportSource(slug: string, requestedDate?: string): Pro
     matches.push({ fixtureId: f.id, teamA, teamB, scoreA: result.homeScore, scoreB: result.awayScore, scorers, playersOfMatch });
   }
   // Preserve legacy summary fields for saved source hashes. The editor renders
-  // the structured fixture explanations, not this old catch-all warning.
+  // the structured fixture explanations, not this old catch-all warning. Its
+  // historic replacement label is NOT an eligibility rule or displayed reason.
   if (pendingFixtures) warnings.push(`${pendingFixtures} published fixture(s) still await a completed result. This will be a partial round-up.`);
   if (omittedFixtures) warnings.push(`${omittedFixtures} fixture(s) omitted: postponed, cancelled, disputed, placeholder, abandonment, replacement or invalid result. Review these separately.`);
   return { leagueId: league.id, leagueName: name(league.name), area: name(league.area) || null, matchDate, matches, pendingFixtures, omittedFixtures, warnings, skippedFixtures };

--- a/tests/report-omissions.browser.cjs
+++ b/tests/report-omissions.browser.cjs
@@ -6,8 +6,9 @@ let browser, server, origin;
 before(async () => {
   const view = JSON.parse(fs.readFileSync('.tmp/report-omissions/view.json', 'utf8'));
   const savedView = JSON.parse(fs.readFileSync('.tmp/report-omissions/saved-view.json', 'utf8'));
+  const replacements = JSON.parse(fs.readFileSync('.tmp/report-omissions/replacement-views.json', 'utf8'));
   const entry = `import React from 'react';import{createRoot}from'react-dom/client';import Editor from './src/components/admin/matchweek-reports/ReportEditor';
-    const root=createRoot(document.getElementById('root'));window.base=${JSON.stringify(view)};window.saved=${JSON.stringify(savedView)};window.nextView=window.base;window.calls=[];
+    const root=createRoot(document.getElementById('root'));window.base=${JSON.stringify(view)};window.saved=${JSON.stringify(savedView)};window.nextView=window.base;window.replacements=${JSON.stringify(replacements)};window.calls=[];
     window.fetch=async(url,opts={})=>{window.calls.push({url,method:opts.method||'GET'});if(opts.method==='POST')throw Error('No generation or save allowed in this test');return new Response(JSON.stringify({ok:true,view:window.nextView}),{headers:{'content-type':'application/json'}})};
     let key=0;window.show=(view)=>root.render(<Editor key={++key} slug='example' initialView={view}/>);window.show(window.base);`;
   const bundle = (await build({ stdin: { contents: entry, resolveDir: process.cwd(), loader: 'tsx' }, bundle: true, write: false, platform: 'browser', format: 'iife', jsx: 'automatic', plugins: [{ name: 'test-router', setup(b) { b.onResolve({ filter: /^next\/navigation$/ }, () => ({ path: 'router', namespace: 'mock' })); b.onLoad({ filter: /.*/, namespace: 'mock' }, () => ({ contents: 'export const useRouter=()=>({push(url){window.lastRoute=url}})' })); } }] })).outputFiles[0].text;
@@ -29,7 +30,7 @@ for (const width of [1440, 390]) test(`current omitted matches are visible and r
     await page.goto(origin);
     const panel = page.getByRole('region', { name: 'Matches not included (2)' }); await panel.waitFor();
     assert.equal(await panel.getByText('Example City', { exact: false }).first().isVisible(), true);
-    assert.equal(await panel.getByText(/last-minute replacement/).isVisible(), true);
+    assert.equal(await panel.getByText(/marked postponed/).isVisible(), true);
     assert.equal(await panel.getByText(/marked cancelled/).isVisible(), true);
     assert.equal(await page.evaluate(() => window.calls.length), 0);
     const link = panel.getByRole('link', { name: /Review Example City/ });
@@ -38,12 +39,12 @@ for (const width of [1440, 390]) test(`current omitted matches are visible and r
     await panel.scrollIntoViewIfNeeded(); await page.screenshot({ path: `.tmp/report-omissions/omissions-${width}.png`, fullPage: true });
     // An older saved draft must not replace the CURRENT review list.
     await page.evaluate(() => window.show(window.saved)); await page.getByRole('heading', { name: 'Saved article' }).waitFor();
-    assert.equal(await panel.getByText(/last-minute replacement/).isVisible(), true);
+    assert.equal(await panel.getByText(/marked postponed/).isVisible(), true);
     assert.equal(await page.getByText('STALE OMITTED LABEL', { exact: false }).count(), 0);
     await page.evaluate(() => { window.nextView = structuredClone(window.saved); window.nextView.source.skippedFixtures = [window.nextView.source.skippedFixtures[0]]; window.nextView.source.omittedFixtures = 1; });
     await page.getByRole('button', { name: 'Check saved status', exact: true }).click();
     await page.getByRole('region', { name: 'Matches not included (1)' }).waitFor();
-    assert.equal(await page.getByText(/last-minute replacement/).count(), 0);
+    assert.equal(await page.getByText(/marked postponed/).count(), 0);
     assert.equal(await page.getByRole('heading', { name: 'Saved article' }).isVisible(), true);
     await page.evaluate(() => { window.nextView = structuredClone(window.saved); window.nextView.source.skippedFixtures = []; window.nextView.source.omittedFixtures = 0; });
     await page.getByRole('button', { name: 'Check saved status', exact: true }).click();
@@ -51,6 +52,21 @@ for (const width of [1440, 390]) test(`current omitted matches are visible and r
     assert.equal(await page.evaluate(() => window.calls.length), 2); assert.ok((await page.evaluate(() => window.calls)).every(c => c.method === 'GET'));
     await page.getByLabel('Match night', { exact: true }).fill('2026-09-09'); await page.getByRole('button', { name: 'Load night', exact: true }).click();
     assert.equal(await page.evaluate(() => window.lastRoute), '/admin/matchweek-reports/example?date=2026-09-09');
+    // Refresh an actual four-to-six source transition without a paid generation
+    // or overwriting the saved four-match article.
+    await page.evaluate(() => { window.show(window.replacements.before); window.nextView = window.replacements.after; });
+    await page.getByRole('region', { name: 'Matches not included (2)' }).waitFor();
+    await page.getByRole('button', { name: 'Check saved status', exact: true }).click();
+    await page.getByRole('region', { name: /Matches not included/ }).waitFor({ state: 'detached' });
+    await page.getByText(/6 included results/).waitFor();
+    await page.getByRole('heading', { name: 'Previously saved four-match draft' }).waitFor();
+    assert.equal(await page.getByText('Keep my original text.', { exact: true }).isVisible(), true);
+    await page.getByText(/recorded results have changed since this draft/).waitFor();
+    await page.getByText('Current source facts (6 results)', { exact: true }).click();
+    assert.equal(await page.getByText(/Example early opponent 1–2 Example Stand-ins/).isVisible(), true);
+    assert.equal(await page.getByText(/Example late opponent 2–3 Example Stand-ins/).isVisible(), true);
+    assert.ok((await page.evaluate(() => window.calls)).every(c => c.method === 'GET'));
+    await page.screenshot({ path: `.tmp/report-omissions/replacements-${width}.png`, fullPage: true });
     assert.deepEqual(errors, []);
   } finally { await page.close(); }
 });

--- a/tests/report-omissions.test.cjs
+++ b/tests/report-omissions.test.cjs
@@ -30,28 +30,34 @@ function loader(mocks = {}, network = async () => { throw Error('External reques
   return load;
 }
 const fixture = (id, extra = {}) => ({ id, status: 'COMPLETED', kickoffAt: new Date('2026-09-08T18:00:00Z'), homeTeam: { id: 'a', name: 'Example Athletic' }, awayTeam: { id: 'b', name: 'Example United' }, result: { homeScore: 2, awayScore: 1, isDisputed: false, disputes: [], teamMetadata: [] }, ...extra });
-function harness(fixtures, exceptions = [], placeholderIds = []) {
+function harness(fixtures, exceptions = [], placeholderIds = [], extraMocks = {}) {
   const queries = [], load = loader({
     '@/lib/prisma': { prisma: { league: { findFirst: async () => ({ id: 'league', name: 'Example Tuesday', area: 'Example' }) },
       fixture: { findMany: async q => { queries.push(q); return fixtures; } },
-      $queryRaw: async q => { queries.push(q); return exceptions; } } },
+      $queryRaw: async q => {
+        queries.push(q);
+        // Model the tables actually queried. Replacement history exists, but
+        // must not enter the blocker set unless production queries it again.
+        return exceptions.filter(row => row.reason !== 'replacement' || q.sql.includes('LastMinuteReplacementResolution'));
+      } } },
     '@/lib/teams/fixture-placeholders': { getFixturePlaceholderTeamIds: async () => new Set(placeholderIds) },
+    ...extraMocks,
   });
   return { facts: load('src/lib/matchweek-reports/facts.ts'), load, queries };
 }
-// Exact former classification, independent of the new explanations. Keep this
-// as an executable assertion that this UI fix does not change report eligibility.
-function oldDisposition(f, exceptions, placeholders) {
+// All former safeguards stay intact, except the explicitly corrected blanket
+// replacement exclusion. Replacements never bypass another genuine blocker.
+function expectedDisposition(f, exceptions, placeholders) {
   const usableName = value => typeof value === 'string' && !value.includes('@') && value.replace(/[\r\n\t]+/g, ' ').trim();
   if (f.status === 'SCHEDULED' || (f.status === 'COMPLETED' && !f.result)) return 'pending';
   if (f.status !== 'COMPLETED') return 'omitted';
   const r = f.result;
-  if (f.kickoffAt > NOW || r.isDisputed || r.disputes.length || exceptions.some(e => e.fixtureId === f.id) || placeholders.includes(f.homeTeam.id) || placeholders.includes(f.awayTeam.id) || [f.homeTeam.name, f.awayTeam.name].some(n => n.trim().toUpperCase() === 'TBC')) return 'omitted';
+  if (f.kickoffAt > NOW || r.isDisputed || r.disputes.length || exceptions.some(e => e.fixtureId === f.id && e.reason !== 'replacement') || placeholders.includes(f.homeTeam.id) || placeholders.includes(f.awayTeam.id) || [f.homeTeam.name, f.awayTeam.name].some(n => n.trim().toUpperCase() === 'TBC')) return 'omitted';
   if (![r.homeScore, r.awayScore].every(n => Number.isInteger(n) && n >= 0 && n <= 99)) return 'omitted';
   if (!usableName(f.homeTeam.name) || !usableName(f.awayTeam.name)) return 'omitted';
   return 'included';
 }
-test('every excluded fixture has its own exact reasons, names, time and unchanged classification', async () => {
+test('every genuine blocker remains explained, including when replacement history exists', async () => {
   const rows = [fixture('included'), fixture('scheduled', { status: 'SCHEDULED', result: null }), fixture('scheduled-score', { status: 'SCHEDULED' }),
     fixture('no-result', { result: null }), fixture('cancelled', { status: 'CANCELLED' }), fixture('postponed', { status: 'POSTPONED' }),
     fixture('flagged', { result: { ...fixture('base').result, isDisputed: true } }), fixture('review', { result: { ...fixture('base').result, disputes: [{ id: 'open-dispute' }] } }),
@@ -63,10 +69,13 @@ test('every excluded fixture has its own exact reasons, names, time and unchange
     fixture('pending-and-replaced', { status: 'SCHEDULED', result: null })];
   const exceptions = [{ fixtureId: 'abandonment', reason: 'abandonment' }, { fixtureId: 'replacement', reason: 'replacement' },
     { fixtureId: 'multiple', reason: 'abandonment' }, { fixtureId: 'multiple', reason: 'replacement' }, { fixtureId: 'multiple', reason: 'replacement' }, { fixtureId: 'pending-and-replaced', reason: 'replacement' }];
+  // Give every case a resolved replacement too: it must neither exclude a
+  // sound result nor let scheduled/disputed/abandoned/invalid matches through.
+  exceptions.push(...rows.map(row => ({ fixtureId: row.id, reason: 'replacement' })));
   const placeholders = ['placeholder-id'], h = harness(rows, exceptions, placeholders), source = await h.facts.getReportSource('example', '2026-09-08');
   assert.equal(source.matches.length + source.skippedFixtures.length, rows.length);
   for (const row of rows) {
-    const expected = oldDisposition(row, exceptions, placeholders), skipped = source.skippedFixtures.find(f => f.fixtureId === row.id);
+    const expected = expectedDisposition(row, exceptions, placeholders), skipped = source.skippedFixtures.find(f => f.fixtureId === row.id);
     if (expected === 'included') { assert.equal(skipped, undefined); assert.ok(source.matches.some(f => f.fixtureId === row.id)); }
     else { assert.equal(skipped.disposition, expected); assert.ok(skipped.teamA && skipped.teamB && skipped.reasons.length); assert.equal(skipped.kickoffAt, row.kickoffAt.toISOString()); }
   }
@@ -74,8 +83,10 @@ test('every excluded fixture has its own exact reasons, names, time and unchange
   assert.deepEqual(byId('cancelled').reasons.map(r => r.code), ['cancelled']);
   assert.deepEqual(byId('postponed').reasons.map(r => r.code), ['postponed']);
   assert.deepEqual(byId('abandonment').reasons.map(r => r.code), ['abandonment']);
-  assert.deepEqual(byId('replacement').reasons.map(r => r.code), ['replacement']);
-  assert.deepEqual(byId('multiple').reasons.map(r => r.code), ['disputed_result', 'unresolved_dispute', 'abandonment', 'replacement']);
+  assert.equal(byId('replacement'), undefined);
+  assert.ok(source.matches.some(f => f.fixtureId === 'replacement'));
+  assert.deepEqual(byId('pending-and-replaced').reasons.map(r => r.code), ['scheduled']);
+  assert.deepEqual(byId('multiple').reasons.map(r => r.code), ['disputed_result', 'unresolved_dispute', 'abandonment']);
   assert.match(byId('scheduled-score').reasons[0].message, /result is saved, but/);
   assert.match(byId('no-result').reasons[0].message, /completed, but no result/);
   assert.equal(source.pendingFixtures, source.skippedFixtures.filter(f => f.disposition === 'pending').length);
@@ -83,7 +94,7 @@ test('every excluded fixture has its own exact reasons, names, time and unchange
   assert.doesNotMatch(JSON.stringify(source), /private@example/);
   assert.equal(h.queries[0].where.publishedAt.not, null);
   assert.equal(h.queries[0].where.kickoffAt.gte.toISOString(), '2026-09-07T23:00:00.000Z');
-  assert.match(h.queries[1].sql, /'abandonment'::text AS "reason"/); assert.match(h.queries[1].sql, /'replacement'::text AS "reason"/);
+  assert.match(h.queries[1].sql, /'abandonment'::text AS "reason"/); assert.doesNotMatch(h.queries[1].sql, /LastMinuteReplacementResolution/);
   assert.doesNotMatch(h.queries[1].sql, /notes|email|payment|SELECT \*/i);
 });
 test('admin-only details preserve old article hashes; included facts and counts still invalidate', async () => {
@@ -110,13 +121,13 @@ test('provider gets included facts/counts only, never omitted identities or admi
   await load('src/lib/matchweek-reports/openai.ts').writeOpenAiReport(source); assert.equal(calls, 1);
 });
 test('owning editor shows current omissions without generation, including with an old saved draft', async () => {
-  const h = harness([fixture('included'), fixture('cancelled', { status: 'CANCELLED', homeTeam: { id: 'c', name: 'Example Rovers' } }), fixture('replacement', { homeTeam: { id: 'r', name: 'Example City' } })], [{ fixtureId: 'replacement', reason: 'replacement' }]);
+  const h = harness([fixture('included'), fixture('cancelled', { status: 'CANCELLED', homeTeam: { id: 'c', name: 'Example Rovers' } }), fixture('replacement', { status: 'POSTPONED', homeTeam: { id: 'r', name: 'Example City' } })], [{ fixtureId: 'replacement', reason: 'replacement' }]);
   const source = await h.facts.getReportSource('example', '2026-09-08');
   const view = { source, sourceHash: h.facts.sourceHash(source), draft: null, configured: true, model: 'test-model', stale: false, generating: false, latestError: null };
   const Editor = h.load('src/components/admin/matchweek-reports/ReportEditor.tsx').default;
   const html = renderToStaticMarkup(React.createElement(Editor, { slug: 'example', initialView: view }));
   assert.match(html, /Matches not included \(2\)/); assert.match(html, /Example Rovers/); assert.match(html, /Example City/);
-  assert.match(html, /marked cancelled/); assert.match(html, /last-minute replacement/); assert.match(html, /19:00/);
+  assert.match(html, /marked cancelled/); assert.match(html, /marked postponed/); assert.match(html, /19:00/);
   assert.match(html, /\/admin\/fixtures\/replacement\/edit/); assert.match(html, /target="_blank"/);
   assert.doesNotMatch(html, /postponed, cancelled, disputed, placeholder/);
   const oldSource = { ...source, skippedFixtures: [{ ...source.skippedFixtures[0], teamA: 'STALE OMITTED LABEL' }] };
@@ -136,4 +147,57 @@ test('empty, pending-only and legacy snapshots render accurately, with no crash 
   const pending = await harness([fixture('pending', { status: 'SCHEDULED', result: null })]).facts.getReportSource('example', '2026-09-08');
   assert.match(render(pending), /Matches not included \(1\)/); assert.match(render(pending), /still marked scheduled/);
   assert.match(render({ ...pending, skippedFixtures: pending.skippedFixtures.map(f => ({ ...f, teamA: '<script>alert(1)</script>' })) }), /&lt;script&gt;/);
+});
+
+// Scores and names here are synthetic; they do not assert live Harrogate results.
+test('two completed replacement games join four results using current teams and scores without rewriting the old draft', async () => {
+  const ordinary = Array.from({ length: 4 }, (_, i) => fixture(`normal-${i}`));
+  const currentGames = ['early', 'late'].map((slot, i) => fixture(`replacement-${slot}`, {
+    homeTeam: { id: `opponent-${slot}`, name: `Example ${slot} opponent` },
+    awayTeam: { id: 'stand-in', name: 'Example Stand-ins' },
+    result: { homeScore: i + 1, awayScore: i + 2, isDisputed: false, disputes: [], teamMetadata: [
+      { teamId: 'stand-in', scorers: [{ name: 'Recorded player', goals: 1 }], playerOfMatchName: 'Recorded player' },
+      { teamId: 'dropped', scorers: [{ name: 'DO_NOT_REPORT_DROPPED_PLAYER', goals: 1 }], playerOfMatchName: 'DO_NOT_REPORT_DROPPED_PLAYER' },
+    ] },
+  }));
+  const history = currentGames.map(f => ({ fixtureId: f.id, reason: 'replacement', droppedTeamId: 'DO_NOT_REPORT_DROPPED_TEAM' }));
+  const originalRows = structuredClone([...ordinary, ...currentGames]), originalHistory = structuredClone(history);
+  let stored, reads = 0;
+  const h = harness([...ordinary, ...currentGames], history, [], {
+    '@/lib/requireAdmin': { requireAdmin: async () => ({ user: { id: 'test-admin' } }) },
+    './store': { readStoredReport: async () => { reads++; return stored; } },
+  });
+  const source = await h.facts.getReportSource('example', '2026-09-08');
+  assert.equal(source.matches.length, 6);
+  assert.equal(source.omittedFixtures, 0); assert.equal(source.pendingFixtures, 0); assert.deepEqual(source.skippedFixtures, []);
+  for (const f of currentGames) {
+    const match = source.matches.find(m => m.fixtureId === f.id);
+    assert.equal(match.teamA, f.homeTeam.name); assert.equal(match.teamB, f.awayTeam.name);
+    assert.equal(match.scoreA, f.result.homeScore); assert.equal(match.scoreB, f.result.awayScore);
+    assert.deepEqual(match.scorers, [{ team: 'Example Stand-ins', name: 'Recorded player', goals: 1 }]);
+    assert.deepEqual(match.playersOfMatch, [{ team: 'Example Stand-ins', name: 'Recorded player' }]);
+  }
+  assert.doesNotMatch(JSON.stringify(source), /DO_NOT_REPORT/);
+  assert.deepEqual([...ordinary, ...currentGames], originalRows); assert.deepEqual(history, originalHistory);
+  const oldSource = { ...source, matches: source.matches.slice(0, 4), omittedFixtures: 2,
+    warnings: ['2 fixture(s) omitted: postponed, cancelled, disputed, placeholder, abandonment, replacement or invalid result. Review these separately.'],
+    skippedFixtures: currentGames.map(f => ({ fixtureId: f.id, teamA: f.homeTeam.name, teamB: f.awayTeam.name, kickoffAt: f.kickoffAt.toISOString(), disposition: 'omitted', reasons: [{ code: 'replacement', message: 'A last-minute replacement is recorded for this fixture; it needs editorial review before inclusion.' }] })),
+  };
+  const content = { title: 'Previously saved four-match draft', introduction: 'Keep my original text.', matches: oldSource.matches.map((f, i) => ({ fixtureId: f.fixtureId, paragraph: `Saved paragraph ${i + 1}.` })), closing: '' };
+  const draft = { id: 'saved-draft', version: 2, source: oldSource, sourceHash: h.facts.sourceHash(oldSource), content, model: 'test', updatedAt: '2026-09-08T22:00:00Z' };
+  stored = { draft, generating: false, latestError: null };
+  const view = await h.load('src/lib/matchweek-reports/service.ts').getReportView('example', '2026-09-08');
+  assert.equal(reads, 1); assert.equal(view.source.matches.length, 6); assert.equal(view.stale, true);
+  assert.strictEqual(view.draft, draft); assert.equal(view.draft.version, 2); assert.strictEqual(view.draft.content, content);
+  let providerCalls = 0;
+  const write = loader({}, async (url, options) => {
+    providerCalls++; const input = JSON.parse(JSON.parse(options.body).input);
+    assert.equal(input.matches.length, 6); assert.deepEqual(input.matches, source.matches);
+    assert.doesNotMatch(JSON.stringify(input), /DO_NOT_REPORT|skippedFixtures|replacementTeamId|droppedTeamId/);
+    const generated = { title: 'Six-match draft', introduction: 'The included games.', matches: input.matches.map((f, i) => ({ fixtureId: f.fixtureId, paragraph: `Match ${i + 1}: ${f.teamA} ${f.scoreA}–${f.scoreB} ${f.teamB}.` })), closing: '' };
+    return new Response(JSON.stringify({ status: 'completed', output: [{ type: 'message', content: [{ type: 'output_text', text: JSON.stringify(generated) }] }] }));
+  });
+  await write('src/lib/matchweek-reports/openai.ts').writeOpenAiReport(source); assert.equal(providerCalls, 1);
+  const target = path.join(ROOT, '.tmp/report-omissions'); fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(target, 'replacement-views.json'), JSON.stringify({ before: { ...view, source: oldSource, sourceHash: draft.sourceHash, stale: false }, after: view }));
 });


### PR DESCRIPTION
Published as 341ac946e56c93bde67266874eaddae37b24bd28. Both Railway and Vercel deployments for that exact main revision report SUCCESS.

## Shared fix

The native getReportSource reader in src/lib/matchweek-reports/facts.ts no longer treats LastMinuteReplacementResolution as a report blocker. Completed replacement fixtures enter the same included-results path as other completed games, using the current assigned teams, saved scores and their team-specific scorer/POTM metadata. The same replacement team can be reported in multiple distinct fixtures. Published/date, completion, missing result, future kick-off, dispute, invalid score/team, placeholder and abandonment checks remain intact. No replacement audit record is deleted and no fixture/result data is rewritten.

The admin report page, read/check-status API and generation service share this source. The current omitted-fixture panel remains in place for genuine blockers. The final source search confirms one eligibility reader and one owning panel, without the replacement-only reason or exception query. The legacy generic backend summary retains its historical text solely for saved source-hash compatibility; it is not displayed or used as an eligibility rule.

## Tests and preservation

Exact head 2ceb6077 against unchanged main 7b13f06d passed all returned PR workflows and its hosted Vercel preview. Dedicated report run 34549022708/job 103107779442 passed native and full-prebuild genuine-blocker cases alongside replacement history, the four-plus-two completed-fixture scenario, current-team metadata filtering, unchanged audit/source objects, preserved saved four-match draft with stale detection, six-match provider payload, existing administrator/proxy tests and real disposable PostgreSQL draft-storage tests. Production build, desktop/mobile editor refresh without POST, critical/DOM checks and actual Vercel function package budget passed.

Downloaded and inspected artifact 10180203268: the four-to-six JSON transition keeps the draft/version unchanged, both screenshots are readable, source inventory is correct, and prepared/native file fingerprints match. Independent local isolated checks also reproduced the original four-included/two-omitted defect and the corrected six-included/zero-omitted result while retaining genuine blockers. These fixtures and scores are synthetic, not asserted live Harrogate data.

Existing saved articles are never rewritten by refresh. Check saved status reloads current eligible facts without an OpenAI call; an explicit regeneration is required to add newly eligible games to an existing article. No automatic generation, customer message, new migration, financial action or production fixture/replacement-history correction was introduced.

## Deployment

Railway deployment 1d41eeb0-00d0-4940-b1af-721d4e5cc8c0 for 341ac946 reached SUCCESS, with Next Ready at 2026-09-11T01:12:52Z. Both scheduled Railway services also report success. No unrelated staged environment changes were applied.

Vercel deployment BGFge1mh19jpMtUwgahXuXmFP1uj for 341ac946 reports SUCCESS / Deployment has completed at 2026-09-11T01:13:20Z through the Vercel GitHub integration. This is exact production-revision confirmation, not merely a preview or local build.

Not verified live: signed-in Harrogate report output and a real regenerated customer article. No paid provider request was made as part of verification.