### PR TITLE
Allow genuine adjustments on historical player payment mismatches

### DIFF
--- a/src/app/api/admin/player-fees/[feeId]/correct-charge/route.ts
+++ b/src/app/api/admin/player-fees/[feeId]/correct-charge/route.ts
@@ -29,7 +29,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ fee
     const body = JSON.parse(raw);
     if (body.action === "preview") {
       const preview = await previewOriginalPlayerCharge({ feeId, actorUserId: user.id,
-        originalPence: parseLedgerMoney(body.originalAmount), reason: String(body.reason ?? ""), noWaiver: body.noWaiver === true });
+        originalPence: parseLedgerMoney(body.originalAmount), reason: String(body.reason ?? ""),
+        resolution: body.resolution === "adjustment" ? "adjustment" : "outstanding",
+        noWaiver: body.noWaiver === true, adjustmentConfirmed: body.adjustmentConfirmed === true });
       return NextResponse.json({ preview }, { headers: { "Cache-Control": "no-store" } });
     }
     if (body.action !== "confirm" || body.confirmed !== true || typeof body.token !== "string") throw new PlayerChargeCorrectionError("Preview and explicitly confirm the correction first.");

--- a/src/components/payments/CorrectOriginalPlayerChargeForm.tsx
+++ b/src/components/payments/CorrectOriginalPlayerChargeForm.tsx
@@ -1,18 +1,22 @@
 "use client";
 import Link from "next/link";
 import { useState, type FormEvent } from "react";
