### PR TITLE
Skip AI Predictor until both teams have played once

### DIFF
--- a/scripts/check-ai-predictor-opponent-adjusted.ts
+++ b/scripts/check-ai-predictor-opponent-adjusted.ts
@@ -130,13 +130,27 @@ assert.notEqual(
 );
 
 const repairSource = fs.readFileSync("src/lib/fixtures/aiPredictionIntegrity.ts", "utf8");
+const storedSource = fs.readFileSync("src/lib/fixtures/storedAiPredictions.ts", "utf8");
+const recoverySource = fs.readFileSync(
+  "src/lib/fixtures/recoverHistoricalAiPredictions.ts",
+  "utf8",
+);
 const migrationSource = fs.readFileSync(
   "prisma/migrations/20260820015500_ai_predictor_model_version/migration.sql",
   "utf8",
 );
-assert.match(repairSource, /opponent-adjusted-poisson-v2/);
+
+assert.match(repairSource, /opponent-adjusted-poisson-v3-min-one-game/);
 assert.match(repairSource, /prediction\."modelVersion" IS DISTINCT FROM/);
 assert.match(repairSource, /"modelVersion" = \$\{PREDICTOR_MODEL_VERSION\}/);
+assert.match(repairSource, /Null is expected for a team's first fixture/);
+assert.match(storedSource, /function hasAtLeastOneCompletedMatch/);
+assert.match(storedSource, /!homeHasHistory \|\| !awayHasHistory/);
+assert.match(storedSource, /DELETE FROM "FixtureAiPrediction"/);
+assert.match(storedSource, /prior_home\."kickoffAt" < fixture\."kickoffAt"/);
+assert.match(storedSource, /prior_away\."kickoffAt" < fixture\."kickoffAt"/);
+assert.match(recoverySource, /function hasPriorCompletedMatch/);
+assert.match(recoverySource, /A team's first match is deliberately not predicted/);
 assert.match(migrationSource, /ADD COLUMN IF NOT EXISTS "modelVersion" TEXT/);
 
 console.log("Opponent-adjusted Poisson predictor contract passed.");

--- a/src/lib/fixtures/aiPredictionIntegrity.ts
+++ b/src/lib/fixtures/aiPredictionIntegrity.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client";
 import { refreshStoredAiPreviewForFixture } from "@/lib/fixtures/storedAiPredictions";
 import { prisma } from "@/lib/prisma";
 
-const PREDICTOR_MODEL_VERSION = "opponent-adjusted-poisson-v2";
+const PREDICTOR_MODEL_VERSION = "opponent-adjusted-poisson-v3-min-one-game";
 
 type PredictionRepairRow = {
   fixtureId: string;
@@ -63,7 +63,8 @@ export async function repairUpcomingAiPredictionIntegrity(limit = 60) {
       });
 
       if (!preview) {
-        failed += 1;
+        // Null is expected for a team's first fixture: refresh removes any stale
+        // stored prediction and deliberately leaves the match without a predictor.
         continue;
       }
 

--- a/src/lib/fixtures/recoverHistoricalAiPredictions.ts
+++ b/src/lib/fixtures/recoverHistoricalAiPredictions.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client";
 
 import { getFallbackFixtureAiPreview } from "@/lib/fixtures/aiPredictor";
 import { buildNameAwareWinChanceFixtures } from "@/lib/fixtures/winChanceHistory";
-import { calculateFixtureWinChance } from "@/lib/fixtures/winChance";
+import { calculateFixtureWinChance, type WinChanceFixture } from "@/lib/fixtures/winChance";
 import { prisma } from "@/lib/prisma";
 import { getFixturePlaceholderTeamIds } from "@/lib/teams/fixture-placeholders";
 
@@ -49,6 +49,15 @@ async function ensurePredictionScoreColumns() {
   );
   await prisma.$executeRawUnsafe(
     'ALTER TABLE "FixtureAiPrediction" ADD COLUMN IF NOT EXISTS "predictedAwayScore" INTEGER',
+  );
+}
+
+function hasPriorCompletedMatch(teamId: string, fixtures: WinChanceFixture[]) {
+  return fixtures.some(
+    (historyFixture) =>
+      historyFixture.status === "COMPLETED" &&
+      Boolean(historyFixture.result) &&
+      (historyFixture.homeTeam.id === teamId || historyFixture.awayTeam.id === teamId),
   );
 }
 
@@ -120,6 +129,17 @@ export async function recoverMissingHistoricalAiPredictions(fixtureIds: string[]
       historyFixtures,
       targetFixtures: [fixture],
     });
