### PR TITLE
Send fixture confirmations to every captain on current main

### DIFF
--- a/.github/workflows/multi-captain-fixture-notifications.yml
+++ b/.github/workflows/multi-captain-fixture-notifications.yml
@@ -1,0 +1,28 @@
+name: Multi-captain fixture notifications
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  multi-captain-fixtures:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Prepare final production source
+        run: npm run prebuild
+      - run: npx prisma generate
+      - name: Check all-captain fixture communications
+        run: node scripts/check-multi-captain-fixture-notifications.mjs
+      - name: Type check
+        run: npx tsc --noEmit

--- a/prisma/migrations/20260911203000_backfill_captain_contact_phones/migration.sql
+++ b/prisma/migrations/20260911203000_backfill_captain_contact_phones/migration.sql
@@ -1,0 +1,96 @@
+-- Backfill captain member-profile mobile numbers from existing team/lead contact data.
+-- Only exact email matches are used. If the same email has conflicting known
+-- mobile numbers for a team, that captain is deliberately skipped.
+-- Existing non-empty TeamMemberProfile.phone values are never overwritten.
+
+DO $$
+BEGIN
+  IF to_regclass('"TeamMemberProfile"') IS NULL THEN
+    RAISE NOTICE 'TeamMemberProfile does not exist yet; runtime contact sync will backfill captains when teams are next touched.';
+    RETURN;
+  END IF;
+
+  CREATE UNIQUE INDEX IF NOT EXISTS "TeamMemberProfile_teamMemberId_key"
+    ON "TeamMemberProfile"("teamMemberId");
+
+  WITH known_contacts AS (
+    SELECT
+      team."id" AS "teamId",
+      LOWER(BTRIM(team."contactEmail")) AS "emailKey",
+      team."contactPhone" AS "phone"
+    FROM "Team" team
+    WHERE NULLIF(BTRIM(team."contactEmail"), '') IS NOT NULL
+      AND NULLIF(BTRIM(team."contactPhone"), '') IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+      team."id" AS "teamId",
+      LOWER(BTRIM(team."secondaryContactEmail")) AS "emailKey",
+      team."secondaryContactPhone" AS "phone"
+    FROM "Team" team
+    WHERE NULLIF(BTRIM(team."secondaryContactEmail"), '') IS NOT NULL
+      AND NULLIF(BTRIM(team."secondaryContactPhone"), '') IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+      lead."convertedTeamId" AS "teamId",
+      LOWER(BTRIM(lead."email")) AS "emailKey",
+      lead."phone" AS "phone"
+    FROM "InterestLead" lead
+    WHERE lead."convertedTeamId" IS NOT NULL
+      AND NULLIF(BTRIM(lead."email"), '') IS NOT NULL
+      AND NULLIF(BTRIM(lead."phone"), '') IS NOT NULL
+  ),
+  normalised_contacts AS (
+    SELECT
+      "teamId",
+      "emailKey",
+      "phone",
+      REGEXP_REPLACE("phone", '\D', '', 'g') AS "phoneKey"
+    FROM known_contacts
+    WHERE NULLIF(REGEXP_REPLACE("phone", '\D', '', 'g'), '') IS NOT NULL
+  ),
+  unambiguous_contacts AS (
+    SELECT
+      "teamId",
+      "emailKey",
+      MIN("phone") AS "phone"
+    FROM normalised_contacts
+    GROUP BY "teamId", "emailKey"
+    HAVING COUNT(DISTINCT "phoneKey") = 1
+  ),
+  captain_matches AS (
+    SELECT
+      member."id" AS "teamMemberId",
+      contact."phone" AS "phone"
+    FROM "TeamMember" member
+    INNER JOIN "User" usr ON usr."id" = member."userId"
+    INNER JOIN unambiguous_contacts contact
+      ON contact."teamId" = member."teamId"
+      AND contact."emailKey" = LOWER(BTRIM(usr."email"))
+    WHERE member."role"::text = 'CAPTAIN'
+  )
+  INSERT INTO "TeamMemberProfile" (
+    "id",
+    "teamMemberId",
+    "phone",
+    "createdAt",
+    "updatedAt"
+  )
+  SELECT
+    'captain_phone_' || MD5(
+      matches."teamMemberId" || ':' || matches."phone" || ':' || RANDOM()::text
+    ),
+    matches."teamMemberId",
+    matches."phone",
+    NOW(),
+    NOW()
+  FROM captain_matches matches
+  ON CONFLICT ("teamMemberId") DO UPDATE
+  SET
+    "phone" = EXCLUDED."phone",
+    "updatedAt" = NOW()
+  WHERE NULLIF(BTRIM("TeamMemberProfile"."phone"), '') IS NULL;
+END $$;