-type Preview = { token: string; originalPence: number; receivedPence: number; outstandingPence: number; reason: string; expiresAt: number };
+type Resolution = "outstanding" | "adjustment";
+type Preview = { token: string; originalPence: number; receivedPence: number; outstandingPence: number; adjustmentPence: number; resolution: Resolution; reason: string; expiresAt: number };
+type SavedResult = { outstandingPence: number; adjustmentPence?: number; resolution?: Resolution };
 const money = (p: number) => new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(p / 100);
 const field = "mt-2 w-full rounded-xl border border-white/20 bg-black/30 px-4 py-3 text-white";
 const button = "rounded-xl bg-emerald-400 px-5 py-3 font-semibold text-black disabled:opacity-50";
 export default function CorrectOriginalPlayerChargeForm({ feeId, teamId, assignedPence, receivedPence }: { feeId: string; teamId: string; assignedPence: number; receivedPence: number }) {
   const [amount, setAmount] = useState((assignedPence / 100).toFixed(2));
   const [reason, setReason] = useState("");
+  const [resolution, setResolution] = useState<Resolution>("outstanding");
   const [noWaiver, setNoWaiver] = useState(false);
+  const [adjustmentConfirmed, setAdjustmentConfirmed] = useState(false);
   const [preview, setPreview] = useState<Preview | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
-  const [saved, setSaved] = useState(false);
+  const [saved, setSaved] = useState<SavedResult | null>(null);
   const [uncertain, setUncertain] = useState(false);
   const account = `/captain/team/${teamId}/player-payments/account/${feeId}`;
   async function submit(action: "preview" | "confirm") {
@@ -21,32 +25,47 @@ export default function CorrectOriginalPlayerChargeForm({ feeId, teamId, assigne
     const timeout = setTimeout(() => controller.abort(), 25000);
     try {
       const response = await fetch(`/api/admin/player-fees/${encodeURIComponent(feeId)}/correct-charge`, { method: "POST", headers: { "Content-Type": "application/json" },
-        signal: controller.signal, body: JSON.stringify(action === "preview" ? { action, originalAmount: amount, reason, noWaiver } : { action, token: preview?.token, confirmed: true }) });
+        signal: controller.signal, body: JSON.stringify(action === "preview"
+          ? { action, originalAmount: amount, reason, resolution, noWaiver, adjustmentConfirmed }
+          : { action, token: preview?.token, confirmed: true }) });
       const result = await response.json();
       if (!response.ok) throw new Error(result.error || "The correction was not saved.");
-      if (action === "preview") setPreview(result.preview); else setSaved(true);
+      if (action === "preview") setPreview(result.preview); else setSaved(result);
     } catch (e) {
       if (action === "confirm") setUncertain(true);
       setError(e instanceof Error ? e.message : "Request failed. Check the account before trying again.");
     } finally { clearTimeout(timeout); setBusy(false); }
   }
   if (saved) return <section role="status" className="space-y-4 rounded-2xl border border-emerald-400/30 p-5">
-    <h2 className="text-xl font-semibold">Correction saved</h2><p>The existing receipts have been preserved. Only the unpaid remainder is owed.</p>
-    <p>Collection remains paused. No payment has been taken and no email or SMS has been requested. Review the account, then use its separate resume control when ready.</p>
+    <h2 className="text-xl font-semibold">Correction saved</h2>
+    {saved.resolution === "adjustment" ? <>
+      <p>The existing payment has been preserved and <strong>{money(saved.adjustmentPence ?? 0)}</strong> is recorded as a SIXFL adjustment. The player owes <strong>{money(saved.outstandingPence)}</strong>.</p>
+      <p>No payment, refund, email or SMS has been requested. Team payments should now show the full assigned share as the verified receipt plus the adjustment.</p>
+    </> : <>
+      <p>The existing receipts have been preserved. Only the unpaid remainder is owed.</p>
+      <p>Collection remains paused. No payment has been taken and no email or SMS has been requested. Review the account, then use its separate resume control when ready.</p>
+    </>}
     <Link className="text-emerald-200 underline" href={account}>Open player account</Link></section>;
   return <section className="space-y-4">
     {error ? <p role="alert" className="rounded-xl border border-red-300/40 p-4 text-red-100">{error}{uncertain ? <> <Link href={account} className="underline">Check the player account before retrying.</Link> A retry of the same confirmation will not add the correction twice.</> : null}</p> : null}
     {!preview ? <form className="space-y-5" onSubmit={(e: FormEvent) => { e.preventDefault(); void submit("preview"); }}>
       <p>Existing recorded Stripe payment: <strong>{money(receivedPence)}</strong>. This is not entered again.</p>
-      <label className="block">Correct original charge (£)<input className={field} value={amount} onChange={e => setAmount(e.target.value)} inputMode="decimal" required disabled={busy}/></label>
-      <label className="block">Reason for correction<textarea className={field} value={reason} onChange={e => setReason(e.target.value)} minLength={10} maxLength={1000} required disabled={busy} placeholder="Original charge was £12. The £8 payment incorrectly cleared the full charge. No £4 waiver was agreed."/></label>
-      <label className="flex gap-3"><input type="checkbox" checked={noWaiver} onChange={e => setNoWaiver(e.target.checked)} required disabled={busy}/><span>I have checked the agreement. The remaining amount was not waived, discounted or paid elsewhere.</span></label>
+      <label className="block">Correct original assigned share (£)<input className={field} value={amount} onChange={e => setAmount(e.target.value)} inputMode="decimal" required disabled={busy}/></label>
+      <fieldset className="space-y-3 rounded-2xl border border-white/10 p-4">
+        <legend className="px-1 font-semibold">What should happen to the difference?</legend>
+        <label className="flex gap-3"><input type="radio" name="resolution" value="outstanding" checked={resolution === "outstanding"} onChange={() => setResolution("outstanding")} disabled={busy}/><span><strong>Player still owes it</strong><span className="mt-1 block text-sm text-white/65">Restore the unpaid remainder and pause collection until you review it.</span></span></label>
+        <label className="flex gap-3"><input type="radio" name="resolution" value="adjustment" checked={resolution === "adjustment"} onChange={() => setResolution("adjustment")} disabled={busy}/><span><strong>Record it as a SIXFL adjustment</strong><span className="mt-1 block text-sm text-white/65">Keep the verified payment, settle the difference as an authorised adjustment and leave the player owing £0.</span></span></label>
+      </fieldset>
+      <label className="block">Reason for correction<textarea className={field} value={reason} onChange={e => setReason(e.target.value)} minLength={10} maxLength={1000} required disabled={busy} placeholder={resolution === "adjustment" ? "Assigned share was £8. Player correctly paid £5 and SIXFL agreed the remaining £3 adjustment." : "Original charge was £12. The £8 payment incorrectly cleared the full charge. No £4 waiver was agreed."}/></label>
+      {resolution === "outstanding" ? <label className="flex gap-3"><input type="checkbox" checked={noWaiver} onChange={e => setNoWaiver(e.target.checked)} required disabled={busy}/><span>I have checked the agreement. The remaining amount was not waived, discounted or paid elsewhere.</span></label> :
+        <label className="flex gap-3"><input type="checkbox" checked={adjustmentConfirmed} onChange={e => setAdjustmentConfirmed(e.target.checked)} required disabled={busy}/><span>I have checked this was a genuine SIXFL adjustment. The player should owe nothing further for this share.</span></label>}
       <button className={button} disabled={busy}>{busy ? "Verifying receipts…" : "Preview correction"}</button>
     </form> : <div className="space-y-5 rounded-2xl border border-amber-400/30 p-5">
-      <h2 className="text-xl font-semibold">Review before saving</h2><dl className="space-y-3"><div className="flex justify-between gap-4"><dt>Correct original charge</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.originalPence)}</dd></div>
-        <div className="flex justify-between gap-4"><dt>Verified Stripe payments — retained once</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.receivedPence)}</dd></div>
-        <div className="flex justify-between gap-4 border-t border-white/15 pt-3 font-semibold"><dt>Still owing · Part-paid</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.outstandingPence)}</dd></div></dl>
-      <p className="break-words text-sm text-white/70">Reason: {preview.reason}</p><p className="text-sm text-white/70">Your administrator identity and this correction will be recorded in the statement. Collection stays paused. No payment, refund or message will be sent.</p>
+      <h2 className="text-xl font-semibold">Review before saving</h2><dl className="space-y-3"><div className="flex justify-between gap-4"><dt>Correct original assigned share</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.originalPence)}</dd></div>
+        <div className="flex justify-between gap-4"><dt>Verified Stripe payment — retained once</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.receivedPence)}</dd></div>
+        {preview.resolution === "adjustment" ? <div className="flex justify-between gap-4"><dt>SIXFL adjustment</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.adjustmentPence)}</dd></div> : null}
+        <div className="flex justify-between gap-4 border-t border-white/15 pt-3 font-semibold"><dt>{preview.resolution === "adjustment" ? "Player still owes · Settled" : "Player still owes · Part-paid"}</dt><dd className="shrink-0 whitespace-nowrap">{money(preview.outstandingPence)}</dd></div></dl>
+      <p className="break-words text-sm text-white/70">Reason: {preview.reason}</p><p className="text-sm text-white/70">Your administrator identity and this correction will be recorded. No new payment, refund or customer message will be sent.</p>
       <div className="flex flex-wrap gap-3"><button className={button} disabled={busy} onClick={() => void submit("confirm")}>{busy ? "Saving correction…" : uncertain ? "Retry same confirmation" : "Confirm correction — no message"}</button>
         <button className="rounded-xl border border-white/20 px-5 py-3 disabled:opacity-50" disabled={busy || uncertain} onClick={() => setPreview(null)}>Back — do not save</button></div>
     </div>}

