### PR TITLE
Add opt-in Veo Priority pilot, off by default

### DIFF
--- a/.github/workflows/veo-priority.yml
+++ b/.github/workflows/veo-priority.yml
@@ -1,0 +1,102 @@
+name: Veo Priority safety
+on:
+  pull_request:
+    paths:
+      - 'src/lib/veo/**'
+      - 'src/app/**/veo-priority/**'
+      - 'src/app/(admin)/admin/fixtures/publish-actions.ts'
+      - 'src/app/captain/team/[teamid]/fixtures/layout.tsx'
+      - 'prisma/migrations/20260912001500_veo_priority_pilot/**'
+      - 'tests/veo-priority/**'
+      - '.github/workflows/veo-priority.yml'
+  push:
+    branches: [feature/veo-priority-pilot]
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: veo-priority-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sixfl_veo_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/sixfl_veo_test
+      VEO_TEST_DATABASE: '1'
+      NEXTAUTH_SECRET: isolated-veo-safety-test-only
+      NEXTAUTH_URL: http://127.0.0.1:3100
+      NEXT_PUBLIC_SITE_URL: http://127.0.0.1:3100
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Pure allocation and fee tests
+        run: node --experimental-strip-types --test tests/veo-priority/allocator.test.mjs
+      - name: Prepare generated application schema
+        run: npm run prebuild && npx prisma generate
+      - name: Create isolated test schema and apply additive Veo migration
+        shell: bash
+        run: |
+          npx prisma db push --skip-generate
+          npx prisma db execute --schema prisma/schema.prisma --stdin <<'SQL'
+          ALTER TABLE "League" ADD COLUMN IF NOT EXISTS "minutesPerGame" INTEGER;
+          ALTER TABLE "Team" ADD COLUMN IF NOT EXISTS "isFixturePlaceholder" BOOLEAN NOT NULL DEFAULT false;
+          SQL
+          npx prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260912001500_veo_priority_pilot/migration.sql
+      - name: Real database safety checks
+        run: npx tsx tests/veo-priority/database.ts
+      - name: Production build
+        run: npm run build
+      - name: Install browser test dependencies
+        run: npm install --no-save --package-lock=false playwright@1.55.0 && npx playwright install --with-deps chromium
+      - name: Start isolated development app
+        shell: bash
+        run: |
+          npx next dev --hostname 127.0.0.1 --port 3100 > veo-dev.log 2>&1 &
+          for attempt in $(seq 1 90); do
+            if curl --silent http://127.0.0.1:3100/login > /dev/null; then exit 0; fi
+            sleep 1
+          done
+          cat veo-dev.log
+          exit 1
+      - name: Mobile and completed-video edit browser checks
+        run: node tests/veo-priority/browser.mjs
+      - name: Check production authentication boundary
+        shell: bash
+        run: |
+          NODE_ENV=production npx next start --hostname 127.0.0.1 --port 3101 > veo-production.log 2>&1 &
+          for attempt in $(seq 1 60); do
+            if curl --silent http://127.0.0.1:3101/login > /dev/null; then break; fi
+            sleep 1
+          done
+          LEAGUE=$(node -p "JSON.parse(require('fs').readFileSync('artifacts/veo/seed.json','utf8')).leagueId")
+          curl --silent --dump-header veo-auth-headers.txt --output /dev/null "http://127.0.0.1:3101/admin/leagues/$LEAGUE/veo-priority"
+          grep -i 'location: /login' veo-auth-headers.txt
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: veo-safety-${{ github.sha }}
+          path: |
+            artifacts/veo/
+            veo-dev.log
+            veo-production.log
+            veo-auth-headers.txt
+          retention-days: 14

--- a/.github/workflows/veo-priority.yml
+++ b/.github/workflows/veo-priority.yml
@@ -30,7 +30,7 @@ jobs:
           POSTGRES_DB: sixfl_veo_test
         ports: ['5432:5432']
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
@@ -62,8 +62,23 @@ jobs:
           npx prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260912001500_veo_priority_pilot/migration.sql
       - name: Real database safety checks
         run: npx tsx tests/veo-priority/database.ts
+      # Production runs prebuild -> prisma generate -> next build once. Preparation
+      # already ran above so that database checks use the same generated schema.
       - name: Production build
-        run: npm run build
+        run: npx next build
+      - name: Check production authentication boundary
+        shell: bash
+        run: |
+          NODE_ENV=production npx next start --hostname 127.0.0.1 --port 3101 > veo-production.log 2>&1 &
+          PROD_PID=$!
+          trap 'kill "$PROD_PID" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 60); do
+            if curl --silent http://127.0.0.1:3101/login > /dev/null; then break; fi
+            sleep 1
+          done
+          LEAGUE=$(node -p "JSON.parse(require('fs').readFileSync('artifacts/veo/seed.json','utf8')).leagueId")
+          curl --silent --dump-header veo-auth-headers.txt --output /dev/null "http://127.0.0.1:3101/admin/leagues/$LEAGUE/veo-priority"
+          grep -i 'location: /login' veo-auth-headers.txt
       - name: Install browser test dependencies
         run: npm install --no-save --package-lock=false playwright@1.55.0 && npx playwright install --with-deps chromium
       - name: Start isolated development app
@@ -78,17 +93,6 @@ jobs:
           exit 1
       - name: Mobile and completed-video edit browser checks
         run: node tests/veo-priority/browser.mjs
-      - name: Check production authentication boundary
-        shell: bash
-        run: |
-          NODE_ENV=production npx next start --hostname 127.0.0.1 --port 3101 > veo-production.log 2>&1 &
-          for attempt in $(seq 1 60); do
-            if curl --silent http://127.0.0.1:3101/login > /dev/null; then break; fi
-            sleep 1
-          done
-          LEAGUE=$(node -p "JSON.parse(require('fs').readFileSync('artifacts/veo/seed.json','utf8')).leagueId")
-          curl --silent --dump-header veo-auth-headers.txt --output /dev/null "http://127.0.0.1:3101/admin/leagues/$LEAGUE/veo-priority"
-          grep -i 'location: /login' veo-auth-headers.txt
       - name: Upload evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/veo-priority.yml
+++ b/.github/workflows/veo-priority.yml
@@ -40,6 +40,11 @@ jobs:
       NEXTAUTH_SECRET: isolated-veo-safety-test-only
       NEXTAUTH_URL: http://127.0.0.1:3100
       NEXT_PUBLIC_SITE_URL: http://127.0.0.1:3100
+      # Inert placeholders satisfy constructors in unrelated application routes.
+      # No real credentials, sends or payment operations are used by these tests.
+      RESEND_API_KEY: re_isolated_veo_test_not_a_real_key
+      STRIPE_SECRET_KEY: sk_test_isolated_veo_not_a_real_key
+      OPENAI_API_KEY: sk-isolated-veo-not-a-real-key
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -65,7 +70,8 @@ jobs:
       # Production runs prebuild -> prisma generate -> next build once. Preparation
       # already ran above so that database checks use the same generated schema.
       - name: Production build
-        run: npx next build
+        shell: bash
+        run: npx next build 2>&1 | tee veo-build.log
       - name: Check production authentication boundary
         shell: bash
         run: |
@@ -100,6 +106,7 @@ jobs:
           name: veo-safety-${{ github.sha }}
           path: |
             artifacts/veo/
+            veo-build.log
             veo-dev.log
             veo-production.log
             veo-auth-headers.txt

--- a/prisma/migrations/20260912001500_veo_priority_pilot/migration.sql
+++ b/prisma/migrations/20260912001500_veo_priority_pilot/migration.sql
@@ -1,0 +1,57 @@
+-- Additive only: no existing leagues, fixtures, prices or payments are changed.
+CREATE TABLE "VeoLeagueSettings" (
+  "leagueId" TEXT PRIMARY KEY REFERENCES "League"("id") ON DELETE CASCADE,
+  "enabled" BOOLEAN NOT NULL DEFAULT false,
+  "pitch" TEXT NOT NULL DEFAULT '',
+  "venueId" TEXT REFERENCES "Venue"("id") ON DELETE RESTRICT,
+  "maxMatches" INTEGER NOT NULL DEFAULT 3 CHECK ("maxMatches" BETWEEN 1 AND 12),
+  "revision" INTEGER NOT NULL DEFAULT 1,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedBy" TEXT,
+  CHECK (NOT "enabled" OR length(trim("pitch")) > 0)
+);
+CREATE TABLE "VeoTeamPriority" (
+  "leagueId" TEXT NOT NULL REFERENCES "League"("id") ON DELETE CASCADE,
+  "teamId" TEXT NOT NULL REFERENCES "Team"("id") ON DELETE CASCADE,
+  "enabled" BOOLEAN NOT NULL DEFAULT false,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedBy" TEXT,
+  PRIMARY KEY ("leagueId", "teamId")
+);
+CREATE TABLE "VeoSettingsAudit" (
+  "id" TEXT PRIMARY KEY,
+  "leagueId" TEXT NOT NULL,
+  "teamId" TEXT,
+  "actorId" TEXT,
+  "details" JSONB NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX "VeoSettingsAudit_leagueId_createdAt_idx" ON "VeoSettingsAudit"("leagueId", "createdAt");
+CREATE TABLE "VeoFixtureSnapshot" (
+  "fixtureId" TEXT PRIMARY KEY REFERENCES "Fixture"("id") ON DELETE RESTRICT,
+  "leagueId" TEXT NOT NULL REFERENCES "League"("id") ON DELETE RESTRICT,
+  "kickoffAt" TIMESTAMP(3) NOT NULL,
+  "venueId" TEXT,
+  "pitch" TEXT,
+  "homeTeamId" TEXT NOT NULL,
+  "awayTeamId" TEXT NOT NULL,
+  "homePriority" BOOLEAN NOT NULL,
+  "awayPriority" BOOLEAN NOT NULL,
+  "allocated" BOOLEAN NOT NULL,
+  "homeBasePence" INTEGER NOT NULL CHECK ("homeBasePence" >= 0),
+  "awayBasePence" INTEGER NOT NULL CHECK ("awayBasePence" >= 0),
+  "homeSupplementPence" INTEGER NOT NULL,
+  "awaySupplementPence" INTEGER NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK ("homeSupplementPence" = CASE WHEN "allocated" AND "homePriority" AND "homeBasePence" > 0 THEN 500 ELSE 0 END),
+  CHECK ("awaySupplementPence" = CASE WHEN "allocated" AND "awayPriority" AND "awayBasePence" > 0 THEN 500 ELSE 0 END)
+);
+CREATE INDEX "VeoFixtureSnapshot_leagueId_kickoffAt_idx" ON "VeoFixtureSnapshot"("leagueId", "kickoffAt");
+-- Preserve the original agreement even when an administrator later issues a fee correction.
+CREATE FUNCTION sixfl_preserve_veo_snapshot() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Veo fixture snapshots are permanent. Use the normal payment adjustment workflow for corrections.';
+END;
+$$;
+CREATE TRIGGER "VeoFixtureSnapshot_immutable" BEFORE UPDATE OR DELETE ON "VeoFixtureSnapshot"
+FOR EACH ROW EXECUTE FUNCTION sixfl_preserve_veo_snapshot();

--- a/src/app/(admin)/admin/fixtures/publish-actions.ts
+++ b/src/app/(admin)/admin/fixtures/publish-actions.ts
@@ -131,7 +131,7 @@ function getTeamDetailsForFixture(fixture: PublishFixtureRecord, teamId: string)
 }
 
 function buildReminderSourceId(input: { fixtureId: string; teamId: string; scheduledFor: Date }) {
-  return `${input.fixtureId}:${input.teamId}:${scheduledFor.toISOString()}`;
+  return `${input.fixtureId}:${input.teamId}:${input.scheduledFor.toISOString()}`;
 }
 
 function isQueuedDispatch(status: NotificationDispatchStatus) {
@@ -139,7 +139,9 @@ function isQueuedDispatch(status: NotificationDispatchStatus) {
 }
 
 function isRetryablePublishError(error: unknown) {
-  if (error instanceof Prisma.PrismaClientKnownRequestError) return error.code === "P2034";
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code === "P2034" || (error.code === "P2010" && ["40001", "40P01"].includes(String(error.meta?.code)));
+  }
   return error instanceof Error && error.message === PUBLISH_RETRY_ERROR;
 }
 

