### PR TITLE
Make Weekly League News prominent and article-led

### DIFF
--- a/src/app/(public)/leagues/[slug]/template.tsx
+++ b/src/app/(public)/leagues/[slug]/template.tsx
@@ -2,5 +2,5 @@ import type { ReactNode } from "react";
 import LatestNews from "@/components/news/LatestNews";
 
 export default function NewsDiscoveryTemplate({ children }: { children: ReactNode }) {
-  return <>{children}<LatestNews scope="league" /></>;
+  return <><LatestNews scope="league" />{children}</>;
 }

--- a/src/app/(public)/teams/[id]/template.tsx
+++ b/src/app/(public)/teams/[id]/template.tsx
@@ -2,5 +2,5 @@ import type { ReactNode } from "react";
 import LatestNews from "@/components/news/LatestNews";
 
 export default function NewsDiscoveryTemplate({ children }: { children: ReactNode }) {
-  return <>{children}<LatestNews scope="team" /></>;
+  return <><LatestNews scope="team" />{children}</>;
 }

--- a/src/app/captain/team/[teamid]/template.tsx
+++ b/src/app/captain/team/[teamid]/template.tsx
@@ -2,5 +2,5 @@ import type { ReactNode } from "react";
 import LatestNews from "@/components/news/LatestNews";
 
 export default function NewsDiscoveryTemplate({ children }: { children: ReactNode }) {
-  return <>{children}<LatestNews scope="captain" /></>;
+  return <><LatestNews scope="captain" />{children}</>;
 }

--- a/src/app/player/team/[teamid]/template.tsx
+++ b/src/app/player/team/[teamid]/template.tsx
@@ -2,5 +2,5 @@ import type { ReactNode } from "react";
 import LatestNews from "@/components/news/LatestNews";
 
 export default function NewsDiscoveryTemplate({ children }: { children: ReactNode }) {
-  return <>{children}<LatestNews scope="player" /></>;
+  return <><LatestNews scope="player" />{children}</>;
 }

--- a/src/components/news/LatestNews.tsx
+++ b/src/components/news/LatestNews.tsx
@@ -1,32 +1,66 @@
 'use client';