--- a/src/lib/payments/player-charge-correction.ts
+++ b/src/lib/payments/player-charge-correction.ts
@@ -2,6 +2,7 @@ import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { getStripeServerClient } from "@/lib/stripe/client";
+import { PLAYER_FEE_CAP_NOTE } from "./player-fee-coverage";
 import { lockLedgerFees, money, readPlayerLedgerState, setLedgerContext } from "./player-ledger";
 import { LEDGER_TRANSACTION_PREFIX } from "./player-ledger-markers";
 
@@ -75,8 +76,9 @@ function secret() {
   if (!value) throw new Error("A signing secret is required for charge corrections.");
   return value;
 }
+type Resolution = "outstanding" | "adjustment";
 type Confirmation = { id: string; actorUserId: string; feeId: string; teamId: string; originalPence: number;
-  receivedPence: number; reason: string; fingerprint: string; expiresAt: number };
+  receivedPence: number; reason: string; fingerprint: string; expiresAt: number; resolution: Resolution };
 function sign(data: Confirmation) {
   const body = Buffer.from(JSON.stringify(data)).toString("base64url");
   return `${body}.${createHmac("sha256", secret()).update(body).digest("base64url")}`;
@@ -88,7 +90,8 @@ function readConfirmation(token: string, actorUserId: string, feeId: string): Co
   const expected = createHmac("sha256", secret()).update(parts[0]).digest();
   const actual = Buffer.from(parts[1], "base64url");
   if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return fail("Correction preview was changed. Preview again.");
-  const value = JSON.parse(Buffer.from(parts[0], "base64url").toString()) as Confirmation;
+  const parsed = JSON.parse(Buffer.from(parts[0], "base64url").toString()) as Omit<Confirmation, "resolution"> & { resolution?: Resolution };
+  const value: Confirmation = { ...parsed, resolution: parsed.resolution === "adjustment" ? "adjustment" : "outstanding" };
   if (value.actorUserId !== actorUserId || value.feeId !== feeId || value.expiresAt < Date.now()) return fail("This preview has expired or belongs to another administrator or fee. Preview again.");
   return value;
 }