+
+    // A team's first match is deliberately not predicted. The historical repair
+    // path must obey the same rule so accuracy pages cannot later invent a call
+    // that was never eligible before kick-off.
+    if (
+      !hasPriorCompletedMatch(fixture.homeTeam.id, predictionHistory) ||
+      !hasPriorCompletedMatch(fixture.awayTeam.id, predictionHistory)
+    ) {
+      continue;
+    }
+
     const winChance = calculateFixtureWinChance({
       homeTeamId: fixture.homeTeam.id,
       awayTeamId: fixture.awayTeam.id,

--- a/src/lib/fixtures/storedAiPredictions.ts
+++ b/src/lib/fixtures/storedAiPredictions.ts
@@ -133,6 +133,15 @@ function canReuseExistingPrediction(input: {
   return !hasOpenAiPredictorConfig();
 }
 
+function hasAtLeastOneCompletedMatch(teamId: string, fixtures: WinChanceFixture[]) {
+  return fixtures.some(
+    (fixture) =>
+      fixture.status === "COMPLETED" &&
+      Boolean(fixture.result) &&
+      (fixture.homeTeam.id === teamId || fixture.awayTeam.id === teamId),
+  );
+}
+
 export async function getStoredAiPreviewsByFixtureIds(fixtureIds: string[]) {
   const ids = Array.from(new Set(fixtureIds.filter(Boolean)));
 
@@ -162,6 +171,24 @@ export async function getStoredAiPreviewsByFixtureIds(fixtureIds: string[]) {
     WHERE prediction."fixtureId" IN (${Prisma.join(ids)})
       AND COALESCE(home_team."isFixturePlaceholder", false) = false
       AND COALESCE(away_team."isFixturePlaceholder", false) = false
+      AND EXISTS (
+        SELECT 1
+        FROM "Fixture" prior_home
+        JOIN "MatchResult" prior_home_result ON prior_home_result."fixtureId" = prior_home."id"
+        WHERE prior_home."leagueId" = fixture."leagueId"
+          AND prior_home."status"::text = 'COMPLETED'
+          AND prior_home."kickoffAt" < fixture."kickoffAt"
+          AND fixture."homeTeamId" IN (prior_home."homeTeamId", prior_home."awayTeamId")
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM "Fixture" prior_away
+        JOIN "MatchResult" prior_away_result ON prior_away_result."fixtureId" = prior_away."id"
+        WHERE prior_away."leagueId" = fixture."leagueId"
+          AND prior_away."status"::text = 'COMPLETED'
+          AND prior_away."kickoffAt" < fixture."kickoffAt"
+          AND fixture."awayTeamId" IN (prior_away."homeTeamId", prior_away."awayTeamId")
+      )
   `;
 
   return new Map(rows.map((row) => [row.fixtureId, toStoredPreview(row)]));
@@ -249,7 +276,16 @@ async function generateAndSave(input: {
     input.fixture.awayTeam.id,
   ]);
 
-  if (placeholderTeamIds.size > 0) {
+  const homeHasHistory = hasAtLeastOneCompletedMatch(
+    input.fixture.homeTeam.id,
+    input.fixtures,
+  );
+  const awayHasHistory = hasAtLeastOneCompletedMatch(
+    input.fixture.awayTeam.id,
+    input.fixtures,
+  );
+
+  if (placeholderTeamIds.size > 0 || !homeHasHistory || !awayHasHistory) {
     await prisma.$executeRaw`
       DELETE FROM "FixtureAiPrediction"
       WHERE "fixtureId" = ${input.fixture.id}


### PR DESCRIPTION
## Requested behaviour
Do not show or generate SIXFL AI Predictor percentages for a brand-new team. A fixture becomes predictor-eligible only once both teams have at least one completed match in that league, so a team's second match is the earliest possible prediction.

## Implementation
- Stored prediction generation now checks both teams for at least one completed result before making any OpenAI/fallback preview. If either side has no history, any stale prediction row for that fixture is deleted and generation returns null.
- Public/admin stored-prediction reads also require a completed prior match for both sides before the target fixture kickoff, so an already-stored first-game prediction disappears immediately instead of waiting for a repair job.
- Historical recovery follows the same rule and will not invent/backfill a prediction for a team's first game.
- Predictor model version is bumped to `opponent-adjusted-poisson-v3-min-one-game`, causing the normal integrity repair to revisit upcoming rows; null is now an expected outcome for first fixtures, not a repair failure.
- Existing score model, percentages, fixture/result data and match history are otherwise unchanged. No customer messages, payments or result writes.

## Verification
The existing opponent-adjusted predictor contract now protects the first-game eligibility gate, display filter, historical-recovery rule and model-version invalidation. Relevant repository checks should pass before merge.