--- a/scripts/apply-multi-captain-operational-notifications.cjs
+++ b/scripts/apply-multi-captain-operational-notifications.cjs
@@ -1,49 +1,161 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const filePath = path.join(
-  process.cwd(),
-  "src",
-  "lib",
-  "fixtures",
-  "night-board-change-notifications.ts",
-);
+const root = process.cwd();
 
-if (!fs.existsSync(filePath)) {
-  throw new Error("Night Board notification source not found for multi-captain patch.");
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
 }
 
-let source = fs.readFileSync(filePath, "utf8");
-let changed = false;
-
-const importAnchor = 'import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";';
-const importLine = 'import { upsertAdditionalCaptainOperationalRecipients } from "@/lib/notifications/team-operational-recipients";';
-if (!source.includes(importLine)) {
-  if (!source.includes(importAnchor)) throw new Error("Multi-captain notification import anchor not found.");
-  source = source.replace(importAnchor, `${importAnchor}\n${importLine}`);
-  changed = true;
+function write(relativePath, source) {
+  fs.writeFileSync(path.join(root, relativePath), source, "utf8");
 }
 
-const marker = "      const additionalCaptainRecipients = await upsertAdditionalCaptainOperationalRecipients({";
-if (!source.includes(marker)) {
+function replaceRequired(source, before, after, label) {
+  if (source.includes(after)) return source;
+  if (!source.includes(before)) throw new Error(`Multi-captain ${label} anchor not found.`);
+  return source.replace(before, after);
+}
+
+function replaceRange(source, startMarker, endMarker, replacement, label) {
+  if (source.includes(replacement)) return source;
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error(`Multi-captain ${label} start anchor not found.`);
+  const end = source.indexOf(endMarker, start);
+  if (end < 0) throw new Error(`Multi-captain ${label} end anchor not found.`);
+  return source.slice(0, start) + replacement + source.slice(end + endMarker.length);
+}
+
+// ---------------------------------------------------------------------------
+// Existing Night Board fan-out: important fixture changes go to every captain.
+// ---------------------------------------------------------------------------
+const nightBoardPath = "src/lib/fixtures/night-board-change-notifications.ts";
+let nightBoard = read(nightBoardPath);
+const nightImportAnchor = 'import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";';
+const nightImportLine = 'import { upsertAdditionalCaptainOperationalRecipients } from "@/lib/notifications/team-operational-recipients";';
+if (!nightBoard.includes(nightImportLine)) {
+  if (!nightBoard.includes(nightImportAnchor)) throw new Error("Multi-captain Night Board import anchor not found.");
+  nightBoard = nightBoard.replace(nightImportAnchor, `${nightImportAnchor}\n${nightImportLine}`);
+}
+const nightMarker = "      const additionalCaptainRecipients = await upsertAdditionalCaptainOperationalRecipients({";
+if (!nightBoard.includes(nightMarker)) {
   const closingAnchor = `      );\n    }\n  }\n\n  const kickoffChanged =`;
-  if (!source.includes(closingAnchor)) {
-    throw new Error("Multi-captain notification team-loop anchor not found.");
-  }
-
+  if (!nightBoard.includes(closingAnchor)) throw new Error("Multi-captain Night Board team-loop anchor not found.");
   const addition = `      );\n\n      const additionalCaptainRecipients = await upsertAdditionalCaptainOperationalRecipients({\n        teamId,\n        excludeEmail: recipient.email,\n        excludePhone: recipient.phone,\n      });\n\n      for (const captainRecipient of additionalCaptainRecipients) {\n        recordOutcome(\n          team,\n          NotificationChannel.EMAIL,\n          await queueOnce({\n            recipientId: captainRecipient.id,\n            channel: NotificationChannel.EMAIL,\n            audience: NotificationAudience.TEAM,\n            subject: emailCopy.subject,\n            body: emailCopy.body,\n            sourceType,\n            sourceId,\n            metadata: { ...metadata, operationalCaptainCopy: true },\n            emailBranding: {\n              teamName: currentTeam.name,\n              teamLogoUrl: currentTeam.logoUrl,\n              leagueName: brandingLeague,\n            },\n            emailCta: { label: emailCopy.ctaLabel, url: dashboardUrl },\n            createdByUserId: input.createdByUserId,\n          }),\n        );\n\n        recordOutcome(\n          team,\n          NotificationChannel.SMS,\n          await queueOnce({\n            recipientId: captainRecipient.id,\n            channel: NotificationChannel.SMS,\n            audience: NotificationAudience.TEAM,\n            body: teamSmsCopy({\n              status: input.after.status,\n              homeTeamName: input.homeTeam.name,\n              awayTeamName: input.awayTeam.name,\n              after: input.after,\n              dashboardUrl,\n            }),\n            sourceType,\n            sourceId,\n            metadata: { ...metadata, operationalCaptainCopy: true },\n            createdByUserId: input.createdByUserId,\n          }),\n        );\n      }\n    }\n  }\n\n  const kickoffChanged =`;
+  nightBoard = nightBoard.replace(closingAnchor, addition);
+}
+if (!nightBoard.includes(nightImportLine) || !nightBoard.includes(nightMarker)) {
+  throw new Error("Multi-captain Night Board notification patch did not apply completely.");
+}
+write(nightBoardPath, nightBoard);
 
-  source = source.replace(closingAnchor, addition);
-  changed = true;
+// ---------------------------------------------------------------------------
+// Captain phone sync: when a known team/lead number matches one captain email
+// unambiguously, expose it through that captain's member profile. Never replace
+// a member phone that is already saved.
+// ---------------------------------------------------------------------------
+const contactsPath = "src/lib/notifications/team-contacts.ts";
+let contacts = read(contactsPath);
+const phoneSyncImport = 'import { syncTeamCaptainPhonesFromKnownContacts } from "@/lib/notifications/team-captain-contact-sync";';
+if (!contacts.includes(phoneSyncImport)) {
+  const anchor = '} from "@/lib/notifications/phone";';
+  if (!contacts.includes(anchor)) throw new Error("Multi-captain team-contact import anchor not found.");
+  contacts = contacts.replace(anchor, `${anchor}\n${phoneSyncImport}`);
+}
+if (!contacts.includes("const { profiles: captainProfiles } =")) {
+  const anchor = `  if (!team) {\n    return null;\n  }\n\n`;
+  if (!contacts.includes(anchor)) throw new Error("Multi-captain team-contact sync anchor not found.");
+  contacts = contacts.replace(anchor, `${anchor}  const { profiles: captainProfiles } =\n    await syncTeamCaptainPhonesFromKnownContacts(team.id);\n\n`);
+}
+if (!contacts.includes("const memberPhone = displayPhone(captainProfiles.get(member.id)?.phone);")) {
+  contacts = replaceRequired(
+    contacts,
+    `  for (const member of team.members) {\n    const key = contactKey({\n      name: member.user.name,\n      email: member.user.email,\n      source: \`member:\${member.id}\`,\n    });`,
+    `  for (const member of team.members) {\n    const memberPhone = displayPhone(captainProfiles.get(member.id)?.phone);\n    const key = contactKey({\n      name: member.user.name,\n      email: member.user.email,\n      phone: memberPhone,\n      source: \`member:\${member.id}\`,\n    });`,
+    "team-contact member phone",
+  );
+  contacts = replaceRequired(
+    contacts,
+    `      email: cleanValue(member.user.email),\n      phone: null,\n      isPrimary: contacts.length === 0,`,
+    `      email: cleanValue(member.user.email),\n      phone: memberPhone,\n      isPrimary: contacts.length === 0,`,
+    "team-contact member phone display",
+  );
+}
+write(contactsPath, contacts);
+
+// ---------------------------------------------------------------------------
+// Confirmation emails: dedupe by email but fan initial and automatic requests
+// out to every captain. Delivery history is checked per recipient, so adding a
+// second captain later backfills only that captain rather than resending all.
+// ---------------------------------------------------------------------------
+const emailPath = "src/lib/fixtures/confirmation-emails.ts";
+let email = read(emailPath);
+email = replaceRequired(
+  email,
+  'import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";',
+  'import { upsertTeamOperationalEmailRecipients } from "@/lib/notifications/team-operational-recipients";',
+  "confirmation-email import",
+);
+if (!email.includes("recipientId: string;\n}")) {
+  email = replaceRequired(
+    email,
+    `async function hasDispatch(input: {\n  sourceType: string;\n  sourceId: string;\n}) {`,
+    `async function hasDispatch(input: {\n  sourceType: string;\n  sourceId: string;\n  recipientId: string;\n}) {`,
+    "confirmation-email dispatch signature",
+  );
+  email = replaceRequired(
+    email,
+    `      sourceType: input.sourceType,\n      sourceId: input.sourceId,\n      status: {`,
+    `      sourceType: input.sourceType,\n      sourceId: input.sourceId,\n      recipientId: input.recipientId,\n      status: {`,
+    "confirmation-email dispatch recipient filter",
+  );
 }
 
-if (!source.includes(importLine) || !source.includes(marker)) {
-  throw new Error("Multi-captain operational notification patch did not apply completely.");
+const initialStart = `  const sourceId = \`\${fixture.id}:\${input.teamId}\`;\n  const sourceType = getSourceType("initial");`;
+const initialEnd = `  return "queued";`;
+const initialReplacement = `  const sourceId = \`\${fixture.id}:\${input.teamId}\`;\n  const sourceType = getSourceType("initial");\n  const team =\n    fixture.homeTeam.id === input.teamId ? fixture.homeTeam : fixture.awayTeam;\n  const opponent =\n    fixture.homeTeam.id === input.teamId ? fixture.awayTeam : fixture.homeTeam;\n  const recipients = await upsertTeamOperationalEmailRecipients(input.teamId);\n  const emailRecipients = recipients.filter((recipient) => recipient.email?.trim());\n  if (emailRecipients.length === 0) return "no-email";\n\n  const captainFixturesUrl = new URL(\n    \`/captain/team/\${input.teamId}/fixtures?fixtureId=\${encodeURIComponent(fixture.id)}\`,\n    getSiteUrl(),\n  ).toString();\n  const copy = getEmailCopy({\n    mode: "initial",\n    teamName: team.name,\n    opponentName: opponent.name,\n    kickoffAt: fixture.kickoffAt,\n  });\n\n  let queued = 0;\n  let alreadySent = 0;\n  for (const recipient of emailRecipients) {\n    if (await hasDispatch({ sourceType, sourceId, recipientId: recipient.id })) {\n      alreadySent += 1;\n      continue;\n    }\n\n    const dispatch = await queueDirectNotification({\n      recipientId: recipient.id,\n      channel: NotificationChannel.EMAIL,\n      audience: NotificationAudience.TEAM,\n      subject: copy.subject,\n      body: copy.body,\n      isTransactional: true,\n      sourceType,\n      sourceId,\n      emailBranding: {\n        teamName: team.name,\n        teamLogoUrl: team.logoUrl ?? null,\n        leagueName: fixture.league.season\n          ? \`\${fixture.league.name} — \${fixture.league.season}\`\n          : fixture.league.name,\n      },\n      emailCta: {\n        label: "Confirm team availability",\n        url: captainFixturesUrl,\n      },\n      metadata: {\n        kind: "fixture_confirmation_email",\n        mode: "initial",\n        trigger: "published_fixture_team_added",\n        fixtureId: fixture.id,\n        leagueId: fixture.leagueId,\n        teamId: input.teamId,\n        teamName: team.name,\n        opponentName: opponent.name,\n        operationalCaptainCopy: true,\n      },\n    });\n    if (dispatch.status === NotificationDispatchStatus.QUEUED) queued += 1;\n  }\n\n  if (queued === 0) return alreadySent > 0 ? "already-sent" : "skipped";\n\n  await prisma.fixtureCaptainConfirmation.upsert({\n    where: {\n      fixtureId_teamId: {\n        fixtureId: fixture.id,\n        teamId: input.teamId,\n      },\n    },\n    update: {\n      status: FixtureCaptainConfirmationStatus.PENDING,\n      lastChasedAt: new Date(),\n    },\n    create: {\n      fixtureId: fixture.id,\n      teamId: input.teamId,\n      status: FixtureCaptainConfirmationStatus.PENDING,\n      lastChasedAt: new Date(),\n    },\n  });\n\n  return "queued";`;
+if (!email.includes("operationalCaptainCopy: true")) {
+  email = replaceRange(email, initialStart, initialEnd, initialReplacement, "initial confirmation-email fan-out");
 }
 
-if (changed) {
-  fs.writeFileSync(filePath, source, "utf8");
-  console.log("Important Night Board fixture updates now fan out to all captains.");
-} else {
-  console.log("Multi-captain operational notifications already applied.");
+const autoStart = `      const team = fixture.homeTeam.id === teamId ? fixture.homeTeam : fixture.awayTeam;`;
+const autoEnd = `      summary.queued += 1;`;
+const autoReplacement = `      const team = fixture.homeTeam.id === teamId ? fixture.homeTeam : fixture.awayTeam;\n      const opponent = fixture.homeTeam.id === teamId ? fixture.awayTeam : fixture.homeTeam;\n      const sourceId = \`\${fixture.id}:\${teamId}\`;\n      const recipients = await upsertTeamOperationalEmailRecipients(teamId);\n      const emailRecipients = recipients.filter((recipient) => recipient.email?.trim());\n      if (emailRecipients.length === 0) {\n        summary.noEmail += 1;\n        continue;\n      }\n\n      const captainFixturesUrl = new URL(\n        \`/captain/team/\${teamId}/fixtures?fixtureId=\${encodeURIComponent(fixture.id)}\`,\n        getSiteUrl(),\n      ).toString();\n      let queuedForTeam = 0;\n\n      for (const recipient of emailRecipients) {\n        const initialSourceType = getSourceType("initial");\n        const initialAlreadySent = await hasDispatch({\n          sourceType: initialSourceType,\n          sourceId,\n          recipientId: recipient.id,\n        });\n\n        let mode: ConfirmationEmailMode | null = null;\n        if (!initialAlreadySent) {\n          mode = "initial";\n        } else if (fixture.kickoffAt <= urgentCutoff) {\n          const sourceType = getSourceType("auto24h");\n          if (!(await hasDispatch({ sourceType, sourceId, recipientId: recipient.id }))) mode = "auto24h";\n        } else if (fixture.kickoffAt <= standardCutoff) {\n          const sourceType = getSourceType("auto72h");\n          if (!(await hasDispatch({ sourceType, sourceId, recipientId: recipient.id }))) mode = "auto72h";\n        }\n\n        if (!mode) {\n          summary.alreadySent += 1;\n          continue;\n        }\n\n        const copy = getEmailCopy({ mode, teamName: team.name, opponentName: opponent.name, kickoffAt: fixture.kickoffAt });\n        const dispatch = await queueDirectNotification({\n          recipientId: recipient.id,\n          channel: NotificationChannel.EMAIL,\n          audience: NotificationAudience.TEAM,\n          subject: copy.subject,\n          body: copy.body,\n          isTransactional: true,\n          sourceType: getSourceType(mode),\n          sourceId,\n          emailBranding: {\n            teamName: team.name,\n            teamLogoUrl: team.logoUrl ?? null,\n            leagueName: fixture.league.season ? \`\${fixture.league.name} — \${fixture.league.season}\` : fixture.league.name,\n          },\n          emailCta: { label: mode === "initial" ? "Confirm team availability" : "Open fixture details", url: captainFixturesUrl },\n          metadata: {\n            kind: "fixture_confirmation_email", mode, fixtureId: fixture.id, leagueId: fixture.leagueId, teamId,\n            teamName: team.name, opponentName: opponent.name, operationalCaptainCopy: true,\n          },\n        });\n        if (dispatch.status === NotificationDispatchStatus.QUEUED) {\n          queuedForTeam += 1;\n          summary.queued += 1;\n        } else {\n          summary.skipped += 1;\n        }\n      }\n\n      if (queuedForTeam > 0) {\n        await prisma.fixtureCaptainConfirmation.upsert({\n          where: { fixtureId_teamId: { fixtureId: fixture.id, teamId } },\n          update: { lastChasedAt: new Date() },\n          create: { fixtureId: fixture.id, teamId, status: FixtureCaptainConfirmationStatus.PENDING, lastChasedAt: new Date() },\n        });\n      }`;
+if (!email.includes("const recipients = await upsertTeamOperationalEmailRecipients(teamId);")) {
+  email = replaceRange(email, autoStart, autoEnd, autoReplacement, "automatic confirmation-email fan-out");
 }
+write(emailPath, email);
+
+// ---------------------------------------------------------------------------
+// Confirmation SMS: same rule, deduplicated by phone and delivery history per
+// recipient. Existing last-minute replacement suppression remains untouched.
+// ---------------------------------------------------------------------------
+const smsPath = "src/lib/fixtures/confirmation-reminders.ts";
+let sms = read(smsPath);
+sms = replaceRequired(
+  sms,
+  'import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";',
+  'import { upsertTeamOperationalSmsRecipients } from "@/lib/notifications/team-operational-recipients";',
+  "confirmation-SMS import",
+);
+if (!sms.includes("recipientId: true,")) {
+  sms = replaceRequired(
+    sms,
+    `    select: {\n      id: true,\n      status: true,\n      createdAt: true,\n    },`,
+    `    select: {\n      id: true,\n      recipientId: true,\n      status: true,\n      createdAt: true,\n    },`,
+    "confirmation-SMS dispatch recipient selection",
+  );
+}
+const smsStart = `  const activeExistingDispatch = existingDispatches.find((dispatch) => {`;
+const smsEnd = `  return { ok: true, status: "queued", teamName: team.name };`;
+const smsReplacement = `  const recipients = await upsertTeamOperationalSmsRecipients(input.teamId);\n  const smsRecipients = recipients.filter((recipient) => recipient.phone?.trim());\n  if (smsRecipients.length === 0) {\n    return { ok: false, status: "no_phone", teamName: team.name };\n  }\n\n  const captainFixturesUrl = buildAbsoluteUrl(\n    \`/captain/team/\${input.teamId}/fixtures?fixtureId=\${encodeURIComponent(fixture.id)}\`,\n  );\n  const smsBody = await buildSmsBody({\n    mode: input.mode,\n    teamName: team.name,\n    opponentName: opponent.name,\n    kickoffAt: fixture.kickoffAt,\n    captainFixturesUrl,\n  });\n  if (!smsBody) return { ok: false, status: "template_missing", teamName: team.name };\n\n  let queued = 0;\n  let alreadySent = 0;\n  for (const recipient of smsRecipients) {\n    const activeExistingDispatch = existingDispatches.find((dispatch) => {\n      if (dispatch.recipientId !== recipient.id) return false;\n      if (staleQueuedDispatchIds.includes(dispatch.id)) return false;\n      return fixture.updatedAt.getTime() <= dispatch.createdAt.getTime();\n    });\n    if (activeExistingDispatch) {\n      alreadySent += 1;\n      continue;\n    }\n\n    const dispatch = await queueDirectNotification({\n      recipientId: recipient.id,\n      channel: NotificationChannel.SMS,\n      audience: NotificationAudience.TEAM,\n      body: smsBody,\n      isTransactional: true,\n      sourceType,\n      sourceId,\n      metadata: {\n        kind: "fixture_confirmation_sms", mode: input.mode, fixtureId: fixture.id, leagueId: fixture.leagueId,\n        teamId: input.teamId, teamName: team.name, opponentName: opponent.name, templateKey: getTemplateKey(input.mode),\n        operationalCaptainCopy: true,\n      },\n    });\n    if (dispatch.status === NotificationDispatchStatus.QUEUED) queued += 1;\n  }\n\n  if (queued > 0) {\n    await prisma.fixtureCaptainConfirmation.upsert({\n      where: { fixtureId_teamId: { fixtureId: fixture.id, teamId: input.teamId } },\n      update: { lastChasedAt: new Date() },\n      create: { fixtureId: fixture.id, teamId: input.teamId, status: FixtureCaptainConfirmationStatus.PENDING, lastChasedAt: new Date() },\n    });\n    return { ok: true, status: "queued", teamName: team.name };\n  }\n  if (alreadySent > 0) return { ok: true, status: "already_sent", teamName: team.name };\n  return { ok: false, status: "skipped", teamName: team.name };`;
+if (!sms.includes("const recipients = await upsertTeamOperationalSmsRecipients(input.teamId);")) {
+  sms = replaceRange(sms, smsStart, smsEnd, smsReplacement, "confirmation-SMS fan-out");
+}
+write(smsPath, sms);
+
+if (!email.includes("upsertTeamOperationalEmailRecipients") || !sms.includes("upsertTeamOperationalSmsRecipients")) {
+  throw new Error("Multi-captain fixture confirmation patch did not apply completely.");
+}
+
+console.log("Important Night Board updates and fixture confirmations now fan out to all captains.");

--- a/scripts/check-multi-captain-fixture-notifications.mjs
+++ b/scripts/check-multi-captain-fixture-notifications.mjs
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`Missing required file: ${relativePath}`);
+    return "";
+  }
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+const recipientPath = "src/lib/notifications/team-operational-recipients.ts";
+const emailPath = "src/lib/fixtures/confirmation-emails.ts";
+const smsPath = "src/lib/fixtures/confirmation-reminders.ts";
+const teamContactPath = "src/lib/notifications/team-contacts.ts";
+const captainPhoneSyncPath = "src/lib/notifications/team-captain-contact-sync.ts";
+const captainPhoneBackfillPath =
+  "prisma/migrations/20260911203000_backfill_captain_contact_phones/migration.sql";
+
+const recipients = read(recipientPath);
+const emails = read(emailPath);
+const sms = read(smsPath);
+const teamContacts = read(teamContactPath);
+const captainPhoneSync = read(captainPhoneSyncPath);
+const captainPhoneBackfill = read(captainPhoneBackfillPath);
+
+expect(
+  recipients.includes("where: { teamId: input.teamId, role: TeamRole.CAPTAIN }") &&
+    recipients.includes("upsertTeamOperationalEmailRecipients") &&
+    recipients.includes("upsertTeamOperationalSmsRecipients"),
+  "operational fixture recipient resolution must include every captain membership",
+);
+
+expect(
+  recipients.includes("seen.has(key)") &&
+    recipients.includes("recipient.email?.trim().toLowerCase()") &&
+    recipients.includes("recipient.phone?.replace(/\\D/g, \"\")"),
+  "all-captain operational recipients must deduplicate shared email addresses and phone numbers",
+);
+
+expect(
+  emails.includes("upsertTeamOperationalEmailRecipients") &&
+    emails.includes("for (const recipient of emailRecipients)") &&
+    emails.includes("recipientId: input.recipientId"),
+  "fixture publication and confirmation emails must fan out to all captains and deduplicate per recipient",
+);
+
+expect(
+  emails.includes("const initialAlreadySent = await hasDispatch({") &&
+    emails.includes("recipientId: recipient.id") &&
+    emails.includes('getSourceType("initial")'),
+  "fixture email recovery must check each captain separately so a second captain can receive a fixture already sent to the primary contact",
+);
+
+expect(
+  emails.includes("getAllocatedReplacementConfirmationBlock") &&
+    sms.includes("getAllocatedReplacementConfirmationBlock"),
+  "multi-captain delivery must preserve last-minute replacement confirmation suppression",
+);
+
+expect(
+  sms.includes("upsertTeamOperationalSmsRecipients") &&
+    sms.includes("recipientId: true") &&
+    sms.includes("dispatch.recipientId !== recipient.id") &&
+    sms.includes("for (const recipient of smsRecipients)"),
+  "fixture confirmation SMS reminders must fan out to every captain with a saved phone number",
+);
+
+expect(
+  captainPhoneSync.includes("syncTeamCaptainPhonesFromKnownContacts") &&
+    captainPhoneSync.includes("team.contactEmail") &&
+    captainPhoneSync.includes("team.secondaryContactEmail") &&
+    captainPhoneSync.includes("team.convertedFromLead?.email") &&
+    captainPhoneSync.includes("candidates.size > 1") &&
+    captainPhoneSync.includes("if (currentPhone) continue") &&
+    captainPhoneSync.includes('INSERT INTO "TeamMemberProfile"'),
+  "known team/lead phone numbers must backfill only unambiguous matching captain profiles without overwriting an existing member phone",
+);
+
+expect(
+  teamContacts.includes("syncTeamCaptainPhonesFromKnownContacts(team.id)") &&
+    teamContacts.includes("captainProfiles.get(member.id)?.phone") &&
+    teamContacts.includes("phone: memberPhone"),
+  "team contact snapshots must surface the captain member-profile phone after contact sync",
+);
+
+expect(
+  captainPhoneBackfill.includes("LOWER(BTRIM(team.\"contactEmail\"))") &&
+    captainPhoneBackfill.includes("LOWER(BTRIM(team.\"secondaryContactEmail\"))") &&
+    captainPhoneBackfill.includes("lead.\"convertedTeamId\"") &&
+    captainPhoneBackfill.includes("HAVING COUNT(DISTINCT \"phoneKey\") = 1") &&
+    captainPhoneBackfill.includes('WHERE NULLIF(BTRIM("TeamMemberProfile"."phone"), \'\') IS NULL'),
+  "deployment migration must backfill existing captains only where the email/phone match is unambiguous and the member phone is blank",
+);
+
+if (failures.length) {
+  console.error("\nMULTI-CAPTAIN FIXTURE NOTIFICATION CONTRACT FAILED\n");
+  for (const failure of failures) console.error(` - ${failure}`);
+  console.error("\nDo not merge until all captain fixture notifications are preserved.\n");
+  process.exit(1);
+}
+
+console.log("Multi-captain fixture notification contract passed.");

--- a/src/lib/notifications/team-captain-contact-sync.ts
+++ b/src/lib/notifications/team-captain-contact-sync.ts
@@ -1,0 +1,144 @@
+// ========================================
+// File: src/lib/notifications/team-captain-contact-sync.ts
+// ========================================
+
+import { randomUUID } from "node:crypto";
+import { TeamRole } from "@prisma/client";
+
+import { getPhoneDisplayValue, normalizePhoneNumber } from "@/lib/notifications/phone";
+import { prisma } from "@/lib/prisma";
+import {
+  getTeamMemberProfilesByTeamMemberIds,
+  type TeamMemberProfile,
+} from "@/lib/teamMemberProfiles";
+
+function normaliseEmail(value?: string | null) {
+  return value?.trim().toLowerCase() || null;
+}
+
+type KnownContact = {
+  email: string | null;
+  phone: string | null;
+};
+
+function addKnownContact(
+  candidatesByEmail: Map<string, Map<string, string>>,
+  contact: KnownContact,
+) {
+  const email = normaliseEmail(contact.email);
+  const displayPhone = getPhoneDisplayValue(contact.phone);
+  const phoneKey = normalizePhoneNumber(displayPhone)?.replace(/\D/g, "") || null;
+
+  if (!email || !displayPhone || !phoneKey) return;
+
+  const phones = candidatesByEmail.get(email) ?? new Map<string, string>();
+  if (!phones.has(phoneKey)) phones.set(phoneKey, displayPhone);
+  candidatesByEmail.set(email, phones);
+}
+
+export type CaptainPhoneSyncResult = {
+  updated: number;
+  matched: number;
+  conflicts: number;
+  profiles: Map<string, TeamMemberProfile>;
+};
+
+export async function syncTeamCaptainPhonesFromKnownContacts(
+  teamId: string,
+): Promise<CaptainPhoneSyncResult> {
+  const team = await prisma.team.findUnique({
+    where: { id: teamId },
+    select: {
+      contactEmail: true,
+      contactPhone: true,
+      secondaryContactEmail: true,
+      secondaryContactPhone: true,
+      convertedFromLead: {
+        select: { email: true, phone: true },
+      },
+      members: {
+        where: { role: TeamRole.CAPTAIN },
+        orderBy: { createdAt: "asc" },
+        select: {
+          id: true,
+          user: { select: { email: true } },
+        },
+      },
+    },
+  });
+
+  if (!team || team.members.length === 0) {
+    return {
+      updated: 0,
+      matched: 0,
+      conflicts: 0,
+      profiles: new Map<string, TeamMemberProfile>(),
+    };
+  }
+
+  const memberIds = team.members.map((member) => member.id);
+  const existingProfiles = await getTeamMemberProfilesByTeamMemberIds(memberIds);
+  const candidatesByEmail = new Map<string, Map<string, string>>();
+
+  addKnownContact(candidatesByEmail, {
+    email: team.contactEmail,
+    phone: team.contactPhone,
+  });
+  addKnownContact(candidatesByEmail, {
+    email: team.secondaryContactEmail,
+    phone: team.secondaryContactPhone,
+  });
+  addKnownContact(candidatesByEmail, {
+    email: team.convertedFromLead?.email ?? null,
+    phone: team.convertedFromLead?.phone ?? null,
+  });
+
+  let updated = 0;
+  let matched = 0;
+  let conflicts = 0;
+
+  for (const member of team.members) {
+    const email = normaliseEmail(member.user.email);
+    if (!email) continue;
+
+    const candidates = candidatesByEmail.get(email);
+    if (!candidates || candidates.size === 0) continue;
+
+    if (candidates.size > 1) {
+      conflicts += 1;
+      continue;
+    }
+
+    matched += 1;
+
+    const currentPhone = existingProfiles.get(member.id)?.phone?.trim() || null;
+    if (currentPhone) continue;
+
+    const phone = Array.from(candidates.values())[0] ?? null;
+    if (!phone) continue;
+
+    await prisma.$executeRaw`
+      INSERT INTO "TeamMemberProfile" (
+        "id",
+        "teamMemberId",
+        "phone",
+        "createdAt",
+        "updatedAt"
+      )
+      VALUES (${randomUUID()}, ${member.id}, ${phone}, NOW(), NOW())
+      ON CONFLICT ("teamMemberId") DO UPDATE
+      SET
+        "phone" = EXCLUDED."phone",
+        "updatedAt" = NOW()
+      WHERE NULLIF(BTRIM("TeamMemberProfile"."phone"), '') IS NULL
+    `;
+
+    updated += 1;
+  }
+
+  const profiles = updated
+    ? await getTeamMemberProfilesByTeamMemberIds(memberIds)
+    : existingProfiles;
+
+  return { updated, matched, conflicts, profiles };
+}

--- a/src/lib/notifications/team-operational-recipients.ts
+++ b/src/lib/notifications/team-operational-recipients.ts
@@ -2,11 +2,13 @@ import {
   NotificationAudience,
   NotificationRecipientSourceType,
   TeamRole,
+  type NotificationRecipient,
 } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { getTeamMemberProfilesByTeamMemberIds } from "@/lib/teamMemberProfiles";
 import { upsertNotificationRecipient } from "@/lib/notifications/recipients";
+import { upsertTeamNotificationRecipient } from "@/lib/notifications/team-contacts";
 
 export async function upsertAdditionalCaptainOperationalRecipients(input: {
   teamId: string;
@@ -65,4 +67,46 @@ export async function upsertAdditionalCaptainOperationalRecipients(input: {
   }
 
   return recipients;
+}
+
+function uniqueByContact(
+  recipients: NotificationRecipient[],
+  getKey: (recipient: NotificationRecipient) => string | null,
+) {
+  const seen = new Set<string>();
+
+  return recipients.filter((recipient) => {
+    const key = getKey(recipient);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export async function upsertTeamOperationalEmailRecipients(teamId: string) {
+  const { recipient: primaryRecipient } = await upsertTeamNotificationRecipient(teamId);
+  const additionalCaptains = await upsertAdditionalCaptainOperationalRecipients({
+    teamId,
+    excludeEmail: primaryRecipient.email,
+    excludePhone: primaryRecipient.phone,
+  });
+
+  return uniqueByContact(
+    [primaryRecipient, ...additionalCaptains],
+    (recipient) => recipient.email?.trim().toLowerCase() || null,
+  );
+}
+
+export async function upsertTeamOperationalSmsRecipients(teamId: string) {
+  const { recipient: primaryRecipient } = await upsertTeamNotificationRecipient(teamId);
+  const additionalCaptains = await upsertAdditionalCaptainOperationalRecipients({
+    teamId,
+    excludeEmail: primaryRecipient.email,
+    excludePhone: primaryRecipient.phone,
+  });
+
+  return uniqueByContact(
+    [primaryRecipient, ...additionalCaptains],
+    (recipient) => recipient.phone?.replace(/\D/g, "") || null,
+  );
 }


### PR DESCRIPTION
Rebuilds old PR #432 on current main while preserving current Night Board, replacement-team and notification safeguards.

- Resolves all CAPTAIN memberships as operational email/SMS recipients, deduplicated by contact detail.
- Initial fixture-confirmation emails fan out to every captain with an email.
- Automatic 72h/24h confirmation emails track delivery per recipient, so a newly added second captain can be backfilled without resending the primary captain.
- Confirmation SMS reminders fan out per captain phone and retain per-recipient stale-dispatch handling.
- Known primary/secondary/converted-lead phone numbers are copied to a matching captain profile only when the email match is exact and the phone is unambiguous; an existing member phone is never overwritten.
- Adds a new current migration for existing captain phone profiles and a dedicated CI contract.
- Preserves the current last-minute replacement confirmation block and existing Night Board multi-captain updates.

No customer notification is sent by this PR itself.