@@ -120,24 +123,33 @@ export async function getOriginalChargeCorrectionCandidate(feeId: string, actorU
     kickoffAt: c.fee.fixture.kickoffAt.toISOString(), assignedPence: c.assigned, receivedPence: c.receivedPence };
 }
 
-export async function previewOriginalPlayerCharge(input: { feeId: string; actorUserId: string; originalPence: number; reason: string; noWaiver: boolean }, stripe = getStripeServerClient()) {
+export async function previewOriginalPlayerCharge(input: {
+  feeId: string; actorUserId: string; originalPence: number; reason: string; noWaiver?: boolean;
+  resolution?: Resolution; adjustmentConfirmed?: boolean;
+}, stripe = getStripeServerClient()) {
   await assertPlayerChargeCorrectionAdmin(input.actorUserId);
   const reason = input.reason.trim();
-  if (!input.noWaiver || reason.length < 10 || reason.length > 1000) return fail("Confirm that no balance was forgiven and enter a reason of 10–1,000 characters.");
+  const resolution: Resolution = input.resolution === "adjustment" ? "adjustment" : "outstanding";
+  if (reason.length < 10 || reason.length > 1000) return fail("Enter a reason of 10–1,000 characters.");
+  if (resolution === "outstanding" && !input.noWaiver) return fail("Confirm that no balance was forgiven before restoring an unpaid remainder.");
+  if (resolution === "adjustment" && !input.adjustmentConfirmed) return fail("Confirm that the difference is a genuine SIXFL adjustment and the player should owe nothing further.");
   const c = await loadCandidate(input.feeId);
   if (!Number.isSafeInteger(input.originalPence) || input.originalPence > 500000 || input.originalPence <= c.receivedPence) return fail("The correct original charge must exceed the verified payments and be no more than £5,000.");
   await verifyReceipts(c, stripe);
+  const difference = input.originalPence - c.receivedPence;
   const data: Confirmation = { id: randomUUID(), actorUserId: input.actorUserId, feeId: c.fee.id, teamId: c.fee.teamId,
-    originalPence: input.originalPence, receivedPence: c.receivedPence, reason, fingerprint: fingerprint(c), expiresAt: Date.now() + 10 * 60_000 };
+    originalPence: input.originalPence, receivedPence: c.receivedPence, reason, fingerprint: fingerprint(c), expiresAt: Date.now() + 10 * 60_000, resolution };
   return { token: sign(data), originalPence: data.originalPence, receivedPence: data.receivedPence,
-    outstandingPence: data.originalPence - data.receivedPence, reason, expiresAt: data.expiresAt };
+    outstandingPence: resolution === "outstanding" ? difference : 0, adjustmentPence: resolution === "adjustment" ? difference : 0,
+    resolution, reason, expiresAt: data.expiresAt };
 }
 
 export async function confirmOriginalPlayerCharge(input: { feeId: string; actorUserId: string; token: string }, stripe = getStripeServerClient()) {
   await assertPlayerChargeCorrectionAdmin(input.actorUserId);
   const p = readConfirmation(input.token, input.actorUserId, input.feeId);
   const existing = await prisma.playerLedgerEntry.findUnique({ where: { sourceKey: correctionKey(p.id) } });
-  if (existing) return { teamId: p.teamId, feeId: p.feeId, outstandingPence: existing.balanceAfterPence, alreadySaved: true };
+  if (existing) return { teamId: p.teamId, feeId: p.feeId, outstandingPence: existing.balanceAfterPence,
+    adjustmentPence: p.resolution === "adjustment" ? p.originalPence - p.receivedPence : 0, resolution: p.resolution, alreadySaved: true };
   try {
   const snapshot = await loadCandidate(p.feeId);
   if (fingerprint(snapshot) !== p.fingerprint) return fail("The charge or its payments changed since preview. Preview again; nothing was changed.");
@@ -147,11 +159,40 @@ export async function confirmOriginalPlayerCharge(input: { feeId: string; actorU
     await db.$queryRaw(Prisma.sql`SELECT id FROM "Team" WHERE id=${p.teamId} FOR UPDATE`);
     await lockLedgerFees(db, [p.feeId]);
     const repeated = await db.playerLedgerEntry.findUnique({ where: { sourceKey: correctionKey(p.id) } });
-    if (repeated) return { teamId: p.teamId, feeId: p.feeId, outstandingPence: repeated.balanceAfterPence, alreadySaved: true };
+    if (repeated) return { teamId: p.teamId, feeId: p.feeId, outstandingPence: repeated.balanceAfterPence,
+      adjustmentPence: p.resolution === "adjustment" ? p.originalPence - p.receivedPence : 0, resolution: p.resolution, alreadySaved: true };
     await db.$queryRaw(Prisma.sql`SELECT id FROM "PaymentTransaction" WHERE id IN (${Prisma.join(snapshot.transactions.map(t => t.id))}) ORDER BY id FOR UPDATE`);
     const c = await loadCandidate(p.feeId, db);
     if (fingerprint(c) !== p.fingerprint) return fail("The balance changed during verification. Preview again; no correction was saved.");
     const balance = p.originalPence - c.receivedPence;
+
+    if (p.resolution === "adjustment") {
+      const capNote = `${PLAYER_FEE_CAP_NOTE}: captain share ${money(p.originalPence)}; player charged ${money(c.receivedPence)}.`;
+      const note = [c.fee.note?.trim(), capNote].filter(Boolean).join("\n");
+      // captainAssignedAmountPence is a production-owned legacy column that is
+      // deliberately not exposed by Prisma's generated PlayerMatchFee type.
+      // Update and verify it with parameterised raw SQL, as the rest of the
+      // historical fee code does, rather than weakening Prisma types.
+      await db.$executeRaw(Prisma.sql`
+        UPDATE "PlayerMatchFee"
+        SET "captainAssignedAmountPence"=${p.originalPence}, note=${note}, "updatedAt"=NOW()
+        WHERE id=${p.feeId}`);
+      await db.playerLedgerEntry.create({ data: {
+        feeId: p.feeId, teamId: p.teamId, kind: "CORRECTION", amountPence: 0, balanceAfterPence: 0,
+        actorUserId: input.actorUserId, sourceKey: correctionKey(p.id),
+        reason: `Historical paid share reconciled as ${money(p.originalPence)} assigned, ${money(c.receivedPence)} verified paid and ${money(balance)} genuine SIXFL adjustment. ${p.reason}`,
+        reference: JSON.stringify({ originalPence: p.originalPence, receivedPence: c.receivedPence, adjustmentPence: balance,
+          previousAssignedPence: c.assigned, previousAmountPence: c.fee.amountPence, receiptIds: c.transactions.map(t => t.id) }),
+      } });
+      const after = (await db.$queryRaw<Array<{ amountPence: number; status: string; note: string | null; assignedPence: number | null }>>(Prisma.sql`
+        SELECT "amountPence", status::text AS status, note, "captainAssignedAmountPence" AS "assignedPence"
+        FROM "PlayerMatchFee" WHERE id=${p.feeId}`))[0];
+      if (!after || after.status !== "PAID" || after.amountPence !== c.receivedPence || after.assignedPence !== p.originalPence || !after.note?.includes(capNote)) {
+        throw new Error("Adjustment correction did not preserve the paid receipt; transaction rolled back.");
+      }
+      return { teamId: p.teamId, feeId: p.feeId, outstandingPence: 0, adjustmentPence: balance, resolution: p.resolution, alreadySaved: false };
+    }
+
     // Adopt the SAME receipts into the shared ledger allocation mechanism. Never
     // insert a second PaymentTransaction or modify its amount/provider reference.
     for (const t of c.transactions) {
@@ -175,13 +216,14 @@ export async function confirmOriginalPlayerCharge(input: { feeId: string; actorU
       "waivedAt"=NULL, "cancelledAt"=NULL, "captainAssignedAmountPence"=${p.originalPence}, "updatedAt"=NOW() WHERE id=${p.feeId}`);
     const after = await readPlayerLedgerState(p.feeId, db);
     if (!after || after.balancePence !== balance || after.receivedPence !== c.receivedPence) throw new Error("Correction did not balance; transaction rolled back.");
-    return { teamId: p.teamId, feeId: p.feeId, outstandingPence: balance, alreadySaved: false };
+    return { teamId: p.teamId, feeId: p.feeId, outstandingPence: balance, adjustmentPence: 0, resolution: p.resolution, alreadySaved: false };
   }, { maxWait: 5000, timeout: 20000 });
   } catch (error) {
     // Another confirmation can finish while this request is verifying provider
     // receipts. The signed nonce identifies that same save, not a new adjustment.
     const saved = await prisma.playerLedgerEntry.findUnique({ where: { sourceKey: correctionKey(p.id) } });
-    if (saved) return { teamId: p.teamId, feeId: p.feeId, outstandingPence: saved.balanceAfterPence, alreadySaved: true };
+    if (saved) return { teamId: p.teamId, feeId: p.feeId, outstandingPence: saved.balanceAfterPence,
+      adjustmentPence: p.resolution === "adjustment" ? p.originalPence - p.receivedPence : 0, resolution: p.resolution, alreadySaved: true };
     throw error;
   }
 }

--- a/tests/player-charge-correction-controls.cjs
+++ b/tests/player-charge-correction-controls.cjs
@@ -28,6 +28,12 @@ test('real correction endpoint takes actor and fee from authentication/route, ne
  assert.equal(state.calls[0].actorUserId,'real-admin');assert.equal(state.calls[0].feeId,'fee-one');assert.equal(state.calls[0].originalPence,1200);
  state.calls=[];const blocked=await route.POST(request({action:'confirm',token:'x'}),{params:Promise.resolve({feeId:'fee-one'})});assert.equal(blocked.status,400);assert.equal(state.calls.length,0);
 });
+test('adjustment preview is explicit and remains bound to the authenticated fee',async()=>{
+ state.calls=[];state.session={user:{email:'admin@example.invalid'}};state.user={id:'real-admin',role:'ADMIN'};
+ const r=await route.POST(request({action:'preview',feeId:'forged',actorUserId:'forged',originalAmount:'8',reason:'Verified five pound payment plus genuine three pound adjustment.',resolution:'adjustment',adjustmentConfirmed:true,noWaiver:false}),{params:Promise.resolve({feeId:'fee-one'})});
+ assert.equal(r.status,200);assert.equal(state.calls.length,1);assert.equal(state.calls[0].feeId,'fee-one');assert.equal(state.calls[0].actorUserId,'real-admin');
+ assert.equal(state.calls[0].resolution,'adjustment');assert.equal(state.calls[0].adjustmentConfirmed,true);assert.equal(state.calls[0].noWaiver,false);assert.equal(state.calls[0].originalPence,800);
+});
 test('all three native admin entry points survive production preparation; no public correction action',()=>{
  // Team Payments now owns the link through PlayerContributionTable. Verify
  // the import, authenticated prop handoff and the actual guarded link, rather
@@ -42,7 +48,7 @@ test('all three native admin entry points survive production preparation; no pub
   const s=fs.readFileSync(path,'utf8');assert.ok(s.includes('correctionAccess.isAdmin'));assert.ok(s.includes('Correct original charge'));assert.ok(s.includes('/correct-charge'));}
  const s=fs.readFileSync('src/app/api/admin/player-fees/[feeId]/correct-charge/route.ts','utf8');assert.ok(s.includes('getServerSession(authOptions)'));assert.ok(s.includes('user.role !== "ADMIN"'));
  const page=fs.readFileSync('src/app/(admin)/admin/payments/player-fees/[feeId]/correct-charge/page.tsx','utf8');assert.ok(page.includes('requireAdmin()'));assert.ok(page.includes('access.user.role !== "ADMIN"'));
- const core=fs.readFileSync('src/lib/payments/player-charge-correction.ts','utf8');assert.ok(core.includes('assertPlayerChargeCorrectionAdmin(input.actorUserId, db)'));assert.ok(!core.includes('paymentTransaction.create('));assert.ok(!core.includes('queueNotification'));assert.ok(!core.includes('refunds.create'));assert.ok(!core.includes('sessions.create'));
+ const core=fs.readFileSync('src/lib/payments/player-charge-correction.ts','utf8');assert.ok(core.includes('assertPlayerChargeCorrectionAdmin(input.actorUserId, db)'));assert.ok(core.includes('PLAYER_FEE_CAP_NOTE'));assert.ok(core.includes('resolution === "adjustment"'));assert.ok(!core.includes('paymentTransaction.create('));assert.ok(!core.includes('queueNotification'));assert.ok(!core.includes('refunds.create'));assert.ok(!core.includes('sessions.create'));
 });
 
 test('configured public origin works behind Railway without accepting cross-site callers',async()=>{


### PR DESCRIPTION
Rebuilds the historical player adjustment fix on top of current main so it coexists with the newer capped/override captain-share correction flow.

For an ordinary historical paid row such as £8 assigned / £5 verified paid, an administrator can explicitly choose either to restore £3 as unpaid debt or record £3 as a genuine SIXFL adjustment. Adjustment mode preserves the original Stripe receipt, records the £8 assigned share plus the existing cap-note adjustment semantics used by payment presentation, leaves the player owing £0, and adds an immutable admin correction entry. It creates no new payment, refund, checkout or customer message.

The newer capped/overridden-player correction page on current main is retained unchanged. Route-boundary coverage checks that adjustment mode is explicit and remains bound to the authenticated admin and route fee.