### PR TITLE
Advertise Veo Priority to captains with admin-approved requests

### DIFF
--- a/.github/workflows/veo-priority.yml
+++ b/.github/workflows/veo-priority.yml
@@ -4,9 +4,12 @@ on:
     paths:
       - 'src/lib/veo/**'
       - 'src/app/**/veo-priority/**'
+      - 'src/components/captain/*Veo*'
+      - 'src/app/captain/team/[teamid]/page.tsx'
+      - 'src/app/(admin)/admin/leagues/[id]/layout.tsx'
       - 'src/app/(admin)/admin/fixtures/publish-actions.ts'
       - 'src/app/captain/team/[teamid]/fixtures/layout.tsx'
-      - 'prisma/migrations/20260912001500_veo_priority_pilot/**'
+      - 'prisma/migrations/*veo_priority*/**'
       - 'tests/veo-priority/**'
       - '.github/workflows/veo-priority.yml'
   push:
@@ -40,8 +43,7 @@ jobs:
       NEXTAUTH_SECRET: isolated-veo-safety-test-only
       NEXTAUTH_URL: http://127.0.0.1:3100
       NEXT_PUBLIC_SITE_URL: http://127.0.0.1:3100
-      # Inert placeholders satisfy constructors in unrelated application routes.
-      # No real credentials, sends or payment operations are used by these tests.
+      # Inert placeholders; no real providers, customer sends or payments.
       RESEND_API_KEY: re_isolated_veo_test_not_a_real_key
       STRIPE_SECRET_KEY: sk_test_isolated_veo_not_a_real_key
       OPENAI_API_KEY: sk-isolated-veo-not-a-real-key
@@ -54,21 +56,34 @@ jobs:
       - run: npm ci
       - name: Pure allocation and fee tests
         run: node --experimental-strip-types --test tests/veo-priority/allocator.test.mjs
+      - name: Native request card and action contracts
+        run: node --test tests/veo-priority/request-ui.test.cjs
       - name: Prepare generated application schema
         run: npm run prebuild && npx prisma generate
-      - name: Create isolated test schema and apply additive Veo migration
+      - name: Prepared request card and action contracts
+        run: node --test tests/veo-priority/request-ui.test.cjs
+      - name: Create isolated test schema and apply additive Veo migrations
         shell: bash
         run: |
           npx prisma db push --skip-generate
           npx prisma db execute --schema prisma/schema.prisma --stdin <<'SQL'
           ALTER TABLE "League" ADD COLUMN IF NOT EXISTS "minutesPerGame" INTEGER;
           ALTER TABLE "Team" ADD COLUMN IF NOT EXISTS "isFixturePlaceholder" BOOLEAN NOT NULL DEFAULT false;
+          ALTER TABLE "TeamMember" ADD COLUMN IF NOT EXISTS "isActive" BOOLEAN NOT NULL DEFAULT true;
+          CREATE TABLE IF NOT EXISTS "LeagueSeasonTeam" (
+            id TEXT PRIMARY KEY, "leagueId" TEXT NOT NULL, "teamId" TEXT NOT NULL,
+            "isActive" BOOLEAN NOT NULL DEFAULT true, "divisionId" TEXT,
+            "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE ("leagueId", "teamId")
+          );
           SQL
           npx prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260912001500_veo_priority_pilot/migration.sql
-      - name: Real database safety checks
+          npx prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260912010000_veo_priority_requests/migration.sql
+      - name: Real allocation database safety checks
         run: npx tsx tests/veo-priority/database.ts
-      # Production runs prebuild -> prisma generate -> next build once. Preparation
-      # already ran above so that database checks use the same generated schema.
+      - name: Real request and approval database safety checks
+        run: npx tsx tests/veo-priority/requests.ts
       - name: Production build
         shell: bash
         run: npx next build 2>&1 | tee veo-build.log
@@ -97,7 +112,7 @@ jobs:
           done
           cat veo-dev.log
           exit 1
-      - name: Mobile and completed-video edit browser checks
+      - name: Mobile, request queue and completed-video browser checks
         run: node tests/veo-priority/browser.mjs
       - name: Upload evidence
         if: always()

--- a/prisma/migrations/20260912010000_veo_priority_requests/migration.sql
+++ b/prisma/migrations/20260912010000_veo_priority_requests/migration.sql
@@ -1,0 +1,16 @@
+-- Requesting Priority is not opting in and does not change fees or fixtures.
+CREATE TABLE "VeoPriorityRequest" (
+  "id" TEXT PRIMARY KEY,
+  "leagueId" TEXT NOT NULL REFERENCES "League"("id") ON DELETE CASCADE,
+  "teamId" TEXT NOT NULL REFERENCES "Team"("id") ON DELETE CASCADE,
+  "requestedBy" TEXT NOT NULL,
+  "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "status" TEXT NOT NULL DEFAULT 'PENDING' CHECK ("status" IN ('PENDING', 'APPROVED', 'DECLINED')),
+  "supplementPence" INTEGER NOT NULL DEFAULT 500 CHECK ("supplementPence" = 500),
+  "termsVersion" TEXT NOT NULL,
+  "reviewedBy" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  CHECK (("status" = 'PENDING' AND "reviewedAt" IS NULL) OR ("status" <> 'PENDING' AND "reviewedAt" IS NOT NULL))
+);
+CREATE UNIQUE INDEX "VeoPriorityRequest_one_pending" ON "VeoPriorityRequest" ("leagueId", "teamId") WHERE "status" = 'PENDING';
+CREATE INDEX "VeoPriorityRequest_league_status_date" ON "VeoPriorityRequest" ("leagueId", "status", "requestedAt");

--- a/src/app/(admin)/admin/leagues/[id]/layout.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/layout.tsx
@@ -6,6 +6,7 @@ import AdminLeagueSeasonTeamsPanel from "@/components/admin/leagues/AdminLeagueS
 import MergeLeagueDivisionsButton from "@/components/admin/leagues/MergeLeagueDivisionsButton";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/requireAdmin";
