### PR TITLE
Stop captain dashboard recreating skipped new-team AI predictions

### DIFF
--- a/src/app/api/captain/team/[teamid]/fixture-badges/route.ts
+++ b/src/app/api/captain/team/[teamid]/fixture-badges/route.ts
@@ -167,7 +167,11 @@ export async function GET(
           storedPrediction,
         };
 
-        if (fixture.status !== "SCHEDULED") {
+        // The stored prediction service is the eligibility gate. If it filtered
+        // this fixture out (for example because either side is playing its first
+        // SIXFL match), the captain dashboard must not manufacture a local
+        // fallback prediction and accidentally put percentages back on screen.
+        if (fixture.status !== "SCHEDULED" || !storedPreview) {
           return {
             ...base,
             winChance: null,
@@ -189,14 +193,12 @@ export async function GET(
           ...base,
           winChance: {
             ...winChance,
-            aiPreview:
-              !storedPreview ||
-              shouldIgnoreStaleTooEarlyPreview({
-                preview: storedPreview,
-                predictedResultLabel: winChance.predictedResult.label,
-              })
-                ? fallbackPreview
-                : storedPreview,
+            aiPreview: shouldIgnoreStaleTooEarlyPreview({
+              preview: storedPreview,
+              predictedResultLabel: winChance.predictedResult.label,
+            })
+              ? fallbackPreview
+              : storedPreview,
           },
         };
       }),


### PR DESCRIPTION
## User-reported regression
A first-game prediction still appeared on the captain dashboard after PR #499 correctly filtered/deleted the stored prediction for a brand-new team.

## Root cause
The captain fixture-badges API treated a missing stored preview as a reason to calculate and return a local fallback `winChance`, so the legacy captain dashboard bridge put the percentages straight back on screen.

## Fix
- Treat `getStoredAiPreviewsByFixtureIds()` as the predictor eligibility gate on the captain fixture-badges API.
- If a scheduled fixture has no valid stored preview, return `winChance: null` instead of manufacturing a fallback prediction.
- Preserve the existing fallback wording only for an eligible stored prediction that needs stale-copy cleanup.
- No fixture, result, payment, notification or stored prediction data is changed by this route.

This makes the captain dashboard obey the same first-game skip rule already introduced in #499: a team cannot show a predictor card until both sides have at least one completed match behind them.