### PR TITLE
Fix missing-email player edit navigation on current main

### DIFF
--- a/src/app/captain/team/[teamid]/player-payments/page.tsx
+++ b/src/app/captain/team/[teamid]/player-payments/page.tsx
@@ -102,12 +102,12 @@ export default async function SquadPaymentsPage(props: Props) {
                       {member.role.replaceAll("_", " ")}
                     </span>
                   </div>
-                  <Link
+                  <a
                     href={`/captain/team/${team.id}/captain-squad/${member.id}/edit`}
                     className="inline-flex min-h-9 items-center justify-center rounded-full border border-white/10 bg-black/20 px-4 text-xs font-semibold text-white/80 transition hover:bg-white/[0.06] hover:text-white"
                   >
                     Add email or mark inactive
-                  </Link>
+                  </a>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
Rebuilds old PR #346 on current main.

The Squad Payments missing-email warning now uses a normal browser navigation for each player-specific **Add email or mark inactive** control. This avoids the stale client-router behaviour where the first click could return to the captain overview instead of opening the player editor.

Scope is intentionally tiny: one current-main file, no payment logic, squad-status logic, database or notification changes.