--- a/src/app/(admin)/admin/fixtures/publish-actions.ts
+++ b/src/app/(admin)/admin/fixtures/publish-actions.ts
@@ -20,6 +20,7 @@ import { getFixturePlaceholderTeamIds } from "@/lib/teams/fixture-placeholders";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
 import { getEmailReplyDomain } from "@/lib/resend/client";
+import { prepareVeoPublication, VeoAllocationError } from "@/lib/veo/service";
 
 type PublishFixtureRecord = {
   id: string;
@@ -130,7 +131,7 @@ function getTeamDetailsForFixture(fixture: PublishFixtureRecord, teamId: string)
 }
 
 function buildReminderSourceId(input: { fixtureId: string; teamId: string; scheduledFor: Date }) {
-  return `${input.fixtureId}:${input.teamId}:${input.scheduledFor.toISOString()}`;
+  return `${input.fixtureId}:${input.teamId}:${scheduledFor.toISOString()}`;
 }
 
 function isQueuedDispatch(status: NotificationDispatchStatus) {
@@ -170,6 +171,7 @@ async function claimUnpublishedLeagueFixtures(input: PublishScope): Promise<Publ
   return withSerializableRetry(async () => {
     return prisma.$transaction(
       async (tx) => {
+        await prepareVeoPublication(tx, input);
         const where = {
           leagueId: input.leagueId,
           publishedAt: null,
@@ -210,7 +212,7 @@ async function claimUnpublishedLeagueFixtures(input: PublishScope): Promise<Publ
         if (updateResult.count !== fixtureIds.length) throw new Error(PUBLISH_RETRY_ERROR);
         return unpublishedFixtures;
       },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, maxWait: 10000, timeout: 60000 },
     );
   });
 }
@@ -271,7 +273,15 @@ async function publishAndEmailFixtureBatch(input: PublishScope) {
   });
   if (!league) throw new Error("League not found.");
 
