### PR TITLE
Apply current player cap to historical fixture adjustment

### DIFF
--- a/src/app/(admin)/admin/payments/player-fees/[feeId]/correct-charge/page.tsx
+++ b/src/app/(admin)/admin/payments/player-fees/[feeId]/correct-charge/page.tsx
@@ -67,10 +67,10 @@ export default async function Page({
               This player has a fee cap or override, so the historical-debt correction is deliberately disabled.
             </p>
             <p className="text-white/75">
-              A cap is a genuine SIXFL concession. Turning the difference into player debt would be wrong. Use this control only to restore what the captain originally assigned — for example £8 assigned while the player was correctly charged £5.
+              A cap is a genuine SIXFL concession. Turning the difference into player debt would be wrong. Use this control to restore what the captain originally assigned and, when the current cap matches the player&apos;s recorded charge, to record that cap on this fixture.
             </p>
             <p className="text-white/65">
-              Saving here changes the captain-assigned share only. It does not change the player&apos;s charge, cap, payment status, receipts or outstanding balance.
+              The player&apos;s real charge, payment status, receipts and outstanding balance stay unchanged. Only the captain share and explicit fixture adjustment evidence can be corrected.
             </p>
           </div>
 
@@ -83,6 +83,7 @@ export default async function Page({
             capPence={shareCandidate.capPence}
             overridePence={shareCandidate.overridePence}
             hasFeeCapEvidence={shareCandidate.hasFeeCapEvidence}
+            canApplyCurrentCapToFixture={shareCandidate.canApplyCurrentCapToFixture}
           />
         </main>
       );

--- a/src/components/payments/CorrectCaptainAssignedShareForm.tsx
+++ b/src/components/payments/CorrectCaptainAssignedShareForm.tsx
@@ -21,6 +21,7 @@ type SaveResult = {
   assignedPence: number;
   playerChargePence: number;
   unchanged: boolean;
+  adjustmentRecorded?: boolean;
 };
 
 export default function CorrectCaptainAssignedShareForm({
@@ -32,6 +33,7 @@ export default function CorrectCaptainAssignedShareForm({
   capPence,
   overridePence,
   hasFeeCapEvidence,
+  canApplyCurrentCapToFixture,
 }: {
   feeId: string;
   teamId: string;
@@ -41,6 +43,7 @@ export default function CorrectCaptainAssignedShareForm({
   capPence: number | null;
   overridePence: number | null;
   hasFeeCapEvidence: boolean;
+  canApplyCurrentCapToFixture: boolean;
 }) {
   const [amount, setAmount] = useState((suggestedAssignedPence / 100).toFixed(2));
   const [confirmed, setConfirmed] = useState(false);
@@ -49,6 +52,7 @@ export default function CorrectCaptainAssignedShareForm({
   const [saved, setSaved] = useState<SaveResult | null>(null);
 
   const account = `/captain/team/${teamId}/player-payments/account/${feeId}`;
+  const adjustmentPence = Math.max(currentAssignedPence - playerChargePence, 0);
 
   async function submit(event: FormEvent) {
     event.preventDefault();
@@ -96,17 +100,26 @@ export default function CorrectCaptainAssignedShareForm({
         className="space-y-4 rounded-2xl border border-emerald-400/30 p-5"
       >
         <h2 className="text-xl font-semibold">
-          {saved.unchanged ? "Captain share already correct" : "Captain share corrected"}
+          {saved.adjustmentRecorded
+            ? "Fixture adjustment recorded"
+            : saved.unchanged
+              ? "Captain share already correct"
+              : "Captain share corrected"}
         </h2>
         <p>
           Captain-assigned share: <strong>{money(saved.assignedPence)}</strong>.
           The player&apos;s recorded charge remains <strong>{money(saved.playerChargePence)}</strong>.
         </p>
+        {saved.adjustmentRecorded ? (
+          <p className="text-sm text-white/70">
+            The difference is now recorded on this fixture as the player&apos;s SIXFL cap adjustment, so the payment row can settle as the assigned share rather than showing “Check balance”.
+          </p>
+        ) : null}
         <p className="text-sm text-white/70">
           No payment was taken, no debt was created, no receipt was changed and no email or SMS was sent.
         </p>
-        <Link className="text-emerald-200 underline" href={account}>
-          Open player account
+        <Link className="text-emerald-200 underline" href={`/captain/team/${teamId}/payments`}>
+          Back to team payments
         </Link>
       </section>
     );
@@ -153,6 +166,15 @@ export default function CorrectCaptainAssignedShareForm({
         )}
       </div>
 
+      {canApplyCurrentCapToFixture ? (
+        <div className="rounded-xl border border-emerald-300/25 bg-emerald-400/[0.06] p-4 text-sm leading-6 text-emerald-50/90">
+          <p className="font-semibold">This is the missing step for this fixture.</p>
+          <p className="mt-1">
+            The captain share is already {money(currentAssignedPence)} and the player cap is {money(playerChargePence)}. Saving below will record the {money(adjustmentPence)} difference on this fixture as the SIXFL cap adjustment, without changing the £5 payment.
+          </p>
+        </div>
+      ) : null}
+
       <form className="space-y-5" onSubmit={submit}>
         <label className="block">
           Correct captain-assigned share (£)
@@ -176,12 +198,18 @@ export default function CorrectCaptainAssignedShareForm({
             className="mt-1"
           />
           <span>
-            I am correcting only what the captain originally assigned. Keep the player&apos;s cap/override, actual charge, payment status and outstanding balance unchanged.
+            {canApplyCurrentCapToFixture
+              ? `I confirm the player's ${money(playerChargePence)} cap applied to this fixture. Keep the real payment unchanged and record the ${money(adjustmentPence)} difference as the SIXFL adjustment.`
+              : "I am correcting only what the captain originally assigned. Keep the player's cap/override, actual charge, payment status and outstanding balance unchanged."}
           </span>
         </label>
 
         <button className={button} disabled={busy || !confirmed}>
-          {busy ? "Saving captain share…" : "Save captain share only"}
+          {busy
+            ? "Saving…"
+            : canApplyCurrentCapToFixture
+              ? `Apply ${money(adjustmentPence)} adjustment to this fixture`
+              : "Save captain share only"}
         </button>
       </form>
     </section>

--- a/src/lib/payments/player-assigned-share-correction.ts
+++ b/src/lib/payments/player-assigned-share-correction.ts
@@ -54,6 +54,10 @@ function formatPoundsForNote(pence: number) {
   return (pence / 100).toFixed(2);
 }
 
+function capNote(assignedPence: number, chargedPence: number) {
+  return `Player fee cap applied: captain share £${formatPoundsForNote(assignedPence)}; player charged £${formatPoundsForNote(chargedPence)}.`;
+}
+
 async function assertAdmin(actorUserId: string, db: Db) {
   const actor = actorUserId
     ? await db.user.findUnique({
@@ -119,9 +123,9 @@ async function loadCandidate(feeId: string, actorUserId: string, db: Db) {
     profile = profiles[0] ?? null;
   }
 
-  const capNote = CAP_NOTE_PATTERN.exec(fee.note ?? "");
-  const noteAssignedPence = parsePoundsToPence(capNote?.[2]);
-  const hasFeeCapEvidence = Boolean(capNote);
+  const capMatch = CAP_NOTE_PATTERN.exec(fee.note ?? "");
+  const noteAssignedPence = parsePoundsToPence(capMatch?.[2]);
+  const hasFeeCapEvidence = Boolean(capMatch);
   const hasCurrentConcession =
     (profile?.cap !== null && profile?.cap !== undefined) ||
     (profile?.override !== null && profile?.override !== undefined);
@@ -137,6 +141,12 @@ async function loadCandidate(feeId: string, actorUserId: string, db: Db) {
       .trim() ||
     fee.prospect?.email?.trim() ||
     "Player";
+
+  const currentCapMatchesCharge =
+    profile?.cap !== null &&
+    profile?.cap !== undefined &&
+    profile.cap === fee.amountPence &&
+    currentAssignedPence > fee.amountPence;
 
   return {
     fee,
@@ -155,6 +165,7 @@ async function loadCandidate(feeId: string, actorUserId: string, db: Db) {
     capPence: profile?.cap ?? null,
     overridePence: profile?.override ?? null,
     hasFeeCapEvidence,
+    canApplyCurrentCapToFixture: !hasFeeCapEvidence && currentCapMatchesCharge,
   };
 }
 
@@ -226,7 +237,11 @@ export async function correctCaptainAssignedShare(input: {
         );
       }
 
-      if (input.assignedPence === candidate.currentAssignedPence) {
+      const applyCurrentCap =
+        candidate.canApplyCurrentCapToFixture &&
+        input.assignedPence === candidate.currentAssignedPence;
+
+      if (input.assignedPence === candidate.currentAssignedPence && !applyCurrentCap) {
         return {
           teamId: candidate.teamId,
           feeId: candidate.feeId,
@@ -234,25 +249,19 @@ export async function correctCaptainAssignedShare(input: {
           assignedPence: input.assignedPence,
           playerChargePence: candidate.playerChargePence,
           unchanged: true,
+          adjustmentRecorded: candidate.hasFeeCapEvidence,
         };
       }
 
       const previousStatus = candidate.fee.status;
       const previousAmountPence = candidate.fee.amountPence;
       const previousNote = candidate.fee.note ?? null;
-      const nextNote =
-        previousNote?.replace(
-          CAP_NOTE_PATTERN,
-          (
-            _match,
-            prefix: string,
-            _oldShare: string,
-            middle: string,
-            charged: string,
-            suffix: string,
-          ) =>
-            `${prefix}${formatPoundsForNote(input.assignedPence)}${middle}${charged}${suffix}`,
-        ) ?? null;
+      const nextCapNote = capNote(input.assignedPence, candidate.playerChargePence);
+      const nextNote = candidate.hasFeeCapEvidence
+        ? previousNote?.replace(CAP_NOTE_PATTERN, nextCapNote) ?? nextCapNote
+        : candidate.canApplyCurrentCapToFixture
+          ? [previousNote?.trim(), nextCapNote].filter(Boolean).join("\n")
+          : previousNote;
 
       await db.$executeRaw(Prisma.sql`
         UPDATE "PlayerMatchFee"
@@ -264,7 +273,7 @@ export async function correctCaptainAssignedShare(input: {
 
       const after = await db.playerMatchFee.findUnique({
         where: { id: input.feeId },
-        select: { amountPence: true, status: true },
+        select: { amountPence: true, status: true, note: true },
       });
       const assignedAfter = await db.$queryRaw<AssignedRow[]>(Prisma.sql`
         SELECT "captainAssignedAmountPence" AS assigned
@@ -276,7 +285,8 @@ export async function correctCaptainAssignedShare(input: {
         !after ||
         after.amountPence !== previousAmountPence ||
         after.status !== previousStatus ||
-        Number(assignedAfter[0]?.assigned) !== input.assignedPence
+        Number(assignedAfter[0]?.assigned) !== input.assignedPence ||
+        ((applyCurrentCap || candidate.hasFeeCapEvidence) && !after.note?.includes(nextCapNote))
       ) {
         throw new Error(
           "Captain-share correction changed an unexpected payment field; transaction rolled back.",
@@ -298,7 +308,9 @@ export async function correctCaptainAssignedShare(input: {
             balanceAfterPence: state.balancePence,
             receiptPence: 0,
             actorUserId: input.actorUserId,
-            reason: `SIXFL corrected the captain-assigned share from ${money(candidate.currentAssignedPence)} to ${money(input.assignedPence)}. The player's charge, payments and outstanding balance were not changed.`,
+            reason: applyCurrentCap
+              ? `SIXFL applied the player's existing ${money(candidate.playerChargePence)} cap to this historical fixture. Captain share ${money(input.assignedPence)}, player charge ${money(candidate.playerChargePence)}, difference ${money(input.assignedPence - candidate.playerChargePence)} recorded as the fixture adjustment. Payment status, receipts and outstanding balance were unchanged.`
+              : `SIXFL corrected the captain-assigned share from ${money(candidate.currentAssignedPence)} to ${money(input.assignedPence)}. The player's charge, payments and outstanding balance were not changed.`,
             sourceKey: `captain-share-correction:${input.feeId}:${randomUUID()}`,
           },
         });
@@ -311,6 +323,7 @@ export async function correctCaptainAssignedShare(input: {
         assignedPence: input.assignedPence,
         playerChargePence: candidate.playerChargePence,
         unchanged: false,
+        adjustmentRecorded: applyCurrentCap || candidate.hasFeeCapEvidence,
       };
     },
     { maxWait: 5000, timeout: 15000 },


### PR DESCRIPTION
Fixes the remaining Will Woolard-style case where the captain share is already correct (£8) and the player charge is correctly capped (£5), but the historical fixture never recorded the cap evidence, so Team Payments still shows “Check balance”.

When the current player cap exactly matches the stored player charge and the captain share is higher, the admin correction screen now explicitly offers to apply that cap to this fixture. Saving writes the existing cap note for this fixture, preserves the real player charge/payment/receipt/outstanding balance, adds an immutable admin ledger entry, and makes the difference count as the SIXFL adjustment in the existing payment presentation.

No new payment, debt, refund, checkout, email or SMS is created. Existing historical cap evidence continues to behave as before, and overrides are not silently treated as caps.