### PR TITLE
Let admins safely restore capped players' captain shares

### DIFF
--- a/src/app/(admin)/admin/payments/player-fees/[feeId]/correct-charge/page.tsx
+++ b/src/app/(admin)/admin/payments/player-fees/[feeId]/correct-charge/page.tsx
@@ -1,26 +1,159 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { requireAdmin } from "@/lib/requireAdmin";
-import { getOriginalChargeCorrectionCandidate, PlayerChargeCorrectionError } from "@/lib/payments/player-charge-correction";
+
+import CorrectCaptainAssignedShareForm from "@/components/payments/CorrectCaptainAssignedShareForm";
 import CorrectOriginalPlayerChargeForm from "@/components/payments/CorrectOriginalPlayerChargeForm";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
+import {
+  getCaptainAssignedShareCorrectionCandidate,
+  PlayerAssignedShareCorrectionError,
+} from "@/lib/payments/player-assigned-share-correction";
+import {
+  getOriginalChargeCorrectionCandidate,
+  PlayerChargeCorrectionError,
+} from "@/lib/payments/player-charge-correction";
+import { requireAdmin } from "@/lib/requireAdmin";
+
 export const dynamic = "force-dynamic";
-export default async function Page({ params }: { params: Promise<{ feeId: string }> }) {
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ feeId: string }>;
+}) {
   const access = await requireAdmin();
   if (!access.user || access.user.role !== "ADMIN") redirect("/dashboard");
+
   const { feeId } = await params;
-  let candidate;
-  try { candidate = await getOriginalChargeCorrectionCandidate(feeId, access.user.id); }
-  catch (error) {
-    if (!(error instanceof PlayerChargeCorrectionError)) throw error;
-    return <main className="mx-auto max-w-3xl space-y-5 p-6 text-white"><h1 className="text-2xl font-semibold">Correct original charge · Admin only</h1>
-      <p role="alert" className="rounded-2xl border border-amber-400/30 p-5">{error.message}</p><Link href="/admin/payments" className="text-emerald-200 underline">Back to payments</Link></main>;
+
+  try {
+    const shareCandidate = await getCaptainAssignedShareCorrectionCandidate(
+      feeId,
+      access.user.id,
+    );
+
+    if (shareCandidate) {
+      return (
+        <main className="mx-auto max-w-3xl space-y-6 p-6 text-white">
+          <Link
+            href={`/captain/team/${shareCandidate.teamId}/payments`}
+            className="text-emerald-200 underline"
+          >
+            Back to team payments
+          </Link>
+
+          <header>
+            <p className="text-sm uppercase text-amber-200">
+              Admin only · Capped/overridden player
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold">
+              Correct captain-assigned share
+            </h1>
+            <p className="mt-3 font-semibold">
+              {shareCandidate.playerName} · {shareCandidate.teamName}
+            </p>
+            <p className="text-sm text-white/65">
+              {shareCandidate.fixtureLabel} ·{" "}
+              {formatDateTimeInLondon(new Date(shareCandidate.kickoffAt), {
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+              })}
+            </p>
+          </header>
+
+          <div className="space-y-3 rounded-xl border border-amber-400/25 bg-amber-500/[0.05] p-4 text-sm leading-6">
+            <p className="font-semibold text-amber-100">
+              This player has a fee cap or override, so the historical-debt correction is deliberately disabled.
+            </p>
+            <p className="text-white/75">
+              A cap is a genuine SIXFL concession. Turning the difference into player debt would be wrong. Use this control only to restore what the captain originally assigned — for example £8 assigned while the player was correctly charged £5.
+            </p>
+            <p className="text-white/65">
+              Saving here changes the captain-assigned share only. It does not change the player&apos;s charge, cap, payment status, receipts or outstanding balance.
+            </p>
+          </div>
+
+          <CorrectCaptainAssignedShareForm
+            feeId={feeId}
+            teamId={shareCandidate.teamId}
+            playerChargePence={shareCandidate.playerChargePence}
+            currentAssignedPence={shareCandidate.currentAssignedPence}
+            suggestedAssignedPence={shareCandidate.suggestedAssignedPence}
+            capPence={shareCandidate.capPence}
+            overridePence={shareCandidate.overridePence}
+            hasFeeCapEvidence={shareCandidate.hasFeeCapEvidence}
+          />
+        </main>
+      );
+    }
+  } catch (error) {
+    if (!(error instanceof PlayerAssignedShareCorrectionError)) throw error;
+    return (
+      <main className="mx-auto max-w-3xl space-y-5 p-6 text-white">
+        <h1 className="text-2xl font-semibold">Correct captain share · Admin only</h1>
+        <p role="alert" className="rounded-2xl border border-amber-400/30 p-5">
+          {error.message}
+        </p>
+        <Link href="/admin/payments" className="text-emerald-200 underline">
+          Back to payments
+        </Link>
+      </main>
+    );
   }
-  return <main className="mx-auto max-w-3xl space-y-6 p-6 text-white">
-    <Link href={`/captain/team/${candidate.teamId}/payments`} className="text-emerald-200 underline">Back to team payments</Link>
-    <header><p className="text-sm uppercase text-amber-200">Admin only · Historical correction</p><h1 className="mt-2 text-3xl font-semibold">Correct original charge</h1>
-      <p className="mt-3 font-semibold">{candidate.playerName} · {candidate.teamName}</p><p className="text-sm text-white/65">{candidate.fixtureLabel} · {formatDateTimeInLondon(new Date(candidate.kickoffAt), { day: "numeric", month: "short", year: "numeric" })}</p></header>
-    <p className="rounded-xl border border-amber-400/25 p-4 text-sm">This restores a historical unpaid remainder. It does not create another charge or payment, and must not be used to reverse a genuine discount or waiver. Existing receipts are verified with Stripe before preview and again before saving.</p>
-    <CorrectOriginalPlayerChargeForm feeId={feeId} teamId={candidate.teamId} assignedPence={candidate.assignedPence} receivedPence={candidate.receivedPence}/>
-  </main>;
+
+  let candidate;
+  try {
+    candidate = await getOriginalChargeCorrectionCandidate(feeId, access.user.id);
+  } catch (error) {
+    if (!(error instanceof PlayerChargeCorrectionError)) throw error;
+    return (
+      <main className="mx-auto max-w-3xl space-y-5 p-6 text-white">
+        <h1 className="text-2xl font-semibold">Correct original charge · Admin only</h1>
+        <p role="alert" className="rounded-2xl border border-amber-400/30 p-5">
+          {error.message}
+        </p>
+        <Link href="/admin/payments" className="text-emerald-200 underline">
+          Back to payments
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-6 text-white">
+      <Link
+        href={`/captain/team/${candidate.teamId}/payments`}
+        className="text-emerald-200 underline"
+      >
+        Back to team payments
+      </Link>
+      <header>
+        <p className="text-sm uppercase text-amber-200">
+          Admin only · Historical correction
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold">Correct original charge</h1>
+        <p className="mt-3 font-semibold">
+          {candidate.playerName} · {candidate.teamName}
+        </p>
+        <p className="text-sm text-white/65">
+          {candidate.fixtureLabel} ·{" "}
+          {formatDateTimeInLondon(new Date(candidate.kickoffAt), {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          })}
+        </p>
+      </header>
+      <p className="rounded-xl border border-amber-400/25 p-4 text-sm">
+        This restores a historical unpaid remainder. It does not create another charge or payment, and must not be used to reverse a genuine discount or waiver. Existing receipts are verified with Stripe before preview and again before saving.
+      </p>
+      <CorrectOriginalPlayerChargeForm
+        feeId={feeId}
+        teamId={candidate.teamId}
+        assignedPence={candidate.assignedPence}
+        receivedPence={candidate.receivedPence}
+      />
+    </main>
+  );
 }

--- a/src/app/api/admin/player-fees/[feeId]/assigned-share/route.ts
+++ b/src/app/api/admin/player-fees/[feeId]/assigned-share/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { revalidatePath } from "next/cache";
+
+import { authOptions } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import {
+  correctCaptainAssignedShare,
+  PlayerAssignedShareCorrectionError,
+} from "@/lib/payments/player-assigned-share-correction";
+import { parseLedgerMoney } from "@/lib/payments/player-ledger";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ feeId: string }> },
+) {
+  const origins = [new URL(request.url).origin];
+  for (const value of [
+    process.env.NEXTAUTH_URL,
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.NEXT_PUBLIC_APP_URL,
+  ]) {
+    if (!value) continue;
+    try {
+      origins.push(new URL(value).origin);
+    } catch {
+      // Ignore invalid optional deployment settings.
+    }
+  }
+
+  if (
+    !origins.includes(request.headers.get("origin") ?? "") ||
+    request.headers.get("sec-fetch-site") === "cross-site" ||
+    !request.headers.get("content-type")?.startsWith("application/json")
+  ) {
+    return NextResponse.json(
+      { error: "Same-origin JSON request required." },
+      { status: 403 },
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+  const email = session?.user?.email?.trim().toLowerCase();
+  const user = email
+    ? await prisma.user.findUnique({
+        where: { email },
+        select: { id: true, role: true },
+      })
+    : null;
+
+  if (!user || user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "Administrator access is required." },
+      { status: 403 },
+    );
+  }
+
+  const { feeId } = await params;
+
+  try {
+    const raw = await request.text();
+    if (raw.length > 8000) {
+      throw new PlayerAssignedShareCorrectionError("Request is too large.");
+    }
+
+    const body = JSON.parse(raw);
+    const result = await correctCaptainAssignedShare({
+      feeId,
+      actorUserId: user.id,
+      assignedPence: parseLedgerMoney(body.assignedAmount),
+      expectedAssignedPence: Number(body.expectedAssignedPence),
+      confirmed: body.confirmed === true,
+    });
+
+    for (const path of [
+      "/admin/payments",
+      `/admin/payments/player-fees/${feeId}/correct-charge`,
+      `/captain/team/${result.teamId}/payments`,
+      `/captain/team/${result.teamId}/player-payments`,
+      `/captain/team/${result.teamId}/player-payments/accounts`,
+      `/captain/team/${result.teamId}/player-payments/account/${feeId}`,
+      `/player/team/${result.teamId}`,
+      `/player/team/${result.teamId}/ledger`,
+    ]) {
+      revalidatePath(path);
+    }
+
+    return NextResponse.json(result, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    if (error instanceof PlayerAssignedShareCorrectionError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+
+    console.error("[player-assigned-share-correction] Request failed", error);
+    return NextResponse.json(
+      {
+        error:
+          "The captain share could not be changed. Reload the player account before retrying. No payment or message was requested.",
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/src/components/payments/CorrectCaptainAssignedShareForm.tsx
+++ b/src/components/payments/CorrectCaptainAssignedShareForm.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type FormEvent } from "react";
+
+const money = (pence: number) =>
+  new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+  }).format(pence / 100);
+
+const field =
+  "mt-2 w-full rounded-xl border border-white/20 bg-black/30 px-4 py-3 text-white";
+const button =
+  "rounded-xl bg-emerald-400 px-5 py-3 font-semibold text-black disabled:opacity-50";
+
+type SaveResult = {
+  teamId: string;
+  feeId: string;
+  previousAssignedPence: number;
+  assignedPence: number;
+  playerChargePence: number;
+  unchanged: boolean;
+};
+
+export default function CorrectCaptainAssignedShareForm({
+  feeId,
+  teamId,
+  playerChargePence,
+  currentAssignedPence,
+  suggestedAssignedPence,
+  capPence,
+  overridePence,
+  hasFeeCapEvidence,
+}: {
+  feeId: string;
+  teamId: string;
+  playerChargePence: number;
+  currentAssignedPence: number;
+  suggestedAssignedPence: number;
+  capPence: number | null;
+  overridePence: number | null;
+  hasFeeCapEvidence: boolean;
+}) {
+  const [amount, setAmount] = useState((suggestedAssignedPence / 100).toFixed(2));
+  const [confirmed, setConfirmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState<SaveResult | null>(null);
+
+  const account = `/captain/team/${teamId}/player-payments/account/${feeId}`;
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    setError("");
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 20000);
+
+    try {
+      const response = await fetch(
+        `/api/admin/player-fees/${encodeURIComponent(feeId)}/assigned-share`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: controller.signal,
+          body: JSON.stringify({
+            assignedAmount: amount,
+            expectedAssignedPence: currentAssignedPence,
+            confirmed,
+          }),
+        },
+      );
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || "The captain share was not changed.");
+      }
+      setSaved(result);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "The captain share could not be changed. Reload and check the player account.",
+      );
+    } finally {
+      clearTimeout(timeout);
+      setBusy(false);
+    }
+  }
+
+  if (saved) {
+    return (
+      <section
+        role="status"
+        className="space-y-4 rounded-2xl border border-emerald-400/30 p-5"
+      >
+        <h2 className="text-xl font-semibold">
+          {saved.unchanged ? "Captain share already correct" : "Captain share corrected"}
+        </h2>
+        <p>
+          Captain-assigned share: <strong>{money(saved.assignedPence)}</strong>.
+          The player&apos;s recorded charge remains <strong>{money(saved.playerChargePence)}</strong>.
+        </p>
+        <p className="text-sm text-white/70">
+          No payment was taken, no debt was created, no receipt was changed and no email or SMS was sent.
+        </p>
+        <Link className="text-emerald-200 underline" href={account}>
+          Open player account
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-5">
+      {error ? (
+        <p role="alert" className="rounded-xl border border-red-300/40 p-4 text-red-100">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-xl border border-white/10 bg-black/20 p-4">
+          <p className="text-xs uppercase tracking-wider text-white/45">Player charge</p>
+          <p className="mt-1 text-lg font-semibold text-white">{money(playerChargePence)}</p>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-black/20 p-4">
+          <p className="text-xs uppercase tracking-wider text-white/45">Current captain share</p>
+          <p className="mt-1 text-lg font-semibold text-white">{money(currentAssignedPence)}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs text-white/65">
+        {capPence !== null ? (
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5">
+            Current player cap {money(capPence)}
+          </span>
+        ) : null}
+        {overridePence !== null ? (
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5">
+            Current player override {money(overridePence)}
+          </span>
+        ) : null}
+        {hasFeeCapEvidence ? (
+          <span className="rounded-full border border-emerald-300/20 bg-emerald-400/10 px-3 py-1.5 text-emerald-100">
+            Cap recorded on this fixture
+          </span>
+        ) : (
+          <span className="rounded-full border border-amber-300/20 bg-amber-400/10 px-3 py-1.5 text-amber-100">
+            Current profile concession only — check this fixture
+          </span>
+        )}
+      </div>
+
+      <form className="space-y-5" onSubmit={submit}>
+        <label className="block">
+          Correct captain-assigned share (£)
+          <input
+            className={field}
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            inputMode="decimal"
+            required
+            disabled={busy}
+          />
+        </label>
+
+        <label className="flex gap-3 rounded-xl border border-amber-300/20 bg-amber-400/[0.06] p-4 text-sm leading-6">
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(event) => setConfirmed(event.target.checked)}
+            required
+            disabled={busy}
+            className="mt-1"
+          />
+          <span>
+            I am correcting only what the captain originally assigned. Keep the player&apos;s cap/override, actual charge, payment status and outstanding balance unchanged.
+          </span>
+        </label>
+
+        <button className={button} disabled={busy || !confirmed}>
+          {busy ? "Saving captain share…" : "Save captain share only"}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/lib/payments/player-assigned-share-correction.ts
+++ b/src/lib/payments/player-assigned-share-correction.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { money } from "./player-ledger";
+
+export class PlayerAssignedShareCorrectionError extends Error {
+  constructor(message: string, public status = 400) {
+    super(message);
+  }
+}
+
+const fail = (message: string, status = 400): never => {
+  throw new PlayerAssignedShareCorrectionError(message, status);
+};
+
+const CAP_NOTE_PATTERN = /(Player fee cap applied: captain share £)([0-9,.]+)(; player charged £)([0-9,.]+)(\.)/i;
+
+type Db = Pick<
+  Prisma.TransactionClient,
+  | "$queryRaw"
+  | "$executeRaw"
+  | "user"
+  | "playerMatchFee"
+  | "playerFeeLedgerState"
+  | "playerLedgerEntry"
+>;
+
+type ProfileRow = {
+  override: number | null;
+  cap: number | null;
+};
+
+type AssignedRow = {
+  assigned: number | null;
+};
+
+function parsePoundsToPence(value: string | undefined) {
+  if (!value) return null;
+  const amount = Number(value.replace(/,/g, ""));
+  if (!Number.isFinite(amount) || amount < 0) return null;
+  return Math.round(amount * 100);
+}
+
+function formatPoundsForNote(pence: number) {
+  return (pence / 100).toFixed(2);
+}
+
+async function assertAdmin(actorUserId: string, db: Db) {
+  const actor = actorUserId
+    ? await db.user.findUnique({
+        where: { id: actorUserId },
+        select: { id: true, role: true },
+      })
+    : null;
+
+  if (!actor || actor.role !== "ADMIN") {
+    fail("Administrator access is required.", 403);
+  }
+}
+
+async function loadCandidate(feeId: string, actorUserId: string, db: Db) {
+  await assertAdmin(actorUserId, db);
+
+  const fee = await db.playerMatchFee.findUnique({
+    where: { id: feeId },
+    include: {
+      team: { select: { name: true } },
+      fixture: {
+        select: {
+          kickoffAt: true,
+          homeTeam: { select: { name: true } },
+          awayTeam: { select: { name: true } },
+        },
+      },
+      teamMember: {
+        select: { user: { select: { name: true, email: true } } },
+      },
+      prospect: {
+        select: {
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
+    },
+  });
+
+  if (!fee) return null;
+
+  const assignedRows = await db.$queryRaw<AssignedRow[]>(Prisma.sql`
+    SELECT "captainAssignedAmountPence" AS assigned
+    FROM "PlayerMatchFee"
+    WHERE id=${feeId}
+  `);
+  const currentAssignedPence =
+    assignedRows[0]?.assigned !== null && assignedRows[0]?.assigned !== undefined
+      ? Number(assignedRows[0].assigned)
+      : fee.amountPence;
+
+  let profile: ProfileRow | null = null;
+  if (fee.teamMemberId) {
+    const profiles = await db.$queryRaw<ProfileRow[]>(Prisma.sql`
+      SELECT
+        (to_jsonb(p)->>'playerMatchFeePenceOverride')::integer AS override,
+        (to_jsonb(p)->>'playerMatchFeeCapPence')::integer AS cap
+      FROM "TeamMemberProfile" p
+      WHERE "teamMemberId"=${fee.teamMemberId}
+      LIMIT 1
+    `);
+    profile = profiles[0] ?? null;
+  }
+
+  const capNote = CAP_NOTE_PATTERN.exec(fee.note ?? "");
+  const noteAssignedPence = parsePoundsToPence(capNote?.[2]);
+  const hasFeeCapEvidence = Boolean(capNote);
+  const hasCurrentConcession =
+    profile?.cap !== null && profile?.cap !== undefined ||
+    profile?.override !== null && profile?.override !== undefined;
+
+  if (!hasFeeCapEvidence && !hasCurrentConcession) return null;
+
+  const playerName = fee.teamMember?.user.name?.trim()
+    || fee.teamMember?.user.email?.trim()
+    || [fee.prospect?.firstName, fee.prospect?.lastName].filter(Boolean).join(" ").trim()
+    || fee.prospect?.email?.trim()
+    || "Player";
+
+  return {
+    fee,
+    feeId,
+    teamId: fee.teamId,
+    teamName: fee.team.name,
+    playerName,
+    fixtureLabel: `${fee.fixture.homeTeam.name} vs ${fee.fixture.awayTeam.name}`,
+    kickoffAt: fee.fixture.kickoffAt.toISOString(),
+    playerChargePence: fee.amountPence,
+    currentAssignedPence,
+    suggestedAssignedPence:
+      noteAssignedPence !== null && noteAssignedPence >= fee.amountPence
+        ? noteAssignedPence
+        : currentAssignedPence,
+    capPence: profile?.cap ?? null,
+    overridePence: profile?.override ?? null,
+    hasFeeCapEvidence,
+  };
+}
+
+export async function getCaptainAssignedShareCorrectionCandidate(
+  feeId: string,
+  actorUserId: string,
+) {
+  const candidate = await loadCandidate(feeId, actorUserId, prisma);
+  if (!candidate) return null;
+
+  const { fee: _fee, ...publicCandidate } = candidate;
+  return publicCandidate;
+}
+
+export async function correctCaptainAssignedShare(input: {
+  feeId: string;
+  actorUserId: string;
+  assignedPence: number;
+  expectedAssignedPence: number;
+  confirmed: boolean;
+}) {
+  if (!input.confirmed) {
+    fail("Confirm that this is only a captain-share correction before saving.");
+  }
+  if (!Number.isSafeInteger(input.assignedPence) || input.assignedPence < 0 || input.assignedPence > 500000) {
+    fail("Enter a valid captain-assigned share of no more than £5,000.");
+  }
+  if (!Number.isSafeInteger(input.expectedAssignedPence) || input.expectedAssignedPence < 0) {
+    fail("The current assigned share could not be verified. Reload the page.");
+  }
+
+  return prisma.$transaction(async (db) => {
+    await assertAdmin(input.actorUserId, db);
+    await db.$queryRaw(Prisma.sql`
+      SELECT id FROM "PlayerMatchFee" WHERE id=${input.feeId} FOR UPDATE
+    `);
+
+    const candidate = await loadCandidate(input.feeId, input.actorUserId, db);
+    if (!candidate) {
+      fail("This player fee no longer has a cap or override. Nothing was changed.");
+    }
+    if (candidate.currentAssignedPence !== input.expectedAssignedPence) {
+      fail("The captain-assigned share changed after this page was opened. Reload before correcting it.");
+    }
+    if (input.assignedPence < candidate.playerChargePence) {
+      fail(
+        `The captain-assigned share cannot be lower than the player's recorded charge of ${money(candidate.playerChargePence)}.`,
+      );
+    }
+
+    if (input.assignedPence === candidate.currentAssignedPence) {
+      return {
+        teamId: candidate.teamId,
+        feeId: candidate.feeId,
+        previousAssignedPence: candidate.currentAssignedPence,
+        assignedPence: input.assignedPence,
+        playerChargePence: candidate.playerChargePence,
+        unchanged: true,
+      };
+    }
+
+    const previousStatus = candidate.fee.status;
+    const previousAmountPence = candidate.fee.amountPence;
+    const previousNote = candidate.fee.note ?? null;
+    const nextNote = previousNote?.replace(
+      CAP_NOTE_PATTERN,
+      (_match, prefix: string, _oldShare: string, middle: string, charged: string, suffix: string) =>
+        `${prefix}${formatPoundsForNote(input.assignedPence)}${middle}${charged}${suffix}`,
+    ) ?? null;
+
+    await db.$executeRaw(Prisma.sql`
+      UPDATE "PlayerMatchFee"
+      SET "captainAssignedAmountPence"=${input.assignedPence},
+          "note"=${nextNote},
+          "updatedAt"=NOW()
+      WHERE id=${input.feeId}
+    `);
+
+    const after = await db.playerMatchFee.findUnique({
+      where: { id: input.feeId },
+      select: { amountPence: true, status: true },
+    });
+    const assignedAfter = await db.$queryRaw<AssignedRow[]>(Prisma.sql`
+      SELECT "captainAssignedAmountPence" AS assigned
+      FROM "PlayerMatchFee"
+      WHERE id=${input.feeId}
+    `);
+
+    if (
+      !after ||
+      after.amountPence !== previousAmountPence ||
+      after.status !== previousStatus ||
+      Number(assignedAfter[0]?.assigned) !== input.assignedPence
+    ) {
+      throw new Error("Captain-share correction changed an unexpected payment field; transaction rolled back.");
+    }
+
+    const state = await db.playerFeeLedgerState.findUnique({
+      where: { feeId: input.feeId },
+      select: { balancePence: true },
+    });
+
+    if (state) {
+      await db.playerLedgerEntry.create({
+        data: {
+          feeId: input.feeId,
+          teamId: candidate.teamId,
+          kind: "CAPTAIN_SHARE_CORRECTION",
+          amountPence: 0,
+          balanceAfterPence: state.balancePence,
+          receiptPence: 0,
+          actorUserId: input.actorUserId,
+          reason: `SIXFL corrected the captain-assigned share from ${money(candidate.currentAssignedPence)} to ${money(input.assignedPence)}. The player's charge, payments and outstanding balance were not changed.`,
+          sourceKey: `captain-share-correction:${input.feeId}:${randomUUID()}`,
+        },
+      });
+    }
+
+    return {
+      teamId: candidate.teamId,
+      feeId: candidate.feeId,
+      previousAssignedPence: candidate.currentAssignedPence,
+      assignedPence: input.assignedPence,
+      playerChargePence: candidate.playerChargePence,
+      unchanged: false,
+    };
+  }, { maxWait: 5000, timeout: 15000 });
+}

--- a/src/lib/payments/player-assigned-share-correction.ts
+++ b/src/lib/payments/player-assigned-share-correction.ts
@@ -16,6 +16,12 @@ const fail = (message: string, status = 400): never => {
 
 const CAP_NOTE_PATTERN = /(Player fee cap applied: captain share £)([0-9,.]+)(; player charged £)([0-9,.]+)(\.)/i;
 
+/**
+ * SIXFL extends Prisma at runtime, so the generated PrismaClient and the
+ * transaction callback client are not structurally assignable even though the
+ * delegates used here have the same runtime contract. Keep the adapter local
+ * to this correction service rather than weakening the application's client.
+ */
 type Db = Pick<
   Prisma.TransactionClient,
   | "$queryRaw"
@@ -25,6 +31,8 @@ type Db = Pick<
   | "playerFeeLedgerState"
   | "playerLedgerEntry"
 >;
+
+const correctionDb = (db: unknown) => db as Db;
 
 type ProfileRow = {
   override: number | null;
@@ -115,16 +123,20 @@ async function loadCandidate(feeId: string, actorUserId: string, db: Db) {
   const noteAssignedPence = parsePoundsToPence(capNote?.[2]);
   const hasFeeCapEvidence = Boolean(capNote);
   const hasCurrentConcession =
-    profile?.cap !== null && profile?.cap !== undefined ||
-    profile?.override !== null && profile?.override !== undefined;
+    (profile?.cap !== null && profile?.cap !== undefined) ||
+    (profile?.override !== null && profile?.override !== undefined);
 
   if (!hasFeeCapEvidence && !hasCurrentConcession) return null;
 
-  const playerName = fee.teamMember?.user.name?.trim()
-    || fee.teamMember?.user.email?.trim()
-    || [fee.prospect?.firstName, fee.prospect?.lastName].filter(Boolean).join(" ").trim()
-    || fee.prospect?.email?.trim()
-    || "Player";
+  const playerName =
+    fee.teamMember?.user.name?.trim() ||
+    fee.teamMember?.user.email?.trim() ||
+    [fee.prospect?.firstName, fee.prospect?.lastName]
+      .filter(Boolean)
+      .join(" ")
+      .trim() ||
+    fee.prospect?.email?.trim() ||
+    "Player";
 
   return {
     fee,
@@ -150,7 +162,11 @@ export async function getCaptainAssignedShareCorrectionCandidate(
   feeId: string,
   actorUserId: string,
 ) {
-  const candidate = await loadCandidate(feeId, actorUserId, prisma);
+  const candidate = await loadCandidate(
+    feeId,
+    actorUserId,
+    correctionDb(prisma),
+  );
   if (!candidate) return null;
 
   const { fee: _fee, ...publicCandidate } = candidate;
@@ -167,107 +183,136 @@ export async function correctCaptainAssignedShare(input: {
   if (!input.confirmed) {
     fail("Confirm that this is only a captain-share correction before saving.");
   }
-  if (!Number.isSafeInteger(input.assignedPence) || input.assignedPence < 0 || input.assignedPence > 500000) {
+  if (
+    !Number.isSafeInteger(input.assignedPence) ||
+    input.assignedPence < 0 ||
+    input.assignedPence > 500000
+  ) {
     fail("Enter a valid captain-assigned share of no more than £5,000.");
   }
-  if (!Number.isSafeInteger(input.expectedAssignedPence) || input.expectedAssignedPence < 0) {
+  if (
+    !Number.isSafeInteger(input.expectedAssignedPence) ||
+    input.expectedAssignedPence < 0
+  ) {
     fail("The current assigned share could not be verified. Reload the page.");
   }
 
-  return prisma.$transaction(async (db) => {
-    await assertAdmin(input.actorUserId, db);
-    await db.$queryRaw(Prisma.sql`
-      SELECT id FROM "PlayerMatchFee" WHERE id=${input.feeId} FOR UPDATE
-    `);
+  return prisma.$transaction(
+    async (transaction) => {
+      const db = correctionDb(transaction);
+      await assertAdmin(input.actorUserId, db);
+      await db.$queryRaw(Prisma.sql`
+        SELECT id FROM "PlayerMatchFee" WHERE id=${input.feeId} FOR UPDATE
+      `);
 
-    const candidate = await loadCandidate(input.feeId, input.actorUserId, db);
-    if (!candidate) {
-      fail("This player fee no longer has a cap or override. Nothing was changed.");
-    }
-    if (candidate.currentAssignedPence !== input.expectedAssignedPence) {
-      fail("The captain-assigned share changed after this page was opened. Reload before correcting it.");
-    }
-    if (input.assignedPence < candidate.playerChargePence) {
-      fail(
-        `The captain-assigned share cannot be lower than the player's recorded charge of ${money(candidate.playerChargePence)}.`,
+      const candidate = await loadCandidate(
+        input.feeId,
+        input.actorUserId,
+        db,
       );
-    }
+      if (!candidate) {
+        throw new PlayerAssignedShareCorrectionError(
+          "This player fee no longer has a cap or override. Nothing was changed.",
+        );
+      }
+      if (candidate.currentAssignedPence !== input.expectedAssignedPence) {
+        fail(
+          "The captain-assigned share changed after this page was opened. Reload before correcting it.",
+        );
+      }
+      if (input.assignedPence < candidate.playerChargePence) {
+        fail(
+          `The captain-assigned share cannot be lower than the player's recorded charge of ${money(candidate.playerChargePence)}.`,
+        );
+      }
 
-    if (input.assignedPence === candidate.currentAssignedPence) {
+      if (input.assignedPence === candidate.currentAssignedPence) {
+        return {
+          teamId: candidate.teamId,
+          feeId: candidate.feeId,
+          previousAssignedPence: candidate.currentAssignedPence,
+          assignedPence: input.assignedPence,
+          playerChargePence: candidate.playerChargePence,
+          unchanged: true,
+        };
+      }
+
+      const previousStatus = candidate.fee.status;
+      const previousAmountPence = candidate.fee.amountPence;
+      const previousNote = candidate.fee.note ?? null;
+      const nextNote =
+        previousNote?.replace(
+          CAP_NOTE_PATTERN,
+          (
+            _match,
+            prefix: string,
+            _oldShare: string,
+            middle: string,
+            charged: string,
+            suffix: string,
+          ) =>
+            `${prefix}${formatPoundsForNote(input.assignedPence)}${middle}${charged}${suffix}`,
+        ) ?? null;
+
+      await db.$executeRaw(Prisma.sql`
+        UPDATE "PlayerMatchFee"
+        SET "captainAssignedAmountPence"=${input.assignedPence},
+            "note"=${nextNote},
+            "updatedAt"=NOW()
+        WHERE id=${input.feeId}
+      `);
+
+      const after = await db.playerMatchFee.findUnique({
+        where: { id: input.feeId },
+        select: { amountPence: true, status: true },
+      });
+      const assignedAfter = await db.$queryRaw<AssignedRow[]>(Prisma.sql`
+        SELECT "captainAssignedAmountPence" AS assigned
+        FROM "PlayerMatchFee"
+        WHERE id=${input.feeId}
+      `);
+
+      if (
+        !after ||
+        after.amountPence !== previousAmountPence ||
+        after.status !== previousStatus ||
+        Number(assignedAfter[0]?.assigned) !== input.assignedPence
+      ) {
+        throw new Error(
+          "Captain-share correction changed an unexpected payment field; transaction rolled back.",
+        );
+      }
+
+      const state = await db.playerFeeLedgerState.findUnique({
+        where: { feeId: input.feeId },
+        select: { balancePence: true },
+      });
+
+      if (state) {
+        await db.playerLedgerEntry.create({
+          data: {
+            feeId: input.feeId,
+            teamId: candidate.teamId,
+            kind: "CAPTAIN_SHARE_CORRECTION",
+            amountPence: 0,
+            balanceAfterPence: state.balancePence,
+            receiptPence: 0,
+            actorUserId: input.actorUserId,
+            reason: `SIXFL corrected the captain-assigned share from ${money(candidate.currentAssignedPence)} to ${money(input.assignedPence)}. The player's charge, payments and outstanding balance were not changed.`,
+            sourceKey: `captain-share-correction:${input.feeId}:${randomUUID()}`,
+          },
+        });
+      }
+
       return {
         teamId: candidate.teamId,
         feeId: candidate.feeId,
         previousAssignedPence: candidate.currentAssignedPence,
         assignedPence: input.assignedPence,
         playerChargePence: candidate.playerChargePence,
-        unchanged: true,
+        unchanged: false,
       };
-    }
-
-    const previousStatus = candidate.fee.status;
-    const previousAmountPence = candidate.fee.amountPence;
-    const previousNote = candidate.fee.note ?? null;
-    const nextNote = previousNote?.replace(
-      CAP_NOTE_PATTERN,
-      (_match, prefix: string, _oldShare: string, middle: string, charged: string, suffix: string) =>
-        `${prefix}${formatPoundsForNote(input.assignedPence)}${middle}${charged}${suffix}`,
-    ) ?? null;
-
-    await db.$executeRaw(Prisma.sql`
-      UPDATE "PlayerMatchFee"
-      SET "captainAssignedAmountPence"=${input.assignedPence},
-          "note"=${nextNote},
-          "updatedAt"=NOW()
-      WHERE id=${input.feeId}
-    `);
-
-    const after = await db.playerMatchFee.findUnique({
-      where: { id: input.feeId },
-      select: { amountPence: true, status: true },
-    });
-    const assignedAfter = await db.$queryRaw<AssignedRow[]>(Prisma.sql`
-      SELECT "captainAssignedAmountPence" AS assigned
-      FROM "PlayerMatchFee"
-      WHERE id=${input.feeId}
-    `);
-
-    if (
-      !after ||
-      after.amountPence !== previousAmountPence ||
-      after.status !== previousStatus ||
-      Number(assignedAfter[0]?.assigned) !== input.assignedPence
-    ) {
-      throw new Error("Captain-share correction changed an unexpected payment field; transaction rolled back.");
-    }
-
-    const state = await db.playerFeeLedgerState.findUnique({
-      where: { feeId: input.feeId },
-      select: { balancePence: true },
-    });
-
-    if (state) {
-      await db.playerLedgerEntry.create({
-        data: {
-          feeId: input.feeId,
-          teamId: candidate.teamId,
-          kind: "CAPTAIN_SHARE_CORRECTION",
-          amountPence: 0,
-          balanceAfterPence: state.balancePence,
-          receiptPence: 0,
-          actorUserId: input.actorUserId,
-          reason: `SIXFL corrected the captain-assigned share from ${money(candidate.currentAssignedPence)} to ${money(input.assignedPence)}. The player's charge, payments and outstanding balance were not changed.`,
-          sourceKey: `captain-share-correction:${input.feeId}:${randomUUID()}`,
-        },
-      });
-    }
-
-    return {
-      teamId: candidate.teamId,
-      feeId: candidate.feeId,
-      previousAssignedPence: candidate.currentAssignedPence,
-      assignedPence: input.assignedPence,
-      playerChargePence: candidate.playerChargePence,
-      unchanged: false,
-    };
-  }, { maxWait: 5000, timeout: 15000 });
+    },
+    { maxWait: 5000, timeout: 15000 },
+  );
 }


### PR DESCRIPTION
## What changed
- Keeps **Correct original charge** blocked for capped/overridden players so a genuine SIXFL concession can never be turned into player debt.
- On that same admin route, capped/overridden rows now open a dedicated **Correct captain-assigned share** control instead of the dead-end warning.
- The admin can restore the captain's original allocation (for example £8 assigned while the player correctly paid £5 under a cap).
- Saving changes only `captainAssignedAmountPence` (and the existing structured cap note when present). It explicitly verifies that the actual player fee amount and status do not change.
- Adds an immutable zero-value ledger audit entry recording the before/after captain share and administrator identity; no balance, receipt or payment is changed.
- No payment, refund, checkout, email or SMS is triggered.

## Why
The previous safety guard was correct for debt correction but left capped historical rows impossible to repair from the UI. The new path separates **captain allocation** from **player charge**, preserving the intended £8/£5 distinction without creating £3 of false debt.