-  const unpublishedFixtures = await claimUnpublishedLeagueFixtures(input);
+  let unpublishedFixtures: PublishFixtureRecord[];
+  try {
+    unpublishedFixtures = await claimUnpublishedLeagueFixtures(input);
+  } catch (error) {
+    if (error instanceof VeoAllocationError) {
+      redirect(`/admin/leagues/${input.leagueId}/veo-priority?error=${encodeURIComponent(error.message)}`);
+    }
+    throw error;
+  }
 
   if (unpublishedFixtures.length === 0) {
     revalidatePath("/admin/fixtures");
@@ -390,6 +400,7 @@ async function publishAndEmailFixtureBatch(input: PublishScope) {
   revalidatePath("/admin/night-board");
   revalidatePath(`/admin/leagues/${input.leagueId}`);
   revalidatePath(`/admin/leagues/${input.leagueId}/fixtures`);
+  revalidatePath(`/admin/leagues/${input.leagueId}/veo-priority`);
   if (league.slug) {
     revalidatePath(`/leagues/${league.slug}`);
     revalidatePath(`/leagues/${league.slug}/fixtures`);

--- a/src/app/(admin)/admin/leagues/[id]/layout.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/layout.tsx
@@ -41,6 +41,12 @@ export default async function AdminLeagueLayout({
         >
           Advert video
         </Link>
+        <Link
+          href={`/admin/leagues/${league.id}/veo-priority`}
+          className="min-h-11 rounded-xl border border-fuchsia-400/25 bg-fuchsia-500/10 px-4 py-2 text-sm font-semibold text-fuchsia-100 transition hover:bg-fuchsia-500/15"
+        >
+          Veo Priority
+        </Link>
       </div>
       <MergeLeagueDivisionsButton />
       <AdminLeagueSeasonTeamsPanel />

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/SubmitButton.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/SubmitButton.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { useFormStatus } from 'react-dom';
+export default function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+  return <button type="submit" disabled={pending} className="min-h-11 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white hover:bg-white/20 disabled:cursor-wait disabled:opacity-50">{pending ? 'Saving…' : children}</button>;
+}

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts
@@ -1,0 +1,108 @@
+'use server';
+
+import { randomUUID } from 'node:crypto';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { normaliseVeoPitch } from '@/lib/veo/allocator';
+import { readVeoSettings, readVeoTeams, VeoAllocationError, validVeoDate } from '@/lib/veo/service';
+
+function back(leagueId: string, form: FormData, error?: string) {
+  const query = new URLSearchParams(error ? { error } : { saved: '1' });
+  const date = String(form.get('date') ?? '');
+  if (validVeoDate(date)) query.set('date', date);
+  revalidatePath(`/admin/leagues/${leagueId}/veo-priority`);
+  redirect(`/admin/leagues/${leagueId}/veo-priority?${query}`);
+}
+function message(error: unknown) {
+  if (error instanceof VeoAllocationError) return error.message;
+  console.error('Unable to save Veo settings', error);
+  return 'The change could not be saved. Refresh and try again.';
+}
+export async function saveVeoSettings(leagueId: string, form: FormData) {
+  const { user } = await requireAdmin();
+  let error: string | undefined;
+  try {
+    const enabled = form.get('enabled') === 'on';
+    const pitch = String(form.get('pitch') ?? '').trim();
+    const venueId = String(form.get('venueId') ?? '').trim() || null;
+    const maxMatches = Number(form.get('maxMatches'));
+    const revision = Number(form.get('revision'));
+    if (pitch.length > 40 || (enabled && !normaliseVeoPitch(pitch))) throw new VeoAllocationError('Enter the Veo pitch label used in your fixtures.');
+    if (!Number.isInteger(maxMatches) || maxMatches < 1 || maxMatches > 12) throw new VeoAllocationError('Choose between 1 and 12 matches per night.');
+    await prisma.$transaction(async tx => {
+      const leagues = await tx.$queryRaw<{ id: string }[]>`SELECT id FROM "League" WHERE id = ${leagueId} FOR UPDATE`;
+      if (!leagues.length) throw new VeoAllocationError('League not found.');
+      const previous = await readVeoSettings(leagueId, tx);
+      if (previous.revision !== revision) throw new VeoAllocationError('These settings changed in another window. Refresh before saving.');
+      if (enabled) {
+        const pitches = await tx.$queryRaw<{ pitch: string | null }[]>`
+          SELECT DISTINCT pitch FROM "Fixture" WHERE "leagueId" = ${leagueId}
+          AND "venueId" IS NOT DISTINCT FROM ${venueId} AND status::text = 'SCHEDULED'
+          AND "kickoffAt" > NOW() AT TIME ZONE 'UTC'
+        `;
+        if (!pitches.some(p => normaliseVeoPitch(p.pitch) === normaliseVeoPitch(pitch))) {
+          throw new VeoAllocationError('No upcoming fixture uses that pitch at the selected venue. Check the fixture pitch labels first.');
+        }
+      }
+      await tx.$executeRaw`
+        INSERT INTO "VeoLeagueSettings" ("leagueId", enabled, pitch, "venueId", "maxMatches", "updatedBy")
+        VALUES (${leagueId}, ${enabled}, ${pitch}, ${venueId}, ${maxMatches}, ${user?.id ?? null})
+        ON CONFLICT ("leagueId") DO UPDATE SET enabled = EXCLUDED.enabled, pitch = EXCLUDED.pitch,
+          "venueId" = EXCLUDED."venueId", "maxMatches" = EXCLUDED."maxMatches", "updatedBy" = EXCLUDED."updatedBy",
+          "updatedAt" = NOW(), revision = "VeoLeagueSettings".revision + 1
+      `;
+      const details = JSON.stringify({ kind: 'league_settings', before: previous, after: { enabled, pitch, venueId, maxMatches }, supplementPence: 500 });
+      await tx.$executeRaw`INSERT INTO "VeoSettingsAudit" (id, "leagueId", "actorId", details) VALUES (${randomUUID()}, ${leagueId}, ${user?.id ?? null}, ${details}::jsonb)`;
+    });
+  } catch (e) { error = message(e); }
+  back(leagueId, form, error);
+}
+export async function setVeoTeamPriority(leagueId: string, form: FormData) {
+  const { user } = await requireAdmin();
+  let error: string | undefined;
+  try {
+    const teamId = String(form.get('teamId') ?? '');
+    const enabled = form.get('enabled') === '1';
+    if (enabled && form.get('agreed') !== 'on') throw new VeoAllocationError('Confirm the captain has agreed to the £5 supplement before switching Priority on.');
+    await prisma.$transaction(async tx => {
+      await tx.$queryRaw`SELECT id FROM "League" WHERE id = ${leagueId} FOR UPDATE`;
+      const team = (await readVeoTeams(leagueId, tx)).find(t => t.id === teamId);
+      if (!team || team.teamMode !== 'STANDARD') throw new VeoAllocationError('Choose a standard team in this league. Managed teams and placeholders cannot opt in.');
+      if (team.priority !== (form.get('previous') === '1')) throw new VeoAllocationError('This team setting changed. Refresh before saving.');
+      await tx.$executeRaw`
+        INSERT INTO "VeoTeamPriority" ("leagueId", "teamId", enabled, "updatedBy")
+        VALUES (${leagueId}, ${teamId}, ${enabled}, ${user?.id ?? null})
+        ON CONFLICT ("leagueId", "teamId") DO UPDATE SET enabled = EXCLUDED.enabled, "updatedAt" = NOW(), "updatedBy" = EXCLUDED."updatedBy"
+      `;
+      const details = JSON.stringify({ kind: 'team_priority', before: team.priority, enabled, captainAgreementConfirmed: enabled, supplementPence: 500 });
+      await tx.$executeRaw`INSERT INTO "VeoSettingsAudit" (id, "leagueId", "teamId", "actorId", details) VALUES (${randomUUID()}, ${leagueId}, ${teamId}, ${user?.id ?? null}, ${details}::jsonb)`;
+    });
+  } catch (e) { error = message(e); }
+  revalidatePath('/captain/team/[teamid]/fixtures', 'layout');
+  back(leagueId, form, error);
+}
+export async function saveVeoVideo(leagueId: string, form: FormData) {
+  await requireAdmin();
+  let error: string | undefined;
+  try {
+    const fixtureId = String(form.get('fixtureId') ?? '');
+    const raw = String(form.get('videoUrl') ?? '').trim();
+    if (raw) {
+      let url: URL;
+      try { url = new URL(raw); } catch { throw new VeoAllocationError('Enter a full HTTPS YouTube or SIXFL TV link.'); }
+      if (raw.length > 2000 || url.protocol !== 'https:' || url.username || url.password || url.port
+        || !['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'sixfl.co.uk', 'www.sixfl.co.uk'].includes(url.hostname)) {
+        throw new VeoAllocationError('Use an HTTPS YouTube or SIXFL TV link.');
+      }
+    }
+    const rows = await prisma.$queryRaw<{ fixtureId: string }[]>`SELECT "fixtureId" FROM "VeoFixtureSnapshot" WHERE "fixtureId" = ${fixtureId} AND "leagueId" = ${leagueId} AND allocated`;
+    if (!rows.length) throw new VeoAllocationError('No Veo allocation exists for this fixture in this league.');
+    await prisma.fixture.update({ where: { id: fixtureId }, data: { sixflTvUrl: raw || null }, select: { id: true } });
+    revalidatePath('/captain/team/[teamid]/fixtures', 'layout');
+    revalidatePath('/leagues/[slug]/fixtures', 'page');
+    revalidatePath('/player/team/[teamid]', 'page');
+  } catch (e) { error = message(e); }
+  back(leagueId, form, error);
+}

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts
@@ -84,7 +84,7 @@ export async function setVeoTeamPriority(leagueId: string, form: FormData) {
   back(leagueId, form, error);
 }
 export async function saveVeoVideo(leagueId: string, form: FormData) {
-  await requireAdmin();
+  const { user } = await requireAdmin();
   let error: string | undefined;
   try {
     const fixtureId = String(form.get('fixtureId') ?? '');
@@ -97,9 +97,17 @@ export async function saveVeoVideo(leagueId: string, form: FormData) {
         throw new VeoAllocationError('Use an HTTPS YouTube or SIXFL TV link.');
       }
     }
-    const rows = await prisma.$queryRaw<{ fixtureId: string }[]>`SELECT "fixtureId" FROM "VeoFixtureSnapshot" WHERE "fixtureId" = ${fixtureId} AND "leagueId" = ${leagueId} AND allocated`;
-    if (!rows.length) throw new VeoAllocationError('No Veo allocation exists for this fixture in this league.');
-    await prisma.fixture.update({ where: { id: fixtureId }, data: { sixflTvUrl: raw || null }, select: { id: true } });
+    await prisma.$transaction(async tx => {
+      // Media-only edit: completed fixtures keep their result, schedule and financial locks.
+      const updated = await tx.$executeRaw`
+        UPDATE "Fixture" f SET "sixflTvUrl" = ${raw || null}, "updatedAt" = NOW()
+        FROM "VeoFixtureSnapshot" s WHERE s."fixtureId" = f.id AND f.id = ${fixtureId}
+          AND s."leagueId" = ${leagueId} AND f."leagueId" = ${leagueId} AND s.allocated
+      `;
+      if (updated !== 1) throw new VeoAllocationError('No Veo allocation exists for this fixture in this league.');
+      const details = JSON.stringify({ kind: 'video_link', fixtureId, url: raw || null });
+      await tx.$executeRaw`INSERT INTO "VeoSettingsAudit" (id, "leagueId", "actorId", details) VALUES (${randomUUID()}, ${leagueId}, ${user?.id ?? null}, ${details}::jsonb)`;
+    });
     revalidatePath('/captain/team/[teamid]/fixtures', 'layout');
     revalidatePath('/leagues/[slug]/fixtures', 'page');
     revalidatePath('/player/team/[teamid]', 'page');

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/page.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/page.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/requireAdmin';
-import { resolveTeamFixtureFeePence } from '@/lib/payments/fixture-fee-policy';
 import { normaliseVeoPitch } from '@/lib/veo/allocator';
 import { londonVeoDate, previewVeoNight, quoteVeoFixture, readVeoNight, readVeoSettings, readVeoSnapshots, readVeoTeams, validVeoDate, VeoAllocationError } from '@/lib/veo/service';
 import { saveVeoSettings, setVeoTeamPriority, saveVeoVideo } from './actions';
@@ -106,11 +105,11 @@ export default async function VeoPriorityPage({ params, searchParams }: {
         const q = !f.locked && f.eligible ? quoteVeoFixture(f, Boolean(choice)) : null;
         const fees = saved ? [{ name: f.homeName, base: saved.homeBasePence, extra: saved.homeSupplementPence }, { name: f.awayName, base: saved.awayBasePence, extra: saved.awaySupplementPence }]
           : q ? [{ name: f.homeName, base: q.home.basePence, extra: q.home.supplementPence }, { name: f.awayName, base: q.away.basePence, extra: q.away.supplementPence }]
-          : [{ name: f.homeName, base: resolveTeamFixtureFeePence(f.homeMatchFeePence, f.homeStandard, f.matchFeePence), extra: 0 }, { name: f.awayName, base: resolveTeamFixtureFeePence(f.awayMatchFeePence, f.awayStandard, f.matchFeePence), extra: 0 }];
+          : [];
         return <article key={f.id} className="space-y-3 rounded-xl border border-white/10 bg-black/20 p-4">
           <div className="flex flex-wrap items-start justify-between gap-3"><div><h3 className="font-semibold">{time(f.kickoffAt)} · {f.homeName} vs {f.awayName}</h3><p className="mt-1 text-sm text-white/60">Pitch {normaliseVeoPitch(saved?.pitch ?? newPitch ?? null) || 'not set'}{choice?.swapWithId || displaced ? ' · pitch swap proposed' : ''}</p></div><span className="rounded-full border border-white/20 px-3 py-1 text-xs">{filmed ? '📹 Veo / SIXFL TV' : 'Not allocated to Veo'}</span></div>
           <p className="text-xs text-white/50">{saved ? 'Saved at publication — original price snapshot' : f.locked ? 'Existing / locked fixture — unchanged by Veo' : 'Preview only — not yet saved'}</p>
-          <div className="grid gap-2 sm:grid-cols-2">{fees.map(fee => <p key={fee.name} className="text-sm leading-6"><span className="text-white/65">{fee.name}: </span>{money(fee.base)}{fee.extra > 0 && ` + ${money(fee.extra)} Veo Priority`}<strong> = {money(fee.base + fee.extra)}</strong></p>)}</div>
+          {fees.length > 0 ? <div className="grid gap-2 sm:grid-cols-2">{fees.map(fee => <p key={fee.name} className="text-sm leading-6"><span className="text-white/65">{fee.name}: </span>{money(fee.base)}{fee.extra > 0 && ` + ${money(fee.extra)} Veo Priority`}<strong> = {money(fee.base + fee.extra)}</strong></p>)}</div> : <p className="text-sm text-white/60">Veo has not changed this fixture’s fees. See Payments for any current charge.</p>}
           {saved?.allocated && <details className="text-sm"><summary className="cursor-pointer py-2 text-fuchsia-200">YouTube / SIXFL TV link</summary><form action={saveVeoVideo.bind(null, id)} className="mt-2 flex flex-col gap-3 sm:flex-row"><input type="hidden" name="date" value={date} /><input type="hidden" name="fixtureId" value={f.id} /><input aria-label={`Video link for ${f.homeName} vs ${f.awayName}`} type="url" name="videoUrl" defaultValue={f.sixflTvUrl ?? ''} placeholder="https://www.youtube.com/watch?v=…" className={input} /><SubmitButton>Save video link</SubmitButton></form></details>}
         </article>;
       })}{!fixtures.length && <p className="py-4 text-white/60">No fixtures on this date.</p>}</div>

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/page.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/page.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { resolveTeamFixtureFeePence } from '@/lib/payments/fixture-fee-policy';
+import { normaliseVeoPitch } from '@/lib/veo/allocator';
+import { londonVeoDate, previewVeoNight, quoteVeoFixture, readVeoNight, readVeoSettings, readVeoSnapshots, readVeoTeams, validVeoDate, VeoAllocationError } from '@/lib/veo/service';
+import { saveVeoSettings, setVeoTeamPriority, saveVeoVideo } from './actions';
+import SubmitButton from './SubmitButton';
+
+export const dynamic = 'force-dynamic';
+const money = (pence: number) => new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(pence / 100);
+const time = (date: Date) => new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/London', hour: '2-digit', minute: '2-digit' }).format(date);
+const input = 'min-h-11 w-full rounded-xl border border-white/20 bg-black/30 px-3 py-2 text-white';
+const panel = 'space-y-4 rounded-2xl border border-white/10 bg-white/[0.03] p-5 sm:p-6';
+
+export default async function VeoPriorityPage({ params, searchParams }: {
+  params: Promise<{ id: string }>; searchParams: Promise<{ date?: string; saved?: string; error?: string }>;
+}) {
+  await requireAdmin();
+  const { id } = await params;
+  const query = await searchParams;
+  const league = await prisma.league.findUnique({ where: { id }, select: { id: true, name: true, venueName: true } });
+  if (!league) notFound();
+  const next = await prisma.fixture.findFirst({ where: { leagueId: id, status: 'SCHEDULED', kickoffAt: { gt: new Date() } }, orderBy: { kickoffAt: 'asc' }, select: { kickoffAt: true } });
+  const date = query.date && validVeoDate(query.date) ? query.date : londonVeoDate(next?.kickoffAt ?? new Date());
+  const [settings, teams, snapshots, venues, fixtures] = await Promise.all([
+    readVeoSettings(id), readVeoTeams(id), readVeoSnapshots(id, date),
+    prisma.$queryRaw<{ id: string | null; name: string }[]>`
+      SELECT DISTINCT f."venueId" AS id, COALESCE(v.name, ${league.venueName || 'League venue (not set on fixtures)'}) AS name
+      FROM "Fixture" f LEFT JOIN "Venue" v ON v.id = f."venueId" WHERE f."leagueId" = ${id}
+      UNION SELECT s."venueId" AS id, COALESCE(v.name, ${league.venueName || 'League venue (not set on fixtures)'}) AS name
+      FROM "VeoLeagueSettings" s LEFT JOIN "Venue" v ON v.id = s."venueId" WHERE s."leagueId" = ${id}
+    `,
+    readVeoNight(id, date),
+  ]);
+  let choices: Awaited<ReturnType<typeof previewVeoNight>>['choices'] = [];
+  let previewError = '';
+  try { choices = (await previewVeoNight(id, date)).choices; }
+  catch (error) { if (error instanceof VeoAllocationError) previewError = error.message; else throw error; }
+  const chosen = new Set(choices.map(c => c.fixtureId));
+  const savedById = new Map(snapshots.map(s => [s.fixtureId, s]));
+  const priorityIds = new Set<string>();
+  const coveredIds = new Set<string>();
+  let supplement = 0;
+  let allocatedCount = 0;
+  for (const f of fixtures) {
+    const s = savedById.get(f.id);
+    const allocated = s?.allocated ?? (chosen.has(f.id) || f.filmed);
+    if (s?.homePriority ?? f.homePriority) priorityIds.add(f.homeTeamId);
+    if (s?.awayPriority ?? f.awayPriority) priorityIds.add(f.awayTeamId);
+    if (allocated) { allocatedCount++; coveredIds.add(f.homeTeamId); coveredIds.add(f.awayTeamId); }
+    if (s) supplement += s.homeSupplementPence + s.awaySupplementPence;
+    else if (!f.locked && f.eligible) { const q = quoteVeoFixture(f, chosen.has(f.id)); supplement += q.home.supplementPence + q.away.supplementPence; }
+  }
+  const missed = [...priorityIds].filter(teamId => !coveredIds.has(teamId)).map(teamId => teams.find(t => t.id === teamId)?.name ?? fixtures.flatMap(f => [{ id: f.homeTeamId, name: f.homeName }, { id: f.awayTeamId, name: f.awayName }]).find(t => t.id === teamId)?.name ?? 'Team');
+  const venueOptions = venues.length ? venues : [{ id: null, name: league.venueName || 'League venue (not set on fixtures)' }];
+
+  return <div className="mx-auto max-w-7xl space-y-6 text-white">
+    <header className="space-y-2">
+      <div className="flex flex-wrap items-center gap-3"><h1 className="text-3xl font-semibold">Veo Priority</h1><span className={`rounded-full border px-3 py-1 text-sm font-semibold ${settings.enabled ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-100' : 'border-white/20 bg-white/5 text-white/70'}`}>{settings.enabled ? 'ON for this league' : 'OFF for this league'}</span></div>
+      <p className="max-w-3xl text-sm leading-6 text-white/65">{league.name}. Priority teams pay their normal match fee plus £5 only when allocated to a Veo match. Other teams keep their normal fee, even when filmed. Free matches stay free.</p>
+    </header>
+    {query.saved && <p role="status" className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-4">Saved. No existing fixtures or charges were recalculated.</p>}
+    {query.error && <p role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 p-4">{query.error.slice(0, 500)}</p>}
+    <section className={panel}>
+      <h2 className="text-xl font-semibold">League settings</h2>
+      <form action={saveVeoSettings.bind(null, id)} className="space-y-5">
+        <input type="hidden" name="date" value={date} /><input type="hidden" name="revision" value={settings.revision} />
+        <label className="flex min-h-11 items-center gap-3"><input type="checkbox" name="enabled" defaultChecked={settings.enabled} className="h-5 w-5" />Enable Veo Priority for future fixture publication</label>
+        <div className="grid gap-5 sm:grid-cols-2">
+          <label className="space-y-2"><span className="block text-sm text-white/70">Veo pitch label</span><input name="pitch" defaultValue={settings.pitch} maxLength={40} placeholder="For example: Pitch 1" className={input} /></label>
+          <label className="space-y-2"><span className="block text-sm text-white/70">Maximum filmed matches per night</span><input name="maxMatches" type="number" min={1} max={12} step={1} required defaultValue={settings.maxMatches} className={input} /></label>
+        </div>
+        <fieldset className="space-y-2"><legend className="mb-2 text-sm text-white/70">Veo venue</legend>{venueOptions.map(v => <label key={v.id ?? 'none'} className="flex min-h-11 items-center gap-3"><input type="radio" name="venueId" value={v.id ?? ''} defaultChecked={v.id === settings.venueId || (venueOptions.length === 1 && settings.revision === 0)} />{v.name}</label>)}</fieldset>
+        <p className="text-sm leading-6 text-white/60">Default capacity: three matches. Allocation prefers Priority-v-Priority fixtures, then gives preference to teams with fewer previous filmed games. It only swaps pitches at the same venue and kick-off time. Published, billed, past and manually marked TV fixtures are left alone.</p>
+        <SubmitButton>Save league settings</SubmitButton>
+      </form>
+    </section>
+    <section className={panel}>
+      <h2 className="text-xl font-semibold">Team Priority</h2>
+      <p className="text-sm leading-6 text-white/60">Record the captain’s agreement before opting a team in. Priority is not a guarantee of filming. Changing a switch affects future publications only; it never changes a saved fixture price. No announcement or payment message is sent by these switches.</p>
+      <div className="divide-y divide-white/10">{teams.map(team => <div key={team.id} className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div><Link href={`/admin/teams/${team.id}`} className="font-semibold hover:underline">{team.name}</Link><p className="mt-1 text-sm text-white/60">{team.teamMode === 'STANDARD' ? `Normal fee ${money(team.standardMatchFeePence ?? 4000)} · Priority ${team.priority ? 'ON' : 'OFF'}` : 'Managed team — Priority not available'}</p></div>
+        {team.teamMode === 'STANDARD' && <form action={setVeoTeamPriority.bind(null, id)} className="flex flex-wrap items-center gap-3 sm:max-w-md">
+          <input type="hidden" name="date" value={date} /><input type="hidden" name="teamId" value={team.id} /><input type="hidden" name="previous" value={team.priority ? '1' : '0'} /><input type="hidden" name="enabled" value={team.priority ? '0' : '1'} />
+          {!team.priority && <label className="flex items-start gap-2 text-xs leading-5 text-white/70"><input type="checkbox" name="agreed" required className="mt-1" />Captain has agreed to the £5 filmed-match supplement</label>}
+          <SubmitButton>{team.priority ? 'Switch Priority off' : 'Switch Priority on'}</SubmitButton>
+        </form>}
+      </div>)}{!teams.length && <p className="py-3 text-white/60">No teams are currently linked to this league or its upcoming fixtures.</p>}</div>
+    </section>
+    <section className={panel}>
+      <h2 className="text-xl font-semibold">Match-night preview and saved allocations</h2>
+      <form method="get" className="flex flex-wrap items-end gap-3"><label className="space-y-2"><span className="block text-sm text-white/70">Match date (UK time)</span><input name="date" type="date" required defaultValue={date} className={input} /></label><button className="min-h-11 rounded-xl border border-white/20 px-4 py-2">Show night</button></form>
+      <p className="text-sm leading-6 text-white/60">This preview does not save anything. Use the normal Publish fixtures action for the whole league night, without a division filter. Allocation and the £5 price snapshots are saved together with publication. Settings can change the preview until then.</p>
+      {!settings.enabled && <p className="rounded-xl bg-white/5 p-4 text-sm">Veo is off. No new allocations or supplements will be added. Existing saved agreements remain visible below.</p>}
+      {previewError && <p role="alert" className="rounded-xl border border-amber-400/30 p-4 text-amber-100">{previewError}</p>}
+      <div className="grid gap-3 sm:grid-cols-3">{[[String(allocatedCount), 'TV matches: saved + preview'], [String(missed.length), 'Priority teams not allocated'], [money(supplement), 'Veo supplement value: saved + preview']].map(([value, label]) => <div key={label} className="rounded-xl border border-white/10 bg-black/20 p-4"><div className="text-2xl font-semibold">{value}</div><p className="mt-1 text-xs leading-5 text-white/60">{label}</p></div>)}</div>
+      <p className="text-xs leading-5 text-white/50">Supplement value is the original agreement or preview, not cash received. Payment corrections and refunds are tracked in Payments. A TV allocation is a filming plan, not confirmation that footage has been uploaded.</p>
+      {missed.length > 0 && <p className="text-sm leading-6 text-amber-100">Not allocated: {missed.join(', ')}. No new Veo supplement is added for these teams.</p>}
+      <div className="space-y-3">{fixtures.map(f => {
+        const saved = savedById.get(f.id); const choice = choices.find(c => c.fixtureId === f.id);
+        const displaced = choices.find(c => c.swapWithId === f.id);
+        const newPitch = choice?.pitch ?? (displaced ? fixtures.find(x => x.id === displaced.fixtureId)?.pitch : f.pitch);
+        const filmed = saved?.allocated ?? (Boolean(choice) || f.filmed);
+        const q = !f.locked && f.eligible ? quoteVeoFixture(f, Boolean(choice)) : null;
+        const fees = saved ? [{ name: f.homeName, base: saved.homeBasePence, extra: saved.homeSupplementPence }, { name: f.awayName, base: saved.awayBasePence, extra: saved.awaySupplementPence }]
+          : q ? [{ name: f.homeName, base: q.home.basePence, extra: q.home.supplementPence }, { name: f.awayName, base: q.away.basePence, extra: q.away.supplementPence }]
+          : [{ name: f.homeName, base: resolveTeamFixtureFeePence(f.homeMatchFeePence, f.homeStandard, f.matchFeePence), extra: 0 }, { name: f.awayName, base: resolveTeamFixtureFeePence(f.awayMatchFeePence, f.awayStandard, f.matchFeePence), extra: 0 }];
+        return <article key={f.id} className="space-y-3 rounded-xl border border-white/10 bg-black/20 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3"><div><h3 className="font-semibold">{time(f.kickoffAt)} · {f.homeName} vs {f.awayName}</h3><p className="mt-1 text-sm text-white/60">Pitch {normaliseVeoPitch(saved?.pitch ?? newPitch ?? null) || 'not set'}{choice?.swapWithId || displaced ? ' · pitch swap proposed' : ''}</p></div><span className="rounded-full border border-white/20 px-3 py-1 text-xs">{filmed ? '📹 Veo / SIXFL TV' : 'Not allocated to Veo'}</span></div>
+          <p className="text-xs text-white/50">{saved ? 'Saved at publication — original price snapshot' : f.locked ? 'Existing / locked fixture — unchanged by Veo' : 'Preview only — not yet saved'}</p>
+          <div className="grid gap-2 sm:grid-cols-2">{fees.map(fee => <p key={fee.name} className="text-sm leading-6"><span className="text-white/65">{fee.name}: </span>{money(fee.base)}{fee.extra > 0 && ` + ${money(fee.extra)} Veo Priority`}<strong> = {money(fee.base + fee.extra)}</strong></p>)}</div>
+          {saved?.allocated && <details className="text-sm"><summary className="cursor-pointer py-2 text-fuchsia-200">YouTube / SIXFL TV link</summary><form action={saveVeoVideo.bind(null, id)} className="mt-2 flex flex-col gap-3 sm:flex-row"><input type="hidden" name="date" value={date} /><input type="hidden" name="fixtureId" value={f.id} /><input aria-label={`Video link for ${f.homeName} vs ${f.awayName}`} type="url" name="videoUrl" defaultValue={f.sixflTvUrl ?? ''} placeholder="https://www.youtube.com/watch?v=…" className={input} /><SubmitButton>Save video link</SubmitButton></form></details>}
+        </article>;
+      })}{!fixtures.length && <p className="py-4 text-white/60">No fixtures on this date.</p>}</div>
+      <Link href={`/admin/fixtures?leagueId=${id}`} className="inline-flex min-h-11 items-center rounded-xl border border-white/20 px-4 py-2 text-sm font-semibold">Open fixtures to publish</Link>
+    </section>
+  </div>;
+}

--- a/src/app/captain/team/[teamid]/fixtures/layout.tsx
+++ b/src/app/captain/team/[teamid]/fixtures/layout.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+import { prisma } from '@/lib/prisma';
+import { requireCaptain } from '@/lib/requireCaptain';
+import SixflTvFixtureBadge from '@/components/sixfl-tv/SixflTvFixtureBadge';
+
+type Row = { fixtureId: string; kickoffAt: Date; allocated: boolean; priority: boolean; base: number; extra: number; opponent: string; url: string | null };
+const money = (pence: number) => new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(pence / 100);
+
+export default async function CaptainFixturesLayout({ children, params }: { children: ReactNode; params: Promise<{ teamid: string }> }) {
+  const { teamid } = await params;
+  await requireCaptain(teamid);
+  const rows = await prisma.$queryRaw<Row[]>`
+    SELECT s."fixtureId", s."kickoffAt", s.allocated, f."sixflTvUrl" AS url,
+      CASE WHEN s."homeTeamId" = ${teamid} THEN s."homePriority" ELSE s."awayPriority" END AS priority,
+      CASE WHEN s."homeTeamId" = ${teamid} THEN s."homeBasePence" ELSE s."awayBasePence" END AS base,
+      CASE WHEN s."homeTeamId" = ${teamid} THEN s."homeSupplementPence" ELSE s."awaySupplementPence" END AS extra,
+      opponent.name AS opponent
+    FROM "VeoFixtureSnapshot" s JOIN "Fixture" f ON f.id = s."fixtureId"
+    JOIN "Team" opponent ON opponent.id = CASE WHEN s."homeTeamId" = ${teamid} THEN s."awayTeamId" ELSE s."homeTeamId" END
+    WHERE (s."homeTeamId" = ${teamid} OR s."awayTeamId" = ${teamid}) AND f."publishedAt" IS NOT NULL
+      AND f.status::text NOT IN ('CANCELLED', 'POSTPONED') AND s."kickoffAt" >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '7 days'
+    ORDER BY s."kickoffAt" LIMIT 8
+  `;
+  return <div className="space-y-6">
+    {rows.length > 0 && <section className="space-y-4 rounded-2xl border border-fuchsia-400/20 bg-fuchsia-500/5 p-5 text-white">
+      <h2 className="text-lg font-semibold">Your Veo match allocations</h2>
+      <p className="text-sm leading-6 text-white/65">Priority adds £5 only when your team is allocated to a Veo match. The opposition’s Priority choice never changes your fee. Filming is subject to availability.</p>
+      {rows.map(row => <div key={row.fixtureId} className="space-y-2 rounded-xl border border-white/10 bg-black/20 p-4">
+        <div className="flex flex-wrap items-center gap-3"><strong>vs {row.opponent}</strong><span className="text-sm text-white/65">{new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/London', weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }).format(row.kickoffAt)}</span><SixflTvFixtureBadge recorded={row.allocated} url={row.url} /></div>
+        <p className="text-sm leading-6">{row.allocated ? '📹 Allocated for filming.' : row.priority ? 'Priority on, but no Veo slot this time. No Veo supplement.' : 'No Veo allocation.'}</p>
+        <p className="text-sm">Match fee {money(row.base)}{row.extra > 0 && ` + Veo Priority ${money(row.extra)}`}<strong> = {money(row.base + row.extra)}</strong></p>
+      </div>)}
+      <p className="text-xs leading-5 text-white/50">These are the prices agreed when the fixtures were published. Payments shows any later corrections or refunds. Video links appear when footage is added.</p>
+    </section>}
+    {children}
+  </div>;
+}

--- a/src/lib/veo/allocator.ts
+++ b/src/lib/veo/allocator.ts
@@ -1,0 +1,82 @@
+/** Pure, deterministic allocation. Only exchange pitches in the same venue/time slot. */
+export const VEO_SUPPLEMENT_PENCE = 500;
+export type VeoFixture = {
+  id: string; kickoffMs: number; durationMinutes: number; venueId: string | null;
+  pitch: string | null; homeTeamId: string; awayTeamId: string;
+  homePriority: boolean; awayPriority: boolean; locked: boolean; eligible: boolean;
+  filmed: boolean;
+};
+export type VeoHistory = Record<string, { count: number; lastMs: number }>;
+export type VeoSettings = { enabled: boolean; pitch: string; venueId: string | null; maxMatches: number };
+export type VeoChoice = { fixtureId: string; swapWithId: string | null; pitch: string };
+export function normaliseVeoPitch(value: string | null): string {
+  return (value ?? '').trim().toLowerCase().replace(/^(?:pitch\s*)+/, '').trim();
+}
+export function veoFee(basePence: number, priority: boolean, allocated: boolean) {
+  if (!Number.isSafeInteger(basePence) || basePence < 0) throw new Error('Invalid base match fee.');
+  // Explicit free matches remain free, including replacement/promotional fixtures.
+  const supplementPence = priority && allocated && basePence > 0 ? VEO_SUPPLEMENT_PENCE : 0;
+  if (!Number.isSafeInteger(basePence + supplementPence)) throw new Error('Invalid total match fee.');
+  return { basePence, supplementPence, totalPence: basePence + supplementPence };
+}
+function overlaps(a: VeoFixture, b: VeoFixture) {
+  return a.kickoffMs < b.kickoffMs + b.durationMinutes * 60000 && b.kickoffMs < a.kickoffMs + a.durationMinutes * 60000;
+}
+type Ranked = { fixture: VeoFixture; anchor: VeoFixture; score: number[] };
+function compareScore(a: number[], b: number[]) {
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+function rank(f: VeoFixture, history: VeoHistory): number[] {
+  const ids = [f.homeTeamId, f.awayTeamId];
+  const priorityIds = ids.filter((_, i) => i === 0 ? f.homePriority : f.awayPriority);
+  const fairIds = priorityIds.length ? priorityIds : ids;
+  return [priorityIds.length, priorityIds.length === 2 ? 1 : 0, 1,
+    -fairIds.reduce((sum, id) => sum + (history[id]?.count ?? 0), 0),
+    -fairIds.reduce((sum, id) => sum + (history[id]?.lastMs ?? 0), 0)];
+}
+/** One call represents ONE London calendar night. Published/billed fixtures are never moved. */
+export function allocateVeoNight(fixtures: VeoFixture[], settings: VeoSettings, history: VeoHistory = {}): VeoChoice[] {
+  if (!settings.enabled) return [];
+  if (!normaliseVeoPitch(settings.pitch) || !Number.isInteger(settings.maxMatches) || settings.maxMatches < 1 || settings.maxMatches > 12) {
+    throw new Error('Choose a Veo pitch and a capacity between 1 and 12.');
+  }
+  if (new Set(fixtures.map(f => f.id)).size !== fixtures.length) throw new Error('Duplicate fixture IDs.');
+  if (fixtures.some(f => !Number.isFinite(f.kickoffMs) || !Number.isInteger(f.durationMinutes) || f.durationMinutes < 1 || f.durationMinutes > 180)) {
+    throw new Error('Invalid fixture timing.');
+  }
+  const atVenue = fixtures.filter(f => f.venueId === settings.venueId);
+  const anchors = atVenue.filter(f => normaliseVeoPitch(f.pitch) === normaliseVeoPitch(settings.pitch));
+  if (new Set(anchors.map(f => f.kickoffMs)).size !== anchors.length) throw new Error('The Veo pitch is double-booked. Fix the fixtures before publishing.');
+  const fixed = anchors.filter(f => f.locked);
+  const capacity = Math.max(0, settings.maxMatches - fixed.filter(f => f.filmed).length);
+  if (!capacity) return [];
+  const options: Ranked[] = [];
+  for (const anchor of anchors) {
+    if (anchor.locked || fixed.some(f => overlaps(f, anchor))) continue;
+    const candidates = atVenue.filter(f => !f.locked && f.eligible && normaliseVeoPitch(f.pitch)
+      && f.kickoffMs === anchor.kickoffMs && f.durationMinutes === anchor.durationMinutes);
+    candidates.sort((a, b) => compareScore(rank(b, history), rank(a, history)) || a.id.localeCompare(b.id));
+    if (candidates[0]) options.push({ fixture: candidates[0], anchor, score: rank(candidates[0], history) });
+  }
+  options.sort((a, b) => (a.anchor.kickoffMs + a.anchor.durationMinutes * 60000)
+    - (b.anchor.kickoffMs + b.anchor.durationMinutes * 60000) || a.fixture.id.localeCompare(b.fixture.id));
+  // Capacity-limited weighted interval scheduling, not a greedy choice that can lose two slots.
+  type Plan = { score: number[]; picks: Ranked[] };
+  const zero = (): Plan => ({ score: [0, 0, 0, 0, 0], picks: [] });
+  const dp: Plan[][] = Array.from({ length: options.length + 1 }, () => Array.from({ length: capacity + 1 }, zero));
+  for (let i = 1; i <= options.length; i++) {
+    const option = options[i - 1];
+    let previous = i - 1;
+    while (previous > 0 && overlaps(options[previous - 1].anchor, option.anchor)) previous--;
+    for (let k = 1; k <= capacity; k++) {
+      const prior = dp[previous][k - 1];
+      const take = { score: option.score.map((v, n) => v + prior.score[n]), picks: [...prior.picks, option] };
+      const skip = dp[i - 1][k];
+      dp[i][k] = compareScore(take.score, skip.score) > 0 ? take : skip;
+    }
+  }
+  return dp[options.length][capacity].picks.map(({ fixture, anchor }) => ({
+    fixtureId: fixture.id, swapWithId: fixture.id === anchor.id ? null : anchor.id, pitch: anchor.pitch!,
+  }));
+}

--- a/src/lib/veo/service.ts
+++ b/src/lib/veo/service.ts
@@ -1,0 +1,163 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { resolveTeamFixtureFeePence } from '@/lib/payments/fixture-fee-policy';
+import { allocateVeoNight, veoFee, type VeoFixture, type VeoHistory, type VeoSettings } from './allocator';
+
+type Db = Prisma.TransactionClient;
+export class VeoAllocationError extends Error {}
+export type LeagueVeoSettings = VeoSettings & { revision: number };
+export type VeoTeam = { id: string; name: string; teamMode: string; standardMatchFeePence: number | null; priority: boolean };
+export type VeoNightFixture = VeoFixture & {
+  kickoffAt: Date; homeName: string; awayName: string; publishedAt: Date | null;
+  homeMatchFeePence: number | null; awayMatchFeePence: number | null; matchFeePence: number | null;
+  homeStandard: number | null; awayStandard: number | null; sixflTvUrl: string | null;
+};
+export function londonVeoDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/London', year: 'numeric', month: '2-digit', day: '2-digit' }).format(date);
+}
+export function validVeoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T12:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+export async function readVeoSettings(leagueId: string, db: Db = prisma): Promise<LeagueVeoSettings> {
+  const rows = await db.$queryRaw<LeagueVeoSettings[]>`
+    SELECT "enabled", "pitch", "venueId", "maxMatches", "revision" FROM "VeoLeagueSettings" WHERE "leagueId" = ${leagueId}
+  `;
+  return rows[0] ?? { enabled: false, pitch: '', venueId: null, maxMatches: 3, revision: 0 };
+}
+export async function readVeoTeams(leagueId: string, db: Db = prisma): Promise<VeoTeam[]> {
+  return db.$queryRaw<VeoTeam[]>`
+    SELECT t.id, t.name, t."teamMode"::text AS "teamMode", t."standardMatchFeePence",
+      COALESCE(p.enabled, false) AS priority
+    FROM "Team" t LEFT JOIN "VeoTeamPriority" p ON p."teamId" = t.id AND p."leagueId" = ${leagueId}
+    WHERE NOT t."isFixturePlaceholder" AND (t."leagueId" = ${leagueId} OR EXISTS (
+      SELECT 1 FROM "Fixture" f WHERE f."leagueId" = ${leagueId} AND f."kickoffAt" > NOW() AT TIME ZONE 'UTC'
+      AND (f."homeTeamId" = t.id OR f."awayTeamId" = t.id)
+    )) ORDER BY t.name, t.id
+  `;
+}
+export async function readVeoNight(leagueId: string, date: string, db: Db = prisma): Promise<VeoNightFixture[]> {
+  if (!validVeoDate(date)) throw new VeoAllocationError('Choose a valid match date.');
+  const rows = await db.$queryRaw<(Omit<VeoNightFixture, 'kickoffMs'>)[]>`
+    SELECT f.id, f."kickoffAt", f."venueId", f.pitch, f."homeTeamId", f."awayTeamId", f."publishedAt",
+      f."homeMatchFeePence", f."awayMatchFeePence", f."matchFeePence", f."sixflTvUrl",
+      h.name AS "homeName", a.name AS "awayName", h."standardMatchFeePence" AS "homeStandard", a."standardMatchFeePence" AS "awayStandard",
+      COALESCE(NULLIF(l."minutesPerGame", 0), 40) AS "durationMinutes",
+      (COALESCE(hp.enabled, false) AND h."teamMode"::text = 'STANDARD') AS "homePriority",
+      (COALESCE(ap.enabled, false) AND a."teamMode"::text = 'STANDARD') AS "awayPriority",
+      (NOT h."isFixturePlaceholder" AND NOT a."isFixturePlaceholder" AND h.id <> a.id AND f.status::text = 'SCHEDULED') AS eligible,
+      (f."publishedAt" IS NOT NULL OR f."kickoffAt" <= NOW() AT TIME ZONE 'UTC' OR f.status::text <> 'SCHEDULED'
+       OR f."sixflTvRecorded" OR EXISTS (SELECT 1 FROM "VeoFixtureSnapshot" s WHERE s."fixtureId" = f.id)
+       OR EXISTS (SELECT 1 FROM "PaymentCharge" c WHERE c."fixtureId" = f.id)
+       OR EXISTS (SELECT 1 FROM "PlayerMatchFee" c WHERE c."fixtureId" = f.id)) AS locked,
+      f."sixflTvRecorded" AS filmed
+    FROM "Fixture" f JOIN "League" l ON l.id = f."leagueId"
+      JOIN "Team" h ON h.id = f."homeTeamId" JOIN "Team" a ON a.id = f."awayTeamId"
+      LEFT JOIN "VeoTeamPriority" hp ON hp."leagueId" = f."leagueId" AND hp."teamId" = h.id
+      LEFT JOIN "VeoTeamPriority" ap ON ap."leagueId" = f."leagueId" AND ap."teamId" = a.id
+    WHERE f."leagueId" = ${leagueId}
+      AND to_char(f."kickoffAt" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/London', 'YYYY-MM-DD') = ${date}
+      AND f.status::text NOT IN ('CANCELLED', 'POSTPONED')
+    ORDER BY f."kickoffAt", f.id
+  `;
+  return rows.map(row => ({ ...row, kickoffMs: row.kickoffAt.getTime() }));
+}
+async function readVeoHistory(leagueId: string, beforeDate: string, db: Db): Promise<VeoHistory> {
+  const rows = await db.$queryRaw<{ teamId: string; count: number; last: Date }[]>`
+    SELECT side."teamId", COUNT(*)::integer AS count, MAX(f."kickoffAt") AS last
+    FROM "Fixture" f CROSS JOIN LATERAL (VALUES (f."homeTeamId"), (f."awayTeamId")) AS side("teamId")
+    WHERE f."leagueId" = ${leagueId} AND f."sixflTvRecorded" AND f.status::text NOT IN ('CANCELLED', 'POSTPONED')
+      AND to_char(f."kickoffAt" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/London', 'YYYY-MM-DD') < ${beforeDate}
+    GROUP BY side."teamId"
+  `;
+  return Object.fromEntries(rows.map(row => [row.teamId, { count: row.count, lastMs: row.last.getTime() }]));
+}
+export async function previewVeoNight(leagueId: string, date: string, db: Db = prisma) {
+  const settings = await readVeoSettings(leagueId, db);
+  const fixtures = await readVeoNight(leagueId, date, db);
+  const history = await readVeoHistory(leagueId, date, db);
+  try {
+    return { settings, fixtures, choices: allocateVeoNight(fixtures, settings, history) };
+  } catch (error) {
+    throw new VeoAllocationError(error instanceof Error ? error.message : 'Unable to allocate the Veo pitch.');
+  }
+}
+export function quoteVeoFixture(f: VeoNightFixture, allocated: boolean) {
+  return {
+    home: veoFee(resolveTeamFixtureFeePence(f.homeMatchFeePence, f.homeStandard, f.matchFeePence), f.homePriority, allocated),
+    away: veoFee(resolveTeamFixtureFeePence(f.awayMatchFeePence, f.awayStandard, f.matchFeePence), f.awayPriority, allocated),
+  };
+}
+/** Called BEFORE publication reads the prices, in its SAME serializable transaction.
+ * Missing settings = OFF. No external calls, charge creation or messaging occurs here.
+ * A rollback undoes the swaps, snapshots, fee changes and publication together.
+ */
+export async function prepareVeoPublication(db: Db, scope: { leagueId: string; round?: number; divisionId?: string | null }) {
+  // Settings changes and parallel publishes serialize on the same existing league row.
+  await db.$queryRaw`SELECT id FROM "League" WHERE id = ${scope.leagueId} FOR UPDATE`;
+  if (!(await readVeoSettings(scope.leagueId, db)).enabled) return;
+  const targets = await db.fixture.findMany({
+    where: { leagueId: scope.leagueId, publishedAt: null, status: 'SCHEDULED', kickoffAt: { gt: new Date() },
+      ...(typeof scope.round === 'number' ? { round: scope.round } : {}), ...(scope.divisionId ? { divisionId: scope.divisionId } : {}) },
+    select: { id: true, kickoffAt: true },
+  });
+  const targetIds = new Set(targets.map(f => f.id));
+  const dates = [...new Set(targets.map(f => londonVeoDate(f.kickoffAt)))].sort();
+  for (const date of dates) {
+    await db.$queryRaw`
+      SELECT id FROM "Fixture" WHERE "leagueId" = ${scope.leagueId}
+      AND to_char("kickoffAt" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/London', 'YYYY-MM-DD') = ${date}
+      ORDER BY id FOR UPDATE
+    `;
+    const { fixtures, choices } = await previewVeoNight(scope.leagueId, date, db);
+    if (fixtures.some(f => !f.locked && !targetIds.has(f.id))) {
+      throw new VeoAllocationError(`Publish all divisions and fixtures for ${date} together so Veo can allocate the whole night fairly.`);
+    }
+    const byId = new Map(fixtures.map(f => [f.id, f]));
+    const selected = new Set(choices.map(c => c.fixtureId));
+    const finalPitch = new Map(fixtures.map(f => [f.id, f.pitch]));
+    for (const choice of choices) {
+      const selectedFixture = byId.get(choice.fixtureId)!;
+      finalPitch.set(choice.fixtureId, choice.pitch);
+      if (choice.swapWithId) finalPitch.set(choice.swapWithId, selectedFixture.pitch);
+    }
+    for (const f of fixtures) {
+      if (f.locked || !targetIds.has(f.id)) continue;
+      if (finalPitch.get(f.id) !== f.pitch) {
+        await db.fixture.update({ where: { id: f.id }, data: { pitch: finalPitch.get(f.id) }, select: { id: true } });
+      }
+      if (!f.eligible) continue;
+      const allocated = selected.has(f.id);
+      const quote = quoteVeoFixture(f, allocated);
+      await db.$executeRaw`
+        INSERT INTO "VeoFixtureSnapshot" ("fixtureId", "leagueId", "kickoffAt", "venueId", pitch,
+          "homeTeamId", "awayTeamId", "homePriority", "awayPriority", allocated,
+          "homeBasePence", "awayBasePence", "homeSupplementPence", "awaySupplementPence")
+        VALUES (${f.id}, ${scope.leagueId}, ${f.kickoffAt}, ${f.venueId}, ${finalPitch.get(f.id) ?? null},
+          ${f.homeTeamId}, ${f.awayTeamId}, ${f.homePriority}, ${f.awayPriority}, ${allocated},
+          ${quote.home.basePence}, ${quote.away.basePence}, ${quote.home.supplementPence}, ${quote.away.supplementPence})
+      `;
+      await db.fixture.update({ where: { id: f.id }, data: {
+        homeMatchFeePence: quote.home.totalPence, awayMatchFeePence: quote.away.totalPence,
+        matchFeePence: Math.max(quote.home.totalPence, quote.away.totalPence), sixflTvRecorded: allocated,
+      }, select: { id: true } });
+    }
+  }
+}
+export type VeoSnapshot = {
+  fixtureId: string; kickoffAt: Date; pitch: string | null; allocated: boolean;
+  homeTeamId: string; awayTeamId: string; homeName: string; awayName: string;
+  homePriority: boolean; awayPriority: boolean; homeBasePence: number; awayBasePence: number;
+  homeSupplementPence: number; awaySupplementPence: number; sixflTvUrl: string | null; status: string;
+};
+export async function readVeoSnapshots(leagueId: string, date: string, db: Db = prisma): Promise<VeoSnapshot[]> {
+  return db.$queryRaw<VeoSnapshot[]>`
+    SELECT s.*, h.name AS "homeName", a.name AS "awayName", f."sixflTvUrl", f.status::text AS status
+    FROM "VeoFixtureSnapshot" s JOIN "Fixture" f ON f.id = s."fixtureId"
+    JOIN "Team" h ON h.id = s."homeTeamId" JOIN "Team" a ON a.id = s."awayTeamId"
+    WHERE s."leagueId" = ${leagueId}
+      AND to_char(s."kickoffAt" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/London', 'YYYY-MM-DD') = ${date}
+    ORDER BY s."kickoffAt", s."fixtureId"
+  `;
+}

--- a/src/lib/veo/service.ts
+++ b/src/lib/veo/service.ts
@@ -1,9 +1,10 @@
-import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { resolveTeamFixtureFeePence } from '@/lib/payments/fixture-fee-policy';
 import { allocateVeoNight, veoFee, type VeoFixture, type VeoHistory, type VeoSettings } from './allocator';
 
-type Db = Prisma.TransactionClient;
+// Match the application's extended Prisma client, not the incompatible bare client.
+// A transaction supplies exactly these methods without exposing nested transactions.
+type Db = Pick<typeof prisma, '$queryRaw' | '$executeRaw' | 'fixture'>;
 export class VeoAllocationError extends Error {}
 export type LeagueVeoSettings = VeoSettings & { revision: number };
 export type VeoTeam = { id: string; name: string; teamMode: string; standardMatchFeePence: number | null; priority: boolean };

--- a/tests/fixture-fee-inheritance.test.cjs
+++ b/tests/fixture-fee-inheritance.test.cjs
@@ -25,6 +25,8 @@ function loader(mocks = {}) {
       if (Object.hasOwn(mocks, id)) return mocks[id];
       if (id === '@/lib/payments/fixture-fee-policy') return load(policyPath);
       if (id === '@/lib/payments/charge-status') return load('src/lib/payments/charge-status.ts');
+      if (id === '@/lib/veo/service') return load('src/lib/veo/service.ts');
+      if (id === './allocator' && filename === path.resolve(root, 'src/lib/veo/service.ts')) return load('src/lib/veo/allocator.ts');
       if (id.startsWith('node:')) return require(id);
       if (id === 'crypto') return require('node:crypto');
       throw new Error(`Unmocked dependency: ${id}`);
@@ -66,6 +68,15 @@ function harness({ homeFee = 4000, awayFee = 3600, placeholderIds = [] } = {}) {
   }
   function chargeView(row) { return { ...row, team:teams.find(t=>t.id===row.teamId) }; }
   const prisma = {
+    // Run the real opt-in hook, returning no Veo settings (the production default).
+    // Only its two read/lock queries are allowed; unexpected SQL still fails closed.
+    $queryRaw: async (strings, ...values) => {
+      const sql = strings.join('?');
+      assert.equal(values[0], league.id);
+      if (/SELECT id FROM "League" WHERE id = \? FOR UPDATE/.test(sql)) return [{ id: league.id }];
+      if (/FROM "VeoLeagueSettings" WHERE "leagueId" = \?/.test(sql)) return [];
+      throw new Error(`Unmocked fixture-fee SQL: ${sql}`);
+    },
     league: { findUnique:async()=>league },
     leagueDivision: { findFirst:async()=>({id:'division'}) },
     team: { findMany:async({select})=>{ selections.push(select); return teams.map(row=>project(row,select)); } },

--- a/tests/fixture-reminder-context.test.cjs
+++ b/tests/fixture-reminder-context.test.cjs
@@ -202,7 +202,7 @@ test('native source keeps the safety guard and shows a truthful partial-publicat
 test('fragment migration is repeatable and preserves saved parent edits and disabled fragments',{skip:process.env.FIXTURE_TEMPLATE_TEST_DB!=='1'},()=>{
   const url=new URL(process.env.DATABASE_URL);assert.ok(['127.0.0.1','localhost'].includes(url.hostname));assert.equal(url.pathname,'/sixfl_fixture_reminder_test');
   const sql=`BEGIN;
-    CREATE TEMP TABLE "NotificationTemplate" ("id" text PRIMARY KEY,"key" text UNIQUE,"name" text,"description" text,"kind" text,"channel" text,"audience" text,"subject" text,"body" text,"ctaLabel" text,"ctaUrlKey" text,"ctaUrlKey" text,"isActive" boolean,"createdAt" timestamptz,"updatedAt" timestamptz);
+    CREATE TEMP TABLE "NotificationTemplate" ("id" text PRIMARY KEY,"key" text UNIQUE,"name" text,"description" text,"kind" text,"channel" text,"audience" text,"subject" text,"body" text,"ctaLabel" text,"ctaUrlKey" text,"isActive" boolean,"createdAt" timestamptz,"updatedAt" timestamptz);
     INSERT INTO "NotificationTemplate" ("id","key","body","isActive") VALUES ('parent','match-fee-reminder-email','Custom parent {{reminderIntro}}',false),('custom','match-fee-reminder-intro-email-first','Edited intro',false);
     ${read(migrationPath)}\n${read(migrationPath)}
     DO $$ BEGIN

--- a/tests/fixture-reminder-context.test.cjs
+++ b/tests/fixture-reminder-context.test.cjs
@@ -53,6 +53,15 @@ function harness() {
   const recipient=id=>({id,email:`${id}@example.invalid`,phone:'+440000000000',displayName:'Test captain',isSuppressed:false,transactionalEmailOptIn:true,transactionalSmsOptIn:true,
     preferences:{emailEnabled:true,smsEnabled:true,marketingEmailEnabled:false,marketingSmsEnabled:false}});
   const db={
+    // The real Veo hook reads no opt-in settings in these existing-league tests.
+    // Keep all provider and unrecognised SQL access blocked.
+    $queryRaw: async (strings, ...values) => {
+      const sql = strings.join('?');
+      assert.equal(values[0], league.id);
+      if (/SELECT id FROM "League" WHERE id = \? FOR UPDATE/.test(sql)) return [{ id: league.id }];
+      if (/FROM "VeoLeagueSettings" WHERE "leagueId" = \?/.test(sql)) return [];
+      throw new Error(`Unexpected fixture-reminder SQL: ${sql}`);
+    },
     notificationTemplate:{findUnique:async({where,select})=>{reads.push(where.key);return project(templates.get(where.key)||null,select);}},
     notificationRecipient:{findUnique:async({where})=>recipient(where.id)},
     notificationDispatch:{
@@ -96,6 +105,7 @@ function harness() {
     '@/lib/notifications/sms-short-links':{shortenSmsBodyLinks:({bodyText})=>({bodyText,links:[]})},
   };
   const allowed=new Set([feePath,batchPath,singlePath,'src/lib/notifications/service.ts','src/lib/notifications/renderer.ts','src/lib/payments/charge-status.ts','src/lib/payments/fixture-fee-policy.ts',
+    'src/lib/veo/service.ts','src/lib/veo/allocator.ts',
     'src/lib/fixtures/kickoff-window.ts','src/lib/email/buildEmail.ts','src/lib/email/footer.ts','src/lib/email/inline-formatting.ts','src/lib/email/template-cta.ts']);
   const cache=new Map();
   function load(file) {
@@ -132,7 +142,6 @@ function harness() {
     charges:[{id:'test-charge',teamId:'home',teamName:teams[0].name,teamLogoUrl:null,paymentToken:'nonfunctional-test-token',amountPence:4000}],...extra};}
   return {db,load,publish,feeInput,fixture,teams,templates,dispatches,charges,publishedWrites,reads,mocks};
 }
-
 for(const mode of ['single','week','batch']) {
   test(`${mode}: real publisher, charge sync, sender and renderer resolve original reminder templates`,async()=>{
     const h=harness();const result=await h.publish(mode);
@@ -193,7 +202,7 @@ test('native source keeps the safety guard and shows a truthful partial-publicat
 test('fragment migration is repeatable and preserves saved parent edits and disabled fragments',{skip:process.env.FIXTURE_TEMPLATE_TEST_DB!=='1'},()=>{
   const url=new URL(process.env.DATABASE_URL);assert.ok(['127.0.0.1','localhost'].includes(url.hostname));assert.equal(url.pathname,'/sixfl_fixture_reminder_test');
   const sql=`BEGIN;
-    CREATE TEMP TABLE "NotificationTemplate" ("id" text PRIMARY KEY,"key" text UNIQUE,"name" text,"description" text,"kind" text,"channel" text,"audience" text,"subject" text,"body" text,"ctaLabel" text,"ctaUrlKey" text,"isActive" boolean,"createdAt" timestamptz,"updatedAt" timestamptz);
+    CREATE TEMP TABLE "NotificationTemplate" ("id" text PRIMARY KEY,"key" text UNIQUE,"name" text,"description" text,"kind" text,"channel" text,"audience" text,"subject" text,"body" text,"ctaLabel" text,"ctaUrlKey" text,"ctaUrlKey" text,"isActive" boolean,"createdAt" timestamptz,"updatedAt" timestamptz);
     INSERT INTO "NotificationTemplate" ("id","key","body","isActive") VALUES ('parent','match-fee-reminder-email','Custom parent {{reminderIntro}}',false),('custom','match-fee-reminder-intro-email-first','Edited intro',false);
     ${read(migrationPath)}\n${read(migrationPath)}
     DO $$ BEGIN

--- a/tests/veo-priority/allocator.test.mjs
+++ b/tests/veo-priority/allocator.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { allocateVeoNight, veoFee, normaliseVeoPitch } from '../../src/lib/veo/allocator.ts';
+const settings = { enabled: true, venueId: 'venue', pitch: 'Pitch 1', maxMatches: 3 };
+function fixture(id, minutes, pitch = '1', overrides = {}) {
+  return { id, kickoffMs: minutes * 60000, durationMinutes: 40, venueId: 'venue', pitch,
+    homeTeamId: id + '-a', awayTeamId: id + '-b', homePriority: false, awayPriority: false,
+    locked: false, eligible: true, filmed: false, ...overrides };
+}
+test('disabled means no allocation, even with missing configuration', () => {
+  assert.deepEqual(allocateVeoNight([fixture('a', 0)], { ...settings, enabled: false, pitch: '' }), []);
+});
+test('£40/£45 matrix is independent for each team; free stays free', () => {
+  for (const priority of [false, true]) for (const allocated of [false, true]) {
+    const q = veoFee(4000, priority, allocated);
+    assert.equal(q.totalPence, priority && allocated ? 4500 : 4000);
+    assert.equal(veoFee(0, priority, allocated).totalPence, 0);
+  }
+  assert.equal(veoFee(3700, true, true).totalPence, 4200);
+  for (const amount of [-1, 0.5, NaN, Infinity]) assert.throws(() => veoFee(amount, true, true));
+});
+test('normalises historic pitch labels without inventing a pitch', () => {
+  assert.equal(normaliseVeoPitch(' Pitch Pitch 1 '), '1');
+  assert.equal(normaliseVeoPitch(null), '');
+  assert.deepEqual(allocateVeoNight([fixture('a', 0, '2')], settings), []);
+});
+test('prefers Priority-v-Priority at the same time without changing input', () => {
+  const matches = [fixture('a', 0, '1', { homePriority: true }), fixture('b', 0, '2', { homePriority: true, awayPriority: true })];
+  const before = structuredClone(matches);
+  assert.deepEqual(allocateVeoNight(matches, settings), [{ fixtureId: 'b', swapWithId: 'a', pitch: '1' }]);
+  assert.deepEqual(matches, before);
+});
+test('fewer past filmed games wins between equally prioritised matches', () => {
+  const matches = [fixture('a', 0, '1', { homePriority: true }), fixture('b', 0, '2', { homePriority: true })];
+  assert.equal(allocateVeoNight(matches, settings, { 'a-a': { count: 3, lastMs: 1 } })[0].fixtureId, 'b');
+});
+test('oldest filming wins when appearance counts tie', () => {
+  const matches = [fixture('a', 0), fixture('b', 0, '2')];
+  const history = { 'a-a': { count: 1, lastMs: 100 }, 'b-a': { count: 1, lastMs: 10 } };
+  assert.equal(allocateVeoNight(matches, settings, history)[0].fixtureId, 'b');
+});
+test('chooses the best three slots across the whole night', () => {
+  const matches = [fixture('a', 0), fixture('b', 40, '1', { homePriority: true }), fixture('c', 80, '1', { homePriority: true }), fixture('d', 120, '1', { homePriority: true, awayPriority: true })];
+  assert.deepEqual(allocateVeoNight(matches, settings).map(c => c.fixtureId), ['b', 'c', 'd']);
+});
+test('six fixtures on two pitches produce three choices and preserve schedule', () => {
+  const matches = Array.from({ length: 6 }, (_, n) => fixture(String(n), Math.floor(n / 2) * 40, String(n % 2 + 1), { homePriority: n % 2 === 1 }));
+  const choices = allocateVeoNight(matches, settings);
+  assert.deepEqual(choices.map(c => c.fixtureId), ['1', '3', '5']);
+  for (const c of choices) {
+    const picked = matches.find(f => f.id === c.fixtureId), displaced = matches.find(f => f.id === c.swapWithId);
+    assert.equal(picked.kickoffMs, displaced.kickoffMs); assert.equal(picked.venueId, displaced.venueId);
+  }
+});
+test('published/billed camera fixtures are immutable and reserve filmed capacity', () => {
+  const matches = [fixture('a', 0, '1', { locked: true, filmed: true }), fixture('x', 0, '2', { homePriority: true, awayPriority: true }), fixture('b', 40), fixture('c', 80), fixture('d', 120)];
+  const choices = allocateVeoNight(matches, settings);
+  assert.equal(choices.length, 2); assert.ok(choices.every(c => c.fixtureId !== 'a' && c.fixtureId !== 'x'));
+});
+test('never moves a billed candidate or takes a placeholder as filmed fixture', () => {
+  const matches = [fixture('a', 0), fixture('b', 0, '2', { locked: true, homePriority: true, awayPriority: true }), fixture('c', 0, '3', { eligible: false, homePriority: true, awayPriority: true })];
+  assert.equal(allocateVeoNight(matches, settings)[0].fixtureId, 'a');
+});
+test('never swaps across venue, kickoff time, or duration', () => {
+  const matches = [fixture('a', 0), fixture('b', 0, '2', { venueId: 'other', homePriority: true }), fixture('c', 10, '2', { homePriority: true }), fixture('d', 0, '3', { durationMinutes: 30, homePriority: true })];
+  assert.equal(allocateVeoNight(matches, settings)[0].fixtureId, 'a');
+});
+test('null venue is an explicit scope, not all venues', () => {
+  assert.deepEqual(allocateVeoNight([fixture('a', 0)], { ...settings, venueId: null }), []);
+});
+test('detects duplicate physical camera bookings and duplicate IDs', () => {
+  assert.throws(() => allocateVeoNight([fixture('a', 0, '1'), fixture('b', 0, 'Pitch 1')], settings), /double-booked/);
+  assert.throws(() => allocateVeoNight([fixture('a', 0), fixture('a', 40)], settings), /Duplicate/);
+});
+test('interval scheduling avoids overlapping camera recordings', () => {
+  const matches = [fixture('a', 0), fixture('long', 20, '1', { durationMinutes: 80 }), fixture('c', 80)];
+  assert.deepEqual(allocateVeoNight(matches, settings).map(c => c.fixtureId), ['a', 'c']);
+});
+test('locked intervals also prevent overlapping allocations', () => {
+  const matches = [fixture('a', 0, '1', { locked: true, filmed: true, durationMinutes: 80 }), fixture('b', 40), fixture('c', 80)];
+  assert.deepEqual(allocateVeoNight(matches, settings).map(c => c.fixtureId), ['c']);
+});
+test('stable output regardless of database input ordering', () => {
+  const matches = [fixture('a', 0), fixture('b', 0, '2'), fixture('c', 40), fixture('d', 40, '2')];
+  assert.deepEqual(allocateVeoNight(matches, settings), allocateVeoNight([...matches].reverse(), settings));
+});

--- a/tests/veo-priority/browser.mjs
+++ b/tests/veo-priority/browser.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { chromium } from 'playwright';
+const seed = JSON.parse(readFileSync('artifacts/veo/seed.json', 'utf8'));
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  const errors = []; page.on('pageerror', error => errors.push(error.message));
+  const url = `http://127.0.0.1:3100/admin/leagues/${seed.leagueId}/veo-priority?date=${seed.date}`;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.getByRole('heading', { name: 'Veo Priority', exact: true }).waitFor();
+  await page.getByText('OFF for this league', { exact: true }).waitFor();
+  assert.equal(await page.locator('select').count(), 0);
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1), 'Mobile page must not overflow horizontally');
+  assert.equal(await page.locator('article').count(), 6);
+  await page.screenshot({ path: 'artifacts/veo/admin-mobile.png', fullPage: true });
+  const completed = page.locator('article').filter({ hasText: 'Veo test team 3 vs Veo test team 4' });
+  await completed.locator('summary').click();
+  await completed.locator('input[name="videoUrl"]').fill('https://www.youtube.com/watch?v=veo-pilot-test');
+  await completed.getByRole('button', { name: 'Save video link', exact: true }).click();
+  await page.getByText('Saved. No existing fixtures or charges were recalculated.', { exact: true }).waitFor();
+  await page.reload({ waitUntil: 'networkidle' });
+  assert.equal(await completed.locator('input[name="videoUrl"]').inputValue(), 'https://www.youtube.com/watch?v=veo-pilot-test');
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.screenshot({ path: 'artifacts/veo/admin-desktop.png', fullPage: true });
+  assert.deepEqual(errors, []);
+  console.log('PASS: mobile layout, OFF state, saved fee rows and completed-fixture video edits.');
+} finally { await browser.close(); }

--- a/tests/veo-priority/database.ts
+++ b/tests/veo-priority/database.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { Prisma } from '@prisma/client';
+import { prisma } from '../../src/lib/prisma';
+import { prepareVeoPublication, previewVeoNight, readVeoSettings, readVeoSnapshots, londonVeoDate, validVeoDate } from '../../src/lib/veo/service';
+
+const url = new URL(process.env.DATABASE_URL!);
+assert.equal(process.env.VEO_TEST_DATABASE, '1', 'Explicit isolated-test opt-in required.');
+assert.ok(['127.0.0.1', 'localhost'].includes(url.hostname), 'Never run against a remote/production database.');
+assert.equal(url.pathname, '/sixfl_veo_test');
+
+const id = (label: string) => `veo-test-${label}-${randomUUID()}`;
+const start = new Date(Date.now() + 7 * 86400000); start.setUTCHours(17, 0, 0, 0);
+const date = londonVeoDate(start);
+const options = { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, maxWait: 10000, timeout: 60000 };
+let passed = 0;
+function pass(label: string) { console.log(`PASS ${++passed}: ${label}`); }
+
+async function publish(leagueId: string) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await prisma.$transaction(async tx => {
+        await prepareVeoPublication(tx, { leagueId });
+        await tx.fixture.updateMany({ where: { leagueId, publishedAt: null, status: 'SCHEDULED' }, data: { publishedAt: new Date() } });
+      }, options);
+    } catch (error) {
+      if (attempt >= 2 || !(error instanceof Prisma.PrismaClientKnownRequestError)
+        || !(error.code === 'P2034' || (error.code === 'P2010' && ['40001', '40P01'].includes(String(error.meta?.code))))) throw error;
+    }
+  }
+}
+async function main() {
+  const venue = await prisma.venue.create({ data: { id: id('venue'), name: 'Veo integration venue' }, select: { id: true } });
+  const league = await prisma.league.create({ data: { id: id('league'), name: 'Veo integration league', slug: id('slug') }, select: { id: true } });
+  const teamIds: string[] = [];
+  const fixtureIds: string[] = [];
+  for (let n = 0; n < 12; n++) {
+    const team = await prisma.team.create({ data: { id: id('team'), name: `Veo test team ${n + 1}`, claimCode: id('claim'), leagueId: league.id, standardMatchFeePence: 4000 }, select: { id: true } });
+    teamIds.push(team.id);
+  }
+  for (let n = 0; n < 6; n++) {
+    const fixture = await prisma.fixture.create({ data: {
+      id: id('fixture'), leagueId: league.id, venueId: venue.id, homeTeamId: teamIds[n * 2], awayTeamId: teamIds[n * 2 + 1],
+      kickoffAt: new Date(start.getTime() + Math.floor(n / 2) * 40 * 60000), pitch: String(n % 2 + 1), round: 1,
+      homeMatchFeePence: 4000, awayMatchFeePence: 4000, matchFeePence: 4000,
+    }, select: { id: true } }); fixtureIds.push(fixture.id);
+  }
+  const before = await prisma.fixture.findMany({ where: { leagueId: league.id }, orderBy: { id: 'asc' } });
+  assert.equal((await readVeoSettings(league.id)).enabled, false);
+  await prisma.$transaction(tx => prepareVeoPublication(tx, { leagueId: league.id }), options);
+  assert.deepEqual(await prisma.fixture.findMany({ where: { leagueId: league.id }, orderBy: { id: 'asc' } }), before);
+  assert.equal((await readVeoSnapshots(league.id, date)).length, 0);
+  pass('missing settings are OFF; fixtures, prices and snapshots untouched');
+
+  await prisma.$executeRaw`INSERT INTO "VeoLeagueSettings" ("leagueId", enabled, pitch, "venueId") VALUES (${league.id}, true, 'Pitch 1', ${venue.id})`;
+  for (const n of [2, 3, 6, 7, 10]) await prisma.$executeRaw`INSERT INTO "VeoTeamPriority" ("leagueId", "teamId", enabled) VALUES (${league.id}, ${teamIds[n]}, true)`;
+  const preview = await previewVeoNight(league.id, date);
+  assert.deepEqual(preview.choices.map(c => c.fixtureId), [fixtureIds[1], fixtureIds[3], fixtureIds[5]]);
+  assert.deepEqual(await prisma.fixture.findMany({ where: { leagueId: league.id }, orderBy: { id: 'asc' } }), before);
+  pass('read-only preview chooses all three Priority fixtures');
+
+  await assert.rejects(prisma.$transaction(async tx => { await prepareVeoPublication(tx, { leagueId: league.id }); throw new Error('intentional rollback'); }, options), /intentional rollback/);
+  assert.deepEqual(await prisma.fixture.findMany({ where: { leagueId: league.id }, orderBy: { id: 'asc' } }), before);
+  assert.equal((await readVeoSnapshots(league.id, date)).length, 0);
+  pass('a failed publication rolls back pitch swaps, fee changes and snapshots');
+
+  await Promise.all([publish(league.id), publish(league.id)]);
+  const snapshots = await readVeoSnapshots(league.id, date);
+  assert.equal(snapshots.length, 6); assert.equal(snapshots.filter(s => s.allocated).length, 3);
+  assert.equal(snapshots.reduce((sum, s) => sum + s.homeSupplementPence + s.awaySupplementPence, 0), 2500);
+  for (const f of await prisma.fixture.findMany({ where: { leagueId: league.id } })) {
+    const previous = before.find(b => b.id === f.id)!;
+    assert.equal(f.kickoffAt.getTime(), previous.kickoffAt.getTime());
+    assert.equal(f.homeTeamId, previous.homeTeamId); assert.equal(f.awayTeamId, previous.awayTeamId); assert.equal(f.venueId, previous.venueId);
+    const s = snapshots.find(s => s.fixtureId === f.id)!;
+    assert.equal(f.homeMatchFeePence, s.homeBasePence + s.homeSupplementPence);
+    assert.equal(f.awayMatchFeePence, s.awayBasePence + s.awaySupplementPence);
+  }
+  assert.equal(snapshots.find(s => s.fixtureId === fixtureIds[5])!.awaySupplementPence, 0);
+  pass('concurrent publishing is idempotent; only the opted-in side receives £5');
+
+  const frozen = JSON.stringify(snapshots);
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = false WHERE "leagueId" = ${league.id}`;
+  await prisma.$executeRaw`UPDATE "VeoTeamPriority" SET enabled = false WHERE "leagueId" = ${league.id}`;
+  await publish(league.id);
+  assert.equal(JSON.stringify(await readVeoSnapshots(league.id, date)), frozen);
+  await assert.rejects(prisma.$executeRaw`UPDATE "VeoFixtureSnapshot" SET "homeBasePence" = 1 WHERE "fixtureId" = ${fixtureIds[1]}`);
+  await assert.rejects(prisma.$executeRaw`DELETE FROM "VeoFixtureSnapshot" WHERE "fixtureId" = ${fixtureIds[1]}`);
+  pass('later switches and repeat publishes cannot rewrite historical agreements');
+
+  // A separate test night checks partial-round publication fails before any writes commit.
+  const nextStart = new Date(start.getTime() + 7 * 86400000);
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = true WHERE "leagueId" = ${league.id}`;
+  for (let n = 0; n < 2; n++) await prisma.fixture.create({ data: { id: id('partial'), leagueId: league.id, venueId: venue.id,
+    homeTeamId: teamIds[n * 2], awayTeamId: teamIds[n * 2 + 1], kickoffAt: nextStart, pitch: String(n + 1), round: n + 2 }, select: { id: true } });
+  await assert.rejects(prisma.$transaction(tx => prepareVeoPublication(tx, { leagueId: league.id, round: 2 }), options), /Publish all divisions/);
+  assert.equal((await readVeoSnapshots(league.id, londonVeoDate(nextStart))).length, 0);
+  pass('partial-night publication fails safely instead of silently misallocating across divisions');
+
+  const freeLeague = await prisma.league.create({ data: { id: id('free-league'), name: 'Veo free fixture test', slug: id('free-slug') }, select: { id: true } });
+  await prisma.$executeRaw`INSERT INTO "VeoLeagueSettings" ("leagueId", enabled, pitch, "venueId") VALUES (${freeLeague.id}, true, '1', ${venue.id})`;
+  for (const teamId of teamIds.slice(0, 2)) await prisma.$executeRaw`INSERT INTO "VeoTeamPriority" ("leagueId", "teamId", enabled) VALUES (${freeLeague.id}, ${teamId}, true)`;
+  const freeFixture = await prisma.fixture.create({ data: { id: id('free'), leagueId: freeLeague.id, venueId: venue.id, homeTeamId: teamIds[0], awayTeamId: teamIds[1], kickoffAt: start, pitch: '1', homeMatchFeePence: 0, awayMatchFeePence: 4000, matchFeePence: 4000 }, select: { id: true } });
+  await publish(freeLeague.id);
+  const free = await prisma.fixture.findUniqueOrThrow({ where: { id: freeFixture.id } });
+  assert.equal(free.homeMatchFeePence, 0); assert.equal(free.awayMatchFeePence, 4500);
+  assert.equal(await prisma.paymentCharge.count(), 0); assert.equal(await prisma.notificationDispatch.count(), 0);
+  pass('explicit £0 stays £0; allocation itself creates no payments or messages');
+
+  assert.equal(londonVeoDate(new Date('2026-09-20T23:30:00Z')), '2026-09-21');
+  assert.equal(londonVeoDate(new Date('2026-12-20T23:30:00Z')), '2026-12-20');
+  assert.equal(validVeoDate('2026-02-30'), false);
+  const source = readFileSync('src/app/(admin)/admin/fixtures/publish-actions.ts', 'utf8');
+  assert.ok(source.indexOf('await prepareVeoPublication(tx, input)') < source.indexOf('const unpublishedFixtures = await tx.fixture.findMany'));
+  assert.ok(!readFileSync('src/app/(admin)/admin/leagues/[id]/veo-priority/page.tsx', 'utf8').includes('<select'));
+  pass('London date boundaries, publication hook order and native UI controls');
+
+  // Leave an OFF league with an already-completed filmed fixture for the browser test.
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = false WHERE "leagueId" = ${league.id}`;
+  await prisma.$executeRaw`UPDATE "Fixture" SET status = 'COMPLETED' WHERE id = ${fixtureIds[1]}`;
+  mkdirSync('artifacts/veo', { recursive: true });
+  writeFileSync('artifacts/veo/seed.json', JSON.stringify({ leagueId: league.id, date, completedFixtureId: fixtureIds[1] }));
+  console.log(`${passed} database checks passed.`);
+}
+main().finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- Native league admin Veo settings and per-team Priority switches, with explicit captain agreement before opting in.
- Deterministic same-kickoff, same-venue pitch allocation: three matches by default, Priority pairs and filming history considered.
- Allocation, immutable original fee snapshots and publication share a serializable transaction. Only opted-in, positively priced sides allocated to filming receive the £5 supplement; explicit free fixtures stay free.
- Existing published, billed, past and manually marked TV fixtures are not reallocated. Later switches do not rewrite saved agreements.
- Admin preview, original supplement-value and missed-Priority summaries; captain allocation and own-price breakdowns; audited media-only video link edits.

## Rollout
The user has requested production deployment. This PR does not enable Veo in any league, opt any team in, send announcements or modify historical prices. The additive migration creates empty opt-in tables only. Controls are at Admin → Leagues → a league → Veo Priority.

## Verification
16 pure allocation/fee tests passed locally. Dedicated CI verifies isolated Postgres rollback/concurrency/immutability, a production build, mobile admin rendering, completed-fixture video editing and production authentication. CI must be checked before merging.

Supplement totals shown are agreement/preview values, not cash received. Corrections or failed filming use the existing Payments adjustment workflow.