### PR TITLE
Make Veo Priority captain-facing and preserve request controls in preview

### DIFF
--- a/src/components/captain/CaptainVeoPriorityCard.tsx
+++ b/src/components/captain/CaptainVeoPriorityCard.tsx
@@ -7,21 +7,56 @@ export default async function CaptainVeoPriorityCard({ teamId, leagueId }: { tea
   const access = await requireCaptain(teamId);
   const offer = await readVeoOffer(leagueId, teamId);
   if (!offer || !leagueId) return null;
+
   const canRequest = access.accessMode === 'captain' && !access.isAdmin && access.isCaptain && Boolean(access.user?.id);
   const pending = offer.request?.status === 'PENDING';
   const declined = offer.request?.status === 'DECLINED';
-  return <section aria-label="Veo Priority" className="space-y-4 rounded-3xl border border-fuchsia-400/30 bg-fuchsia-500/10 p-5 sm:p-6">
-    <div className="flex flex-wrap items-start justify-between gap-3">
-      <div><p className="text-xs font-semibold uppercase tracking-[0.16em] text-fuchsia-200">📹 SIXFL TV · Veo Priority</p>
-        <h2 className="mt-2 text-xl font-bold text-white sm:text-2xl">{offer.priority ? 'Veo Priority is ON for your team' : pending ? 'Veo Priority requested' : 'Get more of your matches on SIXFL TV'}</h2>
-      </div>
-      <span className="rounded-full border border-fuchsia-300/30 px-3 py-1 text-sm font-semibold text-fuchsia-100">{offer.priority ? 'Priority ON' : pending ? 'Awaiting approval' : '£5 when allocated'}</span>
+
+  return (
+    <div className="space-y-3">
+      {!canRequest && (
+        <aside aria-label="Veo preview notice" className="rounded-xl border border-amber-300/20 bg-amber-400/5 px-4 py-3 text-sm leading-6 text-amber-100/80">
+          Preview only — the captain sees the offer below. Request controls are visible but disabled in this view; no request will be sent.
+        </aside>
+      )}
+      <section aria-label="Veo Priority" className="space-y-5 rounded-3xl border border-fuchsia-400/30 bg-fuchsia-500/10 p-5 sm:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-fuchsia-200">📹 SIXFL TV · Veo Priority</p>
+            <h2 className="mt-2 text-xl font-bold text-white sm:text-2xl">
+              {offer.priority ? 'Veo Priority is ON for your team' : pending ? 'Veo Priority requested' : declined ? 'Veo Priority request not approved' : 'Get more of your matches on SIXFL TV'}
+            </h2>
+          </div>
+          <span className="rounded-full border border-fuchsia-300/30 px-3 py-1 text-sm font-semibold text-fuchsia-100">
+            {offer.priority ? 'Priority ON' : pending ? 'Awaiting approval' : declined ? 'Not approved' : '£5 extra per team'}
+          </span>
+        </div>
+
+        <div className="max-w-3xl space-y-3 text-sm leading-6 text-white/80">
+          <p>Watch your goals back and share the game with your squad. Veo Priority gives your team first priority for matches on our camera-equipped pitch.</p>
+          <p><strong className="text-white">Just £5 extra for the whole team</strong> when your match is scheduled on the Veo pitch. Otherwise, you pay your usual match fee.</p>
+          <p className="text-white/65">Recordings may be published publicly on SIXFL TV/YouTube. Filming depends on pitch and camera availability and is not guaranteed for every match.</p>
+        </div>
+
+        {offer.priority ? (
+          <div className="space-y-3">
+            <p className="max-w-3xl text-sm leading-6 text-emerald-100">We will prioritise your team for the Veo pitch when scheduling new matches. Open Fixtures to see which matches are on Veo and what your team will pay. Matches already published are unchanged.</p>
+            <Link href={`/captain/team/${teamId}/fixtures`} className="inline-flex min-h-11 items-center rounded-xl border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:bg-white/10">View your fixtures</Link>
+          </div>
+        ) : pending ? (
+          <p role="status" className="rounded-xl border border-amber-300/30 bg-amber-400/10 p-4 text-sm leading-6 text-amber-100">Your request is awaiting SIXFL approval. We will show Priority ON here if it is approved. You do not need to request it again, and your fees have not changed.</p>
+        ) : declined ? (
+          <p className="text-sm leading-6 text-white/80">Your request was not approved. <Link href={`/captain/team/${teamId}/messages`} className="font-semibold text-fuchsia-100 underline">Contact SIXFL</Link> to discuss Veo Priority.</p>
+        ) : (
+          <div className="space-y-4 rounded-2xl border border-fuchsia-300/20 bg-black/15 p-4 sm:p-5">
+            <div className="max-w-3xl space-y-2">
+              <h3 className="text-base font-semibold text-white">How to switch it on</h3>
+              <p className="text-sm leading-6 text-white/80">Tick the agreement below and press <strong className="text-white">Request Veo Priority</strong>. SIXFL will review your request and, if approved, switch it on for your team. Until then, your fees stay the same.</p>
+            </div>
+            <VeoPriorityRequestForm teamId={teamId} leagueId={leagueId} termsVersion={VEO_REQUEST_TERMS} preview={!canRequest} />
+          </div>
+        )}
+      </section>
     </div>
-    <p className="max-w-3xl text-sm leading-6 text-white/80">Give your team priority for fixtures on our camera-equipped pitch. It is £5 extra per team when allocated to a Veo match, not £5 per player. No Veo allocation means no supplement. Filming is subject to availability, and footage may be published publicly on SIXFL TV/YouTube.</p>
-    {offer.priority ? <div className="space-y-2"><p className="text-sm leading-6 text-emerald-100">Your choice applies to future fixture publications. Check Fixtures to see your filming allocations and agreed match fees.</p><Link href={`/captain/team/${teamId}/fixtures`} className="inline-flex min-h-11 items-center rounded-xl border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:bg-white/10">View your fixtures</Link></div>
-      : pending ? <p role="status" className="rounded-xl border border-amber-300/30 bg-amber-400/10 p-4 text-sm leading-6 text-amber-100">Your request is awaiting SIXFL approval. You do not need to submit it again. Your fees have not changed.</p>
-      : declined ? <p className="text-sm leading-6 text-white/80">Your request was not approved. <Link href={`/captain/team/${teamId}/messages`} className="font-semibold text-fuchsia-100 underline">Contact SIXFL</Link> to discuss Veo Priority.</p>
-      : canRequest ? <VeoPriorityRequestForm teamId={teamId} leagueId={leagueId} termsVersion={VEO_REQUEST_TERMS} />
-      : <p className="text-sm leading-6 text-white/65">This is a read-only preview. The captain can request Priority here when signed in to their own account.</p>}
-  </section>;
+  );
 }

--- a/src/components/captain/CaptainVeoPriorityCard.tsx
+++ b/src/components/captain/CaptainVeoPriorityCard.tsx
@@ -16,7 +16,7 @@ export default async function CaptainVeoPriorityCard({ teamId, leagueId }: { tea
     <div className="space-y-3">
       {!canRequest && (
         <aside aria-label="Veo preview notice" className="rounded-xl border border-amber-300/20 bg-amber-400/5 px-4 py-3 text-sm leading-6 text-amber-100/80">
-          Preview only — the captain sees the offer below. Request controls are visible but disabled in this view; no request will be sent.
+          Preview only — showing the captain's view below. You cannot submit a request from this preview.
         </aside>
       )}
       <section aria-label="Veo Priority" className="space-y-5 rounded-3xl border border-fuchsia-400/30 bg-fuchsia-500/10 p-5 sm:p-6">

--- a/src/components/captain/VeoPriorityRequestForm.tsx
+++ b/src/components/captain/VeoPriorityRequestForm.tsx
@@ -3,20 +3,46 @@
 import { useActionState } from 'react';
 import { requestVeoPriorityAction, type VeoRequestFormState } from '@/app/captain/team/[teamid]/veo-priority/actions';
 
-export default function VeoPriorityRequestForm({ teamId, leagueId, termsVersion }: { teamId: string; leagueId: string; termsVersion: string }) {
+type RequestProps = { teamId: string; leagueId: string; termsVersion: string };
+
+// Both views use these fields, so preview copy and controls cannot drift from
+// the captain experience. Preview buttons are inert even outside a form.
+function RequestFields({ disabled, pending = false, preview = false }: { disabled: boolean; pending?: boolean; preview?: boolean }) {
+  return (
+    <>
+      <label className="flex items-start gap-3 text-sm leading-6 text-white/80">
+        <input type="checkbox" name="agreed" required disabled={disabled} className="mt-1 h-5 w-5 shrink-0" />
+        <span>I agree to an extra £5 on our team's match fee when we are scheduled on the Veo pitch, after SIXFL approves our request. There is no extra charge otherwise. I understand footage may be published publicly on SIXFL TV/YouTube and filming is not guaranteed for every match.</span>
+      </label>
+      <button type={preview ? 'button' : 'submit'} disabled={disabled} className="min-h-11 rounded-xl border border-fuchsia-300/40 bg-fuchsia-500/20 px-5 py-3 font-semibold text-white transition hover:bg-fuchsia-500/30 disabled:cursor-not-allowed disabled:opacity-70">
+        {pending ? 'Sending request…' : 'Request Veo Priority'}
+      </button>
+      <p className="text-xs leading-5 text-white/60">No payment is taken when you request Priority. If approved, it applies to newly published fixtures only. Your existing fixtures and fees stay the same.</p>
+    </>
+  );
+}
+
+function LiveRequestForm({ teamId, leagueId, termsVersion }: RequestProps) {
   const initial: VeoRequestFormState = { status: 'idle', message: '' };
   const [state, action, pending] = useActionState(requestVeoPriorityAction.bind(null, teamId, leagueId), initial);
-  if (state.status === 'pending' || state.status === 'on') return <p role="status" className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100">{state.message}</p>;
-  return <form action={action} className="space-y-4">
-    <input type="hidden" name="termsVersion" value={termsVersion} />
-    <label className="flex items-start gap-3 text-sm leading-6 text-white/80">
-      <input type="checkbox" name="agreed" required disabled={pending} className="mt-1 h-5 w-5 shrink-0" />
-      <span>I agree to the £5 per-team supplement when our team is allocated to a Veo match after SIXFL approves this request. No allocation means no supplement. Footage may be published publicly on SIXFL TV/YouTube; Priority does not guarantee filming.</span>
-    </label>
-    {state.status === 'error' && <p role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{state.message}</p>}
-    <button type="submit" disabled={pending} className="min-h-11 rounded-xl border border-fuchsia-300/40 bg-fuchsia-500/20 px-5 py-3 font-semibold text-white transition hover:bg-fuchsia-500/30 disabled:cursor-wait disabled:opacity-60">
-      {pending ? 'Sending request…' : 'Request Veo Priority'}
-    </button>
-    <p className="text-xs leading-5 text-white/60">Requesting does not take a payment or change your existing fixtures or fees. SIXFL will review your request.</p>
-  </form>;
+  if (state.status === 'pending' || state.status === 'on') {
+    return <p role="status" className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-4 text-sm leading-6 text-emerald-100">{state.message}</p>;
+  }
+  return (
+    <form action={action} className="space-y-4">
+      <input type="hidden" name="termsVersion" value={termsVersion} />
+      {state.status === 'error' && <p role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{state.message}</p>}
+      <RequestFields disabled={pending} pending={pending} />
+    </form>
+  );
+}
+
+export default function VeoPriorityRequestForm({ preview = true, ...props }: RequestProps & { preview?: boolean }) {
+  // Fail closed: only a server-authorised captain explicitly gets the live form.
+  // Do not bind a server action or render a form/hidden action fields in preview.
+  // The server action and database service still independently reject previews.
+  if (preview) {
+    return <div className="space-y-4" data-veo-request-preview="true"><RequestFields disabled preview /></div>;
+  }
+  return <LiveRequestForm {...props} />;
 }

--- a/src/components/captain/VeoPriorityRequestForm.tsx
+++ b/src/components/captain/VeoPriorityRequestForm.tsx
@@ -14,7 +14,7 @@ function RequestFields({ disabled, pending = false, preview = false }: { disable
         <input type="checkbox" name="agreed" required disabled={disabled} className="mt-1 h-5 w-5 shrink-0" />
         <span>I agree to an extra £5 on our team's match fee when we are scheduled on the Veo pitch, after SIXFL approves our request. There is no extra charge otherwise. I understand footage may be published publicly on SIXFL TV/YouTube and filming is not guaranteed for every match.</span>
       </label>
-      <button type={preview ? 'button' : 'submit'} disabled={disabled} className="min-h-11 rounded-xl border border-fuchsia-300/40 bg-fuchsia-500/20 px-5 py-3 font-semibold text-white transition hover:bg-fuchsia-500/30 disabled:cursor-not-allowed disabled:opacity-70">
+      <button type={preview ? 'button' : 'submit'} disabled={disabled} className="min-h-11 w-full rounded-xl border border-fuchsia-300/40 bg-fuchsia-500/20 px-5 py-3 font-semibold text-white transition hover:bg-fuchsia-500/30 disabled:cursor-not-allowed disabled:opacity-70 md:w-auto">
         {pending ? 'Sending request…' : 'Request Veo Priority'}
       </button>
       <p className="text-xs leading-5 text-white/60">No payment is taken when you request Priority. If approved, it applies to newly published fixtures only. Your existing fixtures and fees stay the same.</p>

--- a/tests/veo-priority/browser.mjs
+++ b/tests/veo-priority/browser.mjs
@@ -30,10 +30,13 @@ try {
   await page.screenshot({ path: 'artifacts/veo/admin-desktop.png', fullPage: true });
   assert.deepEqual(errors, []);
 
-  // These HTML artifacts are rendered from the real component and its shared
-  // fields after prebuild; only server auth/data are isolated by the unit harness.
+  // Real component markup after prebuild, plus the actual captain shell's
+  // mobile rules. Only server auth/data are isolated by the unit harness.
   const styles = await page.locator('link[rel="stylesheet"]').evaluateAll(links => links.map(link => link.href));
-  const shell = name => `<!doctype html><html><head>${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}</head><body style="background:#080808"><main class="mx-auto max-w-5xl p-4">${readFileSync(`artifacts/veo/${name}.html`, 'utf8')}</main></body></html>`;
+  const layout = readFileSync('src/app/captain/team/[teamid]/layout.tsx', 'utf8');
+  const captainStyles = layout.match(/const captainMobileStyles = String\.raw`([\s\S]*?)`;/)?.[1];
+  assert.ok(captainStyles, 'Use the current captain layout styles, not a guessed preview stylesheet');
+  const shell = name => `<!doctype html><html><head>${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}<style>${captainStyles}</style></head><body class="captain-team-shell" style="background:#080808"><main class="captain-team-main mx-auto max-w-5xl p-4">${readFileSync(`artifacts/veo/${name}.html`, 'utf8')}</main></body></html>`;
   const promo = await browser.newPage({ viewport: { width: 390, height: 844 } });
   await promo.setContent(shell('captain-promo'), { waitUntil: 'networkidle' });
   const liveCard = promo.getByRole('region', { name: 'Veo Priority', exact: true });
@@ -42,6 +45,7 @@ try {
   assert.equal(await liveCard.getByRole('checkbox').isDisabled(), false);
   assert.equal(await promo.getByRole('complementary', { name: 'Veo preview notice' }).count(), 0);
   const captainCopy = (await liveCard.innerText()).replace(/\s+/g, ' ').trim();
+  const liveButtonWidth = (await liveCard.getByRole('button').boundingBox()).width;
   assert.ok(await promo.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1), 'Captain promo must fit mobile');
   await promo.screenshot({ path: 'artifacts/veo/captain-promo-mobile.png', fullPage: true });
   await promo.setViewportSize({ width: 1440, height: 1000 });
@@ -67,6 +71,7 @@ try {
     await button.scrollIntoViewIfNeeded();
     const box = await button.boundingBox();
     assert.ok(box);
+    assert.ok(Math.abs(box.width - liveButtonWidth) <= 1, 'Mobile preview and live request buttons must have the same width');
     await preview.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
     await preview.keyboard.press('Enter');
     await preview.keyboard.press('Space');

--- a/tests/veo-priority/browser.mjs
+++ b/tests/veo-priority/browser.mjs
@@ -29,13 +29,53 @@ try {
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.screenshot({ path: 'artifacts/veo/admin-desktop.png', fullPage: true });
   assert.deepEqual(errors, []);
+
+  // These HTML artifacts are rendered from the real component and its shared
+  // fields after prebuild; only server auth/data are isolated by the unit harness.
   const styles = await page.locator('link[rel="stylesheet"]').evaluateAll(links => links.map(link => link.href));
+  const shell = name => `<!doctype html><html><head>${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}</head><body style="background:#080808"><main class="mx-auto max-w-5xl p-4">${readFileSync(`artifacts/veo/${name}.html`, 'utf8')}</main></body></html>`;
   const promo = await browser.newPage({ viewport: { width: 390, height: 844 } });
-  await promo.setContent(`<!doctype html><html><head>${styles.map(href => `<link rel="stylesheet" href="${href}">`).join('')}</head><body style="background:#080808"><main class="mx-auto max-w-5xl p-4">${readFileSync('artifacts/veo/captain-promo.html', 'utf8')}</main></body></html>`, { waitUntil: 'networkidle' });
-  await promo.getByRole('button', { name: 'Request Veo Priority', exact: true }).waitFor();
+  await promo.setContent(shell('captain-promo'), { waitUntil: 'networkidle' });
+  const liveCard = promo.getByRole('region', { name: 'Veo Priority', exact: true });
+  await liveCard.getByRole('heading', { name: 'How to switch it on', exact: true }).waitFor();
+  assert.equal(await liveCard.getByRole('button', { name: 'Request Veo Priority', exact: true }).isDisabled(), false);
+  assert.equal(await liveCard.getByRole('checkbox').isDisabled(), false);
+  assert.equal(await promo.getByRole('complementary', { name: 'Veo preview notice' }).count(), 0);
+  const captainCopy = (await liveCard.innerText()).replace(/\s+/g, ' ').trim();
   assert.ok(await promo.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1), 'Captain promo must fit mobile');
   await promo.screenshot({ path: 'artifacts/veo/captain-promo-mobile.png', fullPage: true });
   await promo.setViewportSize({ width: 1440, height: 1000 });
   await promo.screenshot({ path: 'artifacts/veo/captain-promo-desktop.png', fullPage: true });
-  console.log('PASS: request queue, anonymous review refusal, mobile promo, OFF state, saved fee rows and completed-fixture video edits.');
+
+  for (const name of ['admin-preview', 'captain-preview']) {
+    const preview = await browser.newPage({ viewport: { width: 390, height: 844 } });
+    const posts = [];
+    preview.on('request', request => { if (request.method() !== 'GET') posts.push(request.url()); });
+    await preview.setContent(shell(name), { waitUntil: 'networkidle' });
+    const card = preview.getByRole('region', { name: 'Veo Priority', exact: true });
+    const button = card.getByRole('button', { name: 'Request Veo Priority', exact: true });
+    await button.waitFor();
+    assert.equal((await card.innerText()).replace(/\s+/g, ' ').trim(), captainCopy, 'Preview must retain the exact captain-facing offer and instructions');
+    assert.equal(await button.isDisabled(), true);
+    assert.equal(await card.getByRole('checkbox').isDisabled(), true);
+    assert.equal(await button.getAttribute('type'), 'button');
+    assert.equal(await preview.locator('form').count(), 0);
+    assert.equal(await preview.locator('input[type="hidden"]').count(), 0);
+    await preview.getByRole('complementary', { name: 'Veo preview notice' }).waitFor();
+    assert.equal(await card.getByRole('complementary').count(), 0, 'Preview explanation must not replace customer content');
+    assert.ok(await preview.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1), `${name} must fit mobile`);
+    await button.scrollIntoViewIfNeeded();
+    const box = await button.boundingBox();
+    assert.ok(box);
+    await preview.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await preview.keyboard.press('Enter');
+    await preview.keyboard.press('Space');
+    assert.equal(await card.getByRole('checkbox').isChecked(), false);
+    assert.deepEqual(posts, [], 'Preview interactions must not submit a request');
+    await preview.screenshot({ path: `artifacts/veo/${name}-mobile.png`, fullPage: true });
+    await preview.setViewportSize({ width: 1440, height: 1000 });
+    await preview.screenshot({ path: `artifacts/veo/${name}-desktop.png`, fullPage: true });
+    await preview.close();
+  }
+  console.log('PASS: request queue, anonymous review refusal, captain offer and activation instructions, identical safe admin/captain previews on phone and desktop, OFF state, saved fee rows and completed-fixture video edits.');
 } finally { await browser.close(); }

--- a/tests/veo-priority/request-ui.test.cjs
+++ b/tests/veo-priority/request-ui.test.cjs
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const path = require('node:path');
 const ts = require('typescript');
 const React = require('react');
 const { renderToStaticMarkup } = require('react-dom/server');
@@ -42,30 +43,70 @@ async function renderCard(offer, access = normalAccess) {
   }).default;
   return renderToStaticMarkup(await Card({ teamId: 'team', leagueId: 'league' }));
 }
+function customerMarkup(html) {
+  const start = html.indexOf('<section');
+  return html.slice(start, html.indexOf('</section>', start) + '</section>'.length);
+}
+function visibleCopy(html) {
+  return html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+function saveArtifact(name, html) {
+  fs.mkdirSync('artifacts/veo', { recursive: true });
+  fs.writeFileSync(`artifacts/veo/${name}.html`, html);
+}
 test('real captain card is absent when the shared service says the league is off or team ineligible', async () => {
   assert.equal(await renderCard(null), '');
+  for (const access of previewAccess) assert.equal(await renderCard(null, access), '');
 });
-test('eligible captain sees the real opt-in form, agreement, price and public-filming disclosure', async () => {
+test('eligible captain sees a live form, plain pricing, activation steps and public-filming disclosure', async () => {
   const html = await renderCard({ priority: false, request: null });
-  for (const word of ['Get more of your matches', 'Request Veo Priority', '£5', 'not £5 per player', 'YouTube', 'name="agreed"', 'required', 'name="termsVersion"']) assert.ok(html.includes(word), word);
+  for (const word of ['Get more of your matches', 'How to switch it on', 'Tick the agreement', 'Request Veo Priority', 'if approved', '£5 extra for the whole team', 'scheduled on the Veo pitch', 'usual match fee', 'YouTube', 'not guaranteed', 'name="agreed"', 'required', 'name="termsVersion"']) assert.ok(html.includes(word), word);
+  assert.match(html, /<form\b/);
+  assert.doesNotMatch(html.match(/<input\b[^>]*name="agreed"[^>]*>/)[0], /disabled/);
+  assert.doesNotMatch(html.match(/<button\b[^>]*>/)[0], /disabled/);
   assert.ok(!html.includes('name="actorId"'));
-  fs.mkdirSync('artifacts/veo', { recursive: true });
-  fs.writeFileSync('artifacts/veo/captain-promo.html', html);
+  assert.ok(!html.includes('Veo preview notice'));
+  assert.doesNotMatch(customerMarkup(html), /read-only preview|fixture publications|No Veo allocation|supplement/);
+  saveArtifact('captain-promo', html);
 });
-test('pending, approved and declined cards persist without another sign-up button', async () => {
+test('pending, approved and declined cards persist without another sign-up button in live or preview', async () => {
   for (const [offer, expected] of [
     [{ priority: false, request: { status: 'PENDING' } }, 'awaiting SIXFL approval'],
     [{ priority: true, request: { status: 'APPROVED' } }, 'Veo Priority is ON'],
     [{ priority: false, request: { status: 'DECLINED' } }, 'not approved'],
   ]) {
-    const html = await renderCard(offer);
-    assert.ok(html.includes(expected)); assert.ok(!html.includes('Request Veo Priority</button>'));
+    for (const access of [normalAccess, ...previewAccess]) {
+      const html = await renderCard(offer, access);
+      assert.ok(html.includes(expected)); assert.doesNotMatch(customerMarkup(html), /<button|<form|name="agreed"/);
+    }
   }
 });
-test('administrator, captain-only preview and development fallback cannot present a consent button', async () => {
-  for (const access of previewAccess) {
+test('admin and captain-only previews show identical customer copy and disabled controls, never a live form', async () => {
+  const live = customerMarkup(await renderCard({ priority: false, request: null }));
+  for (const [index, access] of previewAccess.entries()) {
     const html = await renderCard({ priority: false, request: null }, access);
-    assert.ok(html.includes('read-only preview')); assert.ok(!html.includes('<form'));
+    const card = customerMarkup(html);
+    assert.ok(html.includes('Veo preview notice'));
+    assert.ok(html.indexOf('</aside>') < html.indexOf('<section'), 'Preview notice stays outside customer card');
+    assert.equal(visibleCopy(card), visibleCopy(live));
+    assert.match(card, /<input\b[^>]*name="agreed"[^>]*disabled=""/);
+    assert.match(card, /<button\b[^>]*type="button"[^>]*disabled=""/);
+    assert.ok(card.includes('Request Veo Priority'));
+    assert.doesNotMatch(html, /<form|\$ACTION_|name="termsVersion"/);
+    assert.doesNotMatch(card, /Preview only|read-only preview/);
+    saveArtifact(index === 0 ? 'admin-preview' : index === 1 ? 'captain-preview' : `fallback-preview-${index}`, html);
+  }
+});
+test('preview is fail-closed by default and does not even bind the request server action', () => {
+  const forbiddenAction = new Proxy(() => { throw new Error('Preview invoked action'); }, {
+    get() { throw new Error('Preview bound action'); },
+  });
+  const Form = load(formPath, { '@/app/captain/team/[teamid]/veo-priority/actions': { requestVeoPriorityAction: forbiddenAction } }).default;
+  for (const preview of [undefined, true]) {
+    const html = renderToStaticMarkup(React.createElement(Form, { teamId: 'team', leagueId: 'league', termsVersion: 'veo-priority-v1', preview }));
+    assert.ok(html.includes('Request Veo Priority'));
+    assert.match(html, /disabled=""/);
+    assert.doesNotMatch(html, /<form|\$ACTION_|name="termsVersion"/);
   }
 });
 test('native action refuses every preview mode and binds the real actor and exact team server-side', async () => {
@@ -110,4 +151,24 @@ test('owning sources retain the promo and admin queue after preparation; no new 
   for (const file of [cardPath, formPath, actionPath, reviewPath, 'src/lib/veo/priority-requests.ts']) {
     assert.doesNotMatch(fs.readFileSync(file, 'utf8'), /MutationObserver|document\.querySelector|sendEmail|queueDirectNotification|stripe\./);
   }
+});
+test('repository-wide source inventory has no stale preview replacement or duplicate Veo request field copy', () => {
+  const refs = [], stale = [], fieldOwners = [];
+  function visit(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const file = path.join(dir, entry.name);
+      if (entry.isDirectory()) { visit(file); continue; }
+      if (!/\.(?:[cm]?[jt]sx?)$/.test(file)) continue;
+      const text = fs.readFileSync(file, 'utf8');
+      if (/CaptainVeoPriorityCard|VeoPriorityRequestForm|requestVeoPriorityAction/.test(text)) refs.push(file);
+      if (text.includes('This is a read-only preview. The captain can request Priority here') || text.includes('£5 when allocated')) stale.push(file);
+      if (text.includes("I agree to an extra £5 on our team's match fee")) fieldOwners.push(file);
+    }
+  }
+  visit('src'); visit('scripts');
+  assert.deepEqual(stale, []);
+  assert.deepEqual(fieldOwners, [formPath]);
+  assert.ok(refs.includes(cardPath) && refs.includes(formPath) && refs.includes(actionPath));
+  fs.mkdirSync('artifacts/veo', { recursive: true });
+  fs.writeFileSync('artifacts/veo/request-source-inventory.json', JSON.stringify({ refs, stale, fieldOwners }, null, 2));
 });

--- a/tests/veo-priority/request-ui.test.cjs
+++ b/tests/veo-priority/request-ui.test.cjs
@@ -54,6 +54,19 @@ function saveArtifact(name, html) {
   fs.mkdirSync('artifacts/veo', { recursive: true });
   fs.writeFileSync(`artifacts/veo/${name}.html`, html);
 }
+// React may move name after disabled; Tailwind's disabled: variants are not
+// a boolean HTML disabled attribute. Check the actual attributes, in any order.
+const disabledAttribute = /\sdisabled(?:\s|=|\/?>)/;
+function agreementTag(html) {
+  const tag = html.match(/<input\b[^>]*name="agreed"[^>]*>/)?.[0];
+  assert.ok(tag, 'Agreement checkbox must be rendered');
+  return tag;
+}
+function buttonTag(html) {
+  const tag = html.match(/<button\b[^>]*>/)?.[0];
+  assert.ok(tag, 'Request button must be rendered');
+  return tag;
+}
 test('real captain card is absent when the shared service says the league is off or team ineligible', async () => {
   assert.equal(await renderCard(null), '');
   for (const access of previewAccess) assert.equal(await renderCard(null, access), '');
@@ -62,8 +75,8 @@ test('eligible captain sees a live form, plain pricing, activation steps and pub
   const html = await renderCard({ priority: false, request: null });
   for (const word of ['Get more of your matches', 'How to switch it on', 'Tick the agreement', 'Request Veo Priority', 'if approved', '£5 extra for the whole team', 'scheduled on the Veo pitch', 'usual match fee', 'YouTube', 'not guaranteed', 'name="agreed"', 'required', 'name="termsVersion"']) assert.ok(html.includes(word), word);
   assert.match(html, /<form\b/);
-  assert.doesNotMatch(html.match(/<input\b[^>]*name="agreed"[^>]*>/)[0], /disabled/);
-  assert.doesNotMatch(html.match(/<button\b[^>]*>/)[0], /disabled/);
+  assert.doesNotMatch(agreementTag(html), disabledAttribute);
+  assert.doesNotMatch(buttonTag(html), disabledAttribute);
   assert.ok(!html.includes('name="actorId"'));
   assert.ok(!html.includes('Veo preview notice'));
   assert.doesNotMatch(customerMarkup(html), /read-only preview|fixture publications|No Veo allocation|supplement/);
@@ -89,8 +102,9 @@ test('admin and captain-only previews show identical customer copy and disabled 
     assert.ok(html.includes('Veo preview notice'));
     assert.ok(html.indexOf('</aside>') < html.indexOf('<section'), 'Preview notice stays outside customer card');
     assert.equal(visibleCopy(card), visibleCopy(live));
-    assert.match(card, /<input\b[^>]*name="agreed"[^>]*disabled=""/);
-    assert.match(card, /<button\b[^>]*type="button"[^>]*disabled=""/);
+    assert.match(agreementTag(card), disabledAttribute);
+    assert.match(buttonTag(card), disabledAttribute);
+    assert.match(buttonTag(card), /type="button"/);
     assert.ok(card.includes('Request Veo Priority'));
     assert.doesNotMatch(html, /<form|\$ACTION_|name="termsVersion"/);
     assert.doesNotMatch(card, /Preview only|read-only preview/);
@@ -105,7 +119,8 @@ test('preview is fail-closed by default and does not even bind the request serve
   for (const preview of [undefined, true]) {
     const html = renderToStaticMarkup(React.createElement(Form, { teamId: 'team', leagueId: 'league', termsVersion: 'veo-priority-v1', preview }));
     assert.ok(html.includes('Request Veo Priority'));
-    assert.match(html, /disabled=""/);
+    assert.match(agreementTag(html), disabledAttribute);
+    assert.match(buttonTag(html), disabledAttribute);
     assert.doesNotMatch(html, /<form|\$ACTION_|name="termsVersion"/);
   }
 });


### PR DESCRIPTION
## User-reported issue
The Veo card used internal allocation/supplement wording, gave no activation instructions, and replaced the request form with a read-only explanation in both Admin Captain view and captain-only preview.

## Changes
- Plain captain-facing offer, whole-team £5 price and explicit How to switch it on instructions: tick agreement, request, await SIXFL approval.
- Both preview modes retain the exact customer offer, checkbox and Request Veo Priority button. Preview explanation is a separate notice outside the customer card.
- One shared RequestFields component for live and preview controls. Preview defaults closed, has disabled controls, no form, no hidden action fields and never binds the server action. Existing server/database permission checks remain unchanged.
- Preserve existing eligibility, pending/ON/declined states, admin approval, filming caveat, public video disclosure, fees and scheduling behaviour.

## Verification
Existing Veo workflow runs extended native and post-prebuild request contracts, repository-wide stale-copy/source inventory, real Postgres permission/concurrency/allocation checks, production build and auth tests. Extended browser checks compare live/preview copy and verify disabled controls, no preview POST and mobile/desktop layout. Await checks before merge.

## Rollout safety
Presentation-only: no migrations, no live opt-ins, no fixture/payment edits, no customer messages or real test requests. Shared sources changed: CaptainVeoPriorityCard.tsx and VeoPriorityRequestForm.tsx. No extra dashboard wrappers or DOM bridges.