+import { pendingVeoRequestCount } from "@/lib/veo/priority-requests";
 
 export default async function AdminLeagueLayout({
   children,
@@ -22,6 +23,7 @@ export default async function AdminLeagueLayout({
   });
 
   if (!league) notFound();
+  const pendingRequests = await pendingVeoRequestCount(id);
 
   return (
     <div className="space-y-5">
@@ -45,7 +47,7 @@ export default async function AdminLeagueLayout({
           href={`/admin/leagues/${league.id}/veo-priority`}
           className="min-h-11 rounded-xl border border-fuchsia-400/25 bg-fuchsia-500/10 px-4 py-2 text-sm font-semibold text-fuchsia-100 transition hover:bg-fuchsia-500/15"
         >
-          Veo Priority
+          Veo Priority{pendingRequests > 0 && <span className="ml-2 rounded-full bg-fuchsia-300/20 px-2 py-0.5 text-xs">{pendingRequests} pending</span>}
         </Link>
       </div>
       <MergeLeagueDivisionsButton />

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/ReviewRequestForm.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/ReviewRequestForm.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { useActionState } from 'react';
+import { reviewVeoPriorityAction, type VeoReviewFormState } from './request-actions';
+
+export default function ReviewRequestForm({ leagueId, requestId }: { leagueId: string; requestId: string }) {
+  const initial: VeoReviewFormState = { done: false, error: false, message: '' };
+  const [state, action, pending] = useActionState(reviewVeoPriorityAction.bind(null, leagueId, requestId), initial);
+  return <form action={action} className="space-y-3">
+    {state.message && <p role={state.error ? 'alert' : 'status'} className={`text-sm leading-6 ${state.error ? 'text-red-200' : 'text-emerald-100'}`}>{state.message}</p>}
+    {!state.done && <div className="flex flex-wrap gap-3">
+      <button type="submit" name="decision" value="APPROVED" disabled={pending} className="min-h-11 rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100 disabled:opacity-50">{pending ? 'Saving decision…' : 'Approve Priority request'}</button>
+      <button type="submit" name="decision" value="DECLINED" disabled={pending} className="min-h-11 rounded-xl border border-white/20 px-4 py-2 text-sm font-semibold text-white/80 disabled:opacity-50">Decline request</button>
+    </div>}
+  </form>;
+}

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts
@@ -7,12 +7,14 @@ import { prisma } from '@/lib/prisma';
 import { requireAdmin } from '@/lib/requireAdmin';
 import { normaliseVeoPitch } from '@/lib/veo/allocator';
 import { readVeoSettings, readVeoTeams, VeoAllocationError, validVeoDate } from '@/lib/veo/service';
+import { approvePendingVeoRequests } from '@/lib/veo/priority-requests';
 
 function back(leagueId: string, form: FormData, error?: string) {
   const query = new URLSearchParams(error ? { error } : { saved: '1' });
   const date = String(form.get('date') ?? '');
   if (validVeoDate(date)) query.set('date', date);
-  revalidatePath(`/admin/leagues/${leagueId}/veo-priority`);
+  revalidatePath(`/admin/leagues/${leagueId}`, 'layout');
+  revalidatePath('/captain/team/[teamid]', 'page');
   redirect(`/admin/leagues/${leagueId}/veo-priority?${query}`);
 }
 function message(error: unknown) {
@@ -76,6 +78,7 @@ export async function setVeoTeamPriority(leagueId: string, form: FormData) {
         VALUES (${leagueId}, ${teamId}, ${enabled}, ${user?.id ?? null})
         ON CONFLICT ("leagueId", "teamId") DO UPDATE SET enabled = EXCLUDED.enabled, "updatedAt" = NOW(), "updatedBy" = EXCLUDED."updatedBy"
       `;
+      if (enabled && user?.id) await approvePendingVeoRequests(tx, leagueId, teamId, user.id);
       const details = JSON.stringify({ kind: 'team_priority', before: team.priority, enabled, captainAgreementConfirmed: enabled, supplementPence: 500 });
       await tx.$executeRaw`INSERT INTO "VeoSettingsAudit" (id, "leagueId", "teamId", "actorId", details) VALUES (${randomUUID()}, ${leagueId}, ${teamId}, ${user?.id ?? null}, ${details}::jsonb)`;
     });

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/layout.tsx
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { pendingVeoRequests } from '@/lib/veo/priority-requests';
+import ReviewRequestForm from './ReviewRequestForm';
+
+export default async function VeoPriorityLayout({ children, params }: { children: ReactNode; params: Promise<{ id: string }> }) {
+  await requireAdmin();
+  const { id } = await params;
+  const requests = await pendingVeoRequests(id);
+  return <div className="space-y-6">
+    <section aria-label="Veo Priority requests" className="mx-auto max-w-7xl space-y-4 rounded-2xl border border-fuchsia-400/25 bg-fuchsia-500/5 p-5 text-white sm:p-6">
+      <h2 className="text-xl font-semibold">Captain requests {requests.length > 0 && <span className="ml-2 rounded-full bg-fuchsia-500/20 px-3 py-1 text-sm">{requests.length} pending</span>}</h2>
+      <p className="text-sm leading-6 text-white/65">Captains agree to the £5 allocated-match supplement when requesting. Requests do not activate Priority. Approve here to enable it for future fixture publications, or decline. No existing fixtures or charges are changed and no email or SMS is sent.</p>
+      {requests.length === 0 ? <p className="text-sm text-white/60">No requests awaiting approval.</p> : <ul className="space-y-4">{requests.map(request => <li key={request.id} className="space-y-3 rounded-xl border border-white/10 bg-black/20 p-4">
+        <div><Link href={`/admin/teams/${request.teamId}`} className="font-semibold hover:underline">{request.teamName}</Link><p className="mt-1 text-sm text-white/60">Requested {new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/London', dateStyle: 'medium', timeStyle: 'short' }).format(request.requestedAt)} · £5 supplement agreed</p></div>
+        <ReviewRequestForm leagueId={id} requestId={request.id} />
+      </li>)}</ul>}
+    </section>
+    {children}
+  </div>;
+}

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/request-actions.ts
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/request-actions.ts
@@ -14,7 +14,7 @@ export async function reviewVeoPriorityAction(leagueId: string, requestId: strin
     const teamId = await reviewVeoPriorityRequest({ leagueId, requestId, actorId: user.id, decision });
     revalidatePath(`/admin/leagues/${leagueId}`, 'layout');
     revalidatePath(`/captain/team/${teamId}`);
-    return { done: true, error: false, message: decision === 'APPROVED' ? 'Approved. Priority is on for future fixture publications. Existing fees are unchanged.' : 'Request declined. Priority and existing fees are unchanged.' };
+    return { done: true, error: false, message: decision === 'APPROVED' ? 'Request approved. Existing fees are unchanged. The current team Priority setting is shown below.' : 'Request declined. Priority and existing fees are unchanged.' };
   } catch (error) {
     if (!(error instanceof VeoRequestError)) console.error('Veo Priority request review failed', error);
     return { done: false, error: true, message: error instanceof VeoRequestError ? error.message : 'The decision could not be saved. Please refresh and try again.' };

--- a/src/app/(admin)/admin/leagues/[id]/veo-priority/request-actions.ts
+++ b/src/app/(admin)/admin/leagues/[id]/veo-priority/request-actions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { reviewVeoPriorityRequest, VeoRequestError } from '@/lib/veo/priority-requests';
+
+export type VeoReviewFormState = { done: boolean; error: boolean; message: string };
+export async function reviewVeoPriorityAction(leagueId: string, requestId: string, _previous: VeoReviewFormState, form: FormData): Promise<VeoReviewFormState> {
+  const { user } = await requireAdmin();
+  if (!user?.id) return { done: false, error: true, message: 'Sign in as an administrator to review requests.' };
+  const decision = String(form.get('decision') ?? '');
+  if (decision !== 'APPROVED' && decision !== 'DECLINED') return { done: false, error: true, message: 'Choose Approve or Decline.' };
+  try {
+    const teamId = await reviewVeoPriorityRequest({ leagueId, requestId, actorId: user.id, decision });
+    revalidatePath(`/admin/leagues/${leagueId}`, 'layout');
+    revalidatePath(`/captain/team/${teamId}`);
+    return { done: true, error: false, message: decision === 'APPROVED' ? 'Approved. Priority is on for future fixture publications. Existing fees are unchanged.' : 'Request declined. Priority and existing fees are unchanged.' };
+  } catch (error) {
+    if (!(error instanceof VeoRequestError)) console.error('Veo Priority request review failed', error);
+    return { done: false, error: true, message: error instanceof VeoRequestError ? error.message : 'The decision could not be saved. Please refresh and try again.' };
+  }
+}

--- a/src/app/captain/team/[teamid]/page.tsx
+++ b/src/app/captain/team/[teamid]/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from "next/navigation";
 
 import CaptainDashboardLeagueTable from "@/components/captain/CaptainDashboardLeagueTable";
 import CaptainOnboardingChecklist from "@/components/captain/CaptainOnboardingChecklist";
+import CaptainVeoPriorityCard from "@/components/captain/CaptainVeoPriorityCard";
 import { getCaptainOnboardingStatus } from "@/lib/captain/onboarding";
 import { getCaptainRelatedTeamContext } from "@/lib/captain/related-teams";
 import { formatDateTimeInLondon } from "@/lib/datetime/london";
@@ -336,6 +337,8 @@ export default async function CaptainOverviewPage({ params }: { params: Promise<
         </section>
       ) : null}
 
+      <CaptainVeoPriorityCard teamId={teamid} leagueId={currentLeagueId} />
+
       <section className="overflow-hidden rounded-3xl border border-emerald-400/15 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.03))] shadow-[0_24px_80px_rgba(0,0,0,0.3)]">
         <div className="grid gap-8 px-6 py-6 lg:grid-cols-[1.2fr_0.8fr] lg:px-8 lg:py-8">
           <div>
@@ -423,7 +426,7 @@ export default async function CaptainOverviewPage({ params }: { params: Promise<
         <div className="rounded-3xl border border-white/10 bg-white/[0.04]">
           <div className="flex items-center justify-between border-b border-white/10 px-6 py-5">
             <div><p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Recent results</p><h2 className="mt-2 text-xl font-semibold text-white">Latest scores</h2></div>
-            <Link href={`/captain/team/${teamid}/results`} className="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15">Open results</Link>
+            <Link href={`/captain/team/${teamid}/results`} className="inline-flex items-center rounded-full border-emerald-400/30 border bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-100 transition hover:bg-emerald-500/15">Open results</Link>
           </div>
           <div className="divide-y divide-white/10">
             {recentResults.length === 0 ? <div className="px-6 py-10 text-sm text-white/55">No results recorded yet.</div> : recentResults.map((fixture) => {

--- a/src/app/captain/team/[teamid]/veo-priority/actions.ts
+++ b/src/app/captain/team/[teamid]/veo-priority/actions.ts
@@ -8,7 +8,7 @@ export type VeoRequestFormState = { status: 'idle' | 'error' | 'pending' | 'on';
 
 export async function requestVeoPriorityAction(teamId: string, leagueId: string, _previous: VeoRequestFormState, form: FormData): Promise<VeoRequestFormState> {
   const access = await requireCaptain(teamId);
-  if (access.accessMode !== 'CAPTAIN' || access.isAdmin || !access.user?.id) {
+  if (access.accessMode !== 'captain' || access.isAdmin || !access.isCaptain || !access.user?.id) {
     return { status: 'error', message: 'Captain previews are read-only. The team captain must submit their own request.' };
   }
   try {

--- a/src/app/captain/team/[teamid]/veo-priority/actions.ts
+++ b/src/app/captain/team/[teamid]/veo-priority/actions.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { requireCaptain } from '@/lib/requireCaptain';
+import { requestVeoPriority, VeoRequestError } from '@/lib/veo/priority-requests';
+
+export type VeoRequestFormState = { status: 'idle' | 'error' | 'pending' | 'on'; message: string };
+
+export async function requestVeoPriorityAction(teamId: string, leagueId: string, _previous: VeoRequestFormState, form: FormData): Promise<VeoRequestFormState> {
+  const access = await requireCaptain(teamId);
+  if (access.accessMode !== 'CAPTAIN' || access.isAdmin || !access.user?.id) {
+    return { status: 'error', message: 'Captain previews are read-only. The team captain must submit their own request.' };
+  }
+  try {
+    const result = await requestVeoPriority({ teamId, leagueId, actorId: access.user.id,
+      agreed: form.get('agreed') === 'on', termsVersion: String(form.get('termsVersion') ?? '') });
+    revalidatePath(`/captain/team/${teamId}`);
+    revalidatePath(`/admin/leagues/${leagueId}`, 'layout');
+    return result === 'ON'
+      ? { status: 'on', message: 'Veo Priority is already ON for your team.' }
+      : { status: 'pending', message: 'Request received — awaiting SIXFL approval. Your fees have not changed.' };
+  } catch (error) {
+    if (!(error instanceof VeoRequestError)) console.error('Veo Priority request failed', error);
+    return { status: 'error', message: error instanceof VeoRequestError ? error.message : 'Your request could not be saved. Please try again. Your fees have not changed.' };
+  }
+}

--- a/src/components/captain/CaptainVeoPriorityCard.tsx
+++ b/src/components/captain/CaptainVeoPriorityCard.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { requireCaptain } from '@/lib/requireCaptain';
+import { readVeoOffer, VEO_REQUEST_TERMS } from '@/lib/veo/priority-requests';
+import VeoPriorityRequestForm from './VeoPriorityRequestForm';
+
+export default async function CaptainVeoPriorityCard({ teamId, leagueId }: { teamId: string; leagueId: string | null }) {
+  const access = await requireCaptain(teamId);
+  const offer = await readVeoOffer(leagueId, teamId);
+  if (!offer || !leagueId) return null;
+  const canRequest = access.accessMode === 'CAPTAIN' && !access.isAdmin && Boolean(access.user?.id);
+  const pending = offer.request?.status === 'PENDING';
+  const declined = offer.request?.status === 'DECLINED';
+  return <section aria-label="Veo Priority" className="space-y-4 rounded-3xl border border-fuchsia-400/30 bg-fuchsia-500/10 p-5 sm:p-6">
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div><p className="text-xs font-semibold uppercase tracking-[0.16em] text-fuchsia-200">📹 SIXFL TV · Veo Priority</p>
+        <h2 className="mt-2 text-xl font-bold text-white sm:text-2xl">{offer.priority ? 'Veo Priority is ON for your team' : pending ? 'Veo Priority requested' : 'Get more of your matches on SIXFL TV'}</h2>
+      </div>
+      <span className="rounded-full border border-fuchsia-300/30 px-3 py-1 text-sm font-semibold text-fuchsia-100">{offer.priority ? 'Priority ON' : pending ? 'Awaiting approval' : '£5 when allocated'}</span>
+    </div>
+    <p className="max-w-3xl text-sm leading-6 text-white/80">Give your team priority for fixtures on our camera-equipped pitch. It is £5 extra per team when allocated to a Veo match, not £5 per player. No Veo allocation means no supplement. Filming is subject to availability, and footage may be published publicly on SIXFL TV/YouTube.</p>
+    {offer.priority ? <div className="space-y-2"><p className="text-sm leading-6 text-emerald-100">Your choice applies to future fixture publications. Check Fixtures to see your filming allocations and agreed match fees.</p><Link href={`/captain/team/${teamId}/fixtures`} className="inline-flex min-h-11 items-center rounded-xl border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:bg-white/10">View your fixtures</Link></div>
+      : pending ? <p role="status" className="rounded-xl border border-amber-300/30 bg-amber-400/10 p-4 text-sm leading-6 text-amber-100">Your request is awaiting SIXFL approval. You do not need to submit it again. Your fees have not changed.</p>
+      : declined ? <p className="text-sm leading-6 text-white/80">Your request was not approved. <Link href={`/captain/team/${teamId}/messages`} className="font-semibold text-fuchsia-100 underline">Contact SIXFL</Link> to discuss Veo Priority.</p>
+      : canRequest ? <VeoPriorityRequestForm teamId={teamId} leagueId={leagueId} termsVersion={VEO_REQUEST_TERMS} />
+      : <p className="text-sm leading-6 text-white/65">This is a read-only preview. The captain can request Priority here when signed in to their own account.</p>}
+  </section>;
+}

--- a/src/components/captain/CaptainVeoPriorityCard.tsx
+++ b/src/components/captain/CaptainVeoPriorityCard.tsx
@@ -7,7 +7,7 @@ export default async function CaptainVeoPriorityCard({ teamId, leagueId }: { tea
   const access = await requireCaptain(teamId);
   const offer = await readVeoOffer(leagueId, teamId);
   if (!offer || !leagueId) return null;
-  const canRequest = access.accessMode === 'CAPTAIN' && !access.isAdmin && Boolean(access.user?.id);
+  const canRequest = access.accessMode === 'captain' && !access.isAdmin && access.isCaptain && Boolean(access.user?.id);
   const pending = offer.request?.status === 'PENDING';
   const declined = offer.request?.status === 'DECLINED';
   return <section aria-label="Veo Priority" className="space-y-4 rounded-3xl border border-fuchsia-400/30 bg-fuchsia-500/10 p-5 sm:p-6">

--- a/src/components/captain/VeoPriorityRequestForm.tsx
+++ b/src/components/captain/VeoPriorityRequestForm.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useActionState } from 'react';
+import { requestVeoPriorityAction, type VeoRequestFormState } from '@/app/captain/team/[teamid]/veo-priority/actions';
+
+export default function VeoPriorityRequestForm({ teamId, leagueId, termsVersion }: { teamId: string; leagueId: string; termsVersion: string }) {
+  const initial: VeoRequestFormState = { status: 'idle', message: '' };
+  const [state, action, pending] = useActionState(requestVeoPriorityAction.bind(null, teamId, leagueId), initial);
+  if (state.status === 'pending' || state.status === 'on') return <p role="status" className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100">{state.message}</p>;
+  return <form action={action} className="space-y-4">
+    <input type="hidden" name="termsVersion" value={termsVersion} />
+    <label className="flex items-start gap-3 text-sm leading-6 text-white/80">
+      <input type="checkbox" name="agreed" required disabled={pending} className="mt-1 h-5 w-5 shrink-0" />
+      <span>I agree to the £5 per-team supplement when our team is allocated to a Veo match after SIXFL approves this request. No allocation means no supplement. Footage may be published publicly on SIXFL TV/YouTube; Priority does not guarantee filming.</span>
+    </label>
+    {state.status === 'error' && <p role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{state.message}</p>}
+    <button type="submit" disabled={pending} className="min-h-11 rounded-xl border border-fuchsia-300/40 bg-fuchsia-500/20 px-5 py-3 font-semibold text-white transition hover:bg-fuchsia-500/30 disabled:cursor-wait disabled:opacity-60">
+      {pending ? 'Sending request…' : 'Request Veo Priority'}
+    </button>
+    <p className="text-xs leading-5 text-white/60">Requesting does not take a payment or change your existing fixtures or fees. SIXFL will review your request.</p>
+  </form>;
+}

--- a/src/lib/veo/priority-requests.ts
+++ b/src/lib/veo/priority-requests.ts
@@ -21,8 +21,11 @@ async function transaction<T>(work: (db: Db) => Promise<T>): Promise<T> {
     try {
       return await prisma.$transaction(work, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, maxWait: 10000, timeout: 20000 });
     } catch (error) {
+      // Simultaneous requests can hit the partial unique index while the second
+      // serializable transaction still sees its older snapshot. Roll it back and
+      // reread in a new transaction; never bypass the one-pending-request index.
       const retry = error instanceof Prisma.PrismaClientKnownRequestError &&
-        (error.code === 'P2034' || (error.code === 'P2010' && ['40001', '40P01'].includes(String(error.meta?.code))));
+        (error.code === 'P2034' || (error.code === 'P2010' && ['40001', '40P01', '23505'].includes(String(error.meta?.code))));
       if (!retry || attempt >= 2) throw error;
     }
   }
@@ -73,7 +76,7 @@ export async function readVeoOffer(leagueId: string | null, teamId: string, db: 
   if (!leagueId || !await eligibleTeam(db, leagueId, teamId)) return null;
   const requests = await db.$queryRaw<VeoRequest[]>`
     SELECT * FROM "VeoPriorityRequest" WHERE "leagueId" = ${leagueId} AND "teamId" = ${teamId}
-    ORDER BY "requestedAt" DESC, id DESC LIMIT 1
+    ORDER BY (status = 'PENDING') DESC, "requestedAt" DESC, id DESC LIMIT 1
   `;
   return { priority: await enabled(db, leagueId, teamId), request: requests[0] ?? null };
 }
@@ -110,6 +113,7 @@ export async function reviewVeoPriorityRequest(input: { leagueId: string; reques
     if (!request) throw new VeoRequestError('Request not found in this league.');
     await lockTeam(db, input.leagueId, request.teamId);
     const current = (await db.$queryRaw<VeoRequest[]>`SELECT * FROM "VeoPriorityRequest" WHERE id = ${request.id} FOR UPDATE`)[0];
+    if (!current) throw new VeoRequestError('Request no longer exists. Refresh the page.');
     if (current.status !== 'PENDING') {
       if (current.status !== input.decision) throw new VeoRequestError('Another administrator has already reviewed this request. Refresh to see the decision.');
       return request.teamId; // Retried approval must not re-enable a subsequently disabled team.

--- a/src/lib/veo/priority-requests.ts
+++ b/src/lib/veo/priority-requests.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from 'node:crypto';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { VEO_SUPPLEMENT_PENCE } from './allocator';
+
+export const VEO_REQUEST_TERMS = 'veo-priority-v1';
+export type VeoRequestStatus = 'PENDING' | 'APPROVED' | 'DECLINED';
+export type VeoRequest = {
+  id: string; leagueId: string; teamId: string; requestedBy: string; requestedAt: Date;
+  status: VeoRequestStatus; supplementPence: number; termsVersion: string;
+};
+export type VeoOffer = { priority: boolean; request: VeoRequest | null };
+export class VeoRequestError extends Error {}
+type Db = Pick<typeof prisma, '$queryRaw' | '$executeRaw'>;
+
+function validId(value: string) {
+  if (!value || value.length > 200) throw new VeoRequestError('The team or league could not be identified. Refresh and try again.');
+}
+async function transaction<T>(work: (db: Db) => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await prisma.$transaction(work, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, maxWait: 10000, timeout: 20000 });
+    } catch (error) {
+      const retry = error instanceof Prisma.PrismaClientKnownRequestError &&
+        (error.code === 'P2034' || (error.code === 'P2010' && ['40001', '40P01'].includes(String(error.meta?.code))));
+      if (!retry || attempt >= 2) throw error;
+    }
+  }
+}
+async function lockTeam(db: Db, leagueId: string, teamId: string) {
+  validId(leagueId); validId(teamId);
+  await db.$queryRaw`SELECT id FROM "League" WHERE id = ${leagueId} FOR UPDATE`;
+  await db.$queryRaw`SELECT id FROM "Team" WHERE id = ${teamId} FOR UPDATE`;
+}
+async function audit(db: Db, leagueId: string, teamId: string, actorId: string, details: object) {
+  await db.$executeRaw`INSERT INTO "VeoSettingsAudit" (id, "leagueId", "teamId", "actorId", details)
+    VALUES (${randomUUID()}, ${leagueId}, ${teamId}, ${actorId}, ${JSON.stringify(details)}::jsonb)`;
+}
+/** Exact current-season membership only. A removed season member cannot fall back
+ * to Team.leagueId. Legacy leagues without any season membership rows still work. */
+async function eligibleTeam(db: Db, leagueId: string, teamId: string): Promise<boolean> {
+  const rows = await db.$queryRaw<{ id: string }[]>`
+    SELECT t.id FROM "Team" t JOIN "League" l ON l.id = ${leagueId}
+    JOIN "VeoLeagueSettings" v ON v."leagueId" = l.id AND v.enabled
+    LEFT JOIN "LeagueCompetition" c ON c.id = l."competitionId"
+    WHERE t.id = ${teamId} AND l."isActive" AND NOT t."isFixturePlaceholder"
+      AND t."teamMode"::text = 'STANDARD'
+      AND (c."currentLeagueId" IS NULL OR c."currentLeagueId" = l.id)
+      AND (EXISTS (SELECT 1 FROM "LeagueSeasonTeam" m WHERE m."leagueId" = l.id AND m."teamId" = t.id AND m."isActive")
+        OR (t."leagueId" = l.id AND NOT EXISTS (SELECT 1 FROM "LeagueSeasonTeam" m WHERE m."leagueId" = l.id)))
+  `;
+  return rows.length === 1;
+}
+async function assertCaptain(db: Db, teamId: string, actorId: string) {
+  validId(actorId);
+  const rows = await db.$queryRaw<{ id: string }[]>`
+    SELECT m.id FROM "TeamMember" m JOIN "User" u ON u.id = m."userId"
+    WHERE m."teamId" = ${teamId} AND m."userId" = ${actorId} AND m.role::text = 'CAPTAIN'
+      AND COALESCE(m."isActive", true) AND u.role::text <> 'ADMIN' FOR UPDATE OF m
+  `;
+  if (!rows.length) throw new VeoRequestError('Only an active captain of this team can request Veo Priority.');
+}
+async function assertAdmin(db: Db, actorId: string) {
+  validId(actorId);
+  const rows = await db.$queryRaw<{ id: string }[]>`SELECT id FROM "User" WHERE id = ${actorId} AND role::text = 'ADMIN'`;
+  if (!rows.length) throw new VeoRequestError('Administrator access is required to review this request.');
+}
+async function enabled(db: Db, leagueId: string, teamId: string) {
+  const rows = await db.$queryRaw<{ enabled: boolean }[]>`SELECT enabled FROM "VeoTeamPriority" WHERE "leagueId" = ${leagueId} AND "teamId" = ${teamId}`;
+  return rows[0]?.enabled === true;
+}
+export async function readVeoOffer(leagueId: string | null, teamId: string, db: Db = prisma): Promise<VeoOffer | null> {
+  if (!leagueId || !await eligibleTeam(db, leagueId, teamId)) return null;
+  const requests = await db.$queryRaw<VeoRequest[]>`
+    SELECT * FROM "VeoPriorityRequest" WHERE "leagueId" = ${leagueId} AND "teamId" = ${teamId}
+    ORDER BY "requestedAt" DESC, id DESC LIMIT 1
+  `;
+  return { priority: await enabled(db, leagueId, teamId), request: requests[0] ?? null };
+}
+export async function requestVeoPriority(input: { leagueId: string; teamId: string; actorId: string; agreed: boolean; termsVersion: string }) {
+  if (!input.agreed || input.termsVersion !== VEO_REQUEST_TERMS) throw new VeoRequestError('Please agree to the £5 allocated-match supplement before requesting Priority.');
+  return transaction(async db => {
+    const { leagueId, teamId, actorId } = input;
+    await lockTeam(db, leagueId, teamId);
+    await assertCaptain(db, teamId, actorId);
+    const offer = await readVeoOffer(leagueId, teamId, db);
+    if (!offer) throw new VeoRequestError('Veo Priority is not currently available for this team in this league.');
+    if (offer.priority) return 'ON' as const;
+    if (offer.request?.status === 'PENDING') return 'PENDING' as const;
+    if (offer.request?.status === 'DECLINED') throw new VeoRequestError('Your request was not approved. Please contact SIXFL to discuss it.');
+    const id = randomUUID();
+    await db.$executeRaw`INSERT INTO "VeoPriorityRequest" (id, "leagueId", "teamId", "requestedBy", "supplementPence", "termsVersion")
+      VALUES (${id}, ${leagueId}, ${teamId}, ${actorId}, ${VEO_SUPPLEMENT_PENCE}, ${VEO_REQUEST_TERMS})`;
+    await audit(db, leagueId, teamId, actorId, { kind: 'captain_priority_request', requestId: id, supplementPence: VEO_SUPPLEMENT_PENCE, termsVersion: VEO_REQUEST_TERMS, agreed: true });
+    return 'PENDING' as const;
+  });
+}
+/** Reused by the existing admin toggle so manual approval cannot leave a request pending. */
+export async function approvePendingVeoRequests(db: Db, leagueId: string, teamId: string, actorId: string) {
+  await db.$executeRaw`UPDATE "VeoPriorityRequest" SET status = 'APPROVED', "reviewedBy" = ${actorId}, "reviewedAt" = NOW()
+    WHERE "leagueId" = ${leagueId} AND "teamId" = ${teamId} AND status = 'PENDING'`;
+}
+export async function reviewVeoPriorityRequest(input: { leagueId: string; requestId: string; actorId: string; decision: 'APPROVED' | 'DECLINED' }) {
+  validId(input.requestId);
+  if (!['APPROVED', 'DECLINED'].includes(input.decision)) throw new VeoRequestError('Choose Approve or Decline.');
+  return transaction(async db => {
+    await assertAdmin(db, input.actorId);
+    const rows = await db.$queryRaw<VeoRequest[]>`SELECT * FROM "VeoPriorityRequest" WHERE id = ${input.requestId} AND "leagueId" = ${input.leagueId}`;
+    const request = rows[0];
+    if (!request) throw new VeoRequestError('Request not found in this league.');
+    await lockTeam(db, input.leagueId, request.teamId);
+    const current = (await db.$queryRaw<VeoRequest[]>`SELECT * FROM "VeoPriorityRequest" WHERE id = ${request.id} FOR UPDATE`)[0];
+    if (current.status !== 'PENDING') {
+      if (current.status !== input.decision) throw new VeoRequestError('Another administrator has already reviewed this request. Refresh to see the decision.');
+      return request.teamId; // Retried approval must not re-enable a subsequently disabled team.
+    }
+    if (input.decision === 'APPROVED') {
+      if (current.supplementPence !== VEO_SUPPLEMENT_PENCE || current.termsVersion !== VEO_REQUEST_TERMS) throw new VeoRequestError('The saved agreement needs reviewing before Priority can be enabled.');
+      if (!await eligibleTeam(db, input.leagueId, request.teamId)) throw new VeoRequestError('This league is off or the team is no longer eligible. Do not approve this request.');
+      await db.$executeRaw`INSERT INTO "VeoTeamPriority" ("leagueId", "teamId", enabled, "updatedBy")
+        VALUES (${input.leagueId}, ${request.teamId}, true, ${input.actorId})
+        ON CONFLICT ("leagueId", "teamId") DO UPDATE SET enabled = true, "updatedAt" = NOW(), "updatedBy" = EXCLUDED."updatedBy"`;
+    }
+    await db.$executeRaw`UPDATE "VeoPriorityRequest" SET status = ${input.decision}, "reviewedBy" = ${input.actorId}, "reviewedAt" = NOW() WHERE id = ${request.id}`;
+    await audit(db, input.leagueId, request.teamId, input.actorId, { kind: 'captain_priority_review', requestId: request.id, decision: input.decision, requestedBy: request.requestedBy, supplementPence: request.supplementPence });
+    return request.teamId;
+  });
+}
+export async function pendingVeoRequests(leagueId: string) {
+  return prisma.$queryRaw<(VeoRequest & { teamName: string })[]>`
+    SELECT r.*, t.name AS "teamName" FROM "VeoPriorityRequest" r JOIN "Team" t ON t.id = r."teamId"
+    WHERE r."leagueId" = ${leagueId} AND r.status = 'PENDING' ORDER BY r."requestedAt", r.id
+  `;
+}
+export async function pendingVeoRequestCount(leagueId: string): Promise<number> {
+  const rows = await prisma.$queryRaw<{ count: number }[]>`SELECT COUNT(*)::integer AS count FROM "VeoPriorityRequest" WHERE "leagueId" = ${leagueId} AND status = 'PENDING'`;
+  return rows[0]?.count ?? 0;
+}

--- a/tests/veo-priority/browser.mjs
+++ b/tests/veo-priority/browser.mjs
@@ -13,6 +13,11 @@ try {
   assert.equal(await page.locator('select').count(), 0);
   assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1), 'Mobile page must not overflow horizontally');
   assert.equal(await page.locator('article').count(), 6);
+  const requests = page.getByRole('region', { name: 'Veo Priority requests', exact: true });
+  await requests.getByText('1 pending', { exact: true }).waitFor();
+  await requests.getByRole('button', { name: 'Approve Priority request', exact: true }).click();
+  await requests.getByRole('alert').filter({ hasText: 'Sign in as an administrator' }).waitFor();
+  await requests.getByText('1 pending', { exact: true }).waitFor();
   await page.screenshot({ path: 'artifacts/veo/admin-mobile.png', fullPage: true });
   const completed = page.locator('article').filter({ hasText: 'Veo test team 3 vs Veo test team 4' });
   await completed.locator('summary').click();
@@ -24,5 +29,13 @@ try {
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.screenshot({ path: 'artifacts/veo/admin-desktop.png', fullPage: true });
   assert.deepEqual(errors, []);
-  console.log('PASS: mobile layout, OFF state, saved fee rows and completed-fixture video edits.');
+  const styles = await page.locator('link[rel="stylesheet"]').evaluateAll(links => links.map(link => link.href));
+  const promo = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await promo.setContent(`<!doctype html><html><head>${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}</head><body style="background:#080808"><main class="mx-auto max-w-5xl p-4">${readFileSync('artifacts/veo/captain-promo.html', 'utf8')}</main></body></html>`, { waitUntil: 'networkidle' });
+  await promo.getByRole('button', { name: 'Request Veo Priority', exact: true }).waitFor();
+  assert.ok(await promo.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1), 'Captain promo must fit mobile');
+  await promo.screenshot({ path: 'artifacts/veo/captain-promo-mobile.png', fullPage: true });
+  await promo.setViewportSize({ width: 1440, height: 1000 });
+  await promo.screenshot({ path: 'artifacts/veo/captain-promo-desktop.png', fullPage: true });
+  console.log('PASS: request queue, anonymous review refusal, mobile promo, OFF state, saved fee rows and completed-fixture video edits.');
 } finally { await browser.close(); }

--- a/tests/veo-priority/request-ui.test.cjs
+++ b/tests/veo-priority/request-ui.test.cjs
@@ -1,7 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
-const path = require('node:path');
 const ts = require('typescript');
 const React = require('react');
 const { renderToStaticMarkup } = require('react-dom/server');
@@ -23,9 +22,16 @@ function load(file, mocks) {
   }, mod, mod.exports);
   return mod.exports;
 }
-const normalAccess = { accessMode: 'CAPTAIN', isAdmin: false, user: { id: 'captain' } };
+// These are the actual requireCaptain access modes, not invented role labels.
+const normalAccess = { accessMode: 'captain', isAdmin: false, isCaptain: true, user: { id: 'captain' } };
+const previewAccess = [
+  { accessMode: 'captain', isAdmin: true, isCaptain: false, user: { id: 'admin' } },
+  { accessMode: 'captain-preview', isAdmin: false, isCaptain: true, user: { id: 'admin' } },
+  { accessMode: 'captain', isAdmin: false, isCaptain: false, user: null },
+  { accessMode: 'captain', isAdmin: false, isCaptain: false, user: { id: 'non-captain' } },
+];
 async function renderCard(offer, access = normalAccess) {
-  const form = load(formPath, { [ '@/app/captain/team/[teamid]/veo-priority/actions' ]: {
+  const form = load(formPath, { '@/app/captain/team/[teamid]/veo-priority/actions': {
     requestVeoPriorityAction: async () => ({ status: 'pending', message: 'Requested' }),
   } }).default;
   const Card = load(cardPath, {
@@ -56,14 +62,14 @@ test('pending, approved and declined cards persist without another sign-up butto
     assert.ok(html.includes(expected)); assert.ok(!html.includes('Request Veo Priority</button>'));
   }
 });
-test('administrator and development previews cannot present a live consent button', async () => {
-  for (const mode of ['ADMIN_VIEW', 'ADMIN_PREVIEW', 'DEV']) {
-    const html = await renderCard({ priority: false, request: null }, { accessMode: mode, isAdmin: true, user: { id: 'admin' } });
+test('administrator, captain-only preview and development fallback cannot present a consent button', async () => {
+  for (const access of previewAccess) {
+    const html = await renderCard({ priority: false, request: null }, access);
     assert.ok(html.includes('read-only preview')); assert.ok(!html.includes('<form'));
   }
 });
-test('native action refuses preview writes and binds the real actor and exact team server-side', async () => {
-  let access = { accessMode: 'ADMIN_PREVIEW', isAdmin: true, user: { id: 'admin' } };
+test('native action refuses every preview mode and binds the real actor and exact team server-side', async () => {
+  let access = previewAccess[0];
   const writes = [], refreshed = [];
   const action = load(actionPath, {
     'next/cache': { revalidatePath: (...args) => refreshed.push(args) },
@@ -71,7 +77,11 @@ test('native action refuses preview writes and binds the real actor and exact te
     '@/lib/veo/priority-requests': { VeoRequestError, requestVeoPriority: async input => { writes.push(input); return 'PENDING'; } },
   }).requestVeoPriorityAction;
   const form = new FormData(); form.set('agreed', 'on'); form.set('termsVersion', 'veo-priority-v1'); form.set('actorId', 'forged-admin');
-  assert.equal((await action('team', 'league', {}, form)).status, 'error'); assert.equal(writes.length, 0);
+  for (const preview of previewAccess) {
+    access = preview;
+    assert.equal((await action('team', 'league', {}, form)).status, 'error');
+    assert.equal(writes.length, 0);
+  }
   access = normalAccess;
   assert.equal((await action('team', 'league', {}, form)).status, 'pending');
   assert.deepEqual(writes[0], { teamId: 'team', leagueId: 'league', actorId: 'captain', agreed: true, termsVersion: 'veo-priority-v1' });

--- a/tests/veo-priority/request-ui.test.cjs
+++ b/tests/veo-priority/request-ui.test.cjs
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+
+const cardPath = 'src/components/captain/CaptainVeoPriorityCard.tsx';
+const formPath = 'src/components/captain/VeoPriorityRequestForm.tsx';
+const actionPath = 'src/app/captain/team/[teamid]/veo-priority/actions.ts';
+const reviewPath = 'src/app/(admin)/admin/leagues/[id]/veo-priority/request-actions.ts';
+class VeoRequestError extends Error {}
+function load(file, mocks) {
+  const mod = { exports: {} };
+  const js = ts.transpileModule(fs.readFileSync(file, 'utf8'), { fileName: file, compilerOptions: {
+    module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true,
+  } }).outputText;
+  new Function('require', 'module', 'exports', js)(key => {
+    if (Object.hasOwn(mocks, key)) return mocks[key];
+    if (key === 'react' || key === 'react/jsx-runtime') return require(key);
+    throw new Error(`Unexpected request UI dependency: ${key}`);
+  }, mod, mod.exports);
+  return mod.exports;
+}
+const normalAccess = { accessMode: 'CAPTAIN', isAdmin: false, user: { id: 'captain' } };
+async function renderCard(offer, access = normalAccess) {
+  const form = load(formPath, { [ '@/app/captain/team/[teamid]/veo-priority/actions' ]: {
+    requestVeoPriorityAction: async () => ({ status: 'pending', message: 'Requested' }),
+  } }).default;
+  const Card = load(cardPath, {
+    'next/link': ({ children, ...props }) => React.createElement('a', props, children),
+    '@/lib/requireCaptain': { requireCaptain: async () => access },
+    '@/lib/veo/priority-requests': { readVeoOffer: async () => offer, VEO_REQUEST_TERMS: 'veo-priority-v1' },
+    './VeoPriorityRequestForm': form,
+  }).default;
+  return renderToStaticMarkup(await Card({ teamId: 'team', leagueId: 'league' }));
+}
+test('real captain card is absent when the shared service says the league is off or team ineligible', async () => {
+  assert.equal(await renderCard(null), '');
+});
+test('eligible captain sees the real opt-in form, agreement, price and public-filming disclosure', async () => {
+  const html = await renderCard({ priority: false, request: null });
+  for (const word of ['Get more of your matches', 'Request Veo Priority', '£5', 'not £5 per player', 'YouTube', 'name="agreed"', 'required', 'name="termsVersion"']) assert.ok(html.includes(word), word);
+  assert.ok(!html.includes('name="actorId"'));
+  fs.mkdirSync('artifacts/veo', { recursive: true });
+  fs.writeFileSync('artifacts/veo/captain-promo.html', html);
+});
+test('pending, approved and declined cards persist without another sign-up button', async () => {
+  for (const [offer, expected] of [
+    [{ priority: false, request: { status: 'PENDING' } }, 'awaiting SIXFL approval'],
+    [{ priority: true, request: { status: 'APPROVED' } }, 'Veo Priority is ON'],
+    [{ priority: false, request: { status: 'DECLINED' } }, 'not approved'],
+  ]) {
+    const html = await renderCard(offer);
+    assert.ok(html.includes(expected)); assert.ok(!html.includes('Request Veo Priority</button>'));
+  }
+});
+test('administrator and development previews cannot present a live consent button', async () => {
+  for (const mode of ['ADMIN_VIEW', 'ADMIN_PREVIEW', 'DEV']) {
+    const html = await renderCard({ priority: false, request: null }, { accessMode: mode, isAdmin: true, user: { id: 'admin' } });
+    assert.ok(html.includes('read-only preview')); assert.ok(!html.includes('<form'));
+  }
+});
+test('native action refuses preview writes and binds the real actor and exact team server-side', async () => {
+  let access = { accessMode: 'ADMIN_PREVIEW', isAdmin: true, user: { id: 'admin' } };
+  const writes = [], refreshed = [];
+  const action = load(actionPath, {
+    'next/cache': { revalidatePath: (...args) => refreshed.push(args) },
+    '@/lib/requireCaptain': { requireCaptain: async () => access },
+    '@/lib/veo/priority-requests': { VeoRequestError, requestVeoPriority: async input => { writes.push(input); return 'PENDING'; } },
+  }).requestVeoPriorityAction;
+  const form = new FormData(); form.set('agreed', 'on'); form.set('termsVersion', 'veo-priority-v1'); form.set('actorId', 'forged-admin');
+  assert.equal((await action('team', 'league', {}, form)).status, 'error'); assert.equal(writes.length, 0);
+  access = normalAccess;
+  assert.equal((await action('team', 'league', {}, form)).status, 'pending');
+  assert.deepEqual(writes[0], { teamId: 'team', leagueId: 'league', actorId: 'captain', agreed: true, termsVersion: 'veo-priority-v1' });
+  assert.ok(refreshed.some(x => x[0] === '/captain/team/team'));
+  assert.ok(refreshed.some(x => x[0] === '/admin/leagues/league' && x[1] === 'layout'));
+});
+test('native admin action rejects anonymous development use and validates a decision before calling the service', async () => {
+  let user = null; const writes = [];
+  const action = load(reviewPath, {
+    'next/cache': { revalidatePath: () => {} }, '@/lib/requireAdmin': { requireAdmin: async () => ({ user }) },
+    '@/lib/veo/priority-requests': { VeoRequestError, reviewVeoPriorityRequest: async input => { writes.push(input); return 'team'; } },
+  }).reviewVeoPriorityAction;
+  const form = new FormData(); form.set('decision', 'APPROVED');
+  assert.equal((await action('league', 'request', {}, form)).error, true); assert.equal(writes.length, 0);
+  user = { id: 'real-admin' };
+  form.set('decision', 'PAY'); assert.equal((await action('league', 'request', {}, form)).error, true);
+  form.set('decision', 'DECLINED'); assert.equal((await action('league', 'request', {}, form)).done, true);
+  assert.deepEqual(writes[0], { leagueId: 'league', requestId: 'request', actorId: 'real-admin', decision: 'DECLINED' });
+});
+test('owning sources retain the promo and admin queue after preparation; no new browser DOM bridges or sending paths', () => {
+  const overview = fs.readFileSync('src/app/captain/team/[teamid]/page.tsx', 'utf8');
+  assert.equal((overview.match(/<CaptainVeoPriorityCard /g) || []).length, 1);
+  assert.ok(overview.includes('leagueId={currentLeagueId}'));
+  const admin = fs.readFileSync('src/app/(admin)/admin/leagues/[id]/veo-priority/actions.ts', 'utf8');
+  assert.ok(admin.includes('approvePendingVeoRequests(tx, leagueId, teamId, user.id)'));
+  for (const file of [cardPath, formPath, actionPath, reviewPath, 'src/lib/veo/priority-requests.ts']) {
+    assert.doesNotMatch(fs.readFileSync(file, 'utf8'), /MutationObserver|document\.querySelector|sendEmail|queueDirectNotification|stripe\./);
+  }
+});

--- a/tests/veo-priority/requests.ts
+++ b/tests/veo-priority/requests.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { prisma } from '../../src/lib/prisma';
+import { requestVeoPriority, readVeoOffer, reviewVeoPriorityRequest, pendingVeoRequests, pendingVeoRequestCount, approvePendingVeoRequests, VEO_REQUEST_TERMS } from '../../src/lib/veo/priority-requests';
+
+const url = new URL(process.env.DATABASE_URL!);
+assert.equal(process.env.VEO_TEST_DATABASE, '1');
+assert.ok(['127.0.0.1', 'localhost'].includes(url.hostname));
+assert.equal(url.pathname, '/sixfl_veo_test', 'Never run request tests against production.');
+const id = () => `veo-request-test-${randomUUID()}`;
+let passed = 0;
+const pass = (name: string) => console.log(`PASS ${++passed}: ${name}`);
+
+async function main() {
+  const league = await prisma.league.create({ data: { id: id(), name: 'Request test league', slug: id() }, select: { id: true } });
+  const team = await prisma.team.create({ data: { id: id(), name: 'Request test team', claimCode: id(), leagueId: league.id, standardMatchFeePence: 4000 }, select: { id: true } });
+  const captain = await prisma.user.create({ data: { id: id(), name: 'Test captain', role: 'USER' }, select: { id: true } });
+  const other = await prisma.user.create({ data: { id: id(), name: 'Test other player', role: 'USER' }, select: { id: true } });
+  const admin = await prisma.user.create({ data: { id: id(), name: 'Test admin', role: 'ADMIN' }, select: { id: true } });
+  await prisma.teamMember.create({ data: { teamId: team.id, userId: captain.id, role: 'CAPTAIN' }, select: { id: true } });
+  await prisma.teamMember.create({ data: { teamId: team.id, userId: other.id, role: 'PLAYER' }, select: { id: true } });
+  const input = { leagueId: league.id, teamId: team.id, actorId: captain.id, agreed: true, termsVersion: VEO_REQUEST_TERMS };
+  const financialState = async () => JSON.stringify({
+    fixtures: await prisma.fixture.findMany({ orderBy: { id: 'asc' } }),
+    charges: await prisma.paymentCharge.findMany({ orderBy: { id: 'asc' } }),
+    playerFees: await prisma.playerMatchFee.findMany({ orderBy: { id: 'asc' } }),
+    messages: await prisma.notificationDispatch.findMany({ orderBy: { id: 'asc' } }),
+  });
+  const financialBefore = await financialState();
+  assert.equal(await readVeoOffer(league.id, team.id), null);
+  await assert.rejects(requestVeoPriority(input), /not currently available/);
+  await prisma.$executeRaw`INSERT INTO "VeoLeagueSettings" ("leagueId", enabled, pitch) VALUES (${league.id}, true, '1')`;
+  assert.ok(await readVeoOffer(league.id, team.id));
+  await assert.rejects(requestVeoPriority({ ...input, agreed: false }), /agree/);
+  await assert.rejects(requestVeoPriority({ ...input, termsVersion: 'wrong' }), /agree/);
+  await assert.rejects(requestVeoPriority({ ...input, actorId: other.id }), /active captain/);
+  await assert.rejects(requestVeoPriority({ ...input, actorId: admin.id }), /active captain/);
+  await assert.rejects(requestVeoPriority({ ...input, teamId: 'unknown-team' }), /active captain/);
+  pass('OFF leagues, missing consent, wrong terms, other players, previews/admins and other teams cannot request');
+
+  await prisma.$executeRaw`UPDATE "Team" SET "teamMode" = 'MANAGED' WHERE id = ${team.id}`;
+  assert.equal(await readVeoOffer(league.id, team.id), null);
+  await assert.rejects(requestVeoPriority(input), /not currently available/);
+  await prisma.$executeRaw`UPDATE "Team" SET "teamMode" = 'STANDARD', "isFixturePlaceholder" = true WHERE id = ${team.id}`;
+  assert.equal(await readVeoOffer(league.id, team.id), null);
+  await prisma.$executeRaw`UPDATE "Team" SET "isFixturePlaceholder" = false WHERE id = ${team.id}`;
+  await prisma.$executeRaw`UPDATE "TeamMember" SET "isActive" = false WHERE "teamId" = ${team.id} AND "userId" = ${captain.id}`;
+  await assert.rejects(requestVeoPriority(input), /active captain/);
+  await prisma.$executeRaw`UPDATE "TeamMember" SET "isActive" = true WHERE "teamId" = ${team.id} AND "userId" = ${captain.id}`;
+  pass('managed teams, placeholders and inactive captains are excluded');
+
+  await prisma.$executeRaw`INSERT INTO "LeagueSeasonTeam" (id, "leagueId", "teamId", "isActive") VALUES (${id()}, ${league.id}, ${team.id}, false)`;
+  assert.equal(await readVeoOffer(league.id, team.id), null);
+  await assert.rejects(requestVeoPriority(input), /not currently available/);
+  await prisma.$executeRaw`UPDATE "LeagueSeasonTeam" SET "isActive" = true WHERE "leagueId" = ${league.id} AND "teamId" = ${team.id}`;
+  const results = await Promise.all([requestVeoPriority(input), requestVeoPriority(input)]);
+  assert.deepEqual(results, ['PENDING', 'PENDING']);
+  assert.equal(await pendingVeoRequestCount(league.id), 1);
+  assert.equal((await readVeoOffer(league.id, team.id))?.priority, false);
+  assert.equal(await financialState(), financialBefore);
+  pass('exact active season membership; concurrent duplicate requests save once without opting in or billing');
+
+  const request = (await pendingVeoRequests(league.id))[0];
+  const review = { leagueId: league.id, requestId: request.id, actorId: admin.id, decision: 'APPROVED' as const };
+  await assert.rejects(reviewVeoPriorityRequest({ ...review, actorId: captain.id }), /Administrator/);
+  await assert.rejects(reviewVeoPriorityRequest({ ...review, leagueId: 'other-league' }), /not found/);
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = false WHERE "leagueId" = ${league.id}`;
+  await assert.rejects(reviewVeoPriorityRequest(review), /no longer eligible/);
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = true WHERE "leagueId" = ${league.id}`;
+  await prisma.$executeRaw`UPDATE "LeagueSeasonTeam" SET "isActive" = false WHERE "leagueId" = ${league.id}`;
+  await assert.rejects(reviewVeoPriorityRequest(review), /no longer eligible/);
+  await prisma.$executeRaw`UPDATE "LeagueSeasonTeam" SET "isActive" = true WHERE "leagueId" = ${league.id}`;
+  await Promise.all([reviewVeoPriorityRequest(review), reviewVeoPriorityRequest(review)]);
+  assert.equal((await readVeoOffer(league.id, team.id))?.priority, true);
+  assert.equal((await readVeoOffer(league.id, team.id))?.request?.status, 'APPROVED');
+  assert.equal(await pendingVeoRequestCount(league.id), 0);
+  assert.equal(await requestVeoPriority(input), 'ON');
+  assert.equal(await financialState(), financialBefore);
+  pass('admin review rechecks current eligibility; approval enables only future Priority and never changes money or fixtures');
+
+  await prisma.$executeRaw`UPDATE "VeoTeamPriority" SET enabled = false WHERE "leagueId" = ${league.id} AND "teamId" = ${team.id}`;
+  await reviewVeoPriorityRequest(review);
+  assert.equal((await readVeoOffer(league.id, team.id))?.priority, false);
+  await requestVeoPriority(input);
+  const second = (await pendingVeoRequests(league.id))[0];
+  await reviewVeoPriorityRequest({ ...review, requestId: second.id, decision: 'DECLINED' });
+  assert.equal((await readVeoOffer(league.id, team.id))?.request?.status, 'DECLINED');
+  assert.equal((await readVeoOffer(league.id, team.id))?.priority, false);
+  await assert.rejects(requestVeoPriority(input), /not approved/);
+  await assert.rejects(reviewVeoPriorityRequest({ ...review, requestId: second.id }), /already reviewed/);
+  pass('stale approval cannot re-enable; declined requests remain visible without automatic billing or repeated spam');
+
+  const competition = await prisma.leagueCompetition.create({ data: { id: id(), name: 'Test competition', slug: id(), currentLeagueId: league.id }, select: { id: true } });
+  const archive = await prisma.league.create({ data: { id: id(), name: 'Test old season', slug: id(), competitionId: competition.id }, select: { id: true } });
+  await prisma.$executeRaw`INSERT INTO "VeoLeagueSettings" ("leagueId", enabled, pitch) VALUES (${archive.id}, true, '1')`;
+  await prisma.$executeRaw`INSERT INTO "LeagueSeasonTeam" (id, "leagueId", "teamId", "isActive") VALUES (${id()}, ${archive.id}, ${team.id}, true)`;
+  assert.equal(await readVeoOffer(archive.id, team.id), null);
+  pass('archived seasons do not advertise or accept requests');
+
+  // Seed a genuine pending request on the existing browser-test league. Keep it OFF
+  // afterwards so the old OFF-state and completed-video tests remain meaningful.
+  const seed = JSON.parse(readFileSync('artifacts/veo/seed.json', 'utf8'));
+  const target = await prisma.team.findFirstOrThrow({ where: { leagueId: seed.leagueId }, orderBy: { name: 'asc' }, select: { id: true } });
+  await prisma.teamMember.create({ data: { teamId: target.id, userId: captain.id, role: 'CAPTAIN' }, select: { id: true } });
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = true WHERE "leagueId" = ${seed.leagueId}`;
+  await requestVeoPriority({ ...input, leagueId: seed.leagueId, teamId: target.id });
+  await prisma.$transaction(tx => approvePendingVeoRequests(tx, seed.leagueId, target.id, admin.id));
+  assert.equal(await pendingVeoRequestCount(seed.leagueId), 0);
+  await requestVeoPriority({ ...input, leagueId: seed.leagueId, teamId: target.id });
+  await prisma.$executeRaw`UPDATE "VeoLeagueSettings" SET enabled = false WHERE "leagueId" = ${seed.leagueId}`;
+  assert.equal(await pendingVeoRequestCount(seed.leagueId), 1);
+  assert.equal(await financialState(), financialBefore);
+  const audit = await prisma.$queryRaw<{ count: number }[]>`SELECT COUNT(*)::integer AS count FROM "VeoSettingsAudit" WHERE "leagueId" = ${league.id} AND details->>'kind' = 'captain_priority_request'`;
+  assert.equal(audit[0].count, 2);
+  pass('manual approval closes the queue; all decisions and consent are audited; no fixture/payment/message mutations');
+  console.log(`${passed} request database checks passed.`);
+}
+main().finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Requested change
Add a Veo Priority promotional card and Request button to the captain team overview, only in enabled leagues. Requests await admin approval and do not change existing charges.

## Implementation
- Native overview card with available, awaiting approval, ON and declined states; actual administrator/captain previews and development fallbacks are read-only.
- Explicit £5 allocated-match agreement, public YouTube/SIXFL TV disclosure and no filming guarantee.
- Shared exact-team/current-season eligibility and request service; deduplicated pending requests, recorded captain consent and audited admin approval/decline.
- Pending-count badge on the league Veo link and Captain requests review controls on the Veo page. Existing manual opt-in resolves pending requests too.
- Additive empty request table. No live teams opted in, no fees/fixtures changed and no customer messages sent.

## Verified head: c25b3b03a89d75870d7d4792bfb4cdc0d15ef5e2
All 52 returned PR workflows completed successfully. Dedicated Veo run 34664193433 passed native and post-prebuild request UI/action contracts, real Postgres allocation/request/approval/concurrency/permissions tests, production build and authentication boundary, mobile promotional card and admin queue checks, and completed-fixture video editing. Desktop/mobile artifacts visually reviewed.

The real concurrent-request test exposed PostgreSQL 23505 on a stale serializable snapshot; fixed by bounded full-transaction retry with the unique pending-request index preserved. Tests were retained. Captain guards use the existing lower-case accessMode contract and isCaptain, not invented role labels.

## Rollout
Normal main merge/deploy. No feature flags or customer preferences enabled by deployment. Requests create only pending records; approval affects future fixture publications. Existing fixtures and prices remain untouched. No authenticated production customer request has been submitted.