+
 import Link from 'next/link';
 import { useParams, usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { PublishedNews } from '@/lib/league-news/types';
 import NewsCard from './NewsCard';
-/** Route-owned discovery slot. Only the root dashboard/landing shows a teaser.
- * Published-only data is read separately, so news cannot delay fixtures/payments. */
+
+/** Root-page discovery slot. Published-only data is read separately so news never
+ * blocks fixtures, payments or other operational dashboard data. */
 export default function LatestNews({ scope }: { scope: 'league' | 'team' | 'captain' | 'player' }) {
-  const params = useParams(), pathname = usePathname();
+  const params = useParams();
+  const pathname = usePathname();
   const value = params[scope === 'league' ? 'slug' : scope === 'team' ? 'id' : 'teamid'];
   const id = typeof value === 'string' ? value : '';
-  const base = scope === 'league' ? `/leagues/${encodeURIComponent(id)}` : scope === 'team' ? `/teams/${encodeURIComponent(id)}` : `/${scope}/team/${encodeURIComponent(id)}`;
+  const base = scope === 'league'
+    ? `/leagues/${encodeURIComponent(id)}`
+    : scope === 'team'
+      ? `/teams/${encodeURIComponent(id)}`
+      : `/${scope}/team/${encodeURIComponent(id)}`;
   const visible = Boolean(id && pathname?.replace(/\/$/, '') === base);
   const compact = scope === 'captain' || scope === 'player';
   const url = scope === 'league' ? `${base}/news` : `/teams/${encodeURIComponent(id)}/news`;
-  const [items, setItems] = useState<PublishedNews[] | null>(null), [error, setError] = useState(false);
+  const [items, setItems] = useState<PublishedNews[] | null>(null);
+  const [error, setError] = useState(false);
+
   useEffect(() => {
     if (!visible) return;
-    const controller = new AbortController(); setItems(null); setError(false);
-    fetch(`/api/public/league-news/${scope === 'league' ? 'league' : 'team'}/${encodeURIComponent(id)}?limit=${compact ? 1 : 2}`, { cache: 'no-store', signal: controller.signal }).then(async r => {
-      const body = await r.json(); if (!r.ok || !Array.isArray(body.items)) throw Error('News unavailable');
+    const controller = new AbortController();
+    setItems(null);
+    setError(false);
+    fetch(`/api/public/league-news/${scope === 'league' ? 'league' : 'team'}/${encodeURIComponent(id)}?limit=${compact ? 1 : 2}`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    }).then(async (response) => {
+      const body = await response.json();
+      if (!response.ok || !Array.isArray(body.items)) throw Error('News unavailable');
       if (!controller.signal.aborted) setItems(body.items);
-    }).catch(() => { if (!controller.signal.aborted) setError(true); });
+    }).catch(() => {
+      if (!controller.signal.aborted) setError(true);
+    });
     return () => controller.abort();
   }, [visible, scope, id, compact]);
+
   if (!visible) return null;
-  return <section aria-label="Latest League News" className="mx-auto my-6 w-full max-w-6xl space-y-4 px-4 py-4 text-white sm:px-6">
-    <div className="flex flex-wrap items-end justify-between gap-3"><h2 className="text-xl font-black">League News</h2><Link href={url} className="inline-flex min-h-10 items-center text-sm font-semibold text-emerald-200">All news →</Link></div>
-    {items?.length ? <div className={`grid gap-4 ${!compact ? 'md:grid-cols-2' : ''}`}>{items.map(n => <NewsCard key={n.id} news={n} teamId={scope === 'league' ? undefined : id} />)}</div> : <p role="status" className="rounded-2xl border border-white/10 p-5 text-sm leading-6 text-white/60">{error ? 'News is temporarily unavailable. Use All news to try again.' : items ? 'Match-night reports will appear here once published by SIXFL.' : 'Loading League News…'}</p>}
-  </section>;
+
+  return (
+    <section aria-label="Latest League News" className="relative z-10 mx-auto w-full max-w-[1400px] px-4 pb-5 pt-5 text-white sm:px-6 sm:pb-7 sm:pt-7 lg:px-10">
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-black uppercase tracking-[0.24em] text-emerald-300">New from SIXFL</p>
+          <h2 className="mt-1 text-2xl font-black tracking-tight sm:text-3xl">This week&apos;s matchnight report</h2>
+        </div>
+        <Link href={url} className="inline-flex min-h-10 items-center rounded-full border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-emerald-200 transition hover:bg-white/[0.08]">All news →</Link>
+      </div>
+
+      {items?.length ? (
+        <NewsCard news={items[0]} teamId={scope === 'league' ? undefined : id} featured />
+      ) : (
+        <p role="status" className="rounded-2xl border border-white/10 bg-white/[0.025] p-4 text-sm leading-6 text-white/55">
+          {error ? 'News is temporarily unavailable. Use All news to try again.' : items ? 'Match-night reports will appear here once published by SIXFL.' : 'Loading League News…'}
+        </p>
+      )}
+    </section>
+  );
 }

--- a/src/components/news/NewsArticle.tsx
+++ b/src/components/news/NewsArticle.tsx
@@ -2,57 +2,178 @@ import Link from 'next/link';
 import { matchAnchor, type PublishedNews } from '@/lib/league-news/types';
 import NewsImage from './NewsImage';
 import NewsShare from './NewsShare';
-export const newsDate = (date: string) => new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'Europe/London' }).format(new Date(date.length === 10 ? `${date}T12:00:00Z` : date));
+
+export const newsDate = (date: string) => new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'Europe/London',
+}).format(new Date(date.length === 10 ? `${date}T12:00:00Z` : date));
+
 /** The same article markup is used in the protected preview and public route. */
-export default function NewsArticle({ news, shareUrl, preview = false, highlightTeamId }: { news: PublishedNews; shareUrl?: string; preview?: boolean; highlightTeamId?: string }) {
-  const a = news.article, goals = a.matches.reduce((n, m) => n + m.scoreA + m.scoreB, 0);
-  return <article className="overflow-hidden rounded-3xl border border-white/10 bg-[#06120d] text-white">
-    <header className="relative border-b border-emerald-300/20 bg-gradient-to-br from-emerald-950 via-[#071a13] to-black px-5 py-10 sm:px-10 sm:py-14">
-      <div className="flex flex-wrap items-center justify-between gap-4 text-xs font-bold uppercase tracking-[0.18em] text-emerald-300"><span>SIXFL · League News</span><span>Matchnight / {newsDate(a.matchDate)}</span></div>
-      <p className="mt-8 text-sm font-semibold text-emerald-200">{a.leagueName}</p>
-      <h1 className="mt-4 max-w-5xl break-words text-3xl font-black leading-[1.08] tracking-tight sm:text-5xl lg:text-6xl">{a.title}</h1>
-      <div className="mt-7 flex flex-wrap gap-x-5 gap-y-2 text-sm text-white/60">
-        <span>By SIXFL</span>{!preview ? <span>Published {newsDate(news.publishedAt)}</span> : <span>Website preview · not published by viewing</span>}
-        <span>{a.matches.length} matches · {goals} goals</span>
-        {!preview && news.updatedAt !== news.publishedAt ? <span>Updated {newsDate(news.updatedAt)}</span> : null}
-      </div>
-    </header>
-    {a.cover ? <figure className="border-b border-white/10">
-      <NewsImage src={a.cover.coverUrl} alt={a.cover.coverAlt} className="max-h-[560px] min-h-48 w-full object-cover" />
-      {a.cover.coverCaption ? <figcaption className="px-5 py-3 text-sm leading-6 text-white/60 sm:px-10">{a.cover.coverCaption}</figcaption> : null}
-    </figure> : null}
-    <div className="grid gap-8 px-5 py-8 sm:px-10 sm:py-10 lg:grid-cols-[minmax(0,1fr)_260px] lg:gap-12">
-      <div className="min-w-0 max-w-3xl">
-        <p className="whitespace-pre-line break-words text-lg leading-8 text-white/85 sm:text-xl sm:leading-9">{a.introduction}</p>
-        <div className="mt-10 space-y-10">
-          {a.matches.map(m => <section key={m.fixtureId} id={matchAnchor(m.fixtureId)} className="scroll-mt-6 border-t border-white/15 pt-7">
-            {highlightTeamId && [m.teamAId, m.teamBId].includes(highlightTeamId) ? <p className="mb-4 text-xs font-bold uppercase tracking-widest text-emerald-300">Featuring your team</p> : null}
-            <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 rounded-2xl border border-emerald-300/15 bg-emerald-400/[0.04] p-4 sm:p-5">
-              <div className="flex min-w-0 flex-col items-center gap-3 text-center"><NewsImage src={m.badgeA} alt={`${m.teamA} badge`} fallback={m.teamA.slice(0, 2).toUpperCase()} className="h-14 w-14 object-contain sm:h-16 sm:w-16" /><Link href={`/teams/${encodeURIComponent(m.teamAId)}`} className="break-words text-sm font-bold leading-6 hover:text-emerald-200 sm:text-base">{m.teamA}</Link></div>
-              <p aria-label={`${m.scoreA} to ${m.scoreB}`} className="whitespace-nowrap text-3xl font-black tabular-nums text-emerald-200 sm:text-4xl">{m.scoreA}<span className="px-1 text-white/35">–</span>{m.scoreB}</p>
-              <div className="flex min-w-0 flex-col items-center gap-3 text-center"><NewsImage src={m.badgeB} alt={`${m.teamB} badge`} fallback={m.teamB.slice(0, 2).toUpperCase()} className="h-14 w-14 object-contain sm:h-16 sm:w-16" /><Link href={`/teams/${encodeURIComponent(m.teamBId)}`} className="break-words text-sm font-bold leading-6 hover:text-emerald-200 sm:text-base">{m.teamB}</Link></div>
+export default function NewsArticle({
+  news,
+  shareUrl,
+  preview = false,
+  highlightTeamId,
+}: {
+  news: PublishedNews;
+  shareUrl?: string;
+  preview?: boolean;
+  highlightTeamId?: string;
+}) {
+  const a = news.article;
+  const goals = a.matches.reduce((n, m) => n + m.scoreA + m.scoreB, 0);
+
+  return (
+    <article className="overflow-hidden rounded-[2rem] border border-white/10 bg-[#f4f5f1] text-[#07130f] shadow-[0_34px_100px_rgba(0,0,0,0.38)]">
+      <header className="grid min-h-[320px] overflow-hidden bg-black lg:grid-cols-[0.9fr_1.1fr]">
+        <div className="relative flex min-h-[300px] flex-col justify-between overflow-hidden px-6 py-8 text-white sm:px-10 sm:py-10 lg:min-h-[430px] lg:px-12">
+          <div className="pointer-events-none absolute -right-10 top-[-8%] h-[120%] w-24 skew-x-[-10deg] bg-emerald-400" />
+          <div className="pointer-events-none absolute -right-2 top-[-8%] h-[120%] w-3 skew-x-[-10deg] bg-white/15" />
+
+          <div className="relative z-10">
+            <p className="text-xs font-black uppercase tracking-[0.28em] text-emerald-300">SIXFL matchnight</p>
+            <div className="mt-7 max-w-sm leading-none">
+              <div className="text-5xl font-black uppercase tracking-[-0.06em] sm:text-6xl lg:text-7xl">Weekly</div>
+              <div className="mt-1 text-5xl font-black uppercase tracking-[-0.06em] text-transparent sm:text-6xl lg:text-7xl" style={{ WebkitTextStroke: '2px #34d399' }}>News</div>
             </div>
-            <h2 className="sr-only">{m.teamA} {m.scoreA}–{m.scoreB} {m.teamB}</h2>
-            <p className="mt-5 whitespace-pre-line break-words text-base leading-8 text-white/80 sm:text-lg sm:leading-9">{m.paragraph}</p>
-            {m.scorers.length || m.playersOfMatch.length ? <div className="mt-5 space-y-2 border-l-2 border-emerald-400/50 pl-4 text-sm leading-6 text-white/60">
-              {m.scorers.length ? <p><strong className="text-white/85">Recorded scorers: </strong>{m.scorers.map(s => `${s.name} (${s.team}, ${s.goals})`).join('; ')}</p> : null}
-              {m.playersOfMatch.length ? <p><strong className="text-white/85">Player of the Match: </strong>{m.playersOfMatch.map(p => `${p.name} (${p.team})`).join('; ')}</p> : null}
-            </div> : null}
-          </section>)}
+          </div>
+
+          <div className="relative z-10 max-w-sm border-l-2 border-emerald-400 pl-4">
+            <p className="text-sm font-bold text-white">{a.leagueName}</p>
+            <p className="mt-1 text-sm text-white/60">{newsDate(a.matchDate)}</p>
+          </div>
         </div>
-        {a.closing ? <p className="mt-10 whitespace-pre-line break-words border-t border-white/15 pt-7 text-lg leading-8 text-white/80">{a.closing}</p> : null}
+
+        <div className="relative min-h-[280px] overflow-hidden border-t border-white/10 bg-[#0b2018] lg:min-h-[430px] lg:border-l lg:border-t-0">
+          {a.cover ? (
+            <>
+              <NewsImage src={a.cover.coverUrl} alt={a.cover.coverAlt} className="absolute inset-0 h-full w-full object-cover" />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/5 to-black/10" />
+              {a.cover.coverCaption ? (
+                <p className="absolute bottom-4 left-5 right-5 rounded-xl bg-black/60 px-4 py-2 text-xs leading-5 text-white/75 backdrop-blur sm:left-7 sm:right-auto sm:max-w-md">
+                  {a.cover.coverCaption}
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <div className="absolute inset-0 overflow-hidden bg-[radial-gradient(circle_at_50%_45%,rgba(52,211,153,0.18),transparent_30%),linear-gradient(135deg,#173b2c_0%,#09150f_55%,#020403_100%)]">
+              <div className="absolute inset-[12%] rounded-[2rem] border-2 border-white/25" />
+              <div className="absolute left-1/2 top-[12%] h-[76%] border-l-2 border-white/20" />
+              <div className="absolute left-1/2 top-1/2 h-24 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white/20 sm:h-32 sm:w-32" />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="rounded-3xl border border-white/10 bg-black/50 px-7 py-6 text-center shadow-2xl backdrop-blur-sm">
+                  <p className="text-xs font-black uppercase tracking-[0.24em] text-emerald-300">The night in numbers</p>
+                  <p className="mt-3 text-5xl font-black text-white">{a.matches.length}</p>
+                  <p className="text-sm font-semibold text-white/60">matches</p>
+                  <p className="mt-4 text-3xl font-black text-emerald-300">{goals}</p>
+                  <p className="text-sm font-semibold text-white/60">goals</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-5xl px-5 py-8 sm:px-10 sm:py-12 lg:px-14 lg:py-14">
+        <div className="flex flex-wrap items-center justify-between gap-4 border-b border-[#07130f]/10 pb-5 text-sm">
+          <div>
+            <p className="font-bold text-emerald-700">{newsDate(a.matchDate)}</p>
+            <p className="mt-1 text-[#07130f]/55">{a.leagueName}</p>
+          </div>
+          <div className="text-right text-[#07130f]/45">
+            <p>By SIXFL</p>
+            <p className="mt-1">{a.matches.length} matches · {goals} goals</p>
+          </div>
+        </div>
+
+        <h1 className="mt-7 max-w-4xl break-words text-3xl font-black leading-[1.08] tracking-[-0.035em] text-[#09140f] sm:text-5xl lg:text-6xl">
+          {a.title}
+        </h1>
+
+        <div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-xs font-semibold uppercase tracking-[0.12em] text-[#07130f]/45">
+          {!preview ? <span>Published {newsDate(news.publishedAt)}</span> : <span>Website preview · not published by viewing</span>}
+          {!preview && news.updatedAt !== news.publishedAt ? <span>Updated {newsDate(news.updatedAt)}</span> : null}
+        </div>
+
+        <p className="mt-8 max-w-4xl whitespace-pre-line break-words text-lg font-medium leading-8 text-[#14231c] sm:text-xl sm:leading-9">
+          {a.introduction}
+        </p>
+
+        <nav aria-label="Jump to match" className="mt-10 border-y border-[#07130f]/10 py-6">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-700">In this week&apos;s report</p>
+              <p className="mt-1 text-sm text-[#07130f]/50">Every result from the night, in one article.</p>
+            </div>
+            <Link href={`/leagues/${news.leagueSlug}/results`} className="text-sm font-bold text-emerald-700 hover:text-emerald-600">Full results →</Link>
+          </div>
+          <div className="mt-5 grid gap-x-6 sm:grid-cols-2">
+            {a.matches.map((m) => (
+              <Link key={m.fixtureId} href={`#${matchAnchor(m.fixtureId)}`} className="flex items-center justify-between gap-3 border-t border-[#07130f]/8 py-3 text-sm first:border-t-0 hover:text-emerald-700 sm:first:border-t">
+                <span className="min-w-0 truncate">{m.teamA} · {m.teamB}</span>
+                <strong className="shrink-0 rounded-full bg-[#07130f] px-3 py-1 font-black tabular-nums text-white">{m.scoreA}–{m.scoreB}</strong>
+              </Link>
+            ))}
+          </div>
+        </nav>
+
+        <div className="mt-2">
+          {a.matches.map((m, index) => {
+            const highlighted = Boolean(highlightTeamId && [m.teamAId, m.teamBId].includes(highlightTeamId));
+            return (
+              <section key={m.fixtureId} id={matchAnchor(m.fixtureId)} className="scroll-mt-6 border-b border-[#07130f]/10 py-9 sm:py-11">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-[#07130f]/35">Match {index + 1}</p>
+                  {highlighted ? <p className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-black uppercase tracking-wider text-emerald-800">Featuring your team</p> : null}
+                </div>
+
+                <div className="mt-5 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 sm:gap-6">
+                  <div className="flex min-w-0 items-center gap-3 sm:gap-4">
+                    <NewsImage src={m.badgeA} alt={`${m.teamA} badge`} fallback={m.teamA.slice(0, 2).toUpperCase()} className="h-11 w-11 shrink-0 object-contain sm:h-14 sm:w-14" />
+                    <Link href={`/teams/${encodeURIComponent(m.teamAId)}`} className="min-w-0 break-words text-sm font-black leading-5 hover:text-emerald-700 sm:text-lg">{m.teamA}</Link>
+                  </div>
+                  <p aria-label={`${m.scoreA} to ${m.scoreB}`} className="whitespace-nowrap rounded-xl bg-[#07130f] px-3 py-2 text-2xl font-black tabular-nums text-white sm:px-5 sm:py-3 sm:text-3xl">
+                    {m.scoreA}<span className="px-1.5 text-white/35">–</span>{m.scoreB}
+                  </p>
+                  <div className="flex min-w-0 items-center justify-end gap-3 text-right sm:gap-4">
+                    <Link href={`/teams/${encodeURIComponent(m.teamBId)}`} className="min-w-0 break-words text-sm font-black leading-5 hover:text-emerald-700 sm:text-lg">{m.teamB}</Link>
+                    <NewsImage src={m.badgeB} alt={`${m.teamB} badge`} fallback={m.teamB.slice(0, 2).toUpperCase()} className="h-11 w-11 shrink-0 object-contain sm:h-14 sm:w-14" />
+                  </div>
+                </div>
+
+                <h2 className="sr-only">{m.teamA} {m.scoreA}–{m.scoreB} {m.teamB}</h2>
+                <p className="mt-6 max-w-4xl whitespace-pre-line break-words text-base leading-8 text-[#25342d] sm:text-lg sm:leading-9">{m.paragraph}</p>
+
+                {m.scorers.length || m.playersOfMatch.length ? (
+                  <div className="mt-6 grid gap-3 rounded-2xl bg-[#e9ede8] p-4 text-sm leading-6 text-[#304139] sm:grid-cols-2 sm:p-5">
+                    {m.scorers.length ? <p><strong className="text-[#07130f]">Recorded scorers: </strong>{m.scorers.map((s) => `${s.name} (${s.team}, ${s.goals})`).join('; ')}</p> : <span />}
+                    {m.playersOfMatch.length ? <p><strong className="text-[#07130f]">Player of the Match: </strong>{m.playersOfMatch.map((p) => `${p.name} (${p.team})`).join('; ')}</p> : null}
+                  </div>
+                ) : null}
+              </section>
+            );
+          })}
+        </div>
+
+        {a.closing ? (
+          <div className="mt-10 border-l-4 border-emerald-500 bg-[#e9ede8] px-5 py-5 sm:px-6">
+            <p className="whitespace-pre-line break-words text-lg font-medium leading-8 text-[#1c2c24]">{a.closing}</p>
+          </div>
+        ) : null}
       </div>
-      <aside className="min-w-0 self-start rounded-2xl border border-white/10 bg-white/[0.025] p-5">
-        <h2 className="text-xs font-bold uppercase tracking-[0.18em] text-emerald-300">In this report</h2>
-        <nav aria-label="Jump to match" className="mt-4 divide-y divide-white/10">{a.matches.map(m => <Link key={m.fixtureId} href={`#${matchAnchor(m.fixtureId)}`} className="block break-words py-3 text-sm leading-6 text-white/75 hover:text-emerald-200">{m.teamA} <strong className="whitespace-nowrap text-emerald-200">{m.scoreA}–{m.scoreB}</strong> {m.teamB}</Link>)}</nav>
-        <p className="mt-4 text-xs leading-6 text-white/50">Match-night round-up. Scorer records may be incomplete.</p>
-      </aside>
-    </div>
-    <footer className="space-y-6 border-t border-white/10 px-5 py-7 sm:px-10">
-      {shareUrl && !preview ? <NewsShare url={shareUrl} title={a.title} /> : null}
-      <nav aria-label="More from the league" className="flex flex-wrap gap-4 text-sm font-semibold text-emerald-200">
-        <Link href={`/leagues/${news.leagueSlug}/news`}>More League News →</Link><Link href={`/leagues/${news.leagueSlug}/results`}>Results</Link><Link href={`/leagues/${news.leagueSlug}#table`}>League table</Link>
-      </nav>
-    </footer>
-  </article>;
+
+      <footer className="bg-[#07130f] px-5 py-7 text-white sm:px-10 lg:px-14">
+        <div className="mx-auto max-w-5xl space-y-6">
+          {shareUrl && !preview ? <NewsShare url={shareUrl} title={a.title} /> : null}
+          <nav aria-label="More from the league" className="flex flex-wrap gap-x-5 gap-y-3 text-sm font-bold text-emerald-300">
+            <Link href={`/leagues/${news.leagueSlug}/news`}>More League News →</Link>
+            <Link href={`/leagues/${news.leagueSlug}/results`}>Results</Link>
+            <Link href={`/leagues/${news.leagueSlug}#table`}>League table</Link>
+          </nav>
+        </div>
+      </footer>
+    </article>
+  );
 }

--- a/src/components/news/NewsArticle.tsx
+++ b/src/components/news/NewsArticle.tsx
@@ -101,7 +101,7 @@ export default function NewsArticle({
           {a.introduction}
         </p>
 
-        <nav aria-label="Jump to match" className="mt-10 border-y border-[#07130f]/10 py-6">
+        <section className="mt-10 border-y border-[#07130f]/10 py-6">
           <div className="flex flex-wrap items-end justify-between gap-3">
             <div>
               <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-700">In this week&apos;s report</p>
@@ -109,15 +109,15 @@ export default function NewsArticle({
             </div>
             <Link href={`/leagues/${news.leagueSlug}/results`} className="text-sm font-bold text-emerald-700 hover:text-emerald-600">Full results →</Link>
           </div>
-          <div className="mt-5 grid gap-x-6 sm:grid-cols-2">
+          <nav aria-label="Jump to match" className="mt-5 grid gap-x-6 sm:grid-cols-2">
             {a.matches.map((m) => (
               <Link key={m.fixtureId} href={`#${matchAnchor(m.fixtureId)}`} className="flex items-center justify-between gap-3 border-t border-[#07130f]/8 py-3 text-sm first:border-t-0 hover:text-emerald-700 sm:first:border-t">
                 <span className="min-w-0 truncate">{m.teamA} · {m.teamB}</span>
                 <strong className="shrink-0 rounded-full bg-[#07130f] px-3 py-1 font-black tabular-nums text-white">{m.scoreA}–{m.scoreB}</strong>
               </Link>
             ))}
-          </div>
-        </nav>
+          </nav>
+        </section>
 
         <div className="mt-2">
           {a.matches.map((m, index) => {

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -2,20 +2,75 @@ import Link from 'next/link';
 import { matchAnchor, newsPath, type PublishedNews } from '@/lib/league-news/types';
 import NewsImage from './NewsImage';
 import { newsDate } from './NewsArticle';
+
 export default function NewsCard({ news, teamId, featured = false }: { news: PublishedNews; teamId?: string; featured?: boolean }) {
-  const a = news.article, url = newsPath(news.leagueSlug, a.matchDate);
-  const teamMatches = a.matches.filter(m => teamId && [m.teamAId, m.teamBId].includes(teamId));
-  return <article className={`overflow-hidden rounded-2xl border border-white/10 bg-[#081810] text-white ${featured ? 'sm:grid sm:grid-cols-[0.8fr_1.2fr]' : ''}`}>
-    <Link href={url} tabIndex={-1} aria-hidden="true" className="relative flex min-h-36 items-center justify-center overflow-hidden border-b border-emerald-300/15 bg-gradient-to-br from-emerald-950 to-black p-5 sm:min-h-44">
-      {a.cover ? <NewsImage src={a.cover.coverUrl} alt="" className="absolute inset-0 h-full w-full object-cover" /> : <div className="text-center"><p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-300">SIXFL Matchnight</p><p className="mt-3 text-4xl font-black tracking-tight">{a.matches.length}<span className="ml-2 text-base font-semibold text-white/50">matches</span></p><p className="mt-3 text-sm text-white/65">{newsDate(a.matchDate)}</p></div>}
-    </Link>
-    <div className="min-w-0 p-5 sm:p-6">
-      <p className="text-xs font-semibold uppercase tracking-wider text-emerald-300">{a.leagueName} · {newsDate(a.matchDate)}</p>
-      {teamMatches.length ? <p className="mt-3 text-xs font-bold text-emerald-200">Featuring your team</p> : null}
-      <h3 className={`mt-3 break-words font-black leading-tight ${featured ? 'text-2xl sm:text-3xl' : 'text-xl'}`}><Link href={url} className="hover:text-emerald-200">{a.title}</Link></h3>
-      <p className="mt-3 line-clamp-3 break-words text-sm leading-7 text-white/65">{a.introduction}</p>
-      <Link href={url} className="mt-4 inline-flex min-h-10 items-center text-sm font-bold text-emerald-200">Read the full report →</Link>
-      {teamMatches.length ? <div className="mt-3 border-t border-white/10 pt-3"><p className="text-xs text-white/50">Jump to your match{teamMatches.length === 1 ? '' : 'es'}</p>{teamMatches.map(m => <Link key={m.fixtureId} href={`${url}#${matchAnchor(m.fixtureId)}`} className="mt-2 block text-sm leading-6 text-white/80 underline decoration-white/20 underline-offset-4 hover:text-emerald-200">{m.teamA} {m.scoreA}–{m.scoreB} {m.teamB}</Link>)}</div> : null}
-    </div>
-  </article>;
+  const a = news.article;
+  const url = newsPath(news.leagueSlug, a.matchDate);
+  const teamMatches = a.matches.filter((m) => teamId && [m.teamAId, m.teamBId].includes(teamId));
+  const goals = a.matches.reduce((sum, match) => sum + match.scoreA + match.scoreB, 0);
+
+  return (
+    <article className={`overflow-hidden rounded-3xl border border-emerald-300/20 bg-[#07130f] text-white shadow-[0_24px_70px_rgba(0,0,0,0.28)] ${featured ? 'lg:grid lg:grid-cols-[0.85fr_1.15fr]' : ''}`}>
+      <Link href={url} tabIndex={-1} aria-hidden="true" className={`relative flex overflow-hidden border-b border-white/10 bg-black ${featured ? 'min-h-56 lg:min-h-full lg:border-b-0 lg:border-r' : 'min-h-44'}`}>
+        {a.cover ? (
+          <>
+            <NewsImage src={a.cover.coverUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-black/15" />
+          </>
+        ) : (
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_72%_30%,rgba(52,211,153,0.22),transparent_24%),linear-gradient(135deg,#0d2d21_0%,#06110c_52%,#000_100%)]">
+            <div className="absolute inset-[14%] rounded-2xl border border-white/15" />
+            <div className="absolute left-1/2 top-[14%] h-[72%] border-l border-white/15" />
+            <div className="absolute left-1/2 top-1/2 h-20 w-20 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15" />
+          </div>
+        )}
+
+        <div className="relative z-10 flex w-full items-end justify-between gap-5 p-5 sm:p-6">
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-[0.26em] text-emerald-300">SIXFL</p>
+            <p className="mt-1 text-3xl font-black uppercase tracking-[-0.04em] sm:text-4xl">Weekly News</p>
+          </div>
+          <div className="shrink-0 rounded-2xl border border-white/10 bg-black/55 px-4 py-3 text-center backdrop-blur-sm">
+            <p className="text-2xl font-black text-emerald-300">{a.matches.length}</p>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-white/50">matches</p>
+            <p className="mt-2 text-lg font-black text-white">{goals}</p>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-white/50">goals</p>
+          </div>
+        </div>
+      </Link>
+
+      <div className="min-w-0 p-5 sm:p-7">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs font-bold uppercase tracking-[0.12em] text-emerald-300">
+          <span>{a.leagueName}</span>
+          <span className="text-white/25">•</span>
+          <span className="text-white/55">{newsDate(a.matchDate)}</span>
+        </div>
+
+        {teamMatches.length ? <p className="mt-4 inline-flex rounded-full bg-emerald-400/12 px-3 py-1 text-xs font-black uppercase tracking-wider text-emerald-200">Featuring your team</p> : null}
+
+        <h3 className={`mt-4 break-words font-black leading-[1.08] tracking-[-0.025em] ${featured ? 'text-2xl sm:text-4xl' : 'text-2xl'}`}>
+          <Link href={url} className="hover:text-emerald-200">{a.title}</Link>
+        </h3>
+
+        <p className="mt-4 line-clamp-3 break-words text-sm leading-7 text-white/65 sm:text-base">{a.introduction}</p>
+
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <Link href={url} className="inline-flex min-h-11 items-center rounded-full bg-emerald-400 px-5 py-2.5 text-sm font-black text-black transition hover:bg-emerald-300">Read this week&apos;s full report →</Link>
+          <Link href={`/leagues/${news.leagueSlug}/results`} className="inline-flex min-h-11 items-center rounded-full border border-white/12 px-4 py-2.5 text-sm font-semibold text-white/70 transition hover:border-white/20 hover:text-white">Results</Link>
+        </div>
+
+        {teamMatches.length ? (
+          <div className="mt-5 border-t border-white/10 pt-4">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-white/40">Your match{teamMatches.length === 1 ? '' : 'es'} in the report</p>
+            {teamMatches.map((m) => (
+              <Link key={m.fixtureId} href={`${url}#${matchAnchor(m.fixtureId)}`} className="mt-3 flex items-center justify-between gap-3 text-sm leading-6 text-white/80 underline decoration-white/20 underline-offset-4 hover:text-emerald-200">
+                <span className="min-w-0">{m.teamA} · {m.teamB}</span>
+                <strong className="shrink-0 text-emerald-200">{m.scoreA}–{m.scoreB}</strong>
+              </Link>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
 }


### PR DESCRIPTION
## What changed
- Restyles the public Matchnight report as one continuous, magazine-style **SIXFL Weekly News** article inspired by the supplied reference without copying its branding.
- Uses a split editorial hero: SIXFL Weekly branding on the left and the optional feature photo on the right; without a photo it falls back to a branded pitch/night-in-numbers treatment.
- Keeps all results, match prose, scorers and Player of the Match details in the same canonical article.
- Reworks team/league/dashboard teasers into a strong **This week's matchnight report** feature with a clear full-report CTA and direct links to a team's match where relevant.
- Moves the Latest League News discovery slot **before** the normal league, team, captain and player root-page content so a newly published report is no longer buried at the bottom.
- Leaves nested fixture/payment/etc pages untouched and keeps the existing published-only privacy boundary.

## Safety / behaviour retained
- One published article per league/matchnight; no duplicate team/player article copies.
- No new AI calls, emails, SMS, social posting, payment or fixture writes.
- Existing public-news reader/API and private draft/public snapshot separation remain unchanged.
- Existing `Jump to match`, team highlighting, sharing and news archive links are preserved.

Please run the existing League News, DOM, TypeScript, build and browser suites before merge.